### PR TITLE
Add a build number to a the moudles replacing the hash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ http {
 	library = 'apache' //Required to use the PATCH method
 }
 
-//A task that backup's the patch numbers json to https://gist.github.com/modmuss50/d60beaf80678bd10524add2920b9736e
+//A task that backs up the patch numbers json to https://gist.github.com/modmuss50/d60beaf80678bd10524add2920b9736e
 task backupJson(type: HttpTask){
 	onlyIf { project.hasProperty('github_token') }
 	config {

--- a/build.gradle
+++ b/build.gradle
@@ -18,17 +18,58 @@ class Globals {
 }
 
 import org.apache.commons.codec.digest.DigestUtils
+import groovy.json.JsonSlurper
+import groovy.json.JsonOutput
 
 def getSubprojectVersion(project, version) {
 	if (grgit == null) {
-		return version + "+nogit"
+		return version + ".9999+nogit"
+	}
+	if(!System.getenv().BUILD_NUMBER){
+		return version + ".9999+local"
 	}
 	def latestCommits = grgit.log(paths: [project.name], maxCommits: 1)
 	if (latestCommits.isEmpty()) {
-		return version + "+uncommited"
+		return version + ".0+uncommited"
 	} else {
-		return version + "+" + latestCommits.get(0).id.substring(0, 8) + DigestUtils.sha256Hex(Globals.mcVersion).substring(0, 2)
+		def commitHash = latestCommits.get(0).id
+		def buildGradleHash = DigestUtils.sha256Hex(file("build.gradle").text)
+		return version + "." + getOrIncrementBuildNumber(project, commitHash + buildGradleHash)
 	}
+}
+
+def getOrIncrementBuildNumber(project, hash) {
+	def jsonSlurper = new JsonSlurper()
+	def jsonFile = new File(project.gradle.gradleUserHomeDir, "fabric_build_numbers.json")
+	def json = [:]
+	if(jsonFile.exists()){
+		json = jsonSlurper.parseText(jsonFile.text)
+	}
+
+	//Gets the project info from the main json
+	def info = json[project.name]
+	if(info == null){
+		info = [:]
+	}
+
+	int buildNumber
+
+	//If the hash exists, we returns its build number
+	if(info[hash] != null){
+		buildNumber = info[hash].build
+	} else {
+		//Not seen this version before, so we increment the build number by one based off all the recorded hashes, so multibranch should work just fine.
+		buildNumber = info.size() + 1
+		info[hash] = [
+		    build: buildNumber
+		]
+	}
+
+	//write out the updated json file
+	json[project.name] = info
+	jsonFile.write(JsonOutput.prettyPrint(JsonOutput.toJson(json)))
+
+	return buildNumber
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
 	id 'net.minecrell.licenser' version '0.4.1'	
 	id "org.ajoberstar.grgit" version "3.1.1"
 	id 'com.matthewprenger.cursegradle' version "1.1.2"
+	id "io.github.http-builder-ng.http-plugin" version "0.1.1"
 }
 
 def ENV = System.getenv()
@@ -17,6 +18,7 @@ class Globals {
 	static def yarnVersion = "+build.1"
 }
 
+import io.github.httpbuilderng.http.HttpTask
 import org.apache.commons.codec.digest.DigestUtils
 import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
@@ -106,6 +108,31 @@ def getPatch(gradleProject, hash, b) {
 	jsonFile.write(JsonOutput.prettyPrint(JsonOutput.toJson(json)))
 
 	return patchNumber
+}
+
+http {
+	library = 'apache' //Required to use the PATCH method
+}
+
+//A task that backup's the patch numbers json to https://gist.github.com/modmuss50/d60beaf80678bd10524add2920b9736e
+task backupJson(type: HttpTask){
+	config {
+		request.contentType = 'application/json'
+	}
+	patch {
+		request.uri = 'https://api.github.com/gists/d60beaf80678bd10524add2920b9736e'
+		request.headers << ['Authorization' : "Basic ${("${project.getProperty('github_username')}:${project.getProperty('github_token')}").bytes.encodeBase64().toString()}"]
+
+		request.body = JsonOutput.toJson([
+			description : "Fabric's patch versions",
+			files : [
+				fabric_patch : [
+					filename : "fabric_patch.json",
+					content : new File(project.gradle.gradleUserHomeDir, "fabric_patch_numbers.json").text
+				]
+			]
+		])
+	}
 }
 
 def cloneJson(input) {

--- a/build.gradle
+++ b/build.gradle
@@ -23,18 +23,18 @@ import groovy.json.JsonOutput
 
 def getSubprojectVersion(project, version) {
 	if (grgit == null) {
-		return version + ".9999+nogit"
+		return version + "+nogit"
 	}
 	if(!System.getenv().BUILD_NUMBER){
-		return version + ".9999+local"
+		return version + "+local"
 	}
 	def latestCommits = grgit.log(paths: [project.name], maxCommits: 1)
 	if (latestCommits.isEmpty()) {
-		return version + ".0+uncommited"
+		return version + "+uncommited"
 	} else {
 		def commitHash = latestCommits.get(0).id
 		def buildGradleHash = DigestUtils.sha256Hex(file("build.gradle").text)
-		return version + "." + getOrIncrementBuildNumber(project, commitHash + buildGradleHash)
+		return version + "+build." + getOrIncrementBuildNumber(project, commitHash + buildGradleHash)
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ def getSubprojectVersion(project, version) {
 		//TODO once we branch out to 1.15 we need to talk about the last parameter
 		def patch = getPatch(project, commitHash + buildGradleHash, Globals.mcVersion)
 
-		return "${version}.${patch}-${Globals.mcVersion}"
+		return "${version}.${patch}+${Globals.mcVersion}"
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,18 +23,18 @@ import groovy.json.JsonOutput
 
 def getSubprojectVersion(project, version) {
 	if (grgit == null) {
-		return version + "+nogit"
+		return version + ".9999+nogit"
 	}
 	if(!System.getenv().BUILD_NUMBER){
-		return version + "+local"
+		return version + ".9999+local"
 	}
 	def latestCommits = grgit.log(paths: [project.name], maxCommits: 1)
 	if (latestCommits.isEmpty()) {
-		return version + "+uncommited"
+		return version + ".0+uncommited"
 	} else {
 		def commitHash = latestCommits.get(0).id
 		def buildGradleHash = DigestUtils.sha256Hex(file("build.gradle").text)
-		return version + "+build." + getOrIncrementBuildNumber(project, commitHash + buildGradleHash)
+		return version + "." + getOrIncrementBuildNumber(project, commitHash + buildGradleHash)
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ def getSubprojectVersion(project, version) {
 	if (version.count(".") != 1) {
 		throw new Exception("${project.name}'s version must only be major.minor")
 	}
+	if(!System.getenv().BUILD_NUMBER){
+		return version + "+local"
+	}
 	if (grgit == null) {
 		return version + "+nogit"
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -21,12 +21,13 @@ import org.apache.commons.codec.digest.DigestUtils
 import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
 
+@SuppressWarnings("unused")
 def getSubprojectVersion(project, version) {
+	if (version.count(".") != 1) {
+		throw new Exception("${project.name}'s version must only be major.minor")
+	}
 	if (grgit == null) {
 		return version + "+nogit"
-	}
-	if(!System.getenv().BUILD_NUMBER){
-		return version + "+local"
 	}
 	def latestCommits = grgit.log(paths: [project.name], maxCommits: 1)
 	if (latestCommits.isEmpty()) {
@@ -34,46 +35,82 @@ def getSubprojectVersion(project, version) {
 	} else {
 		def commitHash = latestCommits.get(0).id
 		def buildGradleHash = DigestUtils.sha256Hex(file("build.gradle").text)
-		return version + "." + getOrIncrementBuildNumber(project, commitHash + buildGradleHash)
+
+		//TODO once we branch out to 1.15 we need to talk about the last parameter
+		def patch = getPatch(project, commitHash + buildGradleHash, Globals.mcVersion)
+
+		return "${version}.${patch}-${Globals.mcVersion}"
 	}
 }
 
-def getOrIncrementBuildNumber(project, hash) {
+def getPatch(gradleProject, hash, b) {
 	def jsonSlurper = new JsonSlurper()
-	def jsonFile = new File(project.gradle.gradleUserHomeDir, "fabric_build_numbers.json")
+	def jsonFile = new File(gradleProject.gradle.gradleUserHomeDir, "fabric_patch_numbers.json")
 	def json = [:]
 	if(jsonFile.exists()){
 		json = jsonSlurper.parseText(jsonFile.text)
 	}
 
-	//Gets the project info from the main json
-	def info = json[project.name]
-	if(info == null){
-		info = [:]
+	def project = json[gradleProject.name]
+	if(project == null){
+		project = [:]
 	}
 
-	int buildNumber
+	def branch = project[b]
+	if(!branch){
+		if(project.size() == 0){
+			//No existing branches found we start from fresh
+			branch = [:]
+		} else {
+			int patchNumber
 
-	//If the hash exists, we returns its build number
-	if(info[hash] != null){
-		buildNumber = info[hash].build
-	} else {
-		info.each {
-			if (it.value.build > buildNumber){
-				buildNumber = it.value.build
+			//Finds the branch with the largest patch number to "fork" from
+			project.each {branches ->
+				branches.value.each {pb ->
+					if(pb.value.patch > patchNumber){
+						branch = cloneJson(branches.value)
+						patchNumber = pb.value.patch
+					}
+				}
 			}
 		}
-		buildNumber++
-		info[hash] = [
-		    build: buildNumber
+
+		if(branch == null){
+			throw new Exception("failed to find branch, something bad happened.")
+		}
+
+		project[b] = branch
+	}
+
+	int patchNumber
+
+	if(branch[hash]){
+		//Returns the existing patch number
+		println(branch[hash])
+		patchNumber = branch[hash].patch
+	} else {
+		//Finds the next patch number, and stores it along with the input hash
+		branch.each {
+			if (it.value.patch > patchNumber){
+				patchNumber = it.value.patch
+			}
+		}
+		patchNumber++
+		branch[hash] = [
+		    patch: patchNumber
 		]
 	}
 
 	//write out the updated json file
-	json[project.name] = info
+	json[gradleProject.name] = project
 	jsonFile.write(JsonOutput.prettyPrint(JsonOutput.toJson(json)))
 
-	return buildNumber
+	return patchNumber
+}
+
+def cloneJson(input) {
+	//Awful code but seemed the easiest way to do this
+	return new JsonSlurper().parseText(JsonOutput.toJson(input))
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,7 @@ http {
 
 //A task that backup's the patch numbers json to https://gist.github.com/modmuss50/d60beaf80678bd10524add2920b9736e
 task backupJson(type: HttpTask){
+	onlyIf { project.hasProperty('github_token') }
 	config {
 		request.contentType = 'application/json'
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ def getSubprojectVersion(project, version) {
 	} else {
 		def commitHash = latestCommits.get(0).id
 		def buildGradleHash = DigestUtils.sha256Hex(file("build.gradle").text)
-		return version + "+build." + getOrIncrementBuildNumber(project, commitHash + buildGradleHash)
+		return version + "." + getOrIncrementBuildNumber(project, commitHash + buildGradleHash)
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ def getSubprojectVersion(project, version) {
 		def buildGradleHash = DigestUtils.sha256Hex(file("build.gradle").text)
 
 		//TODO once we branch out to 1.15 we need to talk about the last parameter
-		def patch = getPatch(project, commitHash + buildGradleHash, "1.15")
+		def patch = getPatch(project, commitHash + buildGradleHash, Globals.mcVersion)
 
 		return "${version}.${patch}+${Globals.mcVersion}"
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,12 @@ def getOrIncrementBuildNumber(project, hash) {
 	if(info[hash] != null){
 		buildNumber = info[hash].build
 	} else {
-		//Not seen this version before, so we increment the build number by one based off all the recorded hashes, so multibranch should work just fine.
-		buildNumber = info.size() + 1
+		info.each {
+			if (it.value.build > buildNumber){
+				buildNumber = it.value.build
+			}
+		}
+		buildNumber++
 		info[hash] = [
 		    build: buildNumber
 		]

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ def getSubprojectVersion(project, version) {
 		def buildGradleHash = DigestUtils.sha256Hex(file("build.gradle").text)
 
 		//TODO once we branch out to 1.15 we need to talk about the last parameter
-		def patch = getPatch(project, commitHash + buildGradleHash, Globals.mcVersion)
+		def patch = getPatch(project, commitHash + buildGradleHash, "1.15")
 
 		return "${version}.${patch}+${Globals.mcVersion}"
 	}
@@ -62,42 +62,42 @@ def getPatch(gradleProject, hash, b) {
 	}
 
 	def branch = project[b]
-	if(!branch){
-		if(project.size() == 0){
-			//No existing branches found we start from fresh
-			branch = [:]
-		} else {
-			int patchNumber
+	int patchNumber = -1
 
-			//Finds the branch with the largest patch number to "fork" from
+	if(!branch){
+
+		if(project.size() > 0){
+			//Finds the branch with the largest patch number to start with
 			project.each {branches ->
 				branches.value.each {pb ->
 					if(pb.value.patch > patchNumber){
-						branch = cloneJson(branches.value)
 						patchNumber = pb.value.patch
 					}
 				}
 			}
+
+			if(patchNumber < 0){
+				throw new Exception("failed to find branch, something bad happened.")
+			}
+		} else {
+			//No existing branches found, so start from 0
+			patchNumber = 0
 		}
 
-		if(branch == null){
-			throw new Exception("failed to find branch, something bad happened.")
-		}
-
+		branch = [:]
 		project[b] = branch
 	}
 
-	int patchNumber
-
 	if(branch[hash]){
 		//Returns the existing patch number
-		println(branch[hash])
 		patchNumber = branch[hash].patch
 	} else {
-		//Finds the next patch number, and stores it along with the input hash
-		branch.each {
-			if (it.value.patch > patchNumber){
-				patchNumber = it.value.patch
+		if(patchNumber < 0){
+			//Finds the next patch number, and stores it along with the input hash
+			branch.each {
+				if (it.value.patch > patchNumber){
+					patchNumber = it.value.patch
+				}
 			}
 		}
 		patchNumber++
@@ -137,11 +137,6 @@ task backupJson(type: HttpTask){
 			]
 		])
 	}
-}
-
-def cloneJson(input) {
-	//Awful code but seemed the easiest way to do this
-	return new JsonSlurper().parseText(JsonOutput.toJson(input))
 }
 
 allprojects {

--- a/fabric-api-base/build.gradle
+++ b/fabric-api-base/build.gradle
@@ -1,2 +1,2 @@
 archivesBaseName = "fabric-api-base"
-version = getSubprojectVersion(project, "0.1.0")
+version = getSubprojectVersion(project, "0.1")

--- a/fabric-biomes-v1/build.gradle
+++ b/fabric-biomes-v1/build.gradle
@@ -1,2 +1,2 @@
 archivesBaseName = "fabric-biomes-v1"
-version = getSubprojectVersion(project, "0.1")
+version = getSubprojectVersion(project, "0.1.0")

--- a/fabric-biomes-v1/build.gradle
+++ b/fabric-biomes-v1/build.gradle
@@ -1,2 +1,2 @@
 archivesBaseName = "fabric-biomes-v1"
-version = getSubprojectVersion(project, "0.1.0")
+version = getSubprojectVersion(project, "0.1")

--- a/fabric-commands-v0/build.gradle
+++ b/fabric-commands-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-commands-v0"
-version = getSubprojectVersion(project, "0.1.1")
+version = getSubprojectVersion(project, "0.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-commands-v0/build.gradle
+++ b/fabric-commands-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-commands-v0"
-version = getSubprojectVersion(project, "0.1")
+version = getSubprojectVersion(project, "0.1.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-containers-v0/build.gradle
+++ b/fabric-containers-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-containers-v0"
-version = getSubprojectVersion(project, "0.1.2")
+version = getSubprojectVersion(project, "0.2")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-containers-v0/build.gradle
+++ b/fabric-containers-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-containers-v0"
-version = getSubprojectVersion(project, "0.2")
+version = getSubprojectVersion(project, "0.1.2")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-containers-v0/build.gradle
+++ b/fabric-containers-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-containers-v0"
-version = getSubprojectVersion(project, "0.1.2")
+version = getSubprojectVersion(project, "0.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-content-registries-v0/build.gradle
+++ b/fabric-content-registries-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-content-registries-v0"
-version = getSubprojectVersion(project, "0.1.1")
+version = getSubprojectVersion(project, "0.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-content-registries-v0/build.gradle
+++ b/fabric-content-registries-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-content-registries-v0"
-version = getSubprojectVersion(project, "0.1")
+version = getSubprojectVersion(project, "0.1.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-crash-report-info-v1/build.gradle
+++ b/fabric-crash-report-info-v1/build.gradle
@@ -1,2 +1,2 @@
 archivesBaseName = "fabric-crash-report-info-v1"
-version = getSubprojectVersion(project, "0.1.0")
+version = getSubprojectVersion(project, "0.1")

--- a/fabric-crash-report-info-v1/build.gradle
+++ b/fabric-crash-report-info-v1/build.gradle
@@ -1,2 +1,2 @@
 archivesBaseName = "fabric-crash-report-info-v1"
-version = getSubprojectVersion(project, "0.1")
+version = getSubprojectVersion(project, "0.1.0")

--- a/fabric-events-interaction-v0/build.gradle
+++ b/fabric-events-interaction-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-events-interaction-v0"
-version = getSubprojectVersion(project, "0.1.0")
+version = getSubprojectVersion(project, "0.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-events-interaction-v0/build.gradle
+++ b/fabric-events-interaction-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-events-interaction-v0"
-version = getSubprojectVersion(project, "0.1")
+version = getSubprojectVersion(project, "0.1.0")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-events-lifecycle-v0/build.gradle
+++ b/fabric-events-lifecycle-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-events-lifecycle-v0"
-version = getSubprojectVersion(project, "0.1")
+version = getSubprojectVersion(project, "0.1.0")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-events-lifecycle-v0/build.gradle
+++ b/fabric-events-lifecycle-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-events-lifecycle-v0"
-version = getSubprojectVersion(project, "0.1.0")
+version = getSubprojectVersion(project, "0.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-item-groups-v0/build.gradle
+++ b/fabric-item-groups-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-item-groups-v0"
-version = getSubprojectVersion(project, "0.1.0")
+version = getSubprojectVersion(project, "0.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-item-groups-v0/build.gradle
+++ b/fabric-item-groups-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-item-groups-v0"
-version = getSubprojectVersion(project, "0.1")
+version = getSubprojectVersion(project, "0.1.0")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-keybindings-v0/build.gradle
+++ b/fabric-keybindings-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-keybindings-v0"
-version = getSubprojectVersion(project, "0.1")
+version = getSubprojectVersion(project, "0.1.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-keybindings-v0/build.gradle
+++ b/fabric-keybindings-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-keybindings-v0"
-version = getSubprojectVersion(project, "0.1.1")
+version = getSubprojectVersion(project, "0.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-loot-tables-v1/build.gradle
+++ b/fabric-loot-tables-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-loot-tables-v1"
-version = getSubprojectVersion(project, "0.1")
+version = getSubprojectVersion(project, "0.1.0")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-loot-tables-v1/build.gradle
+++ b/fabric-loot-tables-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-loot-tables-v1"
-version = getSubprojectVersion(project, "0.1.0")
+version = getSubprojectVersion(project, "0.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-mining-levels-v0/build.gradle
+++ b/fabric-mining-levels-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-mining-levels-v0"
-version = getSubprojectVersion(project, "0.1")
+version = getSubprojectVersion(project, "0.1.0")
 
 dependencies {
     compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-mining-levels-v0/build.gradle
+++ b/fabric-mining-levels-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-mining-levels-v0"
-version = getSubprojectVersion(project, "0.1.0")
+version = getSubprojectVersion(project, "0.1")
 
 dependencies {
     compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-models-v0/build.gradle
+++ b/fabric-models-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-models-v0"
-version = getSubprojectVersion(project, "0.1")
+version = getSubprojectVersion(project, "0.1.0")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-models-v0/build.gradle
+++ b/fabric-models-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-models-v0"
-version = getSubprojectVersion(project, "0.1.0")
+version = getSubprojectVersion(project, "0.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-networking-blockentity-v0/build.gradle
+++ b/fabric-networking-blockentity-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-networking-blockentity-v0"
-version = getSubprojectVersion(project, "0.1")
+version = getSubprojectVersion(project, "0.1.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-networking-blockentity-v0/build.gradle
+++ b/fabric-networking-blockentity-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-networking-blockentity-v0"
-version = getSubprojectVersion(project, "0.1.1")
+version = getSubprojectVersion(project, "0.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-networking-v0/build.gradle
+++ b/fabric-networking-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-networking-v0"
-version = getSubprojectVersion(project, "0.1.2")
+version = getSubprojectVersion(project, "0.2")
 
 dependencies {
     compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-networking-v0/build.gradle
+++ b/fabric-networking-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-networking-v0"
-version = getSubprojectVersion(project, "0.2")
+version = getSubprojectVersion(project, "0.1.2")
 
 dependencies {
     compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-networking-v0/build.gradle
+++ b/fabric-networking-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-networking-v0"
-version = getSubprojectVersion(project, "0.1.2")
+version = getSubprojectVersion(project, "0.1")
 
 dependencies {
     compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-object-builders-v0/build.gradle
+++ b/fabric-object-builders-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-object-builders"
-version = getSubprojectVersion(project, "0.1")
+version = getSubprojectVersion(project, "0.1.1")
 
 dependencies {
     compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-object-builders-v0/build.gradle
+++ b/fabric-object-builders-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-object-builders"
-version = getSubprojectVersion(project, "0.1.1")
+version = getSubprojectVersion(project, "0.1")
 
 dependencies {
     compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-registry-sync-v0/build.gradle
+++ b/fabric-registry-sync-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-registry-sync-v0"
-version = getSubprojectVersion(project, "0.2.2")
+version = getSubprojectVersion(project, "0.3")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-registry-sync-v0/build.gradle
+++ b/fabric-registry-sync-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-registry-sync-v0"
-version = getSubprojectVersion(project, "0.3")
+version = getSubprojectVersion(project, "0.2.2")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-registry-sync-v0/build.gradle
+++ b/fabric-registry-sync-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-registry-sync-v0"
-version = getSubprojectVersion(project, "0.2.2")
+version = getSubprojectVersion(project, "0.2")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-renderer-api-v1/build.gradle
+++ b/fabric-renderer-api-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-renderer-api-v1"
-version = getSubprojectVersion(project, "0.1")
+version = getSubprojectVersion(project, "0.1.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-renderer-api-v1/build.gradle
+++ b/fabric-renderer-api-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-renderer-api-v1"
-version = getSubprojectVersion(project, "0.1.1")
+version = getSubprojectVersion(project, "0.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-renderer-indigo/build.gradle
+++ b/fabric-renderer-indigo/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-renderer-indigo"
-version = getSubprojectVersion(project, "0.1.9")
+version = getSubprojectVersion(project, "0.2")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-renderer-indigo/build.gradle
+++ b/fabric-renderer-indigo/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-renderer-indigo"
-version = getSubprojectVersion(project, "0.2")
+version = getSubprojectVersion(project, "0.1.9")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-renderer-indigo/build.gradle
+++ b/fabric-renderer-indigo/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-renderer-indigo"
-version = getSubprojectVersion(project, "0.1.9")
+version = getSubprojectVersion(project, "0.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-rendering-data-attachment-v1/build.gradle
+++ b/fabric-rendering-data-attachment-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-rendering-data-attachment-v1"
-version = getSubprojectVersion(project, "0.1.0")
+version = getSubprojectVersion(project, "0.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-rendering-data-attachment-v1/build.gradle
+++ b/fabric-rendering-data-attachment-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-rendering-data-attachment-v1"
-version = getSubprojectVersion(project, "0.1")
+version = getSubprojectVersion(project, "0.1.0")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-rendering-fluids-v1/build.gradle
+++ b/fabric-rendering-fluids-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-rendering-fluids-v1"
-version = getSubprojectVersion(project, "0.1.0")
+version = getSubprojectVersion(project, "0.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-rendering-fluids-v1/build.gradle
+++ b/fabric-rendering-fluids-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-rendering-fluids-v1"
-version = getSubprojectVersion(project, "0.1")
+version = getSubprojectVersion(project, "0.1.0")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-rendering-v0/build.gradle
+++ b/fabric-rendering-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-rendering-v0"
-version = getSubprojectVersion(project, "0.1")
+version = getSubprojectVersion(project, "0.1.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-rendering-v0/build.gradle
+++ b/fabric-rendering-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-rendering-v0"
-version = getSubprojectVersion(project, "0.1.1")
+version = getSubprojectVersion(project, "0.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-resource-loader-v0/build.gradle
+++ b/fabric-resource-loader-v0/build.gradle
@@ -1,2 +1,2 @@
 archivesBaseName = "fabric-resource-loader-v0"
-version = getSubprojectVersion(project, "0.1.1")
+version = getSubprojectVersion(project, "0.1")

--- a/fabric-resource-loader-v0/build.gradle
+++ b/fabric-resource-loader-v0/build.gradle
@@ -1,2 +1,2 @@
 archivesBaseName = "fabric-resource-loader-v0"
-version = getSubprojectVersion(project, "0.1")
+version = getSubprojectVersion(project, "0.1.1")

--- a/fabric-tag-extensions-v0/build.gradle
+++ b/fabric-tag-extensions-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-tag-extensions-v0"
-version = getSubprojectVersion(project, "0.1")
+version = getSubprojectVersion(project, "0.1.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-tag-extensions-v0/build.gradle
+++ b/fabric-tag-extensions-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-tag-extensions-v0"
-version = getSubprojectVersion(project, "0.1.1")
+version = getSubprojectVersion(project, "0.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-textures-v0/build.gradle
+++ b/fabric-textures-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-textures-v0"
-version = getSubprojectVersion(project, "0.1.4")
+version = getSubprojectVersion(project, "0.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-textures-v0/build.gradle
+++ b/fabric-textures-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-textures-v0"
-version = getSubprojectVersion(project, "0.2")
+version = getSubprojectVersion(project, "0.1.4")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-textures-v0/build.gradle
+++ b/fabric-textures-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-textures-v0"
-version = getSubprojectVersion(project, "0.1.4")
+version = getSubprojectVersion(project, "0.2")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')


### PR DESCRIPTION
This PR replaces the problemmatic hashes with a build number.

Based off the ideas from #316 but fixes the issue of multiple branches.

This creates a json file that keeps track of the build number -> hash. This json is stored in the global gradle file so will not easily get lost (I can setup a backup job for it on jenkins).

Also returns 9999+local when not being built on jenkins