### PR TITLE
Add /fabric mods command

### DIFF
--- a/src/main/java/net/fabricmc/fabric/impl/FabricAPIInitializer.java
+++ b/src/main/java/net/fabricmc/fabric/impl/FabricAPIInitializer.java
@@ -19,7 +19,14 @@ package net.fabricmc.fabric.impl;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.block.BlockAttackInteractionAware;
 import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
+import net.fabricmc.fabric.api.registry.CommandRegistry;
+import net.fabricmc.loader.FabricLoader;
 import net.minecraft.block.BlockState;
+import net.minecraft.server.command.ServerCommandManager;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.StringTextComponent;
+import net.minecraft.text.TextFormat;
+import net.minecraft.text.TranslatableTextComponent;
 import net.minecraft.util.ActionResult;
 
 public class FabricAPIInitializer implements ModInitializer {
@@ -39,5 +46,20 @@ public class FabricAPIInitializer implements ModInitializer {
 
 			return ActionResult.PASS;
 		});
+		
+		CommandRegistry.INSTANCE.register(false, serverCommandSourceCommandDispatcher ->
+			serverCommandSourceCommandDispatcher.register(ServerCommandManager
+				.literal("fabric")
+				.requires((serverCommandSource_1) -> { return serverCommandSource_1.hasPermissionLevel(2); })
+				.then(ServerCommandManager.literal("mods")
+				.executes(context -> {
+					ServerCommandSource source = context.getSource();
+					String modList = "";
+					for (int i = 0; i < FabricLoader.INSTANCE.getMods().size(); i++) {
+						modList = modList + "\n  " + TextFormat.GREEN + FabricLoader.INSTANCE.getMods().get(i).getInfo().getName() + TextFormat.YELLOW + " " + FabricLoader.INSTANCE.getMods().get(i).getInfo().getVersionString() + TextFormat.RESET + " " + new TranslatableTextComponent("fabric.command.by").getText() + " " + TextFormat.LIGHT_PURPLE + FabricLoader.INSTANCE.getMods().get(i).getInfo().getAuthors();
+					}
+					source.sendFeedback(new StringTextComponent(new TranslatableTextComponent("fabric.command.mods_loaded").getText() + modList), true);
+					return 1;
+		}))));
 	}
 }

--- a/src/main/resources/assets/fabric/lang/en_us.json
+++ b/src/main/resources/assets/fabric/lang/en_us.json
@@ -1,3 +1,5 @@
 {
-  "fabric.gui.creativeTabPage": "Page %d/%d"
+  "fabric.gui.creativeTabPage": "Page %d/%d",
+  "fabric.command.mods_loaded": "Mods loaded:",
+  "fabric.command.by": "by"
 }


### PR DESCRIPTION
The `/fabric mods` command (op players only) returns a list of all the mods loaded, with their name, version and authors.
This is useful if someone does not use ModMenu.