### PR TITLE
Expose getOrLoadModel from ModelLoadingRegistry

### DIFF
--- a/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/ModelProviderContext.java
+++ b/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/ModelProviderContext.java
@@ -33,4 +33,16 @@ public interface ModelProviderContext {
 	 * @return The UnbakedModel. Can return a missing model if it's not present!
 	 */
 	UnbakedModel loadModel(Identifier id);
+
+	/**
+	 * Load a model using a {@link Identifier}, {@link ModelIdentifier}, ...
+	 * <p>
+	 * If the model has already been loaded, it will be retrieved from the cache.
+	 * <p>
+	 * Please note that the game engine keeps track of circular model loading calls on its own.
+	 *
+	 * @param id The model identifier.
+	 * @return The UnbakedModel. Can return a missing model if it's not present!
+	 */
+	UnbakedModel getOrLoadModel(Identifier id);
 }

--- a/fabric-models-v0/src/main/java/net/fabricmc/fabric/impl/client/model/ModelLoadingRegistryImpl.java
+++ b/fabric-models-v0/src/main/java/net/fabricmc/fabric/impl/client/model/ModelLoadingRegistryImpl.java
@@ -70,6 +70,15 @@ public class ModelLoadingRegistryImpl implements ModelLoadingRegistry {
 			return ((ModelLoaderHooks) loader).fabric_loadModel(id);
 		}
 
+		@Override
+		public UnbakedModel getOrLoadModel(Identifier id) {
+			if (loader == null) {
+				throw new RuntimeException("Called getOrLoadModel too late!");
+			}
+
+			return loader.getOrLoadModel(id);
+		}
+
 		public void onModelPopulation(Consumer<ModelIdentifier> addModel) {
 			for (ModelAppender appender : modelAppenders) {
 				appender.appendAll(manager, addModel);

--- a/fabric-testmods/java/net/fabricmc/fabric/model/ModelModClient.java
+++ b/fabric-testmods/java/net/fabricmc/fabric/model/ModelModClient.java
@@ -38,12 +38,22 @@ public class ModelModClient implements ClientModInitializer {
 		ModelLoadingRegistry.INSTANCE.registerAppender((manager, out) -> {
 			System.out.println("--- ModelAppender called! ---");
 			out.accept(new ModelIdentifier("fabric:model#custom"));
+			out.accept(new ModelIdentifier("fabric:model#custom_cached"))
 		});
 
 		ModelLoadingRegistry.INSTANCE.registerVariantProvider(manager -> ((modelId, context) -> {
 			if (modelId.getVariant().equals("custom") && modelId.getNamespace().equals("fabric")) {
 				System.out.println("--- ModelVariantProvider called! ---");
 				return context.loadModel(new Identifier("fabric:custom"));
+			} else {
+				return null;
+			}
+		}));
+
+		ModelLoadingRegistry.INSTANCE.registerVariantProvider(manager -> ((modelId, context) -> {
+			if (modelId.getVariant().equals("custom_cached") && modelId.getNamespace().equals("fabric")) {
+				System.out.println("--- Caching ModelVariantProvider called! ---");
+				return context.getOrLoadModel(new Identifier("fabric:custom"));
 			} else {
 				return null;
 			}


### PR DESCRIPTION
While working with some minor model redirection stuff for my Redstone Tweaks mod, I discovered that Fabric's `ModelLoadingRegistry` (and more specifically its `ModelProviderContext`) didn't expose access to `ModelLoader#getOrLoadModel`. This causes some serious issues, since if you need to load the same model multiple times, it will severely drag down loading times by skipping the cache and reloading the model/blockstate files every time. Although `getOrLoadModel` itself is public, it sadly can't be accessed from `ModelProviderContext`, since the `loader` field thereof is private. This PR simply exposes `getOrLoadModel` as a method of `ModelProviderContext`, in the same way that `loadModel` is already exposed (though there is no need to add it to `ModelLoaderHooks` since it's already public in `ModelLoader`).

While I did not precisely benchmark the different implementations, I estimate the following:

- Baseline: no caching (direct call to `loadModel`), very slow
- Manual caching (`HashMap`, `loadModel` behind `computeIfAbsent`), ~3x faster or more than baseline
- Builtin caching (mixin/PR to expose `getOrLoadModel`), ~2x faster than manual caching

This seems like a fairly serious oversight, and I think it should be directly implemented into the API. I'm honestly kind of baffled that this wasn't already available.