### PR TITLE
Fixing registry id between server and client

### DIFF
--- a/src/main/java/net/fabricmc/fabric/impl/registry/RegistrySyncManager.java
+++ b/src/main/java/net/fabricmc/fabric/impl/registry/RegistrySyncManager.java
@@ -58,7 +58,7 @@ public final class RegistrySyncManager {
 			try {
 				context.getTaskQueue().executeFuture(() -> {
 					try {
-						apply(compound, false);
+						apply(compound, true);
 					} catch (RemapException e) {
 						// TODO: log error properly
 						e.printStackTrace();


### PR DESCRIPTION
This seems to fix the id mismatching, cant find any problems so far but it feels too simple to be the complete solution.

Haven't found any problems with it so its likely the full fix for #88 (in terms of upcrafts comment)