### PR TITLE
Prevent mods from shadowing default resources wrongly (Fixes #66)

### DIFF
--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resources/ModResourcePackCreator.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resources/ModResourcePackCreator.java
@@ -44,7 +44,7 @@ public class ModResourcePackCreator implements ResourcePackCreator {
 			}
 
 			T var3 = ResourcePackContainer.of("fabric/" + ((ModResourcePack) pack).getFabricModMetadata().getId(),
-				false, () -> pack, factory, ResourcePackContainer.InsertionPosition.BOTTOM);
+				false, () -> pack, factory, ResourcePackContainer.InsertionPosition.TOP);
 
 			if (var3 != null) {
 				map.put(var3.getName(), var3);

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resources/MixinDefaultResourcePack.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resources/MixinDefaultResourcePack.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.resources;
+
+import net.minecraft.resource.DefaultResourcePack;
+import net.minecraft.resource.DirectoryResourcePack;
+import net.minecraft.resource.ResourceType;
+import net.minecraft.util.Identifier;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+
+@Mixin(DefaultResourcePack.class)
+public class MixinDefaultResourcePack {
+
+	@Inject(method = "findInputStream", at = @At("HEAD"), cancellable = true)
+	protected void onFindInputStream(ResourceType resourceType, Identifier identifier, CallbackInfoReturnable<InputStream> callback) {
+		if(DefaultResourcePack.RESOURCE_PATH != null) {
+			// Fall through to Vanilla logic, they have a special case here.
+			return;
+		}
+
+		String path = resourceType.getName() + "/" + identifier.getNamespace() + "/" + identifier.getPath();
+		URL found = null;
+
+		try {
+			Enumeration<URL> candidates = DefaultResourcePack.class.getClassLoader().getResources(path);
+
+			// Get the last element
+			while(candidates.hasMoreElements()) {
+				found = candidates.nextElement();
+			}
+
+			if(found == null || !DirectoryResourcePack.isValidPath(new File(found.getFile()), "/" + path)) {
+				// Mimics vanilla behavior
+
+				callback.setReturnValue(null);
+				return;
+			}
+		} catch (IOException var6) {
+			// Default path
+		}
+
+		try {
+			if(found != null) {
+				callback.setReturnValue(found.openStream());
+			}
+		} catch (Exception e) {
+			// Default path
+		}
+	}
+}

--- a/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
+++ b/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
@@ -5,7 +5,8 @@
   "mixins": [
     "MixinKeyedResourceReloadListener$Server",
     "MixinMinecraftServer",
-    "MixinReloadableResourceManagerImpl"
+    "MixinReloadableResourceManagerImpl",
+    "MixinDefaultResourcePack"
   ],
   "client": [
     "MixinKeyedResourceReloadListener$Client",


### PR DESCRIPTION
These changes ensure that the Default resource pack does not capture resources under assets/minecraft and data/minecraft from modded jars, if the resource exists in the minecraft JAR.

This could also fix #186 as well, but I have not tested that.