### PR TITLE
Add a way to retrieve the current MinecraftServer instance

### DIFF
--- a/src/main/java/net/fabricmc/fabric/mixin/server/MixinMinecraftServer.java
+++ b/src/main/java/net/fabricmc/fabric/mixin/server/MixinMinecraftServer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.server;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Inject;
+import net.fabricmc.fabric.server.ServerProvider;
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftServer.class)
+public class MixinMinecraftServer {
+  @Inject(at = @At("RETURN"), method = "<init>")
+  private void init(CallbackInfo info) {
+    ServerProvider.set((MinecraftServer) (Object) this);
+  }
+
+  @Inject(at = @At("RETURN"), method = "shutdown")
+  public void stop(CallbackInfo info) {
+    ServerProvider.set(null);
+  }
+}

--- a/src/main/java/net/fabricmc/fabric/server/ServerProvider.java
+++ b/src/main/java/net/fabricmc/fabric/server/ServerProvider.java
@@ -41,6 +41,7 @@ public final class ServerProvider {
 	 * @param server
 	 */
 	public static void set(MinecraftServer server) {
-		ServerProvider.instance = server;
+		if (server == null || instance == null)
+			ServerProvider.instance = server;
 	}
 }

--- a/src/main/java/net/fabricmc/fabric/server/ServerProvider.java
+++ b/src/main/java/net/fabricmc/fabric/server/ServerProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.server;
+
+import net.minecraft.server.MinecraftServer;
+
+/**
+ * Allows retrieval of the MinecraftServer instance.
+ */
+public final class ServerProvider {
+	private static MinecraftServer instance = null;
+
+	/**
+	 * Returns the current {@code MinecraftServer} instance.
+	 * 
+	 * @return On (physical) client-side, returns an instance of {@code IntegratedServer} when in a
+	 *         world, returns null otherwise. On (physical) server-side returns an instance of
+	 *         {@code DedicatedServer}
+	 */
+	public static MinecraftServer get() {
+		return ServerProvider.instance;
+	}
+
+	/**
+	 * This method is not meant to be called directly.
+	 * 
+	 * @param server
+	 */
+	public static void set(MinecraftServer server) {
+		ServerProvider.instance = server;
+	}
+}

--- a/src/main/java/net/fabricmc/fabric/server/ServerProvider.java
+++ b/src/main/java/net/fabricmc/fabric/server/ServerProvider.java
@@ -41,7 +41,8 @@ public final class ServerProvider {
 	 * @param server
 	 */
 	public static void set(MinecraftServer server) {
-		if (server == null || instance == null)
-			ServerProvider.instance = server;
+		if (server != null && instance != null)
+			throw new IllegalStateException("Only one instance of MinecraftServer is allowed");
+		ServerProvider.instance = server;
 	}
 }

--- a/src/main/resources/net.fabricmc.fabric.mixins.common.json
+++ b/src/main/resources/net.fabricmc.fabric.mixins.common.json
@@ -26,6 +26,7 @@
     "registry.MixinServerPlayNetworkHandler",
     "registry.MixinWorldSaveHandler",
     "resources.MixinMinecraftServer",
+    "server.MixinMinecraftServer",
     "tools.MixinItemStack",
     "tools.MixinMiningToolItem"
   ],


### PR DESCRIPTION
Adding a class called ServerProvider can retreive the current MinecraftServer instance.