### PR TITLE
FabricEntityTypeBuilder: Rename immunteToFire field to immuneToFire

### DIFF
--- a/src/main/java/net/fabricmc/fabric/api/entity/FabricEntityTypeBuilder.java
+++ b/src/main/java/net/fabricmc/fabric/api/entity/FabricEntityTypeBuilder.java
@@ -42,7 +42,7 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 	private int trackingDistance = -1;
 	private int updateIntervalTicks = -1;
 	private boolean alwaysUpdateVelocity = true;
-	private boolean immunteToFire = false;
+	private boolean immuneToFire = false;
 	private EntitySize size = EntitySize.resizeable(-1.0f, -1.0f);
 
 	protected FabricEntityTypeBuilder(EntityCategory category, EntityType.class_4049<T> function) {
@@ -77,7 +77,7 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 	}
 
 	public FabricEntityTypeBuilder<T> setImmuneToFire() {
-		this.immunteToFire = true;
+		this.immuneToFire = true;
 		return this;
 	}
 
@@ -112,7 +112,7 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 			// TODO: Flesh out once modded datafixers exist.
 		}
 
-		EntityType<T> type = new EntityType<T>(this.function, this.category, this.saveable, this.summonable, this.immunteToFire, null, size);
+		EntityType<T> type = new EntityType<T>(this.function, this.category, this.saveable, this.summonable, this.immuneToFire, null, size);
 		if (trackingDistance != -1) {
 			EntityTrackingRegistry.INSTANCE.register(type, trackingDistance, updateIntervalTicks, alwaysUpdateVelocity);
 		}


### PR DESCRIPTION
Saw this spelling error when digging through the code, looks like it's only used internally so nothing should break