### PR TITLE
Allow for running fabric-api-base on the server-side environment

### DIFF
--- a/fabric-api-base/src/main/resources/fabric.mod.json
+++ b/fabric-api-base/src/main/resources/fabric.mod.json
@@ -3,7 +3,7 @@
   "id": "fabric-api-base",
   "name": "Fabric API Base",
   "version": "${version}",
-  "environment": "client",
+  "environment": "*",
   "license": "Apache-2.0",
   "icon": "assets/fabric-api-base/icon.png",
   "contact": {


### PR DESCRIPTION
I suppose that `fabric-api-base` has been mistakenly configured to run only on the client-side. It causes ClassNotFoundException on the server-side:

```
[21:43:39] [main/INFO]: Loading for game Minecraft 1.14.4
[21:43:40] [main/INFO]: [FabricLoader] Loading 28 mods: minecraft@1.14.4, fabric-renderer-api-v1@0.1.1+591e97ae42, fabric-networking-blockentity-v0@0.1.1+591e97ae42, fabric-keybindings-v0@0.1.1+591e97ae42, fabricloader@0.6.1+build.165, fabric-renderer-indigo@0.1.13+591e97ae42, fabric-containers-v0@0.1.2+591e97ae42, fabric-biomes-v1@0.1.0+591e97ae42, fabric-events-interaction-v0@0.1.1+591e97ae42, fabric-crash-report-info-v1@0.1.1+591e97ae42, fabric-api-base@0.1.0+591e97ae42, fabric-rendering-v0@0.1.1+591e97ae42, fabric-rendering-data-attachment-v1@0.1.0+591e97ae42, fabric-resource-loader-v0@0.1.3+591e97ae42, fabric-textures-v0@0.1.4+591e97ae42, fabric-content-registries-v0@0.1.1+591e97ae42, fabric-tag-extensions-v0@0.1.1+591e97ae42, fabric-rendering-fluids-v1@0.1.1+591e97ae42, fabric-commands-v0@0.1.1+591e97ae42, fabric-registry-sync-v0@0.2.2+591e97ae42, fabric-mining-levels-v0@0.1.0+591e97ae42, fabric-events-lifecycle-v0@0.1.1+591e97ae42, fabric-loot-tables-v1@0.1.0+591e97ae42, fabric@0.3.2+build.220-1.14, fabric-item-groups-v0@0.1.0+591e97ae42, fabric-models-v0@0.1.0+591e97ae42, fabric-object-builders-v0@0.1.1+591e97ae42, fabric-networking-v0@0.1.3+591e97ae42
[21:43:40] [main/INFO]: SpongePowered MIXIN Subsystem Version=0.7.11 Source=file:/opt/minecraft/server/1.14.4-fabric/fabric-server-launch.jar Service=Knot/Fabric Env=SERVER
[21:43:40] [main/INFO]: Compatibility level set to JAVA_8
[21:43:41] [main/WARN]: Error loading class: net/fabricmc/fabric/api/event/Event (java.lang.ClassNotFoundException: net/fabricmc/fabric/api/event/Event)
```

So this patch fixes `fabric-api-base` to run on the server-side.