### PR TITLE
Allows generic event declaration

### DIFF
--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
@@ -55,7 +55,7 @@ public final class EventFactory {
 	 * @param <T>            The listener type.
 	 * @return The Event instance.
 	 */
-	public static <T> Event<T> createArrayBacked(Class<T> type, Function<T[], T> invokerFactory) {
+	public static <T> Event<T> createArrayBacked(Class<? super T> type, Function<T[], T> invokerFactory) {
 		return EventFactoryImpl.createArrayBacked(type, invokerFactory);
 	}
 

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/event/ArrayBackedEvent.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/event/ArrayBackedEvent.java
@@ -23,12 +23,12 @@ import java.util.Arrays;
 import java.util.function.Function;
 
 class ArrayBackedEvent<T> extends Event<T> {
-	private final Class<T> type;
+	private final Class<? super T> type;
 	private final Function<T[], T> invokerFactory;
 	private final T dummyInvoker;
 	private T[] handlers;
 
-	ArrayBackedEvent(Class<T> type, T dummyInvoker, Function<T[], T> invokerFactory) {
+	ArrayBackedEvent(Class<? super T> type, T dummyInvoker, Function<T[], T> invokerFactory) {
 		this.type = type;
 		this.dummyInvoker = dummyInvoker;
 		this.invokerFactory = invokerFactory;

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/event/EventFactoryImpl.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/event/EventFactoryImpl.java
@@ -40,11 +40,11 @@ public final class EventFactoryImpl {
 		ARRAY_BACKED_EVENTS.forEach(ArrayBackedEvent::update);
 	}
 
-	public static <T> Event<T> createArrayBacked(Class<T> type, Function<T[], T> invokerFactory) {
+	public static <T> Event<T> createArrayBacked(Class<? super T> type, Function<T[], T> invokerFactory) {
 		return createArrayBacked(type, null /* buildEmptyInvoker(type, invokerFactory) */, invokerFactory);
 	}
 
-	public static <T> Event<T> createArrayBacked(Class<T> type, T emptyInvoker, Function<T[], T> invokerFactory) {
+	public static <T> Event<T> createArrayBacked(Class<? super T> type, T emptyInvoker, Function<T[], T> invokerFactory) {
 		ArrayBackedEvent<T> event = new ArrayBackedEvent<>(type, emptyInvoker, invokerFactory);
 		ARRAY_BACKED_EVENTS.add(event);
 		return event;


### PR DESCRIPTION
Originally part of #383, but it turns out I need to use this elsewhere, so I am pulling this out early.

Example usage: https://github.com/FabricMC/fabric/pull/383/files#diff-702c12488002da9a8842a6c40eef956dR36-R42 (allow generic callbacks)
Example usage 2: https://github.com/liachmodded/cartprotocol/blob/4fa341e55b44c73ade63c05668a2a301800ff7b2/src/code/java/com/github/liachmodded/cartprotocol/api/event/EventTools.java#L27
(Can remove that cast and suppress warnings once this pr is accepted)

@sfPlayer1 This pr should be backward compatible bytecode wise and compilation wise so I hope you can consider this and merge this. It would be very helpful if you do merge this pull request.

Also a cherry pick to 1.14 should be easy as well.

Signed-off-by: liach <liach@users.noreply.github.com>