### PR TITLE
Migrate EntityType API to new mapping changes

### DIFF
--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/entity/FabricEntityTypeBuilder.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/entity/FabricEntityTypeBuilder.java
@@ -87,7 +87,7 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 	 */
 	@Deprecated
 	public FabricEntityTypeBuilder<T> size(float width, float height) {
-		return this.size(EntitySize.resizeable(width, height));
+		return changingDimensions(width, height);
 	}
 
 	/**

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/entity/FabricEntityTypeBuilder.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/entity/FabricEntityTypeBuilder.java
@@ -98,11 +98,23 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 		return dimensions(size);
 	}
 
+	/**
+	 * Defines the default {@link EntitySize} for this entity type
+	 *
+	 * @param dimensions The default dimensions
+	 */
 	public FabricEntityTypeBuilder<T> dimensions(EntitySize dimensions) {
 		this.dimensions = dimensions;
 		return this;
 	}
 
+	/**
+	 * Defines the default {@link EntitySize} for this entity type,
+	 * constructed using {@link EntitySize#resizeable(float, float)}
+	 * 
+	 * @param width The default width
+	 * @param height The default height
+	 */
 	public FabricEntityTypeBuilder<T> dimensions(float width, float height) {
 		return dimensions(EntitySize.resizeable(width, height));
 	}

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/entity/FabricEntityTypeBuilder.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/entity/FabricEntityTypeBuilder.java
@@ -44,7 +44,7 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 	private int updateIntervalTicks = -1;
 	private Boolean alwaysUpdateVelocity;
 	private boolean immuneToFire = false;
-	private EntitySize size = EntitySize.resizeable(-1.0f, -1.0f);
+	private EntitySize dimensions = EntitySize.resizeable(-1.0f, -1.0f);
 
 	protected FabricEntityTypeBuilder(EntityCategory category, EntityType.EntityFactory<T> function) {
 		this.category = category;
@@ -83,17 +83,32 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 	}
 
 	/**
-	 * @deprecated Use {@link FabricEntityTypeBuilder#size(EntitySize)}
+	 * @deprecated Use {@link FabricEntityTypeBuilder#changingDimensions(float, float)}
 	 */
 	@Deprecated
 	public FabricEntityTypeBuilder<T> size(float width, float height) {
-		this.size = EntitySize.resizeable(width, height);
+		return this.size(EntitySize.resizeable(width, height));
+	}
+
+	/**
+	 * @deprecated Use {@link FabricEntityTypeBuilder#dimensions(EntitySize)}
+	 */
+	@Deprecated
+	public FabricEntityTypeBuilder<T> size(EntitySize size) {
+		return dimensions(size);
+	}
+
+	public FabricEntityTypeBuilder<T> dimensions(EntitySize dimensions) {
+		this.dimensions = dimensions;
 		return this;
 	}
 
-	public FabricEntityTypeBuilder<T> size(EntitySize size) {
-		this.size = size;
-		return this;
+	public FabricEntityTypeBuilder<T> fixedDimensions(float width, float height) {
+		return dimensions(EntitySize.constant(width, height));
+	}
+
+	public FabricEntityTypeBuilder<T> changingDimensions(float width, float height) {
+		return dimensions(EntitySize.resizeable(width, height));
 	}
 
 	public FabricEntityTypeBuilder<T> trackable(int trackingDistanceBlocks, int updateIntervalTicks) {
@@ -113,7 +128,7 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 			// TODO: Flesh out once modded datafixers exist.
 		}
 
-		EntityType<T> type = new FabricEntityType<T>(this.function, this.category, this.saveable, this.summonable, this.immuneToFire, null, size, trackingDistance, updateIntervalTicks, alwaysUpdateVelocity);
+		EntityType<T> type = new FabricEntityType<T>(this.function, this.category, this.saveable, this.summonable, this.immuneToFire, null, dimensions, trackingDistance, updateIntervalTicks, alwaysUpdateVelocity);
 
 		return type;
 	}

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/entity/FabricEntityTypeBuilder.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/entity/FabricEntityTypeBuilder.java
@@ -83,11 +83,11 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 	}
 
 	/**
-	 * @deprecated Use {@link FabricEntityTypeBuilder#changingDimensions(float, float)}
+	 * @deprecated Use {@link FabricEntityTypeBuilder#dimensions(float, float)}
 	 */
 	@Deprecated
 	public FabricEntityTypeBuilder<T> size(float width, float height) {
-		return changingDimensions(width, height);
+		return dimensions(width, height);
 	}
 
 	/**
@@ -103,11 +103,7 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 		return this;
 	}
 
-	public FabricEntityTypeBuilder<T> fixedDimensions(float width, float height) {
-		return dimensions(EntitySize.constant(width, height));
-	}
-
-	public FabricEntityTypeBuilder<T> changingDimensions(float width, float height) {
+	public FabricEntityTypeBuilder<T> dimensions(float width, float height) {
 		return dimensions(EntitySize.resizeable(width, height));
 	}
 


### PR DESCRIPTION
Relevant change: https://github.com/FabricMC/yarn/pull/745

Mappings themselves have not been updated for the project sources.
~~Also added two new methods, `fixedDimensions` and `changingDimensions` for cleaner API calls, e.g `dimensions(EntityDimensions.fixed(1.0F, 1.0F))` -> `fixedDimensions(1.0F, 1.0F)`.~~