### PR TITLE
Fixes for Indigo bugs #329 and #330

### DIFF
--- a/fabric-renderer-indigo/build.gradle
+++ b/fabric-renderer-indigo/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-renderer-indigo"
-version = getSubprojectVersion(project, "0.1.9")
+version = getSubprojectVersion(project, "0.1.10")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/aocalc/VanillaAoCalc.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/aocalc/VanillaAoCalc.java
@@ -17,7 +17,7 @@
 package net.fabricmc.indigo.renderer.aocalc;
 
 import java.util.BitSet;
-import java.util.function.ToIntBiFunction;
+import java.util.function.ToIntFunction;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -40,10 +40,10 @@ import net.minecraft.world.ExtendedBlockView;
 public class VanillaAoCalc {
     private int[] vertexData = new int[28];
     private float[] aoBounds = new float[12];
-    private final ToIntBiFunction<BlockState, BlockPos> brightnessFunc;
+    private final ToIntFunction<BlockPos> brightnessFunc;
     private final AoFunc aoFunc;
     
-    public VanillaAoCalc(ToIntBiFunction<BlockState, BlockPos> brightnessFunc, AoFunc aoFunc) {
+    public VanillaAoCalc(ToIntFunction<BlockPos> brightnessFunc, AoFunc aoFunc) {
         this.brightnessFunc = brightnessFunc;
         this.aoFunc = aoFunc;
     }
@@ -61,16 +61,16 @@ public class VanillaAoCalc {
       NeighborData neighborData = NeighborData.getData(side);
       BlockPos.Mutable mpos = new BlockPos.Mutable();
       mpos.set((Vec3i)lightPos).setOffset(neighborData.faces[0]);
-      int int_1 = brightnessFunc.applyAsInt(blockState, mpos);
+      int int_1 = brightnessFunc.applyAsInt(mpos);
       float float_1 = aoFunc.apply(mpos);
       mpos.set((Vec3i)lightPos).setOffset(neighborData.faces[1]);
-      int int_2 = brightnessFunc.applyAsInt(blockState, mpos);
+      int int_2 = brightnessFunc.applyAsInt(mpos);
       float float_2 = aoFunc.apply(mpos);
       mpos.set((Vec3i)lightPos).setOffset(neighborData.faces[2]);
-      int int_3 = brightnessFunc.applyAsInt(blockState, mpos);
+      int int_3 = brightnessFunc.applyAsInt(mpos);
       float float_3 = aoFunc.apply(mpos);
       mpos.set((Vec3i)lightPos).setOffset(neighborData.faces[3]);
-      int int_4 = brightnessFunc.applyAsInt(blockState, mpos);
+      int int_4 = brightnessFunc.applyAsInt(mpos);
       float float_4 = aoFunc.apply(mpos);
       mpos.set((Vec3i)lightPos).setOffset(neighborData.faces[0]).setOffset(side);
       boolean boolean_1 = blockView.getBlockState(mpos).getLightSubtracted(blockView, mpos) == 0;
@@ -88,7 +88,7 @@ public class VanillaAoCalc {
       } else {
          mpos.set((Vec3i)lightPos).setOffset(neighborData.faces[0]).setOffset(neighborData.faces[2]);
          float_6 = aoFunc.apply(mpos);
-         int_6 = brightnessFunc.applyAsInt(blockState, mpos);
+         int_6 = brightnessFunc.applyAsInt(mpos);
       }
 
       float float_8;
@@ -99,7 +99,7 @@ public class VanillaAoCalc {
       } else {
          mpos.set((Vec3i)lightPos).setOffset(neighborData.faces[0]).setOffset(neighborData.faces[3]);
          float_8 = aoFunc.apply(mpos);
-         int_8 = brightnessFunc.applyAsInt(blockState, mpos);
+         int_8 = brightnessFunc.applyAsInt(mpos);
       }
 
       float float_10;
@@ -110,7 +110,7 @@ public class VanillaAoCalc {
       } else {
          mpos.set((Vec3i)lightPos).setOffset(neighborData.faces[1]).setOffset(neighborData.faces[2]);
          float_10 = aoFunc.apply(mpos);
-         int_10 = brightnessFunc.applyAsInt(blockState, mpos);
+         int_10 = brightnessFunc.applyAsInt(mpos);
       }
 
       float float_12;
@@ -121,13 +121,13 @@ public class VanillaAoCalc {
       } else {
          mpos.set((Vec3i)lightPos).setOffset(neighborData.faces[1]).setOffset(neighborData.faces[3]);
          float_12 = aoFunc.apply(mpos);
-         int_12 = brightnessFunc.applyAsInt(blockState, mpos);
+         int_12 = brightnessFunc.applyAsInt(mpos);
       }
 
-      int int_13 = brightnessFunc.applyAsInt(blockState, blockPos);
+      int int_13 = brightnessFunc.applyAsInt(blockPos);
       mpos.set((Vec3i)blockPos).setOffset(side);
       if (bits.get(0) || !blockView.getBlockState(mpos).isFullOpaque(blockView, mpos)) {
-         int_13 = brightnessFunc.applyAsInt(blockState, mpos);
+         int_13 = brightnessFunc.applyAsInt(mpos);
       }
 
       float float_13 = bits.get(0) ? blockView.getBlockState(lightPos).getAmbientOcclusionLightLevel(blockView, lightPos) : blockView.getBlockState(blockPos).getAmbientOcclusionLightLevel(blockView, blockPos);

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractMeshConsumer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractMeshConsumer.java
@@ -17,15 +17,14 @@
 package net.fabricmc.indigo.renderer.render;
 
 import java.util.function.Consumer;
-import java.util.function.ToIntBiFunction;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectFunction;
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext.QuadTransform;
+import net.fabricmc.indigo.renderer.IndigoRenderer;
 import net.fabricmc.indigo.renderer.RenderMaterialImpl;
 import net.fabricmc.indigo.renderer.RenderMaterialImpl.Value;
-import net.fabricmc.indigo.renderer.IndigoRenderer;
 import net.fabricmc.indigo.renderer.accessor.AccessBufferBuilder;
 import net.fabricmc.indigo.renderer.aocalc.AoCalculator;
 import net.fabricmc.indigo.renderer.helper.ColorHelper;
@@ -33,17 +32,15 @@ import net.fabricmc.indigo.renderer.helper.GeometryHelper;
 import net.fabricmc.indigo.renderer.mesh.EncodingFormat;
 import net.fabricmc.indigo.renderer.mesh.MeshImpl;
 import net.fabricmc.indigo.renderer.mesh.MutableQuadViewImpl;
-import net.minecraft.block.BlockState;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.util.math.BlockPos;
 
 /**
  * Consumer for pre-baked meshes.  Works by copying the mesh data to a
  * "editor" quad held in the instance, where all transformations are applied before buffering.
  */
 public abstract class AbstractMeshConsumer extends AbstractQuadRenderer implements Consumer<Mesh> {
-    protected AbstractMeshConsumer(BlockRenderInfo blockInfo, ToIntBiFunction<BlockState, BlockPos> brightnessFunc, Int2ObjectFunction<AccessBufferBuilder> bufferFunc, AoCalculator aoCalc, QuadTransform transform) {
-        super(blockInfo, brightnessFunc, bufferFunc, aoCalc, transform);
+    protected AbstractMeshConsumer(BlockRenderInfo blockInfo, Int2ObjectFunction<AccessBufferBuilder> bufferFunc, AoCalculator aoCalc, QuadTransform transform) {
+        super(blockInfo, bufferFunc, aoCalc, transform);
     }
     
     /** 

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractQuadRenderer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractQuadRenderer.java
@@ -18,8 +18,6 @@ package net.fabricmc.indigo.renderer.render;
 
 import static net.fabricmc.indigo.renderer.helper.GeometryHelper.LIGHT_FACE_FLAG;
 
-import java.util.function.ToIntBiFunction;
-
 import it.unimi.dsi.fastutil.ints.Int2ObjectFunction;
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext.QuadTransform;
 import net.fabricmc.indigo.renderer.accessor.AccessBufferBuilder;
@@ -38,15 +36,13 @@ import net.minecraft.util.math.BlockPos;
 public abstract class AbstractQuadRenderer {
     private static final int FULL_BRIGHTNESS = 15 << 20 | 15 << 4;
     
-    protected final ToIntBiFunction<BlockState, BlockPos> brightnessFunc;
     protected final Int2ObjectFunction<AccessBufferBuilder> bufferFunc;
     protected final BlockRenderInfo blockInfo;
     protected final AoCalculator aoCalc;
     protected final QuadTransform transform;
     
-    AbstractQuadRenderer(BlockRenderInfo blockInfo, ToIntBiFunction<BlockState, BlockPos> brightnessFunc, Int2ObjectFunction<AccessBufferBuilder> bufferFunc, AoCalculator aoCalc, QuadTransform transform) {
+    AbstractQuadRenderer(BlockRenderInfo blockInfo, Int2ObjectFunction<AccessBufferBuilder> bufferFunc, AoCalculator aoCalc, QuadTransform transform) {
         this.blockInfo = blockInfo;
-        this.brightnessFunc = brightnessFunc;
         this.bufferFunc = bufferFunc;
         this.aoCalc = aoCalc;
         this.transform = transform;
@@ -144,6 +140,7 @@ public abstract class AbstractQuadRenderer {
         if((quad.geometryFlags() & LIGHT_FACE_FLAG) != 0 || Block.isShapeFullCube(blockState.getCollisionShape(blockInfo.blockView, pos))) {
             mpos.setOffset(quad.lightFace());
         }
-        return brightnessFunc.applyAsInt(blockState, mpos);
+        // Unfortunately cannot use brightness cache here unless we implement one specifically for flat lighting. See #329
+        return blockState.getBlockBrightness(blockInfo.blockView, mpos);
     }
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractRenderContext.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractRenderContext.java
@@ -40,6 +40,10 @@ abstract class AbstractRenderContext implements RenderContext {
         return activeTransform.transform(q);
     }
     
+    protected boolean hasTransform() {
+        return activeTransform != NO_TRANSFORM;
+    }
+    
     @Override
     public void pushTransform(QuadTransform transform) {
         if(transform == null) {

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/BlockRenderContext.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/BlockRenderContext.java
@@ -18,7 +18,6 @@ package net.fabricmc.indigo.renderer.render;
 
 import java.util.Random;
 import java.util.function.Consumer;
-import java.util.function.ToIntBiFunction;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectFunction;
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
@@ -43,7 +42,7 @@ import net.minecraft.world.ExtendedBlockView;
 public class BlockRenderContext extends AbstractRenderContext implements RenderContext {
     private final BlockRenderInfo blockInfo = new BlockRenderInfo();
     private final AoCalculator aoCalc = new AoCalculator(blockInfo, this::brightness, this::aoLevel);
-    private final MeshConsumer meshConsumer = new MeshConsumer(blockInfo, this::brightness, this::outputBuffer, aoCalc, this::transform);
+    private final MeshConsumer meshConsumer = new MeshConsumer(blockInfo, this::outputBuffer, aoCalc, this::transform);
     private final Random random = new Random();
     private BlockModelRenderer vanillaRenderer;
     private AccessBufferBuilder fabricBuffer;
@@ -59,11 +58,11 @@ public class BlockRenderContext extends AbstractRenderContext implements RenderC
         return isCallingVanilla;
     }
     
-    private int brightness(BlockState blockState, BlockPos pos) {
+    private int brightness(BlockPos pos) {
         if(blockInfo.blockView == null) {
             return 15 << 20 | 15 << 4;
         }
-        return blockState.getBlockBrightness(blockInfo.blockView, pos);
+        return blockInfo.blockView.getBlockState(pos).getBlockBrightness(blockInfo.blockView, pos);
     }
 
     private float aoLevel(BlockPos pos) {
@@ -109,8 +108,8 @@ public class BlockRenderContext extends AbstractRenderContext implements RenderC
     }
     
     private class MeshConsumer extends AbstractMeshConsumer {
-        MeshConsumer(BlockRenderInfo blockInfo, ToIntBiFunction<BlockState, BlockPos> brightnessFunc, Int2ObjectFunction<AccessBufferBuilder> bufferFunc, AoCalculator aoCalc, QuadTransform transform) {
-            super(blockInfo, brightnessFunc, bufferFunc, aoCalc, transform);
+        MeshConsumer(BlockRenderInfo blockInfo, Int2ObjectFunction<AccessBufferBuilder> bufferFunc, AoCalculator aoCalc, QuadTransform transform) {
+            super(blockInfo, bufferFunc, aoCalc, transform);
         }
 
         @Override

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/ChunkRenderInfo.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/ChunkRenderInfo.java
@@ -186,11 +186,11 @@ public class ChunkRenderInfo {
      * Cached values for {@link BlockState#getBlockBrightness(ExtendedBlockView, BlockPos)}.
      * See also the comments for {@link #brightnessCache}.
      */
-    int cachedBrightness(BlockState blockState, BlockPos pos) {
+    int cachedBrightness(BlockPos pos) {
         long key = pos.asLong();
         int result = brightnessCache.get(key);
         if (result == Integer.MAX_VALUE) {
-            result = blockState.getBlockBrightness(blockView, pos);
+            result = blockView.getBlockState(pos).getBlockBrightness(blockView, pos);
             brightnessCache.put(key, result);
         }
         return result;

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/ChunkRenderInfo.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/ChunkRenderInfo.java
@@ -23,7 +23,6 @@ import net.fabricmc.indigo.renderer.accessor.AccessBufferBuilder;
 import net.fabricmc.indigo.renderer.accessor.AccessChunkRenderer;
 import net.fabricmc.indigo.renderer.aocalc.AoLuminanceFix;
 import net.fabricmc.indigo.renderer.mesh.MutableQuadViewImpl;
-import net.minecraft.block.Block;
 import net.minecraft.block.Block.OffsetType;
 import net.minecraft.block.BlockRenderLayer;
 import net.minecraft.block.BlockState;
@@ -77,9 +76,6 @@ public class ChunkRenderInfo {
     ExtendedBlockView blockView;
     boolean [] resultFlags;
     
-    /** Used to check need to cache brightness cache */
-    private Block lastBlock = null;
-    
     private final AccessBufferBuilder[] buffers = new AccessBufferBuilder[4];
     private final BlockRenderLayer[] LAYERS = BlockRenderLayer.values();
     
@@ -120,8 +116,8 @@ public class ChunkRenderInfo {
         chunkOffsetX = -chunkOrigin.getX();
         chunkOffsetY = -chunkOrigin.getY();
         chunkOffsetZ = -chunkOrigin.getZ();
+        brightnessCache.clear();
         aoLevelCache.clear();
-        lastBlock = null;
     }
     
     void release() {
@@ -137,15 +133,6 @@ public class ChunkRenderInfo {
     void beginBlock() {
         final BlockState blockState = blockInfo.blockState;
         final BlockPos blockPos = blockInfo.blockPos;
-        
-        // Unfortunately is necessary to clear the brightness cache for each block 
-        // because results can vary based on requesting block state and not just
-        // position. In vanilla this happens in exactly one case: magma blocks.
-        final Block newBlock = blockState.getBlock();
-        if(lastBlock != newBlock) {
-            lastBlock = newBlock;
-            brightnessCache.clear();
-        }
         
         // When we are using the BufferBuilder input methods, the builder will
         // add the chunk offset for us, so we should only apply the block offset.

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/CompatibilityHelper.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/CompatibilityHelper.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.indigo.renderer.render;
+
+import net.fabricmc.indigo.Indigo;
+
+/**
+ * Controls 1x warning for vanilla quad vertex format when running in compatibility mode.
+ */
+public abstract class CompatibilityHelper {
+    private CompatibilityHelper() {}
+
+    private static boolean logCompatibilityWarning = true;
+    
+    private static boolean isCompatible(int[] vertexData) {
+        final boolean result = vertexData.length == 28;
+        if(!result && logCompatibilityWarning) {
+            logCompatibilityWarning = false;
+            Indigo.LOGGER.warn("[Indigo] Encountered baked quad with non-standard vertex format. Some blocks will not be rendered");
+        }
+        return result;
+    }
+    
+    public static boolean canRender(int[] vertexData) {
+        return !Indigo.ENSURE_VERTEX_FORMAT_COMPATIBILITY || isCompatible(vertexData);
+    }
+}

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/ItemRenderContext.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/ItemRenderContext.java
@@ -61,6 +61,7 @@ public class ItemRenderContext extends AbstractRenderContext implements RenderCo
 
     private final ItemColors colorMap;
     private final Random random = new Random();
+    private final Consumer<BakedModel> fallbackConsumer;
     BufferBuilder bufferBuilder;
     AccessBufferBuilder fabricBuffer;
     private int color;
@@ -86,6 +87,7 @@ public class ItemRenderContext extends AbstractRenderContext implements RenderCo
     
     public ItemRenderContext(ItemColors colorMap) {
         this.colorMap = colorMap;
+        this.fallbackConsumer = this::fallbackConsumer;
     }
     
     public void renderModel(FabricBakedModel model, int color, ItemStack stack, VanillaQuadHandler vanillaHandler) {
@@ -264,7 +266,7 @@ public class ItemRenderContext extends AbstractRenderContext implements RenderCo
     
     @Override
     public Consumer<BakedModel> fallbackConsumer() {
-        return this::fallbackConsumer;
+        return fallbackConsumer;
     }
 
     @Override

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainFallbackConsumer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainFallbackConsumer.java
@@ -62,7 +62,6 @@ public class TerrainFallbackConsumer extends AbstractQuadRenderer implements Con
     private final ChunkRenderInfo chunkInfo;
     
     TerrainFallbackConsumer(BlockRenderInfo blockInfo, ChunkRenderInfo chunkInfo, AoCalculator aoCalc, QuadTransform transform) {
-        // Unfortunately cannot use brightness cache here unless we implement one specifically for flat lighting. See #329
         super(blockInfo, chunkInfo::getInitializedBuffer, aoCalc, transform);
         this.chunkInfo = chunkInfo;
     }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainFallbackConsumer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainFallbackConsumer.java
@@ -24,9 +24,8 @@ import java.util.function.Supplier;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.renderer.v1.model.ModelHelper;
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext.QuadTransform;
-import net.fabricmc.indigo.renderer.RenderMaterialImpl.Value;
-import net.fabricmc.indigo.Indigo;
 import net.fabricmc.indigo.renderer.IndigoRenderer;
+import net.fabricmc.indigo.renderer.RenderMaterialImpl.Value;
 import net.fabricmc.indigo.renderer.aocalc.AoCalculator;
 import net.fabricmc.indigo.renderer.helper.GeometryHelper;
 import net.fabricmc.indigo.renderer.mesh.EncodingFormat;
@@ -58,20 +57,6 @@ import net.minecraft.util.math.Direction;
 public class TerrainFallbackConsumer extends AbstractQuadRenderer implements Consumer<BakedModel> {
     private static Value MATERIAL_FLAT = (Value) IndigoRenderer.INSTANCE.materialFinder().disableAo(0, true).find();
     private static Value MATERIAL_SHADED = (Value) IndigoRenderer.INSTANCE.materialFinder().find();
-    
-    /**
-     * Controls 1x warning for vanilla quad vertex format when running in compatibility mode.
-     */
-    private static boolean logCompatibilityWarning = true;
-    
-    private static boolean isCompatible(int[] vertexData) {
-    	final boolean result = vertexData.length == 28;
-    	if(!result && logCompatibilityWarning) {
-    		logCompatibilityWarning = false;
-			Indigo.LOGGER.warn("[Indigo] Encountered baked quad with non-standard vertex format. Some blocks will not be rendered");
-    	}
-    	return result;
-    }
     
     private final int[] editorBuffer = new int[28];
     private final ChunkRenderInfo chunkInfo;
@@ -125,7 +110,7 @@ public class TerrainFallbackConsumer extends AbstractQuadRenderer implements Con
     
     private void renderQuad(BakedQuad quad, Direction cullFace, Value defaultMaterial) {
         final int[] vertexData = quad.getVertexData();
-        if(Indigo.ENSURE_VERTEX_FORMAT_COMPATIBILITY && !isCompatible(vertexData)) {
+        if(!CompatibilityHelper.canRender(vertexData)) {
         	return;
         }
         

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainFallbackConsumer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainFallbackConsumer.java
@@ -62,7 +62,8 @@ public class TerrainFallbackConsumer extends AbstractQuadRenderer implements Con
     private final ChunkRenderInfo chunkInfo;
     
     TerrainFallbackConsumer(BlockRenderInfo blockInfo, ChunkRenderInfo chunkInfo, AoCalculator aoCalc, QuadTransform transform) {
-        super(blockInfo, chunkInfo::cachedBrightness, chunkInfo::getInitializedBuffer, aoCalc, transform);
+        // Unfortunately cannot use brightness cache here unless we implement one specifically for flat lighting. See #329
+        super(blockInfo, chunkInfo::getInitializedBuffer, aoCalc, transform);
         this.chunkInfo = chunkInfo;
     }
     

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainMeshConsumer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainMeshConsumer.java
@@ -23,7 +23,7 @@ import net.fabricmc.indigo.renderer.mesh.MutableQuadViewImpl;
 public class TerrainMeshConsumer extends AbstractMeshConsumer {
     private final ChunkRenderInfo chunkInfo;
     TerrainMeshConsumer(TerrainBlockRenderInfo blockInfo,  ChunkRenderInfo chunkInfo, AoCalculator aoCalc, QuadTransform transform) {
-        super(blockInfo, chunkInfo::cachedBrightness, chunkInfo::getInitializedBuffer, aoCalc, transform);
+        super(blockInfo, chunkInfo::getInitializedBuffer, aoCalc, transform);
         this.chunkInfo = chunkInfo;
     }
     


### PR DESCRIPTION
See #329 and #330 for explanation.

Changes include:

- Move compatibility warning to a separate class for reuse
- Implement tranform in ItemRenderContext
- Remove block state from  method signature for Ao brightness cache function (can only cause problems)
- Remove brightness cache function for flat rendering path
- Use block state value for lit block to retrieve block brightness for flat lighting, w/o caching (must be done this way to match vanilla logic)

Test build available here:  https://github.com/grondag/fabric/releases/download/indigo-0.1.10-rc1/fabric-renderer-indigo-0.1.10-rc1.jar