### PR TITLE
Honor special case water/glass rendering

### DIFF
--- a/fabric-rendering-fluids-v1/build.gradle
+++ b/fabric-rendering-fluids-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-rendering-fluids-v1"
-version = getSubprojectVersion(project, "0.1.0")
+version = getSubprojectVersion(project, "0.1.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-rendering-fluids-v1/src/main/java/net/fabricmc/fabric/mixin/client/render/fluid/MixinFluidRenderer.java
+++ b/fabric-rendering-fluids-v1/src/main/java/net/fabricmc/fabric/mixin/client/render/fluid/MixinFluidRenderer.java
@@ -23,6 +23,7 @@ import net.minecraft.client.render.BufferBuilder;
 import net.minecraft.client.render.block.FluidRenderer;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.fluid.FluidState;
+import net.minecraft.tag.FluidTags;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.ExtendedBlockView;
 import org.spongepowered.asm.mixin.Mixin;
@@ -74,7 +75,13 @@ public class MixinFluidRenderer {
 
     @ModifyVariable(at = @At(value = "INVOKE", target = "net/minecraft/client/render/block/FluidRenderer.isSameFluid(Lnet/minecraft/world/BlockView;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/Direction;Lnet/minecraft/fluid/FluidState;)Z"), method = "tesselate", ordinal = 0)
     public boolean modLavaCheck(boolean chk) {
-        return fabric_renderHandler.get().handler != null || chk;
+        // First boolean local is set by vanilla according to 'matches lava'
+        // but uses the negation consistent with 'matches water'
+        // for determining if special water sprite should be used behind glass.
+        
+        // Has other uses but those have already happened by the time the hook is called.
+        final FluidRendererHookContainer ctr = fabric_renderHandler.get();
+        return chk || (ctr != null && !ctr.state.matches(FluidTags.WATER));
     }
 
     @ModifyVariable(at = @At(value = "INVOKE", target = "net/minecraft/client/render/block/FluidRenderer.isSameFluid(Lnet/minecraft/world/BlockView;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/Direction;Lnet/minecraft/fluid/FluidState;)Z"), method = "tesselate", ordinal = 0)


### PR DESCRIPTION
Fixes #333

Vanilla uses brittle special-case logic to render water next to glass using a specialized sprite. 

This PR sets the local variable that controls that logic in a way that should activate it for any fluid that matches the `WATER` tag. 

Test build here:  https://github.com/grondag/fabric/releases/download/fluidrender-0.1.1-rc1/fabric-renderer-api-v1-0.1.1+099c1e8b-dev.jar