### PR TITLE
Fix dark faces on interior quads with flat lighting

### DIFF
--- a/fabric-renderer-indigo/build.gradle
+++ b/fabric-renderer-indigo/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-renderer-indigo"
-version = getSubprojectVersion(project, "0.1.6")
+version = getSubprojectVersion(project, "0.1.7")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainFallbackConsumer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainFallbackConsumer.java
@@ -133,6 +133,8 @@ public class TerrainFallbackConsumer extends AbstractQuadRenderer implements Con
 			// For flat lighting, cull face drives everything and light face is ignored.
             if(cullFace == null) {
                 editorQuad.invalidateShape();
+                // Can't rely on lazy computation in tesselateFlat() because needs to happen before offsets are applied
+                editorQuad.geometryFlags();
             } else {
                 editorQuad.geometryFlags(GeometryHelper.LIGHT_FACE_FLAG);
                 editorQuad.lightFace(cullFace);


### PR DESCRIPTION
Fixes #272.

The defect was introduced with PR #254.  Before that change, geometry flags were always set to 0 for interior faces with flat lighting.

That change instead invalidated the quad geometry flags to force geometric analysis of the quad to determine if the face is actually an interior face or on the block face.  (Quads on the block face should use neighbor brightness instead of interior brightness.) Vanilla flat lighting operates similarly via BlockModelRenderer.updateShape(), but that method is incompatible with the Mesh/QuadView data structures used by Indigo.

That change was OK except that geometry analysis flags are lazily computed.  This meant they were not being computed until they were needed in AbstractQuadRenderer.flatBrightness().  But this call happens *after* block position offsets are applied, which invalidates the quad geometry. 

With positions offsets applied, vertices will almost always have values outside the 0-1 range and thus be classified as "on-face" quads. Those quads use neighbor brightness, which for something like a door is usually an opaque block with zero brightness.  The result is completely dark lighting.

The fix is simply to call QuadView.geometryFlags() immediately after invalidation to ensure geometric analysis happens before offsets are applied.  The same thing is done for quads with AmbientOcclusion shading a few lines above for the same reason.

The defect wasn't caught by the AoCalculator vanilla comparison logic because that validation (obviously) does not cover flat lighting.  It may be worth adding a comparison validation for flat lighting in the future but it would be non-trivial and outside the scope of this PR.  Nothing indicates the flat lighting output is wrong; the problem here was incorrect input. 