### PR TITLE
Fix container desync in the client (#61)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ minecraft {
 
 dependencies {
 	minecraft "com.mojang:minecraft:$mcVersion"
-	mappings "net.fabricmc:yarn:$mcVersion.12"
+	mappings "net.fabricmc:yarn:$mcVersion.24"
 	modCompile "net.fabricmc:fabric-loader:0.3.2.92"
 }
 

--- a/src/main/java/net/fabricmc/fabric/impl/client/gui/GuiProviderImpl.java
+++ b/src/main/java/net/fabricmc/fabric/impl/client/gui/GuiProviderImpl.java
@@ -74,6 +74,7 @@ public class GuiProviderImpl implements GuiProviderRegistry {
 					return;
 				}
 				ContainerGui gui = factory.create(syncId, identifier, packetContext.getPlayer(), packetByteBuf);
+				packetContext.getPlayer().container = gui.getContainer();
 				MinecraftClient.getInstance().openGui(gui);
 			});
 		});

--- a/src/test/java/net/fabricmc/fabric/containers/ContainerMod.java
+++ b/src/test/java/net/fabricmc/fabric/containers/ContainerMod.java
@@ -19,8 +19,9 @@ package net.fabricmc.fabric.containers;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.container.ContainerProviderRegistry;
 import net.fabricmc.fabric.commands.CommandRegistry;
-import net.minecraft.class_3917;
 import net.minecraft.container.Container;
+import net.minecraft.container.ContainerType;
+import net.minecraft.container.Slot;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.server.command.ServerCommandManager;
@@ -31,6 +32,7 @@ public class ContainerMod implements ModInitializer {
 
 	public static final Identifier EXAMPLE_CONTAINER = new Identifier("fabric_container", "example_container");
 	public static final Identifier EXAMPLE_CONTAINER_2 = new Identifier("fabric_container", "example_container_2");
+	public static final Identifier EXAMPLE_INVENTORY_CONTAINER = new Identifier("fabric_container", "example_inventory_container");
 
 	@Override
 	public void onInitialize() {
@@ -42,7 +44,7 @@ public class ContainerMod implements ModInitializer {
 					BlockPos pos = context.getSource().getEntity().getPos();
 
 					//Opens a container, sending the block pos
-					ContainerProviderRegistry.INSTANCE.openContainer(EXAMPLE_CONTAINER, context.getSource().getPlayer(), buf -> buf.writeBlockPos(pos));
+					ContainerProviderRegistry.INSTANCE.openContainer(EXAMPLE_INVENTORY_CONTAINER, context.getSource().getPlayer(), buf -> buf.writeBlockPos(pos));
 
 					return 1;
 				})));
@@ -55,6 +57,9 @@ public class ContainerMod implements ModInitializer {
 		ContainerProviderRegistry.INSTANCE.registerFactory(EXAMPLE_CONTAINER_2, (syncId, identifier, player, buf) -> {
 			BlockPos pos = buf.readBlockPos();
 			return new ExampleContainer(syncId, pos, player);
+		});
+		ContainerProviderRegistry.INSTANCE.registerFactory(EXAMPLE_INVENTORY_CONTAINER, (syncId, identifier, player, buf) -> {
+			return new ExampleInventoryContainer(syncId, player);
 		});
 	}
 
@@ -71,7 +76,7 @@ public class ContainerMod implements ModInitializer {
 		}
 
 		@Override
-		public class_3917<?> method_17358() {
+		public ContainerType<?> getType() {
 			return null;
 		}
 
@@ -81,4 +86,32 @@ public class ContainerMod implements ModInitializer {
 		}
 	}
 
+	public static class ExampleInventoryContainer extends Container {
+		public final PlayerInventory playerInventory;
+		BlockPos pos;
+
+		public ExampleInventoryContainer(int syncId, PlayerEntity playerEntity) {
+			super(syncId);
+			this.playerInventory = playerEntity.inventory;
+			for(int i = 0; i < 3; ++i) {
+				for(int j = 0; j < 9; ++j) {
+					this.addSlot(new Slot(playerInventory, j + i * 9 + 9, 8 + j * 18, 84 + i * 18));
+				}
+			}
+
+			for(int j = 0; j < 9; ++j) {
+				this.addSlot(new Slot(playerInventory, j, 8 + j * 18, 142));
+			}
+		}
+
+		@Override
+		public ContainerType<?> getType() {
+			return null;
+		}
+
+		@Override
+		public boolean canUse(PlayerEntity playerEntity) {
+			return true;
+		}
+	}
 }

--- a/src/test/java/net/fabricmc/fabric/containers/ContainerModClient.java
+++ b/src/test/java/net/fabricmc/fabric/containers/ContainerModClient.java
@@ -16,11 +16,13 @@
 
 package net.fabricmc.fabric.containers;
 
+import com.mojang.blaze3d.platform.GlStateManager;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.gui.GuiProviderRegistry;
 import net.minecraft.client.gui.ContainerGui;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.text.StringTextComponent;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 
 public class ContainerModClient implements ClientModInitializer {
@@ -35,6 +37,9 @@ public class ContainerModClient implements ClientModInitializer {
 
 		//Registers a gui factory that opens our example gui, this uses the container created by ContainerProviderRegistry
 		GuiProviderRegistry.INSTANCE.registerFactory(ContainerMod.EXAMPLE_CONTAINER_2, ExampleContainerGui2::new);
+
+		//Registers a gui factory that opens our example inventory gui
+		GuiProviderRegistry.INSTANCE.registerFactory(ContainerMod.EXAMPLE_INVENTORY_CONTAINER, ExampleInventoryContainerGui::new);
 	}
 
 	//A container gui that shows the block pos that was sent
@@ -67,6 +72,23 @@ public class ContainerModClient implements ClientModInitializer {
 		@Override
 		protected void drawBackground(float v, int i, int i1) {
 			fontRenderer.draw(pos.toString(), width / 2, height / 2, 0);
+		}
+	}
+
+	//A container gui that has the player's inventory
+	public static class ExampleInventoryContainerGui extends ContainerGui<ContainerMod.ExampleInventoryContainer> {
+
+		private static final Identifier BG_TEXTURE = new Identifier("textures/gui/container/horse.png");
+
+		public ExampleInventoryContainerGui(ContainerMod.ExampleInventoryContainer container) {
+			super(container, container.playerInventory, new StringTextComponent("Example Inventory GUI"));
+		}
+
+		@Override
+		protected void drawBackground(float v, int i, int i1) {
+			GlStateManager.color4f(1.0F, 1.0F, 1.0F, 1.0F);
+			client.getTextureManager().bindTexture(BG_TEXTURE);
+			this.drawTexturedRect(left, top, 0, 0, containerWidth, containerHeight);
 		}
 	}
 


### PR DESCRIPTION
The default minecraft packet handler for opening containers updates the container in the player entity while the fabric one didn't, this caused some desync issues as mentioned in #64.