### PR TITLE
A violent fix for #364

### DIFF
--- a/fabric-events-interaction-v0/build.gradle
+++ b/fabric-events-interaction-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-events-interaction-v0"
-version = getSubprojectVersion(project, "0.1.3")
+version = getSubprojectVersion(project, "0.2.0")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-events-interaction-v0/build.gradle
+++ b/fabric-events-interaction-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-events-interaction-v0"
-version = getSubprojectVersion(project, "0.1.2")
+version = getSubprojectVersion(project, "0.1.3")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/UseItemCallback.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/UseItemCallback.java
@@ -19,8 +19,10 @@ package net.fabricmc.fabric.api.event.player;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
+import net.minecraft.util.TypedActionResult;
 import net.minecraft.world.World;
 
 /**
@@ -34,17 +36,17 @@ import net.minecraft.world.World;
  */
 public interface UseItemCallback {
 	public static final Event<UseItemCallback> EVENT = EventFactory.createArrayBacked(UseItemCallback.class,
-		(listeners) -> (player, world, hand) -> {
+		listeners -> (player, world, hand) -> {
 			for (UseItemCallback event : listeners) {
-				ActionResult result = event.interact(player, world, hand);
-				if (result != ActionResult.PASS) {
+				TypedActionResult<ItemStack> result = event.interact(player, world, hand);
+				if (result.getResult() != ActionResult.PASS) {
 					return result;
 				}
 			}
 
-			return ActionResult.PASS;
+			return TypedActionResult.method_22430(ItemStack.EMPTY);
 		}
 	);
 
-	ActionResult interact(PlayerEntity player, World world, Hand hand);
+	TypedActionResult<ItemStack> interact(PlayerEntity player, World world, Hand hand);
 }

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/eventsinteraction/MixinClientPlayerInteractionManager.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/eventsinteraction/MixinClientPlayerInteractionManager.java
@@ -24,11 +24,13 @@ import net.minecraft.client.network.ClientPlayerInteractionManager;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
 import net.minecraft.server.network.packet.PlayerInteractBlockC2SPacket;
 import net.minecraft.server.network.packet.PlayerInteractEntityC2SPacket;
 import net.minecraft.server.network.packet.PlayerInteractItemC2SPacket;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
+import net.minecraft.util.TypedActionResult;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.EntityHitResult;
 import net.minecraft.util.math.BlockPos;
@@ -87,10 +89,10 @@ public class MixinClientPlayerInteractionManager {
 	}
 
 	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayNetworkHandler;sendPacket(Lnet/minecraft/network/Packet;)V", ordinal = 0), method = "interactItem", cancellable = true)
-	public void interactItem(PlayerEntity player, World world, Hand hand, CallbackInfoReturnable<ActionResult> info) {
-		ActionResult result = UseItemCallback.EVENT.invoker().interact(player, world, hand);
-		if (result != ActionResult.PASS) {
-			if (result == ActionResult.SUCCESS) {
+	public void interactItem(PlayerEntity player, World world, Hand hand, CallbackInfoReturnable<TypedActionResult<ItemStack>> info) {
+		TypedActionResult<ItemStack> result = UseItemCallback.EVENT.invoker().interact(player, world, hand);
+		if (result.getResult() != ActionResult.PASS) {
+			if (result.getResult() == ActionResult.SUCCESS) {
 				this.networkHandler.sendPacket(new PlayerInteractItemC2SPacket(hand));
 			}
 			info.setReturnValue(result);

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/eventsinteraction/MixinServerPlayerInteractionManager.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/eventsinteraction/MixinServerPlayerInteractionManager.java
@@ -28,6 +28,7 @@ import net.minecraft.server.network.packet.PlayerActionC2SPacket;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
+import net.minecraft.util.TypedActionResult;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
@@ -68,9 +69,9 @@ public class MixinServerPlayerInteractionManager {
 
 	@Inject(at = @At("HEAD"), method = "interactItem", cancellable = true)
 	public void interactItem(PlayerEntity player, World world, ItemStack stack, Hand hand, CallbackInfoReturnable<ActionResult> info) {
-		ActionResult result = UseItemCallback.EVENT.invoker().interact(player, world, hand);
-		if (result != ActionResult.PASS) {
-			info.setReturnValue(result);
+		TypedActionResult<ItemStack> result = UseItemCallback.EVENT.invoker().interact(player, world, hand);
+		if (result.getResult() != ActionResult.PASS) {
+			info.setReturnValue(result.getResult());
 			info.cancel();
 			return;
 		}

--- a/fabric-events-interaction-v0/src/main/resources/fabric.mod.json
+++ b/fabric-events-interaction-v0/src/main/resources/fabric.mod.json
@@ -17,7 +17,8 @@
   ],
   "depends": {
     "fabricloader": ">=0.4.0",
-    "fabric-api-base": "*"
+    "fabric-api-base": "*",
+    "minecraft": ">=1.15-alpha.19.37.a"
   },
   "entrypoints": {
     "main": [


### PR DESCRIPTION
Changed the use item callback to always return a typed action result (which now includes hand swing info for client after the latest 19w37a update)

Signed-off-by: liach <liach@users.noreply.github.com>