### PR TITLE
Make HYBRID the default indigo lighting model

### DIFF
--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/Indigo.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/Indigo.java
@@ -103,7 +103,7 @@ public class Indigo implements ClientModInitializer {
 		}
 
 		ALWAYS_TESSELATE_INDIGO = asBoolean((String) properties.computeIfAbsent("always-tesselate-blocks", (a) -> "auto"), true);
-		AMBIENT_OCCLUSION_MODE = asEnum((String) properties.computeIfAbsent("ambient-occlusion-mode", (a) -> "enhanced"), AoConfig.ENHANCED);
+		AMBIENT_OCCLUSION_MODE = asEnum((String) properties.computeIfAbsent("ambient-occlusion-mode", (a) -> "hybrid"), AoConfig.HYBRID);
 		DEBUG_COMPARE_LIGHTING = asBoolean((String) properties.computeIfAbsent("debug-compare-lighting", (a) -> "auto"), false);
 		FIX_SMOOTH_LIGHTING_OFFSET = asBoolean((String) properties.computeIfAbsent("fix-smooth-lighting-offset", (a) -> "auto"), true);
 		FIX_EXTERIOR_VERTEX_LIGHTING = asBoolean((String) properties.computeIfAbsent("fix-exterior-vertex-lighting", (a) -> "auto"), true);


### PR DESCRIPTION
Fixes #234.

This should reduce reported issues with vanilla blocks/resource packs but still offer decent lighting for models using the API.  The tradeoff is some potential minor inconsistency on lighting outcomes between vanilla models and modded models having the same geometry.  

Given that vanilla and vanilla resource packs routinely exploit the shortcomings of the vanilla lighter to achieve effects that aren't directly supported, the potential for discrepancy really can't be helped without a much more extensive change.

If someone really wants consistent lighting then they can always change the mode to ENHANCED, (or VANILLA/EMULATED) or create a resource pack with models that exploit the API.