### PR TITLE
Improve the keybinding apis, use a proper builder, and document all t…

### DIFF
--- a/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/FabricKeyBinding.java
+++ b/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/FabricKeyBinding.java
@@ -27,23 +27,54 @@ import net.minecraft.util.Identifier;
  * {@link KeyBindingRegistry#register(FabricKeyBinding)}!
  */
 public class FabricKeyBinding extends KeyBinding {
-	protected FabricKeyBinding(Identifier id, InputUtil.Type type, int code, String category) {
-		super("key." + id.toString().replace(':', '.'), type, code, category);
+	protected FabricKeyBinding(String name, InputUtil.Type type, int code, String category) {
+		super(name, type, code, category);
 	}
 
 	public static class Builder {
-		protected final FabricKeyBinding binding;
 
-		protected Builder(FabricKeyBinding binding) {
-			this.binding = binding;
+	    private InputUtil.Type type = InputUtil.Type.KEYSYM;
+
+		private String keyName = "key.fabric.unnamed";
+
+		private int code;
+
+		private String category = KeyCategory.MISC;
+
+		private Builder() {
+
+		}
+
+		public Builder name(String keyName) {
+		    this.keyName = keyName;
+		    return this;
+		}
+
+		public Builder name(Identifier keyName) {
+		    return name("key." + keyName.toString().replace(':', '.').replace('/', '/'));
+		}
+
+		public Builder category(String category) {
+		    this.category = "key.categories." + category;
+		    return this;
+		}
+
+		public Builder code(int keyCode) {
+		    this.code = keyCode;
+		    return this;
+		}
+
+		public Builder type(InputUtil.Type type) {
+		    this.type = type;
+		    return this;
 		}
 
 		public FabricKeyBinding build() {
-			return binding;
+			return new FabricKeyBinding(keyName, type, code, category);
 		}
 
-		public static Builder create(Identifier id, InputUtil.Type type, int code, String category) {
-			return new Builder(new FabricKeyBinding(id, type, code, category));
+		public static Builder create() {
+			return new Builder();
 		}
 	}
 }

--- a/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/FabricKeyBinding.java
+++ b/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/FabricKeyBinding.java
@@ -33,7 +33,7 @@ public class FabricKeyBinding extends KeyBinding {
 
 	public static class Builder {
 
-	    private InputUtil.Type type = InputUtil.Type.KEYSYM;
+		private InputUtil.Type type = InputUtil.Type.KEYSYM;
 
 		private String keyName = "key.fabric.unnamed";
 
@@ -46,27 +46,27 @@ public class FabricKeyBinding extends KeyBinding {
 		}
 
 		public Builder name(String keyName) {
-		    this.keyName = keyName;
-		    return this;
+			this.keyName = keyName;
+			return this;
 		}
 
 		public Builder name(Identifier keyName) {
-		    return name("key." + keyName.toString().replace(':', '.').replace('/', '/'));
+			return name("key." + keyName.toString().replace(':', '.').replace('/', '/'));
 		}
 
 		public Builder category(String category) {
-		    this.category = "key.categories." + category;
-		    return this;
+			this.category = category.contains("key.categories.") ? category : "key.categories." + category;
+			return this;
 		}
 
 		public Builder code(int keyCode) {
-		    this.code = keyCode;
-		    return this;
+			this.code = keyCode;
+			return this;
 		}
 
 		public Builder type(InputUtil.Type type) {
-		    this.type = type;
-		    return this;
+			this.type = type;
+			return this;
 		}
 
 		public FabricKeyBinding build() {
@@ -75,6 +75,15 @@ public class FabricKeyBinding extends KeyBinding {
 
 		public static Builder create() {
 			return new Builder();
+		}
+
+		@Deprecated
+		public static Builder create(Identifier id, InputUtil.Type type, int code, String category) {
+			return new Builder()
+					.name(id)
+					.type(type)
+					.code(code)
+					.category(category);
 		}
 	}
 }

--- a/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/KeyCategory.java
+++ b/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/KeyCategory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.client.keybinding;
+
+public interface KeyCategory {
+    String MOVEMENT = "movement";
+    String INVENTORY = "inventory";
+    String CREATIVE = "creative";
+    String GAMEPLAY = "gameplay";
+    String MULTIPLAYER = "multiplayer";
+    String MISC = "misc";
+}


### PR DESCRIPTION
…he vanilla cetegory types.

The old builder... wasn't really a builder. I also don't like that it cut you off from using the vanilla constructor. The best API is an optional API, after all.

With this new design you can generate Keybindings like so:

```
KeyBinding binding = FabricKeyBinding.Builder.create()
    .name(new Identifier("minelittlepony", "settings")) // Or just "key.minelittlepony.settings" if you got that from your lang file
    .code(GLFW.GLFW_KEY_F9)
    .type(InputUtil.Type.KEYSYM) // optional
    .category(KeyCategory.MISC) // optional
    .build();
```