### PR TITLE
Fix BlockRenderLayerMapImpl no longer working in 19w42a. Move some LOG.warns to InvalidParameterException

### DIFF
--- a/fabric-blockrenderlayer-v1/build.gradle
+++ b/fabric-blockrenderlayer-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-blockrenderlayer-v1"
-version = getSubprojectVersion(project, "1.1.0")
+version = getSubprojectVersion(project, "1.1.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-blockrenderlayer-v1/src/main/java/net/fabricmc/fabric/impl/blockrenderlayer/BlockRenderLayerMapImpl.java
+++ b/fabric-blockrenderlayer-v1/src/main/java/net/fabricmc/fabric/impl/blockrenderlayer/BlockRenderLayerMapImpl.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.fabric.impl.blockrenderlayer;
 
-import java.security.InvalidParameterException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -34,10 +33,10 @@ public class BlockRenderLayerMapImpl implements BlockRenderLayerMap {
 	@Override
 	public void putBlock(Block block, RenderLayer renderLayer) {
 		if (block == null) {
-			throw new InvalidParameterException("Request to map null block to BlockRenderLayer");
+			throw new IllegalArgumentException("Request to map null block to BlockRenderLayer");
 		}
 		if (renderLayer == null) {
-			throw new InvalidParameterException("Request to map block " + block.toString() + " to null BlockRenderLayer");
+			throw new IllegalArgumentException("Request to map block " + block.toString() + " to null BlockRenderLayer");
 		}
 		blockHandler.accept(block, renderLayer);
 	}
@@ -45,10 +44,10 @@ public class BlockRenderLayerMapImpl implements BlockRenderLayerMap {
 	@Override
 	public void putItem(Item item, RenderLayer renderLayer) {
 		if (item == null) {
-			throw new InvalidParameterException("Request to map null item to BlockRenderLayer");
+			throw new IllegalArgumentException("Request to map null item to BlockRenderLayer");
 		}
 		if (renderLayer == null) {
-			throw new InvalidParameterException("Request to map item " + item.toString() + " to null BlockRenderLayer");
+			throw new IllegalArgumentException("Request to map item " + item.toString() + " to null BlockRenderLayer");
 		}
 		itemHandler.accept(item, renderLayer);
 	}
@@ -56,10 +55,10 @@ public class BlockRenderLayerMapImpl implements BlockRenderLayerMap {
 	@Override
 	public void putFluid(Fluid fluid, RenderLayer renderLayer) {
 		if (fluid == null) {
-			throw new InvalidParameterException("Request to map null fluid to BlockRenderLayer");
+			throw new IllegalArgumentException("Request to map null fluid to BlockRenderLayer");
 		}
 		if (renderLayer == null) {
-			throw new InvalidParameterException("Request to map fluid " + fluid.toString() + " to null BlockRenderLayer");
+			throw new IllegalArgumentException("Request to map fluid " + fluid.toString() + " to null BlockRenderLayer");
 		}
 		fluidHandler.accept(fluid, renderLayer);
 	}

--- a/fabric-blockrenderlayer-v1/src/main/java/net/fabricmc/fabric/impl/blockrenderlayer/BlockRenderLayerMapImpl.java
+++ b/fabric-blockrenderlayer-v1/src/main/java/net/fabricmc/fabric/impl/blockrenderlayer/BlockRenderLayerMapImpl.java
@@ -32,34 +32,25 @@ public class BlockRenderLayerMapImpl implements BlockRenderLayerMap {
 	
 	@Override
 	public void putBlock(Block block, RenderLayer renderLayer) {
-		if (block == null) {
-			throw new IllegalArgumentException("Request to map null block to BlockRenderLayer");
-		}
-		if (renderLayer == null) {
-			throw new IllegalArgumentException("Request to map block " + block.toString() + " to null BlockRenderLayer");
-		}
+		if (block == null) throw new IllegalArgumentException("Request to map null block to BlockRenderLayer");
+		if (renderLayer == null) throw new IllegalArgumentException("Request to map block " + block.toString() + " to null BlockRenderLayer");
+
 		blockHandler.accept(block, renderLayer);
 	}
 
 	@Override
 	public void putItem(Item item, RenderLayer renderLayer) {
-		if (item == null) {
-			throw new IllegalArgumentException("Request to map null item to BlockRenderLayer");
-		}
-		if (renderLayer == null) {
-			throw new IllegalArgumentException("Request to map item " + item.toString() + " to null BlockRenderLayer");
-		}
+		if (item == null) throw new IllegalArgumentException("Request to map null item to BlockRenderLayer");
+		if (renderLayer == null) throw new IllegalArgumentException("Request to map item " + item.toString() + " to null BlockRenderLayer");
+
 		itemHandler.accept(item, renderLayer);
 	}
 
 	@Override
 	public void putFluid(Fluid fluid, RenderLayer renderLayer) {
-		if (fluid == null) {
-			throw new IllegalArgumentException("Request to map null fluid to BlockRenderLayer");
-		}
-		if (renderLayer == null) {
-			throw new IllegalArgumentException("Request to map fluid " + fluid.toString() + " to null BlockRenderLayer");
-		}
+		if (fluid == null) throw new IllegalArgumentException("Request to map null fluid to BlockRenderLayer");
+		if (renderLayer == null) throw new IllegalArgumentException("Request to map fluid " + fluid.toString() + " to null BlockRenderLayer");
+
 		fluidHandler.accept(fluid, renderLayer);
 	}
 	

--- a/fabric-blockrenderlayer-v1/src/main/java/net/fabricmc/fabric/impl/blockrenderlayer/BlockRenderLayerMapImpl.java
+++ b/fabric-blockrenderlayer-v1/src/main/java/net/fabricmc/fabric/impl/blockrenderlayer/BlockRenderLayerMapImpl.java
@@ -35,33 +35,33 @@ public class BlockRenderLayerMapImpl implements BlockRenderLayerMap {
 	public void putBlock(Block block, RenderLayer renderLayer) {
 		if (block == null) {
 			throw new InvalidParameterException("Request to map null block to BlockRenderLayer");
-		} else if (renderLayer == null) {
-			throw new InvalidParameterException("Request to map block " + block.toString() + " to null BlockRenderLayer");
-		} else {
-			blockHandler.accept(block, renderLayer);
 		}
+		if (renderLayer == null) {
+			throw new InvalidParameterException("Request to map block " + block.toString() + " to null BlockRenderLayer");
+		}
+		blockHandler.accept(block, renderLayer);
 	}
 
 	@Override
 	public void putItem(Item item, RenderLayer renderLayer) {
 		if (item == null) {
 			throw new InvalidParameterException("Request to map null item to BlockRenderLayer");
-		} else if (renderLayer == null) {
-			throw new InvalidParameterException("Request to map item " + item.toString() + " to null BlockRenderLayer");
-		} else {
-			itemHandler.accept(item, renderLayer);
 		}
+		if (renderLayer == null) {
+			throw new InvalidParameterException("Request to map item " + item.toString() + " to null BlockRenderLayer");
+		}
+		itemHandler.accept(item, renderLayer);
 	}
 
 	@Override
 	public void putFluid(Fluid fluid, RenderLayer renderLayer) {
 		if (fluid == null) {
 			throw new InvalidParameterException("Request to map null fluid to BlockRenderLayer");
-		} else if (renderLayer == null) {
-			throw new InvalidParameterException("Request to map fluid " + fluid.toString() + " to null BlockRenderLayer");
-		} else {
-			fluidHandler.accept(fluid, renderLayer);
 		}
+		if (renderLayer == null) {
+			throw new InvalidParameterException("Request to map fluid " + fluid.toString() + " to null BlockRenderLayer");
+		}
+		fluidHandler.accept(fluid, renderLayer);
 	}
 	
 	public static final BlockRenderLayerMap INSTANCE = new BlockRenderLayerMapImpl();

--- a/fabric-blockrenderlayer-v1/src/main/java/net/fabricmc/fabric/impl/blockrenderlayer/BlockRenderLayerMapImpl.java
+++ b/fabric-blockrenderlayer-v1/src/main/java/net/fabricmc/fabric/impl/blockrenderlayer/BlockRenderLayerMapImpl.java
@@ -16,12 +16,13 @@
 
 package net.fabricmc.fabric.impl.blockrenderlayer;
 
+import java.security.InvalidParameterException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.BiConsumer;
 
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.item.Item;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
 import net.minecraft.block.Block;
@@ -33,9 +34,9 @@ public class BlockRenderLayerMapImpl implements BlockRenderLayerMap {
 	@Override
 	public void putBlock(Block block, RenderLayer renderLayer) {
 		if (block == null) {
-			LOG.warn("Ignoring request to map null block to BlockRenderLayer");
+			throw new InvalidParameterException("Request to map null block to BlockRenderLayer");
 		} else if (renderLayer == null) {
-			LOG.warn("Ignoring request to map block " + block.toString() + " to null BlockRenderLayer");
+			throw new InvalidParameterException("Request to map block " + block.toString() + " to null BlockRenderLayer");
 		} else {
 			blockHandler.accept(block, renderLayer);
 		}
@@ -44,9 +45,9 @@ public class BlockRenderLayerMapImpl implements BlockRenderLayerMap {
 	@Override
 	public void putItem(Item item, RenderLayer renderLayer) {
 		if (item == null) {
-			LOG.warn("Ignoring request to map null item to BlockRenderLayer");
+			throw new InvalidParameterException("Request to map null item to BlockRenderLayer");
 		} else if (renderLayer == null) {
-			LOG.warn("Ignoring request to map item " + item.toString() + " to null BlockRenderLayer");
+			throw new InvalidParameterException("Request to map item " + item.toString() + " to null BlockRenderLayer");
 		} else {
 			itemHandler.accept(item, renderLayer);
 		}
@@ -55,35 +56,32 @@ public class BlockRenderLayerMapImpl implements BlockRenderLayerMap {
 	@Override
 	public void putFluid(Fluid fluid, RenderLayer renderLayer) {
 		if (fluid == null) {
-			LOG.warn("Ignoring request to map null fluid to BlockRenderLayer");
+			throw new InvalidParameterException("Request to map null fluid to BlockRenderLayer");
 		} else if (renderLayer == null) {
-			LOG.warn("Ignoring request to map fluid " + fluid.toString() + " to null BlockRenderLayer");	
+			throw new InvalidParameterException("Request to map fluid " + fluid.toString() + " to null BlockRenderLayer");
 		} else {
 			fluidHandler.accept(fluid, renderLayer);
 		}
 	}
 	
 	public static final BlockRenderLayerMap INSTANCE = new BlockRenderLayerMapImpl();
-	
-	private static final Logger LOG = LogManager.getLogger();
-	
-	// These should never be used before our Mixin populates them because a non-null BRL instance is 
-	// a required parameter of our methods. They are given dummy consumers that log
-	// warnings in case something goes wrong.
-	
-	private static BiConsumer<Block, RenderLayer> blockHandler = (b, l) -> {
-		LOG.warn("Unable to map Block {} to BlockRenderLayer. Mapping handler not ready.", b);
-	};
 
-	private static BiConsumer<Item, RenderLayer> itemHandler = (b, l) -> {
-		LOG.warn("Unable to map Item {} to BlockRenderLayer. Mapping handler not ready.", b);
-	};
+	private static Map<Block, RenderLayer> blockRenderLayerMap = new HashMap<>();
+	private static Map<Item, RenderLayer> itemRenderLayerMap = new HashMap<>();
+	private static Map<Fluid, RenderLayer> fluidRenderLayerMap = new HashMap<>();
 
-	private static BiConsumer<Fluid, RenderLayer> fluidHandler = (f, b) -> {
-		LOG.warn("Unable to map Fluid {} to BlockRenderLayer. Mapping handler not ready.", f);
-	};
+	//This consumers initially add to the maps above, and then are later set (when initialize is called) to insert straight into the target map.
+	private static BiConsumer<Block, RenderLayer> blockHandler = (b, l) -> blockRenderLayerMap.put(b, l);
+	private static BiConsumer<Item, RenderLayer> itemHandler = (i, l) -> itemRenderLayerMap.put(i, l);
+	private static BiConsumer<Fluid, RenderLayer> fluidHandler = (f, b) -> fluidRenderLayerMap.put(f, b);
 
 	public static void initialize(BiConsumer<Block, RenderLayer> blockHandlerIn, BiConsumer<Item, RenderLayer> itemHandlerIn, BiConsumer<Fluid, RenderLayer> fluidHandlerIn) {
+		//Add all the pre existing render layers
+		blockRenderLayerMap.forEach(blockHandlerIn);
+		itemRenderLayerMap.forEach(itemHandlerIn);
+		fluidRenderLayerMap.forEach(fluidHandlerIn);
+
+		//Set the handlers to directly accept later additions
 		blockHandler = blockHandlerIn;
 		itemHandler = itemHandlerIn;
 		fluidHandler = fluidHandlerIn;


### PR DESCRIPTION
In 19w42a new class (class_4699) that contains 3 maps for Item, Block and Fluid RenderLayers.
Before these maps were in the RenderLayer class causing them to be populated well before this API had a chance to get to handling the consumers.

I have tweaked the impl to handle RenderLayers being added before initialize is called and after, this removes the need to ensure the class load order is correct.