### PR TITLE
FabricKeyBinding configured KeyCode getter

### DIFF
--- a/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/FabricKeyBinding.java
+++ b/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/FabricKeyBinding.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.api.client.keybinding;
 
+import net.fabricmc.fabric.mixin.client.keybinding.MixinKeyBindingAccessor;
 import net.minecraft.client.options.KeyBinding;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.util.Identifier;
@@ -29,6 +30,15 @@ import net.minecraft.util.Identifier;
 public class FabricKeyBinding extends KeyBinding {
 	protected FabricKeyBinding(Identifier id, InputUtil.Type type, int code, String category) {
 		super("key." + id.toString().replace(':', '.'), type, code, category);
+	}
+
+	/**
+	 * Returns the configured KeyCode assigned to the KeyBinding from the player's settings.
+	 * @return
+	 */
+	public InputUtil.KeyCode getConfiguredKeyCode()
+	{
+		return ((MixinKeyBindingAccessor) this).getConfiguredKeyCode();
 	}
 
 	public static class Builder {

--- a/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/mixin/client/keybinding/MixinKeyBindingAccessor.java
+++ b/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/mixin/client/keybinding/MixinKeyBindingAccessor.java
@@ -1,0 +1,13 @@
+package net.fabricmc.fabric.mixin.client.keybinding;
+
+import net.minecraft.client.options.KeyBinding;
+import net.minecraft.client.util.InputUtil;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(KeyBinding.class)
+public interface MixinKeyBindingAccessor
+{
+	@Accessor("keyCode")
+	InputUtil.KeyCode getConfiguredKeyCode();
+}

--- a/fabric-keybindings-v0/src/main/resources/fabric-keybindings-v0.mixins.json
+++ b/fabric-keybindings-v0/src/main/resources/fabric-keybindings-v0.mixins.json
@@ -4,7 +4,8 @@
   "compatibilityLevel": "JAVA_8",
   "client": [
     "MixinGameOptions",
-    "MixinKeyBinding"
+    "MixinKeyBinding",
+    "MixinKeyBindingAccessor"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
KeyBinding stores a configured KeyCode and a default KeyCode. As #171 mentions, the configured KeyCode is not public and doesn't have a getter method, so the only solution for people looking to get the key is an accessor mixin. I propose we simply add a getter method to the already existing FabricKeyBinding class to make this easier.

**Naming:**
KeyBinding already has a _getDefaultKeyCode_ method, so it makes sense to name the new method _getConfiguredKeyCode_.
There's already a MixinKeyBinding class so I opted to name the new mixin _MixinKeyBindingAccessor_-- can't come up with anything better.

**Usage:**
Key press emulation. Can't retrieve the configured key codes without an accessor, so it seems fairly appropriate to add to the API.

I can't get the test project to run so I'm unable to test this in full, but it does work in a mod in a separate environment. 