### PR TITLE
Add a sync() method to BlockEntityClientSerializable

### DIFF
--- a/fabric-networking-blockentity-v0/src/main/java/net/fabricmc/fabric/api/block/entity/BlockEntityClientSerializable.java
+++ b/fabric-networking-blockentity-v0/src/main/java/net/fabricmc/fabric/api/block/entity/BlockEntityClientSerializable.java
@@ -42,6 +42,6 @@ public interface BlockEntityClientSerializable {
 		}
 	}
 
-	public World getWorld();
-	public BlockPos getPos();
+	World getWorld();
+	BlockPos getPos();
 }

--- a/fabric-networking-blockentity-v0/src/main/java/net/fabricmc/fabric/api/block/entity/BlockEntityClientSerializable.java
+++ b/fabric-networking-blockentity-v0/src/main/java/net/fabricmc/fabric/api/block/entity/BlockEntityClientSerializable.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.block.entity;
 
+import com.google.common.base.Preconditions;
+
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.world.ServerWorld;
@@ -31,19 +33,20 @@ public interface BlockEntityClientSerializable {
 	CompoundTag toClientTag(CompoundTag tag);
 	
 	/**
-	 * Call this method on the server to schedule a BlockEntity sync to client. This will call
-	 * {@link #toClientTag(CompoundTag)} on the server to generate the packet data, and then
-	 * {@link #fromClientTag(CompoundTag)} on the client to decode that data. This is preferable
-	 * to {@link World#updateListeners(net.minecraft.util.math.BlockPos, net.minecraft.block.BlockState, net.minecraft.block.BlockState, int)}
+	 * When called on the server, schedules a BlockEntity sync to client.
+	 * This will cause {@link #toClientTag(CompoundTag)} to be called on the
+	 * server to generate the packet data, and then
+	 * {@link #fromClientTag(CompoundTag)} on the client to decode that data.
+	 * 
+	 * <p>This is preferable to
+	 * {@link World#updateListeners(net.minecraft.util.math.BlockPos, net.minecraft.block.BlockState, net.minecraft.block.BlockState, int)}
 	 * because it does not cause entities to update their pathing as a side effect.
 	 */
 	default void sync() {
-		if (this instanceof BlockEntity) {
-			World world = ((BlockEntity) this).getWorld();
-
-			if (world instanceof ServerWorld) {
-				((ServerWorld) world).method_14178().markForUpdate(((BlockEntity) this).getPos());
-			}
-		}
+		World world = ((BlockEntity) this).getWorld();
+		Preconditions.checkNotNull(world); //Maintain distinct failure case from below
+		if (!(world instanceof ServerWorld)) throw new UnsupportedOperationException("Cannot call sync() on the logical client! Did you check world.isClient first?");
+		
+		((ServerWorld) world).method_14178().markForUpdate(((BlockEntity) this).getPos());
 	}
 }

--- a/fabric-networking-blockentity-v0/src/main/java/net/fabricmc/fabric/api/block/entity/BlockEntityClientSerializable.java
+++ b/fabric-networking-blockentity-v0/src/main/java/net/fabricmc/fabric/api/block/entity/BlockEntityClientSerializable.java
@@ -33,13 +33,16 @@ public interface BlockEntityClientSerializable {
 	/**
 	 * Call this method on the server to schedule a BlockEntity sync to client. This will call
 	 * {@link #toClientTag(CompoundTag)} on the server to generate the packet data, and then
-	 * {@link #fromClientTag(CompoundTag)} on the client to decode that data.
+	 * {@link #fromClientTag(CompoundTag)} on the client to decode that data. This is preferable
+	 * to {@link World#updateListeners(net.minecraft.util.math.BlockPos, net.minecraft.block.BlockState, net.minecraft.block.BlockState, int)}
+	 * because it does not cause entities to update their pathing as a side effect.
 	 */
 	default void sync() {
 		if (this instanceof BlockEntity) {
-			World world = ((BlockEntity)this).getWorld();
+			World world = ((BlockEntity) this).getWorld();
+
 			if (world instanceof ServerWorld) {
-				((ServerWorld)world).method_14178().markForUpdate(((BlockEntity)this).getPos());
+				((ServerWorld) world).method_14178().markForUpdate(((BlockEntity) this).getPos());
 			}
 		}
 	}

--- a/fabric-networking-blockentity-v0/src/main/java/net/fabricmc/fabric/api/block/entity/BlockEntityClientSerializable.java
+++ b/fabric-networking-blockentity-v0/src/main/java/net/fabricmc/fabric/api/block/entity/BlockEntityClientSerializable.java
@@ -45,7 +45,7 @@ public interface BlockEntityClientSerializable {
 	default void sync() {
 		World world = ((BlockEntity) this).getWorld();
 		Preconditions.checkNotNull(world); //Maintain distinct failure case from below
-		if (!(world instanceof ServerWorld)) throw new UnsupportedOperationException("Cannot call sync() on the logical client! Did you check world.isClient first?");
+		if (!(world instanceof ServerWorld)) throw new IllegalStateException("Cannot call sync() on the logical client! Did you check world.isClient first?");
 		
 		((ServerWorld) world).method_14178().markForUpdate(((BlockEntity) this).getPos());
 	}

--- a/fabric-networking-blockentity-v0/src/main/java/net/fabricmc/fabric/api/block/entity/BlockEntityClientSerializable.java
+++ b/fabric-networking-blockentity-v0/src/main/java/net/fabricmc/fabric/api/block/entity/BlockEntityClientSerializable.java
@@ -17,6 +17,9 @@
 package net.fabricmc.fabric.api.block.entity;
 
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 
 /**
  * Implement this interace on a BlockEntity which you would like to be
@@ -26,4 +29,19 @@ public interface BlockEntityClientSerializable {
 	void fromClientTag(CompoundTag tag);
 
 	CompoundTag toClientTag(CompoundTag tag);
+	
+	/**
+	 * Call this method on the server to schedule a BlockEntity sync to client. This will call
+	 * {@link #toClientTag(CompoundTag)} on the server to generate the packet data, and then
+	 * {@link #fromClientTag(CompoundTag)} on the client to decode that data.
+	 */
+	default void sync() {
+		World world = getWorld();
+		if (world instanceof ServerWorld) {
+			((ServerWorld)world).method_14178().markForUpdate(getPos());
+		}
+	}
+
+	public World getWorld();
+	public BlockPos getPos();
 }

--- a/fabric-networking-blockentity-v0/src/main/java/net/fabricmc/fabric/api/block/entity/BlockEntityClientSerializable.java
+++ b/fabric-networking-blockentity-v0/src/main/java/net/fabricmc/fabric/api/block/entity/BlockEntityClientSerializable.java
@@ -16,9 +16,9 @@
 
 package net.fabricmc.fabric.api.block.entity;
 
+import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 /**
@@ -36,12 +36,11 @@ public interface BlockEntityClientSerializable {
 	 * {@link #fromClientTag(CompoundTag)} on the client to decode that data.
 	 */
 	default void sync() {
-		World world = getWorld();
-		if (world instanceof ServerWorld) {
-			((ServerWorld)world).method_14178().markForUpdate(getPos());
+		if (this instanceof BlockEntity) {
+			World world = ((BlockEntity)this).getWorld();
+			if (world instanceof ServerWorld) {
+				((ServerWorld)world).method_14178().markForUpdate(((BlockEntity)this).getPos());
+			}
 		}
 	}
-
-	World getWorld();
-	BlockPos getPos();
 }


### PR DESCRIPTION
Currently BlockEntityClientSerializable is missing a clear and side-effect-free way to trigger the actual sync. Marking the block for update on the world itself causes mobs to re-path around the block, so we let the ServerChunkManager know (in the future we might perhaps map `method_14178` as `getServerChunkManager`, as it's a casted version of `getChunkManager`).

This is the sync method working in https://github.com/CottonMC/UnitedConveyors/blob/master/src/main/java/io/github/cottonmc/conveyors/ConveyorBlockEntity.java#L227-L231