### PR TITLE
Add a proper builder for key bindings

### DIFF
--- a/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/FabricKeyBinding.java
+++ b/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/FabricKeyBinding.java
@@ -16,21 +16,53 @@
 
 package net.fabricmc.fabric.api.client.keybinding;
 
+import net.fabricmc.fabric.mixin.client.keybinding.KeyCodeAccessor;
+
+import java.util.Objects;
 import net.minecraft.client.options.KeyBinding;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.util.Identifier;
-
-import net.fabricmc.fabric.mixin.client.keybinding.KeyCodeAccessor;
 
 /**
  * Expanded version of {@link KeyBinding} for use by Fabric mods.
  *
  * <p>*ALL* instantiated FabricKeyBindings should be registered in
  * {@link KeyBindingRegistry#register(FabricKeyBinding)}!
+ * </p>
+ * <pre><code>
+ * FabricKeyBinding.Builder builder = FabricKeyBinding.builder();
+ * FabricKeyBinding left = builder
+ *			.id(new Identifier("example", "left"))
+ *			.code(Keys.Left)
+ *			.build();
+ * FabricKeyBinding right = builder
+ *			.id(new Identifier("example", "right"))
+ *			.code(Keys.Right)
+ *			.build();
+ * KeyBindingRegistry.register(left);
+ * KeyBindingRegistry.register(right);
+ * </code></pre>
  */
 public class FabricKeyBinding extends KeyBinding {
+
+	private final Identifier id;
+
 	protected FabricKeyBinding(Identifier id, InputUtil.Type type, int code, String category) {
-		super("key." + id.toString().replace(':', '.'), type, code, category);
+		super(formatKeyName(id), type, code, category);
+		this.id = id;
+	}
+
+	public static String formatKeyName(Identifier id) {
+		return String.format("key.%s.%s", id.getNamespace(), id.getPath());
+	}
+
+	/**
+	 * Original identifier used to register this key.
+	 *
+	 * May be different from the {@link getId()}.
+	 */
+	public Identifier getIdentifier() {
+		return id;
 	}
 
 	/**
@@ -41,19 +73,64 @@ public class FabricKeyBinding extends KeyBinding {
 		return ((KeyCodeAccessor) this).getKeyCode();
 	}
 
-	public static class Builder {
-		protected final FabricKeyBinding binding;
+	public static Builder builder() {
+		return new Builder();
+	}
 
-		protected Builder(FabricKeyBinding binding) {
-			this.binding = binding;
+	public static class Builder {
+
+		private InputUtil.Type type = InputUtil.Type.KEYSYM;
+
+		private Identifier id = null;
+
+		private boolean unassigned = false;
+		private int code = InputUtil.UNKNOWN_KEYCODE.getKeyCode();
+
+		private String category = KeyCategories.MISC;
+
+		private Builder() {
+		}
+
+		public Builder id(Identifier keyName) {
+			this.id = keyName;
+			return this;
+		}
+
+		public Builder category(String category) {
+			this.category = category;
+			return this;
+		}
+
+		public Builder code(int keyCode) {
+			this.code = keyCode;
+			return this;
+		}
+
+		public Builder unassigned() {
+			return this;
+		}
+
+		public Builder type(InputUtil.Type type) {
+			this.type = type;
+			return this;
 		}
 
 		public FabricKeyBinding build() {
-			return binding;
+			Objects.requireNonNull(id, "Keybindings should be created with an identifier.");
+
+			if (!unassigned && code == InputUtil.UNKNOWN_KEYCODE.getKeyCode()) {
+				throw new IllegalStateException("Keybingings need a default keycode.");
+			}
+
+			return new FabricKeyBinding(id, type, code, category);
 		}
 
+		/**
+		 * @deprecated Prefer using the builder itself.
+		 */
+		@Deprecated
 		public static Builder create(Identifier id, InputUtil.Type type, int code, String category) {
-			return new Builder(new FabricKeyBinding(id, type, code, category));
+			return builder().id(id).type(type).code(code).category(category);
 		}
 	}
 }

--- a/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/FabricKeyBinding.java
+++ b/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/FabricKeyBinding.java
@@ -19,6 +19,9 @@ package net.fabricmc.fabric.api.client.keybinding;
 import net.fabricmc.fabric.mixin.client.keybinding.KeyCodeAccessor;
 
 import java.util.Objects;
+
+import com.google.common.base.Preconditions;
+
 import net.minecraft.client.options.KeyBinding;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.util.Identifier;
@@ -44,16 +47,11 @@ import net.minecraft.util.Identifier;
  * </code></pre>
  */
 public class FabricKeyBinding extends KeyBinding {
-
 	private final Identifier id;
 
-	protected FabricKeyBinding(Identifier id, InputUtil.Type type, int code, String category) {
-		super(formatKeyName(id), type, code, category);
+	protected FabricKeyBinding(Identifier id, String translationKey, InputUtil.Type type, int code, String category) {
+		super(translationKey, type, code, category);
 		this.id = id;
-	}
-
-	public static String formatKeyName(Identifier id) {
-		return String.format("key.%s.%s", id.getNamespace(), id.getPath());
 	}
 
 	/**
@@ -73,56 +71,114 @@ public class FabricKeyBinding extends KeyBinding {
 		return ((KeyCodeAccessor) this).getKeyCode();
 	}
 
+	/**
+	 * Creates a new builder for constructing custom key bindings.
+	 */
 	public static Builder builder() {
 		return new Builder();
 	}
 
 	public static class Builder {
+		private static final int UNASSIGNED = InputUtil.UNKNOWN_KEYCODE.getKeyCode();
 
 		private InputUtil.Type type = InputUtil.Type.KEYSYM;
 
 		private Identifier id = null;
+		private String translationKey;
 
 		private boolean unassigned = false;
-		private int code = InputUtil.UNKNOWN_KEYCODE.getKeyCode();
+		private boolean registered = false;
+
+		private int code = UNASSIGNED;
 
 		private String category = KeyCategories.MISC;
 
 		private Builder() {
 		}
 
-		public Builder id(Identifier keyName) {
-			this.id = keyName;
+		/**
+		 * Sets the key binding id and translation key for this builder.
+		 * <br>
+		 * Key bindings will be assigned a translation key of the format "key.{namespace}.{path}"
+		 *
+		 * @param id Unique identifier for the bound key.
+		 */
+		public Builder id(Identifier id) {
+			this.id = id;
+			this.translationKey = String.format("key.%s.%s", id.getNamespace(), id.getPath());
 			return this;
 		}
 
+		/**
+		 * Sets the translation key for the key's category. {@see KeyCategories} for
+		 * all possible values, vanilla values.
+		 *
+		 * @param category The category under which key bindings created by this builder will be grouped.
+		 */
 		public Builder category(String category) {
 			this.category = category;
 			return this;
 		}
 
+		/**
+		 * Sets the default key to be used for the key binding created using this builder.
+		 *
+		 * @param keyCode The default key code. Must be a valid key. May not be -1.
+		 */
 		public Builder code(int keyCode) {
+			Preconditions.checkState(keyCode != UNASSIGNED, "UNASSIGNED is not a valid key code.");
 			this.code = keyCode;
+			this.unassigned = false;
 			return this;
 		}
 
+		/**
+		 * Indicates to this builder that keybindings built through it are intended to be unbound.
+		 */
 		public Builder unassigned() {
+			this.code = UNASSIGNED;
+			this.unassigned = true;
 			return this;
 		}
 
+		/**
+		 * Sets this builder to auto-register any key bindings created using it.
+		 * <p>
+		 * Mods who intend to register their own key bindings manually may choose not to use this.
+		 */
+		public Builder registered() {
+			this.registered = true;
+			return this;
+		}
+
+		/**
+		 * Sets the key's type. Maybe be one of [KEYSYM (keyboard), SCANCODE, MOUSE]
+		 *
+		 * @param type The binding type.
+		 */
 		public Builder type(InputUtil.Type type) {
 			this.type = type;
 			return this;
 		}
 
+		/**
+		 * Returns a key binding with a matching configuration to that of this builder.
+		 * <p>
+		 * Implementation Note:
+		 * <p>
+		 * At current this returns a <i>new</i> key binding that modders should
+		 * hold onto for their own use, though this may change in the future.
+		 */
 		public FabricKeyBinding build() {
 			Objects.requireNonNull(id, "Keybindings should be created with an identifier.");
+			Preconditions.checkState(unassigned || code != UNASSIGNED, "Keybingings need a default keycode.");
 
-			if (!unassigned && code == InputUtil.UNKNOWN_KEYCODE.getKeyCode()) {
-				throw new IllegalStateException("Keybingings need a default keycode.");
+			FabricKeyBinding binding = new FabricKeyBinding(id, translationKey, type, code, category);
+			if (registered) {
+				KeyBindingRegistry.INSTANCE.register(binding);
 			}
 
-			return new FabricKeyBinding(id, type, code, category);
+			return binding;
 		}
 
 		/**

--- a/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/KeyCategories.java
+++ b/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/KeyCategories.java
@@ -16,13 +16,38 @@
 
 package net.fabricmc.fabric.api.client.keybinding;
 
+/**
+ * Contains all of the known key categories present in vanilla minecraft.
+ * These may be used without having to first register them.
+ */
 public final class KeyCategories {
+    /**
+     * Player movement controls.
+     */
 	public static final String MOVEMENT =    "key.categories.movement";
+	/**
+	 * Inventory and item movement and sorting.
+	 */
 	public static final String INVENTORY =   "key.categories.inventory";
+	/**
+	 * Creative mode controls (save/load toolbar, etc)
+	 */
 	public static final String CREATIVE =    "key.categories.creative";
+	/**
+	 * Attack and using items, activating blocks.
+	 */
 	public static final String GAMEPLAY =    "key.categories.gameplay";
+	/**
+	 * Multiplayer chat and commands keys.
+	 */
 	public static final String MULTIPLAYER = "key.categories.multiplayer";
+	/**
+	 * Miscellaneous, non-gameplay controls. Unused by mojang.
+	 */
 	public static final String UI =          "key.categories.ui";
+	/**
+	 * Anything else.
+	 */
 	public static final String MISC =        "key.categories.misc";
 
 	private KeyCategories() {

--- a/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/KeyCategories.java
+++ b/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/KeyCategories.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.client.keybinding;
+
+public final class KeyCategories {
+	public static final String MOVEMENT =    "key.categories.movement";
+	public static final String INVENTORY =   "key.categories.inventory";
+	public static final String CREATIVE =    "key.categories.creative";
+	public static final String GAMEPLAY =    "key.categories.gameplay";
+	public static final String MULTIPLAYER = "key.categories.multiplayer";
+	public static final String UI =          "key.categories.ui";
+	public static final String MISC =        "key.categories.misc";
+
+	private KeyCategories() {
+	}
+}

--- a/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/StickyFabricKeyBinding.java
+++ b/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/StickyFabricKeyBinding.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.client.keybinding;
+
+import java.util.function.BooleanSupplier;
+
+import net.minecraft.client.util.InputUtil.Type;
+import net.minecraft.util.Identifier;
+
+public class StickyFabricKeyBinding extends FabricKeyBinding {
+
+	private final BooleanSupplier toggled;
+
+	protected StickyFabricKeyBinding(Identifier id, String translationKey, Type type, int code, String category, BooleanSupplier toggled) {
+		super(id, translationKey, type, code, category);
+		this.toggled = toggled;
+	}
+
+	@Override
+	public void setPressed(boolean pressed) {
+		if (toggled.getAsBoolean()) {
+			if (pressed) {
+				super.setPressed(!isPressed());
+			}
+		} else {
+			super.setPressed(pressed);
+		}
+
+	}
+}

--- a/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
+++ b/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
@@ -41,6 +41,7 @@ public class KeyBindingRegistryImpl implements KeyBindingRegistry {
 		fabricKeyBindingList = new ArrayList<>();
 	}
 
+	@SuppressWarnings("unchecked")
 	private Map<String, Integer> getCategoryMap() {
 		if (cachedCategoryMap == null) {
 			try {


### PR DESCRIPTION
This does ~~two~~ three things:
 - it adds proper builder-esque methods for the FabricKeyBinding.Builder class.
 - it adds a list of vanilla keybindings so modders can easily pick and choose which ones are available.
 - expose the identifier mods use to create/register their keybindings so it can be used later.

I'd like to allow custom categories, but I don't know where the warning on "unknown key categories" comes from so I can't change that.