### PR TITLE
Fix wrong placeholders.

### DIFF
--- a/src/main/java/net/fabricmc/fabric/impl/client/gui/GuiProviderImpl.java
+++ b/src/main/java/net/fabricmc/fabric/impl/client/gui/GuiProviderImpl.java
@@ -56,7 +56,7 @@ public class GuiProviderImpl implements GuiProviderRegistry {
 		registerFactory(identifier, (syncId, identifier1, player, buf) -> {
 			C container = ContainerProviderImpl.INSTANCE.createContainer(syncId, identifier1, player, buf);
 			if(container == null){
-				LOGGER.error("Could not open container for %s - a null object was created!", identifier1.toString());
+				LOGGER.error("Could not open container for {} - a null object was created!", identifier1.toString());
 				return null;
 			}
 			return guiFactory.create(container);
@@ -70,7 +70,7 @@ public class GuiProviderImpl implements GuiProviderRegistry {
 			MinecraftClient.getInstance().execute(() -> {
 				ContainerFactory<ContainerGui> factory = FACTORIES.get(identifier);
 				if (factory == null) {
-					LOGGER.error("No GUI factory found for %s!", identifier.toString());
+					LOGGER.error("No GUI factory found for {}!", identifier.toString());
 					return;
 				}
 				ContainerGui gui = factory.create(syncId, identifier, packetContext.getPlayer(), packetByteBuf);

--- a/src/main/java/net/fabricmc/fabric/impl/container/ContainerProviderImpl.java
+++ b/src/main/java/net/fabricmc/fabric/impl/container/ContainerProviderImpl.java
@@ -88,7 +88,7 @@ public class ContainerProviderImpl implements ContainerProviderRegistry {
 	public <C extends Container> C createContainer(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf){
 		ContainerFactory<Container> factory = FACTORIES.get(identifier);
 		if (factory == null) {
-			LOGGER.error("No container factory found for %s!", identifier.toString());
+			LOGGER.error("No container factory found for {}!", identifier.toString());
 			return null;
 		}
 		return (C) factory.create(syncId, identifier, player, buf);


### PR DESCRIPTION
The placeholders for the GuiProvider/ContainerProvider error-messages are wrong: it should be `{}` instead of `%s`

Before commit:
`No container factory found for %s`

After commit:
`No container factory found for Minecraft:example_container_not_found!`