### PR TITLE
Add a license to the ServerEventMod

### DIFF
--- a/src/test/java/net/fabricmc/fabric/events/ServerEventMod.java
+++ b/src/test/java/net/fabricmc/fabric/events/ServerEventMod.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.events;
 
 import net.fabricmc.api.ModInitializer;


### PR DESCRIPTION
The missing license was causing the build to fail. Really sorry about this - I keep forgetting to add it to the test sources.