### PR TITLE
More lifecycle hooks, first draft

### DIFF
--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/server/ServerReloadCallback.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/server/ServerReloadCallback.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.event.server;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.server.MinecraftServer;
+
+/**
+ * A callback for a server's data reload.
+ */
+public interface ServerReloadCallback {
+	/**
+	 * An event fired before the data packs are reloaded.
+	 *
+	 * <p>Mods should register to this event for keeping information across reloads,
+	 * e.g. identifiers of advancements obtained before reload.
+	 */
+	Event<ServerReloadCallback> PRE_EVENT = EventFactory.createArrayBacked(ServerReloadCallback.class,
+		listeners -> server -> {
+			for (ServerReloadCallback event : listeners) {
+				event.onReload(server);
+			}
+		}
+	);
+
+	/**
+	 * An event fired after the data packs are reloaded and the updated vanilla advancements, recipes,
+	 * etc. have been sent to the clients.
+	 *
+	 * <p>Mods can retrieve the information they've saved in the pre-event and send necessary contents
+	 * to the client, etc.
+	 */
+	Event<ServerReloadCallback> POST_EVENT = EventFactory.createArrayBacked(ServerReloadCallback.class,
+		listeners -> server -> {
+			for (ServerReloadCallback event : listeners) {
+				event.onReload(server);
+			}
+		}
+	);
+
+	/**
+	 * Triggers the callback.
+	 *
+	 * @param server the server
+	 */
+	void onReload(MinecraftServer server);
+}

--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/server/ServerSaveCallback.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/server/ServerSaveCallback.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.event.server;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.server.MinecraftServer;
+
+/**
+ * A callback for server/game saving.
+ */
+public interface ServerSaveCallback {
+	/**
+	 * This event is triggered when the server finished saving all its worlds and {@code level.dat} file.
+	 *
+	 * @see MinecraftServer#save(boolean, boolean, boolean)
+	 */
+	Event<ServerSaveCallback> EVENT = EventFactory.createArrayBacked(ServerSaveCallback.class,
+		listeners -> (server, silent, flush, enforced) -> {
+			for (ServerSaveCallback event : listeners) {
+				event.onSave(server, silent, flush, enforced);
+			}
+		}
+	);
+
+	/**
+	 * Perform a custom saving logic.
+	 *
+	 * @param server the server
+	 * @param silent true if the saving produces visible log messages
+	 * @param flush true if the anvil chunk storage should flush its output
+	 * @param enforced false if the saving should respect save-on/save-off command's settings
+	 */
+	void onSave(MinecraftServer server, boolean silent, boolean flush, boolean enforced);
+}

--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/server/ServerSaveCallback.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/server/ServerSaveCallback.java
@@ -19,20 +19,23 @@ package net.fabricmc.fabric.api.event.server;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.level.LevelProperties;
 
 /**
- * A callback for server/game saving.
+ * A callback for server/game saving. This is called when all worlds have been saved and the level properties
+ * have been initialized but not yet written to file.
  */
 public interface ServerSaveCallback {
 	/**
-	 * This event is triggered when the server finished saving all its worlds and {@code level.dat} file.
+	 * This event is triggered when the server finished saving all its worlds and preparing level properties
+	 * before writing it to file.
 	 *
 	 * @see MinecraftServer#save(boolean, boolean, boolean)
 	 */
 	Event<ServerSaveCallback> EVENT = EventFactory.createArrayBacked(ServerSaveCallback.class,
-		listeners -> (server, silent, flush, enforced) -> {
+		listeners -> (server, properties) -> {
 			for (ServerSaveCallback event : listeners) {
-				event.onSave(server, silent, flush, enforced);
+				event.onSave(server, properties);
 			}
 		}
 	);
@@ -40,10 +43,10 @@ public interface ServerSaveCallback {
 	/**
 	 * Perform a custom saving logic.
 	 *
+	 * <p>The level properties is provided in case mods need to tweak it.
+	 *
 	 * @param server the server
-	 * @param silent true if the saving produces visible log messages
-	 * @param flush true if the anvil chunk storage should flush its output
-	 * @param enforced false if the saving should respect save-on/save-off command's settings
+	 * @param properties the level properties
 	 */
-	void onSave(MinecraftServer server, boolean silent, boolean flush, boolean enforced);
+	void onSave(MinecraftServer server, LevelProperties properties);
 }

--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/mixin/eventslifecycle/MixinMinecraftServer.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/mixin/eventslifecycle/MixinMinecraftServer.java
@@ -16,22 +16,43 @@
 
 package net.fabricmc.fabric.mixin.eventslifecycle;
 
+import net.fabricmc.fabric.api.event.server.ServerReloadCallback;
+import net.fabricmc.fabric.api.event.server.ServerSaveCallback;
 import net.fabricmc.fabric.api.event.server.ServerStartCallback;
 import net.fabricmc.fabric.api.event.server.ServerStopCallback;
 import net.fabricmc.fabric.api.event.server.ServerTickCallback;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.world.level.LevelProperties;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.util.function.BooleanSupplier;
 
 @Mixin(MinecraftServer.class)
 public class MixinMinecraftServer {
-	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;setFavicon(Lnet/minecraft/server/ServerMetadata;)V", ordinal = 0), method = "run")
+	@Inject(at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/server/MinecraftServer;setFavicon(Lnet/minecraft/server/ServerMetadata;)V", ordinal = 0), method = "run")
 	public void afterSetupServer(CallbackInfo info) {
 		ServerStartCallback.EVENT.invoker().onStartServer((MinecraftServer) (Object) this);
+	}
+
+	@Inject(method = "reload()V", at = @At(value = "INVOKE", target = "Lnet/minecraft/resource/ResourcePackContainerManager;callCreators()V"))
+	public void beforeReload(CallbackInfo info) {
+		ServerReloadCallback.PRE_EVENT.invoker().onReload((MinecraftServer) (Object) this);
+	}
+
+	@Inject(method = "reload()V", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/server/PlayerManager;onDataPacksReloaded()V"))
+	public void afterReload(CallbackInfo info) {
+		ServerReloadCallback.POST_EVENT.invoker().onReload((MinecraftServer) (Object) this);
+	}
+
+	@Inject(method = "save(ZZZ)Z", at = @At("RETURN"), locals = LocalCapture.CAPTURE_FAILHARD)
+	public void onSave(CallbackInfoReturnable<Boolean> info, boolean silent, boolean flush, boolean enforced, boolean iteratedWorlds, ServerWorld overworld, LevelProperties mainLevelProperties) {
+		ServerSaveCallback.EVENT.invoker().onSave((MinecraftServer) (Object) this, silent, flush, enforced);
 	}
 
 	@Inject(at = @At("HEAD"), method = "shutdown")

--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/mixin/eventslifecycle/MixinMinecraftServer.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/mixin/eventslifecycle/MixinMinecraftServer.java
@@ -50,9 +50,12 @@ public class MixinMinecraftServer {
 		ServerReloadCallback.POST_EVENT.invoker().onReload((MinecraftServer) (Object) this);
 	}
 
-	@Inject(method = "save(ZZZ)Z", at = @At("RETURN"), locals = LocalCapture.CAPTURE_FAILHARD)
-	public void onSave(CallbackInfoReturnable<Boolean> info, boolean silent, boolean flush, boolean enforced, boolean iteratedWorlds, ServerWorld overworld, LevelProperties mainLevelProperties) {
-		ServerSaveCallback.EVENT.invoker().onSave((MinecraftServer) (Object) this, silent, flush, enforced);
+	@Inject(method = "save(ZZZ)Z",
+		at = @At(value = "INVOKE",
+			target = "Lnet/minecraft/world/WorldSaveHandler;saveWorld(Lnet/minecraft/world/level/LevelProperties;Lnet/minecraft/nbt/CompoundTag;)V"
+		), locals = LocalCapture.CAPTURE_FAILHARD)
+	public void onSave(boolean silent, boolean flush, boolean enforced, CallbackInfoReturnable<Boolean> info, boolean iteratedWorlds, ServerWorld overworld, LevelProperties mainLevelProperties) {
+		ServerSaveCallback.EVENT.invoker().onSave((MinecraftServer) (Object) this, mainLevelProperties);
 	}
 
 	@Inject(at = @At("HEAD"), method = "shutdown")

--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/mixin/eventslifecycle/MixinWorld.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/mixin/eventslifecycle/MixinWorld.java
@@ -25,7 +25,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(World.class)
 public class MixinWorld {
-	// TODO split into ClientWorld/ServerWorld ticks? mmm need more mappings
+
 	@Inject(at = @At("RETURN"), method = "tickBlockEntities")
 	public void tickBlockEntitiesAfter(CallbackInfo info) {
 		WorldTickCallback.EVENT.invoker().tick((World) (Object) this);


### PR DESCRIPTION
I am actually not sure if we want the disposal events of worlds... maybe we can change to save event for server and drop the one for the client

On a side note, the resource reload post event can cover #262's need