### PR TITLE
Probable fix for #198

### DIFF
--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinItemRenderer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinItemRenderer.java
@@ -54,8 +54,13 @@ public abstract class MixinItemRenderer {
     private void hookRenderModel(BakedModel model, int color, ItemStack stack, CallbackInfo ci) {
         FabricBakedModel fabricModel = (FabricBakedModel)model;
         if(!fabricModel.isVanillaAdapter()) {
-            CONTEXTS.get().renderModel(fabricModel, color, stack, this::renderQuads);
+            CONTEXTS.get().renderModel(fabricModel, color, stack, (b, q, c, a) -> reliableRenderQuads(b, q, c, a));
             ci.cancel();
         }
+    }
+
+    // Workaround for #198
+    private void reliableRenderQuads(BufferBuilder bufferBuilder, List<BakedQuad> quads, int color, ItemStack stack) {
+	    renderQuads(bufferBuilder, quads, color, stack);
     }
 }


### PR DESCRIPTION
I'm not able to get the build working locally so I've been unable to test this fully, but I believe the the method reference to a shadowed method is the part that isn't getting remapped correctly.

It's possible the proposed fix is overkill - maybe referencing the shadowed method directly in the lambda would be sufficient - but as I noted above I wasn't able to make a local build to know for certain.