### PR TITLE
Fix SimpleResourceReloadListener reload override

### DIFF
--- a/src/main/java/net/fabricmc/fabric/api/resource/SimpleResourceReloadListener.java
+++ b/src/main/java/net/fabricmc/fabric/api/resource/SimpleResourceReloadListener.java
@@ -44,7 +44,8 @@ import java.util.concurrent.Executor;
  * @param <T> The data object.
  */
 public interface SimpleResourceReloadListener<T> extends IdentifiableResourceReloadListener {
-	default CompletableFuture<Void> apply(ResourceReloadListener.Helper helper, ResourceManager manager, Profiler loadProfiler, Profiler applyProfiler, Executor loadExecutor, Executor applyExecutor) {
+	@Override
+	default CompletableFuture<Void> reload(ResourceReloadListener.Helper helper, ResourceManager manager, Profiler loadProfiler, Profiler applyProfiler, Executor loadExecutor, Executor applyExecutor) {
 		return load(manager, loadProfiler, loadExecutor).thenCompose(helper::waitForAll).thenCompose(
 			(o) -> apply(o, manager, applyProfiler, applyExecutor)
 		);


### PR DESCRIPTION
`ResourceReloadListener#apply` was recently renamed to `reload` in yarn. Because Fabric's override wasn't marked as such, it seems it was missed during the update.