### PR TITLE
Add API for checking if a tag has been replaced

### DIFF
--- a/fabric-tag-hooks/src/main/java/net/fabricmc/fabric/api/tag/FabricTag.java
+++ b/fabric-tag-hooks/src/main/java/net/fabricmc/fabric/api/tag/FabricTag.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.tag;
+
+/**
+ * Interface implemented by {@link net.minecraft.tag.Tag} instances when
+ * Fabric API is present.
+ *
+ * @param <T>
+ */
+public interface FabricTag<T> {
+	/**
+	 * @return True if the given tag has been "replaced" by a datapack at least once.
+	 */
+	boolean hasBeenReplaced();
+}

--- a/fabric-tag-hooks/src/main/java/net/fabricmc/fabric/api/tag/FabricTagBuilder.java
+++ b/fabric-tag-hooks/src/main/java/net/fabricmc/fabric/api/tag/FabricTagBuilder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.tag;
+
+/**
+ * Interface implemented by {@link net.minecraft.tag.Tag.Builder} instances when
+ * Fabric API is present.
+ *
+ * @param <T>
+ */
+public interface FabricTagBuilder<T> {
+	/**
+	 * Clear the contained entries and mark the tag as replaced.
+	 */
+	void clearTagEntries();
+}

--- a/fabric-tag-hooks/src/main/java/net/fabricmc/fabric/impl/tag/FabricTagHooks.java
+++ b/fabric-tag-hooks/src/main/java/net/fabricmc/fabric/impl/tag/FabricTagHooks.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.tag;
+
+public interface FabricTagHooks {
+	void fabric_setExtraData(int clearCount);
+}

--- a/fabric-tag-hooks/src/main/java/net/fabricmc/fabric/mixin/tag/MixinTag.java
+++ b/fabric-tag-hooks/src/main/java/net/fabricmc/fabric/mixin/tag/MixinTag.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.tag;
+
+import net.fabricmc.fabric.api.tag.FabricTag;
+import net.fabricmc.fabric.impl.tag.FabricTagHooks;
+import net.minecraft.tag.Tag;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(Tag.class)
+public class MixinTag<T> implements FabricTag<T>, FabricTagHooks {
+	private int fabric_clearCount;
+
+	@Override
+	public boolean hasBeenReplaced() {
+		return fabric_clearCount > 0;
+	}
+
+	@Override
+	public void fabric_setExtraData(int clearCount) {
+		this.fabric_clearCount = clearCount;
+	}
+}

--- a/fabric-tag-hooks/src/main/java/net/fabricmc/fabric/mixin/tag/MixinTagBuilder.java
+++ b/fabric-tag-hooks/src/main/java/net/fabricmc/fabric/mixin/tag/MixinTagBuilder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.tag;
+
+import com.google.common.collect.Sets;
+import com.google.gson.JsonObject;
+import net.fabricmc.fabric.api.tag.FabricTagBuilder;
+import net.fabricmc.fabric.impl.tag.FabricTagHooks;
+import net.minecraft.tag.Tag;
+import net.minecraft.util.Identifier;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+@Mixin(Tag.Builder.class)
+public class MixinTagBuilder<T> implements FabricTagBuilder<T> {
+	@Shadow
+	private Set<Tag.Entry<T>> entries;
+	private int fabric_clearCount;
+
+	@Inject(at = @At("RETURN"), method = "build")
+	public void onBuildFinished(Identifier id, CallbackInfoReturnable<Tag<T>> info) {
+		((FabricTagHooks) info.getReturnValue()).fabric_setExtraData(fabric_clearCount);
+	}
+
+	@Inject(at = @At(value = "INVOKE", target = "Ljava/util/Set;clear()V"), method = "fromJson")
+	public void onFromJsonClear(Predicate<Identifier> predicate_1, Function<Identifier, T> function_1, JsonObject jsonObject_1, CallbackInfoReturnable<Tag.Builder<T>> info) {
+		fabric_clearCount++;
+	}
+
+	@Override
+	public void clearTagEntries() {
+		entries.clear();
+		fabric_clearCount++;
+	}
+}

--- a/fabric-tag-hooks/src/main/resources/fabric-tag-hooks.mixins.json
+++ b/fabric-tag-hooks/src/main/resources/fabric-tag-hooks.mixins.json
@@ -1,0 +1,12 @@
+{
+  "required": true,
+  "package": "net.fabricmc.fabric.mixin.tag",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "MixinTag",
+    "MixinTagBuilder"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
The idea is being able to, say, provide vanilla behaviour compatibility in a hook, but also allow overriding it for "total conversion" datapacks.