### PR TITLE
Fix bad flat lighting on inset quads

### DIFF
--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractQuadRenderer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractQuadRenderer.java
@@ -27,6 +27,7 @@ import net.fabricmc.indigo.renderer.aocalc.AoCalculator;
 import net.fabricmc.indigo.renderer.helper.ColorHelper;
 import net.fabricmc.indigo.renderer.mesh.EncodingFormat;
 import net.fabricmc.indigo.renderer.mesh.MutableQuadViewImpl;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.util.math.BlockPos;
 
@@ -140,7 +141,7 @@ public abstract class AbstractQuadRenderer {
      */
     int flatBrightness(MutableQuadViewImpl quad, BlockState blockState, BlockPos pos) {
         mpos.set(pos);
-        if((quad.geometryFlags() & LIGHT_FACE_FLAG) != 0) {
+        if((quad.geometryFlags() & LIGHT_FACE_FLAG) != 0 || Block.isShapeFullCube(blockState.getCollisionShape(blockInfo.blockView, pos))) {
             mpos.setOffset(quad.lightFace());
         }
         return brightnessFunc.applyAsInt(blockState, mpos);

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainFallbackConsumer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainFallbackConsumer.java
@@ -132,7 +132,7 @@ public class TerrainFallbackConsumer extends AbstractQuadRenderer implements Con
             // vanilla compatibility hack
 			// For flat lighting, cull face drives everything and light face is ignored.
             if(cullFace == null) {
-                editorQuad.geometryFlags(0);
+                editorQuad.invalidateShape();
             } else {
                 editorQuad.geometryFlags(GeometryHelper.LIGHT_FACE_FLAG);
                 editorQuad.lightFace(cullFace);


### PR DESCRIPTION
Closes #253 

For quads with no cull face, re-enables the geometry check that was disabled for #223 so that quad on the block face use neighbor brightness instead of self brightness.   Also mimics the Block.isShapeFullCube() check that the vanilla BlockModelRenderer performs in this case, which also forces neighbor brightness when true.