### PR TITLE
Fix indigo rendering in 19w42a

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 def ENV = System.getenv()
 
 class Globals {
-	static def baseVersion = "0.4.6"
+	static def baseVersion = "0.4.7"
 	static def mcVersion = "19w42a"
 	static def yarnVersion = "+build.1"
 }

--- a/fabric-renderer-indigo/build.gradle
+++ b/fabric-renderer-indigo/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-renderer-indigo"
-version = getSubprojectVersion(project, "0.2.6")
+version = getSubprojectVersion(project, "0.2.7")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/IndigoMixinConfigPlugin.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/IndigoMixinConfigPlugin.java
@@ -61,14 +61,6 @@ public class IndigoMixinConfigPlugin implements IMixinConfigPlugin {
 	}
 
 	static boolean shouldForceCompatibility() {
-		if(true){
-			/**
-			 * TODO: remove me, and fix indigo
-			 *
-			 * This has been done to work around some funky rendering issues as of 19w42a
-			 */
-			return true;
-		}
 		loadIfNeeded();
 		return forceCompatibility;
 	}

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractQuadRenderer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractQuadRenderer.java
@@ -45,6 +45,8 @@ public abstract class AbstractQuadRenderer {
 
 	protected abstract Matrix4f matrix();
 
+	protected abstract int overlay();
+
 	AbstractQuadRenderer(BlockRenderInfo blockInfo, Function<RenderLayer, VertexConsumer> bufferFunc, AoCalculator aoCalc, QuadTransform transform) {
 		this.blockInfo = blockInfo;
 		this.bufferFunc = bufferFunc;
@@ -69,15 +71,16 @@ public abstract class AbstractQuadRenderer {
 
 	/** final output step, common to all renders */
 	private void bufferQuad(MutableQuadViewImpl quad, RenderLayer renderLayer) {
-		bufferQuad(bufferFunc.apply(renderLayer), quad, matrix());
+		bufferQuad(bufferFunc.apply(renderLayer), quad, matrix(), overlay());
 	}
 
-	public static void bufferQuad(VertexConsumer buff, MutableQuadViewImpl quad, Matrix4f matrix) {
+	public static void bufferQuad(VertexConsumer buff, MutableQuadViewImpl quad, Matrix4f matrix, int overlay) {
 		for (int i = 0; i < 4; i++) {
 			buff.vertex(matrix, quad.x(i), quad.y(i), quad.z(i));
 			final int color = quad.spriteColor(i, 0);
 			buff.color(color & 0xFF, (color >> 8) & 0xFF, (color >> 16) & 0xFF, (color >> 24) & 0xFF);
 			buff.texture(quad.spriteU(i, 0), quad.spriteV(i, 0));
+			buff.defaultOverlay(overlay);
 			buff.light(quad.lightmap(i));
 			buff.normal(quad.normalX(i), quad.normalY(i), quad.normalZ(i));
 			buff.next();

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractRenderContext.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractRenderContext.java
@@ -25,6 +25,7 @@ abstract class AbstractRenderContext implements RenderContext {
 	private final ObjectArrayList<QuadTransform> transformStack = new ObjectArrayList<>();
 	private static final QuadTransform NO_TRANSFORM = (q) -> true;
 	protected Matrix4f matrix;
+	protected int overlay;
 
 	private final QuadTransform stackTransform = (q) -> {
 		int i = transformStack.size() - 1;

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractRenderContext.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractRenderContext.java
@@ -19,26 +19,12 @@ package net.fabricmc.indigo.renderer.render;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
-import net.minecraft.block.BlockState;
 import net.minecraft.client.util.math.Matrix4f;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.MatrixStack;
-import net.minecraft.util.math.Vec3d;
-import net.minecraft.world.BlockRenderView;
 
 abstract class AbstractRenderContext implements RenderContext {
 	private final ObjectArrayList<QuadTransform> transformStack = new ObjectArrayList<>();
 	private static final QuadTransform NO_TRANSFORM = (q) -> true;
-	protected MatrixStack matrixStack;
 	protected Matrix4f matrix;
-
-	protected void prepareMatrix(BlockState blockState, BlockPos blockPos, BlockRenderView blockView, MatrixStack matrixStack) {
-		this.matrixStack = matrixStack;
-		Vec3d vec = blockState.getOffsetPos(blockView, blockPos);
-		matrixStack.push();
-		matrixStack.translate((double)(blockPos.getX() & 15) + vec.x, (double)(blockPos.getY() & 15) + vec.y, (double)(blockPos.getZ() & 15) + vec.z);
-		matrix = matrixStack.peek();
-	}
 
 	private final QuadTransform stackTransform = (q) -> {
 		int i = transformStack.size() - 1;

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/BlockRenderContext.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/BlockRenderContext.java
@@ -50,6 +50,7 @@ public class BlockRenderContext extends AbstractRenderContext implements RenderC
 	private int overlay;
 	private boolean isCallingVanilla = false;
 	private boolean didOutput = false;
+	private MatrixStack matrixStack;
 
 	public boolean isCallingVanilla() {
 		return isCallingVanilla;
@@ -76,7 +77,8 @@ public class BlockRenderContext extends AbstractRenderContext implements RenderC
 	public boolean tesselate(BlockModelRenderer vanillaRenderer, BlockRenderView blockView, BakedModel model, BlockState state, BlockPos pos, MatrixStack matrixStack, VertexConsumer buffer, boolean checkSides, long seed, int overlay) {
 		this.vanillaRenderer = vanillaRenderer;
 		this.bufferBuilder = buffer;
-		this.prepareMatrix(state, pos, blockView, matrixStack);
+		this.matrixStack = matrixStack;
+		this.matrix = matrixStack.peek();
 
 		this.seed = seed;
 		this.overlay = overlay;
@@ -90,8 +92,6 @@ public class BlockRenderContext extends AbstractRenderContext implements RenderC
 		this.vanillaRenderer = null;
 		blockInfo.release();
 		this.bufferBuilder = null;
-
-		matrixStack.pop();
 
 		return didOutput;
 	}

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/BlockRenderContext.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/BlockRenderContext.java
@@ -47,7 +47,6 @@ public class BlockRenderContext extends AbstractRenderContext implements RenderC
 	private BlockModelRenderer vanillaRenderer;
 	private VertexConsumer bufferBuilder;
 	private long seed;
-	private int overlay;
 	private boolean isCallingVanilla = false;
 	private boolean didOutput = false;
 	private MatrixStack matrixStack;
@@ -110,6 +109,11 @@ public class BlockRenderContext extends AbstractRenderContext implements RenderC
 		@Override
 		protected Matrix4f matrix() {
 			return matrix;
+		}
+
+		@Override
+		protected int overlay() {
+			return overlay;
 		}
 	}
 

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/ItemRenderContext.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/ItemRenderContext.java
@@ -88,6 +88,7 @@ public class ItemRenderContext extends AbstractRenderContext implements RenderCo
 		this.bufferBuilder = buffer;
 		this.matrixStack = matrixStack;
 		this.matrix = matrixStack.peek();
+		this.overlay = overlay;
 
 		this.vanillaHandler = vanillaHandler;
 		model.emitItemQuads(stack, randomSupplier, this);
@@ -155,7 +156,7 @@ public class ItemRenderContext extends AbstractRenderContext implements RenderCo
 			quad.lightmap(i, ColorHelper.maxBrightness(quad.lightmap(i), lightmap));
 		}
 
-		AbstractQuadRenderer.bufferQuad(bufferBuilder, quad, matrix);
+		AbstractQuadRenderer.bufferQuad(bufferBuilder, quad, matrix, overlay);
 	}
 
 	@Override

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainFallbackConsumer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainFallbackConsumer.java
@@ -55,7 +55,7 @@ import net.minecraft.util.math.Direction;
  *  vertex data is sent to the byte buffer.  Generally POJO array access will be faster than
  *  manipulating the data via NIO.
  */
-public class TerrainFallbackConsumer extends AbstractQuadRenderer implements Consumer<BakedModel> {
+public abstract class TerrainFallbackConsumer extends AbstractQuadRenderer implements Consumer<BakedModel> {
 	private static Value MATERIAL_FLAT = (Value) IndigoRenderer.INSTANCE.materialFinder().disableAo(0, true).find();
 	private static Value MATERIAL_SHADED = (Value) IndigoRenderer.INSTANCE.materialFinder().find();
 

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainMeshConsumer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainMeshConsumer.java
@@ -22,7 +22,7 @@ import net.fabricmc.fabric.api.renderer.v1.render.RenderContext.QuadTransform;
 import net.fabricmc.indigo.renderer.aocalc.AoCalculator;
 import net.minecraft.client.util.math.Matrix4f;
 
-public class TerrainMeshConsumer extends AbstractMeshConsumer {
+public abstract class TerrainMeshConsumer extends AbstractMeshConsumer {
 	final Supplier<Matrix4f> matrixSupplier;
 
 	TerrainMeshConsumer(TerrainBlockRenderInfo blockInfo, ChunkRenderInfo chunkInfo, AoCalculator aoCalc, QuadTransform transform, Supplier<Matrix4f> matrixSupplier) {

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainRenderContext.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainRenderContext.java
@@ -46,8 +46,20 @@ public class TerrainRenderContext extends AbstractRenderContext implements Rende
 	private final TerrainBlockRenderInfo blockInfo = new TerrainBlockRenderInfo();
 	private final ChunkRenderInfo chunkInfo = new ChunkRenderInfo();
 	private final AoCalculator aoCalc = new AoCalculator(blockInfo, chunkInfo::cachedBrightness, chunkInfo::cachedAoLevel);
-	private final TerrainMeshConsumer meshConsumer = new TerrainMeshConsumer(blockInfo, chunkInfo, aoCalc, this::transform, this::matrix);
-	private final TerrainFallbackConsumer fallbackConsumer = new TerrainFallbackConsumer(blockInfo, chunkInfo, aoCalc, this::transform, this::matrix);
+
+	private final TerrainMeshConsumer meshConsumer = new TerrainMeshConsumer(blockInfo, chunkInfo, aoCalc, this::transform, this::matrix) {
+		@Override
+		protected int overlay() {
+			return overlay;
+		}
+	};
+
+	private final TerrainFallbackConsumer fallbackConsumer = new TerrainFallbackConsumer(blockInfo, chunkInfo, aoCalc, this::transform, this::matrix) {
+		@Override
+		protected int overlay() {
+			return overlay;
+		}
+	};
 
 	public TerrainRenderContext prepare(ChunkRendererRegion blockView, ChunkRenderer chunkRenderer, ChunkRenderData chunkData, BlockLayeredBufferBuilderStorage builders) {
 		blockInfo.setBlockView(blockView);

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainRenderContext.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainRenderContext.java
@@ -66,7 +66,7 @@ public class TerrainRenderContext extends AbstractRenderContext implements Rende
 
 	/** Called from chunk renderer hook. */
 	public boolean tesselateBlock(BlockState blockState, BlockPos blockPos, final BakedModel model, MatrixStack matrixStack) {
-		prepareMatrix(blockState, blockPos, blockInfo.blockView, matrixStack);
+		this.matrix = matrixStack.peek();
 		try {
 			aoCalc.clear();
 			blockInfo.prepareForBlock(blockState, blockPos, model.useAmbientOcclusion());
@@ -77,7 +77,6 @@ public class TerrainRenderContext extends AbstractRenderContext implements Rende
 			CrashReportSection.addBlockInfo(crashReportElement_1, blockPos, blockState);
 			throw new CrashException(crashReport_1);
 		}
-		matrixStack.pop();
 		// false because we've already marked the chunk as populated - caller doesn't need to
 		return false;
 	}


### PR DESCRIPTION
Mojang moved matrix translation setup for chunk position up the stack into the methods that call `tesselateBlock.`  Indigo still applies the matrix to vertex data but the translation setup logic was removed.