### PR TITLE
Prevent registry remap crashes

### DIFF
--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/RemapStateImpl.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/RemapStateImpl.java
@@ -22,10 +22,13 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.fabricmc.fabric.api.event.registry.RegistryIdRemapCallback;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class RemapStateImpl<T> implements RegistryIdRemapCallback.RemapState<T> {
 	private final Int2IntMap rawIdChangeMap;
 	private final Int2ObjectMap<Identifier> newIdMap;
+	private static final Logger LOGGER = LogManager.getLogger();
 
 	public RemapStateImpl(Registry<T> registry, Int2IntMap rawIdChangeMap) {
 		this.rawIdChangeMap = rawIdChangeMap;
@@ -33,6 +36,7 @@ public class RemapStateImpl<T> implements RegistryIdRemapCallback.RemapState<T> 
 
 		for (Int2IntMap.Entry entry : rawIdChangeMap.int2IntEntrySet()) {
 			Identifier id = registry.getId(registry.get(entry.getIntValue()));
+			if (newIdMap.containsKey(entry.getIntValue())) LOGGER.error("Two registry entries may be pointing to the same int value! This could cause issues!");
 			newIdMap.put(entry.getIntValue(), id);
 		}
 	}

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/client/MixinItemModelMap.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/client/MixinItemModelMap.java
@@ -38,7 +38,7 @@ public class MixinItemModelMap {
 
 	@Inject(method = "<init>", at = @At("RETURN"))
 	public void onInit(BakedModelManager bakedModelManager, CallbackInfo info) {
-		Int2ObjectMapTracker.register(Registry.ITEM, modelIds);
-		Int2ObjectMapTracker.register(Registry.ITEM, models);
+		Int2ObjectMapTracker.register(Registry.ITEM, "model_ids", modelIds);
+		Int2ObjectMapTracker.register(Registry.ITEM, "baked_models", models);
 	}
 }

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/client/MixinParticleManager.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/client/MixinParticleManager.java
@@ -36,6 +36,6 @@ public class MixinParticleManager {
 
 	@Inject(method = "<init>", at = @At("RETURN"))
 	public void onInit(World world, TextureManager textureManager, CallbackInfo info) {
-		Int2ObjectMapTracker.register(Registry.PARTICLE_TYPE, factories);
+		Int2ObjectMapTracker.register(Registry.PARTICLE_TYPE, "particle_factories", factories);
 	}
 }


### PR DESCRIPTION
Hotfix for #231.
It seems like, from [this](https://github.com/FabricMC/fabric/issues/231#issuecomment-499715120) crash log, the Int2ObjectMap is crashing when multiple old IDs point to the same object. **This may not be a fix for that underlying problem**, but it should hopefully prevent crashes from it trying to convert a messed-up map to a less messed-up one. Currently unsure of impact on load/remap times.