### PR TITLE
Add an event for when the server is about to stop

### DIFF
--- a/src/main/java/net/fabricmc/fabric/events/ServerEvent.java
+++ b/src/main/java/net/fabricmc/fabric/events/ServerEvent.java
@@ -24,6 +24,7 @@ import java.util.function.Consumer;
 
 public final class ServerEvent {
 	public static final HandlerRegistry<Consumer<MinecraftServer>> START = new HandlerArray<>(Consumer.class);
+	public static final HandlerRegistry<Consumer<MinecraftServer>> STOP = new HandlerArray<>(Consumer.class);
 
 	private ServerEvent() {
 

--- a/src/main/java/net/fabricmc/fabric/mixin/events/server/MixinMinecraftServer.java
+++ b/src/main/java/net/fabricmc/fabric/mixin/events/server/MixinMinecraftServer.java
@@ -35,11 +35,8 @@ public class MixinMinecraftServer {
 		}
 	}
 
-	@Inject(
-		at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;exit()V", shift = At.Shift.BY, by = -2, ordinal = 0),
-		method = "run"
-	)
-	public void beforeExitServer(CallbackInfo info) {
+	@Inject(at = @At("HEAD"), method = "shutdown")
+	public void beforeShutdownServer(CallbackInfo info) {
 		for (Consumer<MinecraftServer> handler : ((HandlerArray<Consumer<MinecraftServer>>) ServerEvent.STOP).getBackingArray()) {
 			handler.accept((MinecraftServer) (Object) this);
 		}

--- a/src/main/java/net/fabricmc/fabric/mixin/events/server/MixinMinecraftServer.java
+++ b/src/main/java/net/fabricmc/fabric/mixin/events/server/MixinMinecraftServer.java
@@ -34,4 +34,14 @@ public class MixinMinecraftServer {
 			handler.accept((MinecraftServer) (Object) this);
 		}
 	}
+
+	@Inject(
+		at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;exit()V", shift = At.Shift.BY, by = -2, ordinal = 0),
+		method = "run"
+	)
+	public void beforeExitServer(CallbackInfo info) {
+		for (Consumer<MinecraftServer> handler : ((HandlerArray<Consumer<MinecraftServer>>) ServerEvent.STOP).getBackingArray()) {
+			handler.accept((MinecraftServer) (Object) this);
+		}
+	}
 }

--- a/src/test/java/net/fabricmc/fabric/events/ServerEventMod.java
+++ b/src/test/java/net/fabricmc/fabric/events/ServerEventMod.java
@@ -1,0 +1,15 @@
+package net.fabricmc.fabric.events;
+
+import net.fabricmc.api.ModInitializer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class ServerEventMod implements ModInitializer {
+	private static final Logger LOGGER = LogManager.getLogger();
+
+	@Override
+	public void onInitialize() {
+		ServerEvent.START.register(server -> LOGGER.info("Server starting (" + server + ")"));
+		ServerEvent.STOP.register(server -> LOGGER.info("Server stopped (" + server + ")"));
+	}
+}

--- a/src/test/java/net/fabricmc/fabric/events/ServerEventMod.java
+++ b/src/test/java/net/fabricmc/fabric/events/ServerEventMod.java
@@ -10,6 +10,6 @@ public class ServerEventMod implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		ServerEvent.START.register(server -> LOGGER.info("Server starting (" + server + ")"));
-		ServerEvent.STOP.register(server -> LOGGER.info("Server stopped (" + server + ")"));
+		ServerEvent.STOP.register(server -> LOGGER.info("Server stopping (" + server + ")"));
 	}
 }

--- a/src/test/resources/mod.json
+++ b/src/test/resources/mod.json
@@ -6,6 +6,7 @@
   "description": "A series of test mods to check Fabric works.",
   "license": "Apache-2.0",
   "initializers": [
-    "net.fabricmc.fabric.colormapper.ColorProviderMod"
+    "net.fabricmc.fabric.colormapper.ColorProviderMod",
+    "net.fabricmc.fabric.events.ServerEventMod"
   ]
 }


### PR DESCRIPTION
This may allow mods to perform any additional clean up of resources, or what not.

Note, this is fired _after_ `MinecraftServer.shutdown()` has been called, but before `MinecraftServer.exit()`, and so things like the player list has been removed, the network shutdown, etc.... I'd like some feedback on if this is the most useful place for this event  or if there's another, more-suitable palace to fire it.