### PR TITLE
Fix mixin crash with startBlockBreak

### DIFF
--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/eventsinteraction/MixinServerPlayerInteractionManager.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/eventsinteraction/MixinServerPlayerInteractionManager.java
@@ -47,7 +47,7 @@ public class MixinServerPlayerInteractionManager {
 	public ServerPlayerEntity player;
 
 	@Inject(at = @At("HEAD"), method = "method_14263", cancellable = true)
-	public void startBlockBreak(BlockPos pos, PlayerActionC2SPacket.Action playerAction, Direction direction, int i, CallbackInfo info) {
+	public void startBlockBreak(BlockPos pos, Direction direction, CallbackInfo info) {
 		ActionResult result = AttackBlockCallback.EVENT.invoker().interact(player, world, Hand.MAIN_HAND, pos, direction);
 		if (result != ActionResult.PASS) {
 			// The client might have broken the block on its side, so make sure to let it know.


### PR DESCRIPTION
The signature of the target method changed in 1.14.4 so this method breaks. Only causes errors sometimes under strange and inconsistent circumstances, but this should theoretically fix it.