### PR TITLE
Add support for other blocks as beacon bases

### DIFF
--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/mixin/registryextras/MixinBeaconBlockEntity.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/mixin/registryextras/MixinBeaconBlockEntity.java
@@ -1,0 +1,22 @@
+package net.fabricmc.fabric.mixin.registryextras;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.entity.BeaconBlockEntity;
+import net.minecraft.tag.BlockTags;
+import net.minecraft.tag.Tag;
+import net.minecraft.util.Identifier;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(BeaconBlockEntity.class)
+public abstract class MixinBeaconBlockEntity{
+
+	@ModifyVariable(method = "updateLevel", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/block/BlockState;getBlock()Lnet/minecraft/block/Block;", ordinal = 0))
+	private Block checkBeaconCompatible(Block original) {
+		Tag<Block> beaconBaseTag = BlockTags.getContainer().get(new Identifier("fabric", "beacon_base"));
+		if (beaconBaseTag != null && beaconBaseTag.contains(original)) return Blocks.IRON_BLOCK;
+		else return original;
+	}
+}

--- a/fabric-content-registries-v0/src/main/resources/fabric-content-registries-v0.mixins.json
+++ b/fabric-content-registries-v0/src/main/resources/fabric-content-registries-v0.mixins.json
@@ -4,7 +4,8 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinAbstractFurnaceBlockEntity",
-    "MixinFireBlock"
+    "MixinFireBlock",
+    "MixinBeaconBlockEntity"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Problem: The blocks that are usable as beacon bases are hardcoded, and stuck within two `for` statements that each use `break`s. Injecting in to change the `if` statement used for compatibility checks is nigh impossible, due to `Inject` not supporting flow control.

Solution: Add a check for if the tag `fabric:beacon_base` contains the block currently being checked, and if so, modify the Block being passed to the if statement to be a `minecraft:iron_block`, which will allow it to be part of the beacon base. This isn't an optimal solution, but it's the best I can think of without the ability to control for statement flow.

I couldn't find a great place to put this, so I just put it inside content registries, even though it uses a tag.