### PR TITLE
Add checkstyle, format existing code accordingly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .gradle
 
 # Eclipse
+.checkstyle
 .classpath
 .metadata
 .settings
@@ -20,6 +21,7 @@ bin/
 build/
 jars/
 out/
+classes/
 
 # Debug artifacts
 run

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ def getBranch(){
 }
 
 allprojects {
+	apply plugin: 'checkstyle'
 	apply plugin: 'maven-publish'
 	apply plugin: 'fabric-loom'
 	apply plugin: 'net.minecrell.licenser'
@@ -51,8 +52,6 @@ allprojects {
 	targetCompatibility = 1.8
 
 	group = "net.fabricmc.fabric-api"
-
-
 
 	dependencies {
 		minecraft "com.mojang:minecraft:$Globals.mcVersion"
@@ -105,9 +104,14 @@ allprojects {
 		classifier = 'sources'
 		from sourceSets.main.allSource
 	}
-	
+
+	checkstyle {
+		configFile = rootProject.file("checkstyle.xml")
+		toolVersion = '8.25'
+	}
 }
-javadoc{
+
+javadoc {
 	options.memberLevel = "PACKAGE"
 	allprojects.each{
 			source( it.sourceSets.main.allJava.srcDirs)

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+	<property name="charset" value="UTF-8"/>
+	<property name="fileExtensions" value="java"/>
+
+	<module name="NewlineAtEndOfFile"/>
+
+	<!-- disallow trailing whitespace -->
+	<module name="RegexpSingleline">
+		<property name="format" value="\s+$"/>
+		<property name="message" value="trailing whitespace"/>
+	</module>
+
+	<!-- note: RegexpMultiline shows nicer messages than Regexp, but has to be outside TreeWalker -->
+	<!-- disallow multiple consecutive blank lines -->
+	<module name="RegexpMultiline">
+		<property name="format" value="\n[\r\t ]*\n[\r\t ]*\n"/>
+		<property name="message" value="adjacent blank lines"/>
+	</module>
+
+	<!-- disallow blank after { -->
+	<module name="RegexpMultiline">
+		<property name="format" value="\{[\r\t ]*\n[\r\t ]*\n"/>
+		<property name="message" value="blank line after '{'"/>
+	</module>
+
+	<!-- disallow blank before } -->
+	<module name="RegexpMultiline">
+		<property name="format" value="\n[\r\t ]*\n[\r\t ]*\}"/>
+		<property name="message" value="blank line before '}'"/>
+	</module>
+
+	<!-- require blank before { in the same indentation level -->
+	<module name="RegexpMultiline">
+		<!-- the regex works as follows:
+		It matches (=fails) for \n<indentation><something>\n<same indentation><control statement>[...]{\n
+		while <something> is a single line comment, it'll look for a blank line one line earlier
+		if <something> is a space, indicating a formatting error or ' */', it'll ignore the instance
+		if <something> is a tab, indicating a continued line, it'll ignore the instance
+		<control statement> is 'if', 'do', 'while', 'for' or nothing (instance initializer block)
+
+		- first \n: with positive lookbehind (?<=\n) to move the error marker to a more reasonable place
+		- capture tabs for <indentation>, later referenced via \1
+		- remaining preceding line as a non-comment (doesn't start with '/', '//', ' ' or '\t') or multiple lines where all but the first are a single line comment with the same indentation
+		- new line
+		- <indentation> as captured earlier
+		- <control statement> as specified above
+		- { before the next new line -->
+		<property name="format" value="(?&lt;=\n)([\t]+)(?:[^/\n \t][^\n]*|/[^/\n][^\n]*|[^/\n][^\n]*(\n\1//[^\n]*)+)\n\1(|(if|do|while|for)[^\n]+)\{[\r\t ]*\n"/>
+		<property name="message" value="missing blank line before block at same indentation level"/>
+	</module>
+
+	<!-- require blank after } in the same indentation level -->
+	<module name="RegexpMultiline">
+		<!-- \n<indentation>}\n<same indentation><whatever unless newline, '}' or starting with cas(e) or def(ault)> -->
+		<property name="format" value="(?&lt;=\n)([\t]+)\}\n\1(?:[^\r\n\}cd]|c[^\r\na]|ca[^\r\ns]|d[^\r\ne]|de[^\r\nf])"/>
+		<property name="message" value="missing blank line after block at same indentation level"/>
+	</module>
+
+	<module name="TreeWalker">
+		<!-- Ensure all imports are ship shape -->
+		<module name="AvoidStarImport"/>
+		<module name="IllegalImport"/>
+		<module name="RedundantImport"/>
+		<module name="UnusedImports"/>
+
+		<module name="ImportOrder">
+			<property name="groups" value="java,javax,*,net.minecraft,net.fabricmc"/>
+			<property name="ordered" value="false"/><!-- the plugin orders alphabetically without considering separators.. -->
+			<property name="separated" value="true"/>
+			<property name="option" value="top"/>
+			<property name="sortStaticImportsAlphabetically" value="true"/>
+		</module>
+
+		<!-- Ensures braces are at the end of a line -->
+		<module name="LeftCurly"/>
+		<module name="RightCurly"/>
+
+		<!-- single line statements on one line, -->
+		<module name="NeedBraces">
+			<property name="tokens" value="LITERAL_IF,LITERAL_FOR,LITERAL_WHILE"/>
+			<property name="allowSingleLineStatement" value="true"/>
+		</module>
+		<module name="NeedBraces">
+			<property name="tokens" value="LITERAL_ELSE,LITERAL_DO"/>
+			<property name="allowSingleLineStatement" value="false"/>
+		</module>
+
+		<module name="EmptyLineSeparator">
+			<property name="allowNoEmptyLineBetweenFields" value="true"/>
+			<property name="allowMultipleEmptyLines" value="false"/>
+			<!-- exclude  METHOD_DEF and VARIABLE_DEF -->
+			<property name="tokens" value="PACKAGE_DEF,IMPORT,STATIC_IMPORT,CLASS_DEF,INTERFACE_DEF,ENUM_DEF,STATIC_INIT,INSTANCE_INIT,CTOR_DEF"/>
+		</module>
+
+		<module name="Indentation">
+			<property name="basicOffset" value="8"/>
+			<property name="caseIndent" value="0"/>
+			<property name="throwsIndent" value="8"/>
+			<property name="arrayInitIndent" value="8"/>
+			<property name="lineWrappingIndentation" value="16"/>
+		</module>
+
+		<module name="WhitespaceAround">
+			<!-- Allow PLUS, MINUS, MUL, DIV as they may be more readable without spaces in some cases -->
+			<property name="tokens" value="ASSIGN,BAND,BAND_ASSIGN,BOR,BOR_ASSIGN,BSR,BSR_ASSIGN,BXOR,BXOR_ASSIGN,COLON,DIV_ASSIGN,DO_WHILE,EQUAL,GE,GT,LAMBDA,LAND,LCURLY,LE,LITERAL_CATCH,LITERAL_DO,LITERAL_ELSE,LITERAL_FINALLY,LITERAL_FOR,LITERAL_IF,LITERAL_RETURN,LITERAL_SWITCH,LITERAL_SYNCHRONIZED,LITERAL_TRY,LITERAL_WHILE,LOR,LT,MINUS_ASSIGN,MOD,MOD_ASSIGN,NOT_EQUAL,PLUS_ASSIGN,QUESTION,RCURLY,SL,SLIST,SL_ASSIGN,SR,SR_ASSIGN,STAR,STAR_ASSIGN,LITERAL_ASSERT,TYPE_EXTENSION_AND"/>
+		</module>
+		<module name="SingleSpaceSeparator"/>
+		<module name="GenericWhitespace"/>
+		<module name="CommentsIndentation"/>
+
+		<module name="ArrayTypeStyle"/>
+		<module name="DefaultComesLast">
+			<property name="skipIfLastAndSharedWithCase" value="true"/>
+		</module>
+		<module name="SimplifyBooleanExpression"/>
+		<module name="SimplifyBooleanReturn"/>
+		<module name="StringLiteralEquality"/>
+
+		<module name="ModifierOrder"/>
+		<module name="RedundantModifier"/>
+
+		<module name="AnnotationLocation"/>
+		<module name="MissingOverride"/>
+
+		<!-- By default this allows catch blocks with only comments -->
+		<module name="EmptyCatchBlock"/>
+
+		<!-- Enforce tabs -->
+		<module name="RegexpSinglelineJava">
+			<property name="format" value="^\t* ([^*]|\*[^ /])"/>
+			<property name="message" value="non-tab indentation"/>
+		</module>
+
+		<module name="OuterTypeFilename"/>
+
+		<!--<module name="InvalidJavadocPosition"/>-->
+		<module name="JavadocParagraph"/>
+		<module name="JavadocStyle"/>
+		<module name="AtclauseOrder">
+			<property name="tagOrder" value="@param,@return,@throws,@deprecated"/>
+		</module>
+	</module>
+</module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -38,7 +38,7 @@
 		while <something> is a single line comment, it'll look for a blank line one line earlier
 		if <something> is a space, indicating a formatting error or ' */', it'll ignore the instance
 		if <something> is a tab, indicating a continued line, it'll ignore the instance
-		<control statement> is 'if', 'do', 'while', 'for' or nothing (instance initializer block)
+		<control statement> is 'if', 'do', 'while', 'for', 'try' or nothing (instance initializer block)
 
 		- first \n: with positive lookbehind (?<=\n) to move the error marker to a more reasonable place
 		- capture tabs for <indentation>, later referenced via \1
@@ -47,7 +47,7 @@
 		- <indentation> as captured earlier
 		- <control statement> as specified above
 		- { before the next new line -->
-		<property name="format" value="(?&lt;=\n)([\t]+)(?:[^/\n \t][^\n]*|/[^/\n][^\n]*|[^/\n][^\n]*(\n\1//[^\n]*)+)\n\1(|(if|do|while|for)[^\n]+)\{[\r\t ]*\n"/>
+		<property name="format" value="(?&lt;=\n)([\t]+)(?:[^/\n \t][^\n]*|/[^/\n][^\n]*|[^/\n][^\n]*(\n\1//[^\n]*)+)\n\1(|(if|do|while|for|try)[^\n]+)\{[\r\t ]*\n"/>
 		<property name="message" value="missing blank line before block at same indentation level"/>
 	</module>
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -94,6 +94,16 @@
 			<property name="tokens" value="PACKAGE_DEF,IMPORT,STATIC_IMPORT,CLASS_DEF,INTERFACE_DEF,ENUM_DEF,STATIC_INIT,INSTANCE_INIT,CTOR_DEF"/>
 		</module>
 
+		<module name="OperatorWrap"/>
+		<module name="SeparatorWrap">
+			<property name="tokens" value="DOT,ELLIPSIS,AT"/>
+			<property name="option" value="nl"/>
+		</module>
+		<module name="SeparatorWrap">
+			<property name="tokens" value="COMMA,SEMI"/>
+			<property name="option" value="eol"/>
+		</module>
+
 		<module name="Indentation">
 			<property name="basicOffset" value="8"/>
 			<property name="caseIndent" value="0"/>
@@ -102,6 +112,13 @@
 			<property name="lineWrappingIndentation" value="16"/>
 		</module>
 
+		<module name="ParenPad"/>
+		<module name="NoWhitespaceBefore"/>
+		<module name="NoWhitespaceAfter">
+			<!-- allow ARRAY_INIT -->
+			<property name="tokens" value="AT,INC,DEC,UNARY_MINUS,UNARY_PLUS,BNOT,LNOT,DOT,ARRAY_DECLARATOR,INDEX_OP"/>
+		</module>
+		<module name="WhitespaceAfter"/>
 		<module name="WhitespaceAround">
 			<!-- Allow PLUS, MINUS, MUL, DIV as they may be more readable without spaces in some cases -->
 			<property name="tokens" value="ASSIGN,BAND,BAND_ASSIGN,BOR,BOR_ASSIGN,BSR,BSR_ASSIGN,BXOR,BXOR_ASSIGN,COLON,DIV_ASSIGN,DO_WHILE,EQUAL,GE,GT,LAMBDA,LAND,LCURLY,LE,LITERAL_CATCH,LITERAL_DO,LITERAL_ELSE,LITERAL_FINALLY,LITERAL_FOR,LITERAL_IF,LITERAL_RETURN,LITERAL_SWITCH,LITERAL_SYNCHRONIZED,LITERAL_TRY,LITERAL_WHILE,LOR,LT,MINUS_ASSIGN,MOD,MOD_ASSIGN,NOT_EQUAL,PLUS_ASSIGN,QUESTION,RCURLY,SL,SLIST,SL_ASSIGN,SR,SR_ASSIGN,STAR,STAR_ASSIGN,LITERAL_ASSERT,TYPE_EXTENSION_AND"/>

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/Event.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/Event.java
@@ -32,8 +32,8 @@ public abstract class Event<T> {
 
 	/**
 	 * Returns the invoker instance.
-	 * <p>
-	 * An "invoker" is an object which hides multiple registered
+	 *
+	 * <p>An "invoker" is an object which hides multiple registered
 	 * listeners of type T under one instance of type T, executing
 	 * them and leaving early as necessary.
 	 *

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
@@ -16,9 +16,9 @@
 
 package net.fabricmc.fabric.api.event;
 
-import net.fabricmc.fabric.impl.event.EventFactoryImpl;
-
 import java.util.function.Function;
+
+import net.fabricmc.fabric.impl.event.EventFactoryImpl;
 
 /**
  * Helper for creating {@link Event} classes.
@@ -26,9 +26,7 @@ import java.util.function.Function;
 public final class EventFactory {
 	private static boolean profilingEnabled = true;
 
-	private EventFactory() {
-
-	}
+	private EventFactory() { }
 
 	/**
 	 * @return True if events are supposed to be profiled.
@@ -61,8 +59,8 @@ public final class EventFactory {
 
 	/**
 	 * Create an "array-backed" Event instance with a custom empty invoker.
-	 * <p>
-	 * Having a custom empty invoker (of type (...) -&gt; {}) increases performance
+	 *
+	 * <p>Having a custom empty invoker (of type (...) -&gt; {}) increases performance
 	 * relative to iterating over an empty array; however, it only really matters
 	 * if the event is executed thousands of times a second.
 	 *

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/util/NbtType.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/util/NbtType.java
@@ -22,10 +22,10 @@ import net.minecraft.nbt.Tag;
 /**
  * NBT type ID constants. Useful for filtering by value type in a few cases.
  *
+ * <p>For the current list of types, check with {@link Tag#TYPES}.
+ *
  * @see CompoundTag#containsKey(String, int)
  * @see Tag#idToString(int)
- * <p>
- * For the current list of types, check with {@link Tag#TYPES}.
  */
 public final class NbtType {
 	public static final int END = 0;
@@ -49,7 +49,5 @@ public final class NbtType {
 	 */
 	public static final int NUMBER = 99;
 
-	private NbtType() {
-
-	}
+	private NbtType() { }
 }

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/event/ArrayBackedEvent.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/event/ArrayBackedEvent.java
@@ -16,11 +16,11 @@
 
 package net.fabricmc.fabric.impl.event;
 
-import net.fabricmc.fabric.api.event.Event;
-
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.function.Function;
+
+import net.fabricmc.fabric.api.event.Event;
 
 class ArrayBackedEvent<T> extends Event<T> {
 	private final Class<? super T> type;

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/event/EventFactoryImpl.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/event/EventFactoryImpl.java
@@ -16,8 +16,6 @@
 
 package net.fabricmc.fabric.impl.event;
 
-import net.fabricmc.fabric.api.event.Event;
-
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -29,12 +27,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
+import net.fabricmc.fabric.api.event.Event;
+
 public final class EventFactoryImpl {
 	private static final List<ArrayBackedEvent<?>> ARRAY_BACKED_EVENTS = new ArrayList<>();
 
-	private EventFactoryImpl() {
-
-	}
+	private EventFactoryImpl() { }
 
 	public static void invalidate() {
 		ARRAY_BACKED_EVENTS.forEach(ArrayBackedEvent::update);

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/api/biomes/v1/FabricBiomes.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/api/biomes/v1/FabricBiomes.java
@@ -16,24 +16,22 @@
 
 package net.fabricmc.fabric.api.biomes.v1;
 
-import net.fabricmc.fabric.impl.biomes.InternalBiomeData;
 import net.minecraft.world.biome.Biome;
 
+import net.fabricmc.fabric.impl.biomes.InternalBiomeData;
+
 /**
- * General API that applies to all biome sources
+ * General API that applies to all biome sources.
  */
 public final class FabricBiomes {
-
-	private FabricBiomes() {
-	}
+	private FabricBiomes() { }
 
 	/**
-	 * Allows players to naturally spawn in this biome
+	 * Allows players to naturally spawn in this biome.
 	 *
 	 * @param biome a biome the player should be able to spawn in
 	 */
 	public static void addSpawnBiome(Biome biome) {
 		InternalBiomeData.addSpawnBiome(biome);
 	}
-
 }

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/api/biomes/v1/OverworldBiomes.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/api/biomes/v1/OverworldBiomes.java
@@ -16,16 +16,15 @@
 
 package net.fabricmc.fabric.api.biomes.v1;
 
-import net.fabricmc.fabric.impl.biomes.InternalBiomeData;
 import net.minecraft.world.biome.Biome;
 
+import net.fabricmc.fabric.impl.biomes.InternalBiomeData;
+
 /**
- * API that exposes some internals of the minecraft default biome source for the overworld
+ * API that exposes some internals of the minecraft default biome source for the overworld.
  */
 public final class OverworldBiomes {
-
-	private OverworldBiomes() {
-	}
+	private OverworldBiomes() { }
 
 	/**
 	 * Adds the biome to the specified climate group, with the specified weight. This is only for the biomes that make up the initial continents in generation.
@@ -41,7 +40,7 @@ public final class OverworldBiomes {
 	}
 
 	/**
-	 * Adds the biome as a hills variant of the parent biome, with the specified weight
+	 * Adds the biome as a hills variant of the parent biome, with the specified weight.
 	 *
 	 * @param parent the biome to where the hills variant is added
 	 * @param hills the biome to be set as a hills variant
@@ -54,7 +53,7 @@ public final class OverworldBiomes {
 	}
 
 	/**
-	 * Adds the biome as a shore/beach biome for the parent biome, with the specified weight
+	 * Adds the biome as a shore/beach biome for the parent biome, with the specified weight.
 	 *
 	 * @param parent the base biome to where the shore biome is added
 	 * @param shore the biome to be added as a shore biome
@@ -67,7 +66,7 @@ public final class OverworldBiomes {
 	}
 
 	/**
-	 * Adds the biome as an an edge biome (excluding as a beach) of the parent biome, with the specified weight
+	 * Adds the biome as an an edge biome (excluding as a beach) of the parent biome, with the specified weight.
 	 *
 	 * @param parent the base biome to where the edge biome is added
 	 * @param edge the biome to be added as an edge biome
@@ -81,7 +80,8 @@ public final class OverworldBiomes {
 
 	/**
 	 * Adds a 'variant' biome which replaces another biome on occasion.
-	 * For example, addBiomeVariant(Biomes.JUNGLE, Biomes.DESERT, 0.2) will replace 20% of jungles with deserts.
+	 *
+	 * <p>For example, addBiomeVariant(Biomes.JUNGLE, Biomes.DESERT, 0.2) will replace 20% of jungles with deserts.
 	 * This method is rather useful for replacing biomes not generated through standard methods, such as oceans,
 	 * deep oceans, jungles, mushroom islands, etc. When replacing ocean and deep ocean biomes, one must specify
 	 * the biome without temperature (Biomes.OCEAN / Biomes.DEEP_OCEAN) only, as ocean temperatures have not been
@@ -107,5 +107,4 @@ public final class OverworldBiomes {
 	public static void setRiverBiome(Biome parent, Biome river) {
 		InternalBiomeData.setOverworldRiverBiome(parent, river);
 	}
-
 }

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/api/biomes/v1/OverworldClimate.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/api/biomes/v1/OverworldClimate.java
@@ -17,27 +17,26 @@
 package net.fabricmc.fabric.api.biomes.v1;
 
 /**
- * Represents the climates of biomes on the overworld continents
+ * Represents the climates of biomes on the overworld continents.
  */
 public enum OverworldClimate {
-
 	/**
-	 * Includes Snowy Tundra (with a weight of 3) and Snowy Taiga (with a weight of 1)
+	 * Includes Snowy Tundra (with a weight of 3) and Snowy Taiga (with a weight of 1).
 	 */
 	SNOWY,
 
 	/**
-	 * Includes Forest, Taiga, Mountains, and Plains (all with weights of 1)
+	 * Includes Forest, Taiga, Mountains, and Plains (all with weights of 1).
 	 */
 	COOL,
 
 	/**
-	 * Includes Forest, Dark Forest, Mountains, Plains, Birch Forest, and Swamp (all with weights of 1)
+	 * Includes Forest, Dark Forest, Mountains, Plains, Birch Forest, and Swamp (all with weights of 1).
 	 */
 	TEMPERATE,
 
 	/**
-	 * Includes Desert (with a weight of 3), Savanna (with a weight of 2), and Plains (with a weight of 1)
+	 * Includes Desert (with a weight of 3), Savanna (with a weight of 2), and Plains (with a weight of 1).
 	 */
 	DRY
 }

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/impl/biomes/BiomeVariant.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/impl/biomes/BiomeVariant.java
@@ -19,10 +19,9 @@ package net.fabricmc.fabric.impl.biomes;
 import net.minecraft.world.biome.Biome;
 
 /**
- * Represents a biome variant and its corresponding chance
+ * Represents a biome variant and its corresponding chance.
  */
 final class BiomeVariant {
-
 	private final Biome variant;
 	private final double chance;
 
@@ -48,5 +47,4 @@ final class BiomeVariant {
 	double getChance() {
 		return chance;
 	}
-
 }

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/impl/biomes/ContinentalBiomeEntry.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/impl/biomes/ContinentalBiomeEntry.java
@@ -19,7 +19,7 @@ package net.fabricmc.fabric.impl.biomes;
 import net.minecraft.world.biome.Biome;
 
 /**
- * Represents a biome and its corresponding weight
+ * Represents a biome and its corresponding weight.
  */
 final class ContinentalBiomeEntry {
 	private final Biome biome;

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/impl/biomes/InternalBiomeData.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/impl/biomes/InternalBiomeData.java
@@ -16,23 +16,29 @@
 
 package net.fabricmc.fabric.impl.biomes;
 
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import net.fabricmc.fabric.api.biomes.v1.OverworldClimate;
+
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.Biomes;
 import net.minecraft.world.biome.layer.BiomeLayers;
 
-import java.util.*;
+import net.fabricmc.fabric.api.biomes.v1.OverworldClimate;
 
 /**
  * Lists and maps for internal use only! Stores data that is used by the various mixins into the world generation
  */
 public final class InternalBiomeData {
-
-	private InternalBiomeData() {
-	}
+	private InternalBiomeData() { }
 
 	private static final EnumMap<OverworldClimate, WeightedBiomePicker> OVERWORLD_MODDED_CONTINENTAL_BIOME_PICKERS = new EnumMap<>(OverworldClimate.class);
 	private static final Map<Biome, WeightedBiomePicker> OVERWORLD_HILLS_MAP = new HashMap<>();
@@ -91,6 +97,7 @@ public final class InternalBiomeData {
 	public static void setOverworldRiverBiome(Biome primary, Biome river) {
 		Preconditions.checkArgument(primary != null, "Primary biome is null");
 		OVERWORLD_RIVER_MAP.put(primary, river);
+
 		if (river != null) {
 			OVERWORLD_INJECTED_BIOMES.add(river);
 		}

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/impl/biomes/InternalBiomeUtils.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/impl/biomes/InternalBiomeUtils.java
@@ -16,23 +16,22 @@
 
 package net.fabricmc.fabric.impl.biomes;
 
-import net.fabricmc.fabric.api.biomes.v1.OverworldClimate;
+import java.util.List;
+import java.util.Map;
+import java.util.function.IntConsumer;
+
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.layer.LayerRandomnessSource;
 
-import java.util.List;
-import java.util.Map;
-import java.util.function.IntConsumer;
+import net.fabricmc.fabric.api.biomes.v1.OverworldClimate;
 
 /**
- * Internal utilities used for biome sampling
+ * Internal utilities used for biome sampling.
  */
 public final class InternalBiomeUtils {
-
-	private InternalBiomeUtils() {
-	}
+	private InternalBiomeUtils() { }
 
 	/**
 	 * @param north raw id of the biome to the north
@@ -85,14 +84,17 @@ public final class InternalBiomeUtils {
 		reqWeightSum -= vanillaArrayWeight;
 		int low = 0;
 		int high = moddedBiomes.size() - 1;
+
 		while (low < high) {
 			int mid = (high + low) >>> 1;
+
 			if (reqWeightSum < moddedBiomes.get(mid).getUpperWeightBound()) {
 				high = mid;
 			} else {
 				low = mid + 1;
 			}
 		}
+
 		return low;
 	}
 
@@ -127,7 +129,7 @@ public final class InternalBiomeUtils {
 		}
 
 		int vanillaArrayWeight = vanillaArray.length;
-		double reqWeightSum = (double) random.nextInt(Integer.MAX_VALUE) * (vanillaArray.length + picker.getCurrentWeightTotal()) / Integer.MAX_VALUE;
+		double reqWeightSum = random.nextInt(Integer.MAX_VALUE) * (vanillaArray.length + picker.getCurrentWeightTotal()) / Integer.MAX_VALUE;
 
 		if (reqWeightSum < vanillaArray.length) {
 			// Vanilla biome; look it up from the vanilla array and transform accordingly.

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/impl/biomes/VariantTransformer.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/impl/biomes/VariantTransformer.java
@@ -16,17 +16,18 @@
 
 package net.fabricmc.fabric.impl.biomes;
 
-import net.fabricmc.fabric.api.biomes.v1.OverworldClimate;
-import net.minecraft.world.biome.Biome;
-import net.minecraft.world.biome.layer.LayerRandomnessSource;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.layer.LayerRandomnessSource;
+
+import net.fabricmc.fabric.api.biomes.v1.OverworldClimate;
+
 /**
- * Deals with picking variants for you
+ * Deals with picking variants for you.
  */
 final class VariantTransformer {
 	private final SubTransformer defaultTransformer = new SubTransformer();
@@ -49,7 +50,7 @@ final class VariantTransformer {
 	}
 
 	/**
-	 * Transforms a biome into a variant randomly depending on its chance
+	 * Transforms a biome into a variant randomly depending on its chance.
 	 *
 	 * @param replaced biome to transform
 	 * @param random the {@link LayerRandomnessSource} from the layer
@@ -81,7 +82,7 @@ final class VariantTransformer {
 		}
 
 		/**
-		 * Transforms a biome into a variant randomly depending on its chance
+		 * Transforms a biome into a variant randomly depending on its chance.
 		 *
 		 * @param replaced biome to transform
 		 * @param random the {@link LayerRandomnessSource} from the layer
@@ -93,6 +94,7 @@ final class VariantTransformer {
 					return variant.getVariant();
 				}
 			}
+
 			return replaced;
 		}
 	}

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/impl/biomes/WeightedBiomePicker.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/impl/biomes/WeightedBiomePicker.java
@@ -16,12 +16,13 @@
 
 package net.fabricmc.fabric.impl.biomes;
 
-import com.google.common.base.Preconditions;
-import net.minecraft.world.biome.Biome;
-import net.minecraft.world.biome.layer.LayerRandomnessSource;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import com.google.common.base.Preconditions;
+
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.layer.LayerRandomnessSource;
 
 /**
  * Picks biomes with arbitrary double weights using a binary search.
@@ -46,13 +47,13 @@ public final class WeightedBiomePicker {
 	}
 
 	public Biome pickRandom(LayerRandomnessSource random) {
-		double target = (double) random.nextInt(Integer.MAX_VALUE) * getCurrentWeightTotal() / Integer.MAX_VALUE;
+		double target = random.nextInt(Integer.MAX_VALUE) * getCurrentWeightTotal() / Integer.MAX_VALUE;
 
 		return search(target).getBiome();
 	}
 
 	/**
-	 * Searches with the specified target value
+	 * Searches with the specified target value.
 	 *
 	 * @param target The target value, must satisfy the constraint 0 <= target <= currentTotal
 	 * @return The result of the search
@@ -67,6 +68,7 @@ public final class WeightedBiomePicker {
 
 		while (low < high) {
 			int mid = (high + low) >>> 1;
+
 			if (target < entries.get(mid).getUpperWeightBound()) {
 				high = mid;
 			} else {

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/mixin/biomes/MixinAddEdgeBiomesLayer.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/mixin/biomes/MixinAddEdgeBiomesLayer.java
@@ -16,32 +16,33 @@
 
 package net.fabricmc.fabric.mixin.biomes;
 
-import net.fabricmc.fabric.api.biomes.v1.OverworldBiomes;
-import net.fabricmc.fabric.impl.biomes.InternalBiomeData;
-import net.fabricmc.fabric.impl.biomes.InternalBiomeUtils;
-import net.minecraft.util.registry.Registry;
-import net.minecraft.world.biome.Biome;
-import net.minecraft.world.biome.layer.AddEdgeBiomesLayer;
-import net.minecraft.world.biome.layer.LayerRandomnessSource;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import net.minecraft.util.registry.Registry;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.layer.AddEdgeBiomesLayer;
+import net.minecraft.world.biome.layer.LayerRandomnessSource;
+
+import net.fabricmc.fabric.api.biomes.v1.OverworldBiomes;
+import net.fabricmc.fabric.impl.biomes.InternalBiomeData;
+import net.fabricmc.fabric.impl.biomes.InternalBiomeUtils;
+
 /**
- * Adds edges and shores specified in {@link OverworldBiomes#addEdgeBiome(Biome, Biome, double)} and {@link OverworldBiomes#addShoreBiome(Biome, Biome, double)} to the edges layer
+ * Adds edges and shores specified in {@link OverworldBiomes#addEdgeBiome(Biome, Biome, double)} and {@link OverworldBiomes#addShoreBiome(Biome, Biome, double)} to the edges layer.
  */
 @Mixin(AddEdgeBiomesLayer.class)
 public class MixinAddEdgeBiomesLayer {
-
 	@Inject(at = @At("HEAD"), method = "sample", cancellable = true)
 	private void sample(LayerRandomnessSource rand, int north, int east, int south, int west, int center, CallbackInfoReturnable<Integer> info) {
 		Biome centerBiome = Registry.BIOME.get(center);
+
 		if (InternalBiomeData.getOverworldShores().containsKey(centerBiome) && InternalBiomeUtils.neighborsOcean(north, east, south, west)) {
 			info.setReturnValue(Registry.BIOME.getRawId(InternalBiomeData.getOverworldShores().get(centerBiome).pickRandom(rand)));
 		} else if (InternalBiomeData.getOverworldEdges().containsKey(centerBiome) && InternalBiomeUtils.isEdge(north, east, south, west, center)) {
 			info.setReturnValue(Registry.BIOME.getRawId(InternalBiomeData.getOverworldEdges().get(centerBiome).pickRandom(rand)));
 		}
 	}
-
 }

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/mixin/biomes/MixinAddHillsLayer.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/mixin/biomes/MixinAddHillsLayer.java
@@ -16,26 +16,27 @@
 
 package net.fabricmc.fabric.mixin.biomes;
 
-import net.fabricmc.fabric.api.biomes.v1.OverworldBiomes;
-import net.fabricmc.fabric.impl.biomes.InternalBiomeData;
-import net.fabricmc.fabric.impl.biomes.WeightedBiomePicker;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.layer.AddHillsLayer;
 import net.minecraft.world.biome.layer.BiomeLayers;
 import net.minecraft.world.biome.layer.LayerRandomnessSource;
 import net.minecraft.world.biome.layer.LayerSampler;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.fabricmc.fabric.api.biomes.v1.OverworldBiomes;
+import net.fabricmc.fabric.impl.biomes.InternalBiomeData;
+import net.fabricmc.fabric.impl.biomes.WeightedBiomePicker;
 
 /**
- * Injects hills biomes specified from {@link OverworldBiomes#addHillsBiome(Biome, Biome, double)}into the default hills layer
+ * Injects hills biomes specified from {@link OverworldBiomes#addHillsBiome(Biome, Biome, double)}into the default hills layer.
  */
 @Mixin(AddHillsLayer.class)
 public class MixinAddHillsLayer {
-
 	@Inject(at = @At("HEAD"), method = "sample", cancellable = true)
 	private void sample(LayerRandomnessSource rand, LayerSampler biomeSampler, LayerSampler noiseSampler, int chunkX, int chunkZ, CallbackInfoReturnable<Integer> info) {
 		if (InternalBiomeData.getOverworldHills().isEmpty()) {
@@ -67,18 +68,23 @@ public class MixinAddHillsLayer {
 
 			if (biomeReturn != biomeId) {
 				int similarity = 0;
+
 				if (BiomeLayers.areSimilar(biomeSampler.sample(chunkX, chunkZ - 1), biomeId)) {
 					++similarity;
 				}
+
 				if (BiomeLayers.areSimilar(biomeSampler.sample(chunkX + 1, chunkZ), biomeId)) {
 					++similarity;
 				}
+
 				if (BiomeLayers.areSimilar(biomeSampler.sample(chunkX - 1, chunkZ), biomeId)) {
 					++similarity;
 				}
+
 				if (BiomeLayers.areSimilar(biomeSampler.sample(chunkX, chunkZ + 1), biomeId)) {
 					++similarity;
 				}
+
 				if (similarity >= 3) {
 					info.setReturnValue(biomeReturn);
 					return;
@@ -89,5 +95,4 @@ public class MixinAddHillsLayer {
 		// Cancel vanilla logic.
 		info.setReturnValue(biomeId);
 	}
-
 }

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/mixin/biomes/MixinAddRiversLayer.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/mixin/biomes/MixinAddRiversLayer.java
@@ -16,13 +16,8 @@
 
 package net.fabricmc.fabric.mixin.biomes;
 
-import net.fabricmc.fabric.api.biomes.v1.OverworldBiomes;
-import net.fabricmc.fabric.impl.biomes.InternalBiomeData;
-import net.minecraft.util.registry.Registry;
-import net.minecraft.world.biome.Biome;
-import net.minecraft.world.biome.layer.AddRiversLayer;
-import net.minecraft.world.biome.layer.LayerRandomnessSource;
-import net.minecraft.world.biome.layer.LayerSampler;
+import java.util.Map;
+
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -30,14 +25,20 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.Map;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.layer.AddRiversLayer;
+import net.minecraft.world.biome.layer.LayerRandomnessSource;
+import net.minecraft.world.biome.layer.LayerSampler;
+
+import net.fabricmc.fabric.api.biomes.v1.OverworldBiomes;
+import net.fabricmc.fabric.impl.biomes.InternalBiomeData;
 
 /**
- * Sets river biomes specified with {@link OverworldBiomes#setRiverBiome(Biome, Biome)}
+ * Sets river biomes specified with {@link OverworldBiomes#setRiverBiome(Biome, Biome)}.
  */
 @Mixin(AddRiversLayer.class)
 public class MixinAddRiversLayer {
-
 	@Shadow
 	@Final
 	private static int RIVER_ID;
@@ -49,10 +50,10 @@ public class MixinAddRiversLayer {
 
 		int riverBiomeId = riverSampler.sample(x, z);
 		Map<Biome, Biome> overworldRivers = InternalBiomeData.getOverworldRivers();
+
 		if (overworldRivers.containsKey(landBiome) && riverBiomeId == RIVER_ID) {
 			Biome riverBiome = overworldRivers.get(landBiome);
 			info.setReturnValue(riverBiome == null ? landBiomeId : Registry.BIOME.getRawId(riverBiome));
 		}
 	}
-
 }

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/mixin/biomes/MixinBiomeSource.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/mixin/biomes/MixinBiomeSource.java
@@ -16,9 +16,11 @@
 
 package net.fabricmc.fabric.mixin.biomes;
 
-import net.fabricmc.fabric.impl.biomes.InternalBiomeData;
-import net.minecraft.world.biome.Biome;
-import net.minecraft.world.biome.source.BiomeSource;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -26,17 +28,16 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.source.BiomeSource;
+
+import net.fabricmc.fabric.impl.biomes.InternalBiomeData;
 
 /**
  * Adds spawn biomes to the base {@link BiomeSource} class.
  */
 @Mixin(BiomeSource.class)
 public class MixinBiomeSource {
-
 	@Shadow
 	@Final
 	private static List<Biome> SPAWN_BIOMES;
@@ -44,9 +45,9 @@ public class MixinBiomeSource {
 	@Inject(at = @At("RETURN"), cancellable = true, method = "getSpawnBiomes")
 	private void getSpawnBiomes(CallbackInfoReturnable<List<Biome>> info) {
 		Set<Biome> biomes = new LinkedHashSet<>(info.getReturnValue());
+
 		if (biomes.addAll(InternalBiomeData.getSpawnBiomes())) {
 			info.setReturnValue(new ArrayList<>(biomes));
 		}
 	}
-
 }

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/mixin/biomes/MixinSetBaseBiomesLayer.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/mixin/biomes/MixinSetBaseBiomesLayer.java
@@ -16,12 +16,6 @@
 
 package net.fabricmc.fabric.mixin.biomes;
 
-import net.fabricmc.fabric.api.biomes.v1.OverworldClimate;
-import net.fabricmc.fabric.impl.biomes.InternalBiomeUtils;
-import net.minecraft.util.registry.Registry;
-import net.minecraft.world.biome.Biome;
-import net.minecraft.world.biome.layer.LayerRandomnessSource;
-import net.minecraft.world.biome.layer.SetBaseBiomesLayer;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
@@ -30,12 +24,19 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import net.minecraft.util.registry.Registry;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.layer.LayerRandomnessSource;
+import net.minecraft.world.biome.layer.SetBaseBiomesLayer;
+
+import net.fabricmc.fabric.api.biomes.v1.OverworldClimate;
+import net.fabricmc.fabric.impl.biomes.InternalBiomeUtils;
+
 /**
- * Injects biomes into the arrays of biomes in the {@link SetBaseBiomesLayer}
+ * Injects biomes into the arrays of biomes in the {@link SetBaseBiomesLayer}.
  */
 @Mixin(SetBaseBiomesLayer.class)
 public class MixinSetBaseBiomesLayer {
-
 	@Shadow
 	@Final
 	@Mutable
@@ -112,5 +113,4 @@ public class MixinSetBaseBiomesLayer {
 
 		info.setReturnValue(InternalBiomeUtils.transformBiome(random, biome, climate));
 	}
-
 }

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/mixin/biomes/MixinVanillaLayeredBiomeSource.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/mixin/biomes/MixinVanillaLayeredBiomeSource.java
@@ -16,18 +16,24 @@
 
 package net.fabricmc.fabric.mixin.biomes;
 
-import net.fabricmc.fabric.impl.biomes.InternalBiomeData;
-import net.minecraft.block.BlockState;
-import net.minecraft.world.biome.Biome;
-import net.minecraft.world.biome.source.VanillaLayeredBiomeSource;
-import net.minecraft.world.gen.feature.StructureFeature;
-import org.spongepowered.asm.mixin.*;
+import java.util.List;
+import java.util.Set;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.List;
-import java.util.Set;
+import net.minecraft.block.BlockState;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.source.VanillaLayeredBiomeSource;
+import net.minecraft.world.gen.feature.StructureFeature;
+
+import net.fabricmc.fabric.impl.biomes.InternalBiomeData;
 
 /**
  * Adds the biomes in world gen to the array for the vanilla layered biome source.
@@ -35,7 +41,6 @@ import java.util.Set;
  */
 @Mixin(VanillaLayeredBiomeSource.class)
 public class MixinVanillaLayeredBiomeSource {
-
 	@Shadow
 	@Final
 	@Mutable
@@ -58,6 +63,7 @@ public class MixinVanillaLayeredBiomeSource {
 	private void updateInjections() {
 		List<Biome> injectedBiomes = InternalBiomeData.getOverworldInjectedBiomes();
 		int currentSize = injectedBiomes.size();
+
 		if (this.injectionCount < currentSize) {
 			List<Biome> toInject = injectedBiomes.subList(injectionCount, currentSize - 1);
 
@@ -66,6 +72,7 @@ public class MixinVanillaLayeredBiomeSource {
 			System.arraycopy(oldBiomes, 0, this.biomes, 0, oldBiomes.length);
 
 			int index = oldBiomes.length;
+
 			for (Biome injected : toInject) {
 				biomes[index++] = injected;
 			}
@@ -73,5 +80,4 @@ public class MixinVanillaLayeredBiomeSource {
 			injectionCount += toInject.size();
 		}
 	}
-
 }

--- a/fabric-commands-v0/src/main/java/net/fabricmc/fabric/api/registry/CommandRegistry.java
+++ b/fabric-commands-v0/src/main/java/net/fabricmc/fabric/api/registry/CommandRegistry.java
@@ -16,11 +16,13 @@
 
 package net.fabricmc.fabric.api.registry;
 
+import java.util.function.Consumer;
+
 import com.mojang.brigadier.CommandDispatcher;
-import net.fabricmc.fabric.impl.registry.CommandRegistryImpl;
+
 import net.minecraft.server.command.ServerCommandSource;
 
-import java.util.function.Consumer;
+import net.fabricmc.fabric.impl.registry.CommandRegistryImpl;
 
 /**
  * Registry for server-side command providers.

--- a/fabric-commands-v0/src/main/java/net/fabricmc/fabric/impl/registry/CommandRegistryImpl.java
+++ b/fabric-commands-v0/src/main/java/net/fabricmc/fabric/impl/registry/CommandRegistryImpl.java
@@ -16,13 +16,14 @@
 
 package net.fabricmc.fabric.impl.registry;
 
-import com.mojang.brigadier.CommandDispatcher;
-import net.minecraft.server.command.ServerCommandSource;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
+
+import com.mojang.brigadier.CommandDispatcher;
+
+import net.minecraft.server.command.ServerCommandSource;
 
 public class CommandRegistryImpl {
 	public static final CommandRegistryImpl INSTANCE = new CommandRegistryImpl();

--- a/fabric-commands-v0/src/main/java/net/fabricmc/fabric/mixin/registrycommands/MixinCommandManagerIntegrated.java
+++ b/fabric-commands-v0/src/main/java/net/fabricmc/fabric/mixin/registrycommands/MixinCommandManagerIntegrated.java
@@ -17,14 +17,16 @@
 package net.fabricmc.fabric.mixin.registrycommands;
 
 import com.mojang.brigadier.CommandDispatcher;
-import net.fabricmc.fabric.impl.registry.CommandRegistryImpl;
-import net.minecraft.server.command.CommandManager;
-import net.minecraft.server.command.ServerCommandSource;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
+
+import net.fabricmc.fabric.impl.registry.CommandRegistryImpl;
 
 @Mixin(CommandManager.class)
 public class MixinCommandManagerIntegrated {

--- a/fabric-commands-v0/src/main/java/net/fabricmc/fabric/mixin/registrycommands/MixinMinecraftDedicatedServer.java
+++ b/fabric-commands-v0/src/main/java/net/fabricmc/fabric/mixin/registrycommands/MixinMinecraftDedicatedServer.java
@@ -16,27 +16,28 @@
 
 package net.fabricmc.fabric.mixin.registrycommands;
 
+import java.io.File;
+import java.net.Proxy;
+
 import com.mojang.authlib.GameProfileRepository;
 import com.mojang.authlib.minecraft.MinecraftSessionService;
 import com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService;
 import com.mojang.datafixers.DataFixer;
-import net.fabricmc.fabric.impl.registry.CommandRegistryImpl;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.WorldGenerationProgressListenerFactory;
-import net.minecraft.server.command.CommandManager;
-import net.minecraft.server.dedicated.MinecraftDedicatedServer;
-import net.minecraft.util.UserCache;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.io.File;
-import java.net.Proxy;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.WorldGenerationProgressListenerFactory;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.dedicated.MinecraftDedicatedServer;
+import net.minecraft.util.UserCache;
+
+import net.fabricmc.fabric.impl.registry.CommandRegistryImpl;
 
 @Mixin(MinecraftDedicatedServer.class)
 public abstract class MixinMinecraftDedicatedServer extends MinecraftServer {
-
 	public MixinMinecraftDedicatedServer(File file_1, Proxy proxy_1, DataFixer dataFixer_1, CommandManager serverCommandManager_1, YggdrasilAuthenticationService yggdrasilAuthenticationService_1, MinecraftSessionService minecraftSessionService_1, GameProfileRepository gameProfileRepository_1, UserCache userCache_1, WorldGenerationProgressListenerFactory worldGenerationProgressListenerFactory_1, String string_1) {
 		super(file_1, proxy_1, dataFixer_1, serverCommandManager_1, yggdrasilAuthenticationService_1, minecraftSessionService_1, gameProfileRepository_1, userCache_1, worldGenerationProgressListenerFactory_1, string_1);
 	}

--- a/fabric-containers-v0/src/main/java/net/fabricmc/fabric/api/client/screen/ContainerScreenFactory.java
+++ b/fabric-containers-v0/src/main/java/net/fabricmc/fabric/api/client/screen/ContainerScreenFactory.java
@@ -21,7 +21,5 @@ import net.minecraft.container.Container;
 
 @FunctionalInterface
 public interface ContainerScreenFactory<C extends Container> {
-
 	AbstractContainerScreen create(C container);
-
 }

--- a/fabric-containers-v0/src/main/java/net/fabricmc/fabric/api/client/screen/ScreenProviderRegistry.java
+++ b/fabric-containers-v0/src/main/java/net/fabricmc/fabric/api/client/screen/ScreenProviderRegistry.java
@@ -16,15 +16,15 @@
 
 package net.fabricmc.fabric.api.client.screen;
 
-import net.fabricmc.fabric.api.container.ContainerFactory;
-import net.fabricmc.fabric.api.container.ContainerProviderRegistry;
-import net.fabricmc.fabric.impl.client.gui.ScreenProviderRegistryImpl;
 import net.minecraft.client.gui.screen.ingame.AbstractContainerScreen;
 import net.minecraft.container.Container;
 import net.minecraft.util.Identifier;
 
-public interface ScreenProviderRegistry {
+import net.fabricmc.fabric.api.container.ContainerFactory;
+import net.fabricmc.fabric.api.container.ContainerProviderRegistry;
+import net.fabricmc.fabric.impl.client.gui.ScreenProviderRegistryImpl;
 
+public interface ScreenProviderRegistry {
 	ScreenProviderRegistry INSTANCE = ScreenProviderRegistryImpl.INSTANCE;
 
 	/**
@@ -43,5 +43,4 @@ public interface ScreenProviderRegistry {
 	 * @param factory    the gui factory, this should return a new {@link AbstractContainerScreen}
 	 */
 	void registerFactory(Identifier identifier, ContainerFactory<AbstractContainerScreen> factory);
-
 }

--- a/fabric-containers-v0/src/main/java/net/fabricmc/fabric/api/container/ContainerFactory.java
+++ b/fabric-containers-v0/src/main/java/net/fabricmc/fabric/api/container/ContainerFactory.java
@@ -22,7 +22,6 @@ import net.minecraft.util.PacketByteBuf;
 
 @FunctionalInterface
 public interface ContainerFactory<T> {
-
 	/**
 	 * Creates the new object.
 	 *
@@ -33,5 +32,4 @@ public interface ContainerFactory<T> {
 	 * @return the new gui or container
 	 */
 	T create(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf);
-
 }

--- a/fabric-containers-v0/src/main/java/net/fabricmc/fabric/api/container/ContainerProviderRegistry.java
+++ b/fabric-containers-v0/src/main/java/net/fabricmc/fabric/api/container/ContainerProviderRegistry.java
@@ -16,18 +16,18 @@
 
 package net.fabricmc.fabric.api.container;
 
-import net.fabricmc.fabric.api.client.screen.ScreenProviderRegistry;
-import net.fabricmc.fabric.impl.container.ContainerProviderImpl;
+import java.util.function.Consumer;
+
 import net.minecraft.container.Container;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.PacketByteBuf;
 
-import java.util.function.Consumer;
+import net.fabricmc.fabric.api.client.screen.ScreenProviderRegistry;
+import net.fabricmc.fabric.impl.container.ContainerProviderImpl;
 
 public interface ContainerProviderRegistry {
-
 	ContainerProviderRegistry INSTANCE = ContainerProviderImpl.INSTANCE;
 
 	/**

--- a/fabric-containers-v0/src/main/java/net/fabricmc/fabric/impl/client/gui/ScreenProviderRegistryImpl.java
+++ b/fabric-containers-v0/src/main/java/net/fabricmc/fabric/impl/client/gui/ScreenProviderRegistryImpl.java
@@ -16,26 +16,27 @@
 
 package net.fabricmc.fabric.impl.client.gui;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.ingame.AbstractContainerScreen;
+import net.minecraft.container.Container;
+import net.minecraft.util.Identifier;
+
 import net.fabricmc.fabric.api.client.screen.ContainerScreenFactory;
 import net.fabricmc.fabric.api.client.screen.ScreenProviderRegistry;
 import net.fabricmc.fabric.api.container.ContainerFactory;
 import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
 import net.fabricmc.fabric.impl.container.ContainerProviderImpl;
 import net.fabricmc.fabric.impl.network.PacketTypes;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.ingame.AbstractContainerScreen;
-import net.minecraft.container.Container;
-import net.minecraft.util.Identifier;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class ScreenProviderRegistryImpl implements ScreenProviderRegistry {
-
 	/**
-	 * Use the instance provided by ScreenProviderRegistry
+	 * Use the instance provided by ScreenProviderRegistry.
 	 */
 	public static final ScreenProviderRegistry INSTANCE = new ScreenProviderRegistryImpl();
 
@@ -43,10 +44,12 @@ public class ScreenProviderRegistryImpl implements ScreenProviderRegistry {
 
 	private static final Map<Identifier, ContainerFactory<AbstractContainerScreen>> FACTORIES = new HashMap<>();
 
+	@Override
 	public void registerFactory(Identifier identifier, ContainerFactory<AbstractContainerScreen> factory) {
 		if (FACTORIES.containsKey(identifier)) {
 			throw new RuntimeException("A factory has already been registered as " + identifier + "!");
 		}
+
 		FACTORIES.put(identifier, factory);
 	}
 
@@ -54,10 +57,12 @@ public class ScreenProviderRegistryImpl implements ScreenProviderRegistry {
 	public <C extends Container> void registerFactory(Identifier identifier, ContainerScreenFactory<C> containerScreenFactory) {
 		registerFactory(identifier, (syncId, identifier1, player, buf) -> {
 			C container = ContainerProviderImpl.INSTANCE.createContainer(syncId, identifier1, player, buf);
+
 			if (container == null) {
 				LOGGER.error("Could not open container for {} - a null object was created!", identifier1.toString());
 				return null;
 			}
+
 			return containerScreenFactory.create(container);
 		});
 	}
@@ -71,10 +76,12 @@ public class ScreenProviderRegistryImpl implements ScreenProviderRegistry {
 			MinecraftClient.getInstance().execute(() -> {
 				try {
 					ContainerFactory<AbstractContainerScreen> factory = FACTORIES.get(identifier);
+
 					if (factory == null) {
 						LOGGER.error("No GUI factory found for {}!", identifier.toString());
 						return;
 					}
+
 					AbstractContainerScreen gui = factory.create(syncId, identifier, packetContext.getPlayer(), packetByteBuf);
 					packetContext.getPlayer().container = gui.getContainer();
 					MinecraftClient.getInstance().openScreen(gui);

--- a/fabric-containers-v0/src/main/java/net/fabricmc/fabric/impl/container/ContainerProviderImpl.java
+++ b/fabric-containers-v0/src/main/java/net/fabricmc/fabric/impl/container/ContainerProviderImpl.java
@@ -16,28 +16,29 @@
 
 package net.fabricmc.fabric.impl.container;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
 import io.netty.buffer.Unpooled;
-import net.fabricmc.fabric.api.container.ContainerFactory;
-import net.fabricmc.fabric.api.container.ContainerProviderRegistry;
-import net.fabricmc.fabric.impl.network.PacketTypes;
-import net.fabricmc.fabric.mixin.container.ServerPlayerEntityAccessor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import net.minecraft.client.network.packet.CustomPayloadS2CPacket;
 import net.minecraft.container.Container;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.PacketByteBuf;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Consumer;
+import net.fabricmc.fabric.api.container.ContainerFactory;
+import net.fabricmc.fabric.api.container.ContainerProviderRegistry;
+import net.fabricmc.fabric.impl.network.PacketTypes;
+import net.fabricmc.fabric.mixin.container.ServerPlayerEntityAccessor;
 
 public class ContainerProviderImpl implements ContainerProviderRegistry {
-
 	/**
-	 * Use the instance provided by ContainerProviderRegistry
+	 * Use the instance provided by ContainerProviderRegistry.
 	 */
 	public static final ContainerProviderImpl INSTANCE = new ContainerProviderImpl();
 
@@ -50,6 +51,7 @@ public class ContainerProviderImpl implements ContainerProviderRegistry {
 		if (FACTORIES.containsKey(identifier)) {
 			throw new RuntimeException("A factory has already been registered as " + identifier.toString());
 		}
+
 		FACTORIES.put(identifier, factory);
 	}
 
@@ -96,19 +98,23 @@ public class ContainerProviderImpl implements ContainerProviderRegistry {
 		clonedBuf.readUnsignedByte();
 
 		Container container = createContainer(syncId, identifier, player, clonedBuf);
+
 		if (container == null) {
 			return;
 		}
+
 		player.container = container;
 		player.container.addListener(player);
 	}
 
 	public <C extends Container> C createContainer(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
 		ContainerFactory<Container> factory = FACTORIES.get(identifier);
+
 		if (factory == null) {
 			LOGGER.error("No container factory found for {}!", identifier.toString());
 			return null;
 		}
+
 		//noinspection unchecked
 		return (C) factory.create(syncId, identifier, player, buf);
 	}

--- a/fabric-containers-v0/src/main/java/net/fabricmc/fabric/impl/container/ServerPlayerEntitySyncHook.java
+++ b/fabric-containers-v0/src/main/java/net/fabricmc/fabric/impl/container/ServerPlayerEntitySyncHook.java
@@ -20,12 +20,10 @@ package net.fabricmc.fabric.impl.container;
  * This is a interface that is present on a ServerPlayerEntity, it allows access to the sync id.
  */
 public interface ServerPlayerEntitySyncHook {
-
 	/**
-	 * gets and sets the new player sync id, and returns the new value
+	 * Gets and sets the new player sync id, and returns the new value.
 	 *
 	 * @return the new sync id of the player
 	 */
 	int fabric_incrementSyncId();
-
 }

--- a/fabric-containers-v0/src/main/java/net/fabricmc/fabric/mixin/container/MixinServerPlayerEntity.java
+++ b/fabric-containers-v0/src/main/java/net/fabricmc/fabric/mixin/container/MixinServerPlayerEntity.java
@@ -16,10 +16,12 @@
 
 package net.fabricmc.fabric.mixin.container;
 
-import net.fabricmc.fabric.impl.container.ServerPlayerEntitySyncHook;
-import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import net.fabricmc.fabric.impl.container.ServerPlayerEntitySyncHook;
 
 @Mixin(ServerPlayerEntity.class)
 public abstract class MixinServerPlayerEntity implements ServerPlayerEntitySyncHook {

--- a/fabric-containers-v0/src/main/java/net/fabricmc/fabric/mixin/container/ServerPlayerEntityAccessor.java
+++ b/fabric-containers-v0/src/main/java/net/fabricmc/fabric/mixin/container/ServerPlayerEntityAccessor.java
@@ -16,9 +16,10 @@
 
 package net.fabricmc.fabric.mixin.container;
 
-import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.server.network.ServerPlayerEntity;
 
 @Mixin(ServerPlayerEntity.class)
 public interface ServerPlayerEntityAccessor {

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/CompostingChanceRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/CompostingChanceRegistry.java
@@ -21,8 +21,8 @@ import net.fabricmc.fabric.impl.registry.CompostingChanceRegistryImpl;
 
 /**
  * Registry of items to 0.0-1.0 values, defining the chance of a given item
- * increasing the Composter block's level
+ * increasing the Composter block's level.
  */
 public interface CompostingChanceRegistry extends Item2ObjectMap<Float> {
-	final CompostingChanceRegistry INSTANCE = new CompostingChanceRegistryImpl();
+	CompostingChanceRegistry INSTANCE = new CompostingChanceRegistryImpl();
 }

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/FlammableBlockRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/FlammableBlockRegistry.java
@@ -16,11 +16,12 @@
 
 package net.fabricmc.fabric.api.registry;
 
-import net.fabricmc.fabric.api.util.Block2ObjectMap;
-import net.fabricmc.fabric.impl.registry.FlammableBlockRegistryImpl;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.tag.Tag;
+
+import net.fabricmc.fabric.api.util.Block2ObjectMap;
+import net.fabricmc.fabric.impl.registry.FlammableBlockRegistryImpl;
 
 public interface FlammableBlockRegistry extends Block2ObjectMap<FlammableBlockRegistry.Entry> {
 	static FlammableBlockRegistry getDefaultInstance() {
@@ -39,7 +40,7 @@ public interface FlammableBlockRegistry extends Block2ObjectMap<FlammableBlockRe
 		this.add(tag, new Entry(burn, spread));
 	}
 
-	public static final class Entry {
+	final class Entry {
 		private final int burn, spread;
 
 		public Entry(int burn, int spread) {

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/FuelRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/FuelRegistry.java
@@ -23,5 +23,5 @@ import net.fabricmc.fabric.impl.registry.FuelRegistryImpl;
  * Registry of items to 0-32767 fuel burn time values, in in-game ticks.
  */
 public interface FuelRegistry extends Item2ObjectMap<Integer> {
-	final FuelRegistry INSTANCE = FuelRegistryImpl.INSTANCE;
+	FuelRegistry INSTANCE = FuelRegistryImpl.INSTANCE;
 }

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/LootEntryTypeRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/LootEntryTypeRegistry.java
@@ -16,16 +16,17 @@
 
 package net.fabricmc.fabric.api.registry;
 
+import net.minecraft.world.loot.entry.LootEntry;
+
 import net.fabricmc.fabric.impl.registry.LootEntryTypeRegistryImpl;
 
-import net.minecraft.world.loot.entry.LootEntry;
 /**
  * @deprecated Use {@link net.fabricmc.fabric.api.loot.v1.LootEntryTypeRegistry}
  */
 @Deprecated
 public interface LootEntryTypeRegistry {
 	@Deprecated
-	final LootEntryTypeRegistry INSTANCE = LootEntryTypeRegistryImpl.INSTANCE;
+	LootEntryTypeRegistry INSTANCE = LootEntryTypeRegistryImpl.INSTANCE;
 
 	@Deprecated
 	void register(LootEntry.Serializer<?> serializer);

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/registry/CompostingChanceRegistryImpl.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/registry/CompostingChanceRegistryImpl.java
@@ -16,11 +16,12 @@
 
 package net.fabricmc.fabric.impl.registry;
 
-import net.fabricmc.fabric.api.registry.CompostingChanceRegistry;
 import net.minecraft.block.ComposterBlock;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemConvertible;
 import net.minecraft.tag.Tag;
+
+import net.fabricmc.fabric.api.registry.CompostingChanceRegistry;
 
 public class CompostingChanceRegistryImpl implements CompostingChanceRegistry {
 	@Override

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/registry/FireBlockHooks.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/registry/FireBlockHooks.java
@@ -16,8 +16,9 @@
 
 package net.fabricmc.fabric.impl.registry;
 
-import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
 import net.minecraft.block.BlockState;
+
+import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
 
 public interface FireBlockHooks {
 	FlammableBlockRegistry.Entry fabric_getVanillaEntry(BlockState block);

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/registry/FlammableBlockRegistryImpl.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/registry/FlammableBlockRegistryImpl.java
@@ -16,20 +16,21 @@
 
 package net.fabricmc.fabric.impl.registry;
 
-import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
-import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
-import net.fabricmc.fabric.api.resource.ResourceReloadListenerKeys;
-import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import net.minecraft.block.Block;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.tag.Tag;
 import net.minecraft.util.Identifier;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
+import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
+import net.fabricmc.fabric.api.resource.ResourceReloadListenerKeys;
+import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
 
 public class FlammableBlockRegistryImpl implements FlammableBlockRegistry, SimpleSynchronousResourceReloadListener {
 	private static final FlammableBlockRegistry.Entry REMOVED = new FlammableBlockRegistry.Entry(0, 0);
@@ -59,13 +60,16 @@ public class FlammableBlockRegistryImpl implements FlammableBlockRegistry, Simpl
 
 	private void reload() {
 		computedEntries.clear();
+
 		// tags take precedence before blocks
 		for (Tag<Block> tag : registeredEntriesTag.keySet()) {
 			FlammableBlockRegistry.Entry entry = registeredEntriesTag.get(tag);
+
 			for (Block block : tag.values()) {
 				computedEntries.put(block, entry);
 			}
 		}
+
 		computedEntries.putAll(registeredEntriesBlock);
 
 		/* computedBurnChances.clear();
@@ -82,6 +86,7 @@ public class FlammableBlockRegistryImpl implements FlammableBlockRegistry, Simpl
 	@Override
 	public Entry get(Block block) {
 		Entry entry = computedEntries.get(block);
+
 		if (entry != null) {
 			return entry;
 		} else {

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/registry/FuelRegistryImpl.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/registry/FuelRegistryImpl.java
@@ -16,17 +16,19 @@
 
 package net.fabricmc.fabric.impl.registry;
 
+import java.util.Map;
+
 import it.unimi.dsi.fastutil.objects.Object2IntLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import net.fabricmc.fabric.api.registry.FuelRegistry;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import net.minecraft.block.entity.AbstractFurnaceBlockEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemConvertible;
 import net.minecraft.tag.Tag;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
-import java.util.Map;
+import net.fabricmc.fabric.api.registry.FuelRegistry;
 
 // TODO: Clamp values to 32767 (+ add hook for mods which extend the limit to disable the check?)
 public class FuelRegistryImpl implements FuelRegistry {
@@ -35,9 +37,7 @@ public class FuelRegistryImpl implements FuelRegistry {
 	private final Object2IntMap<ItemConvertible> itemCookTimes = new Object2IntLinkedOpenHashMap<>();
 	private final Object2IntMap<Tag<Item>> tagCookTimes = new Object2IntLinkedOpenHashMap<>();
 
-	public FuelRegistryImpl() {
-
-	}
+	public FuelRegistryImpl() { }
 
 	@Override
 	public Integer get(ItemConvertible item) {
@@ -49,6 +49,7 @@ public class FuelRegistryImpl implements FuelRegistry {
 		if (cookTime > 32767) {
 			LOGGER.warn("Tried to register an overly high cookTime: " + cookTime + " > 32767! (" + item + ")");
 		}
+
 		itemCookTimes.put(item, cookTime.intValue());
 	}
 
@@ -57,6 +58,7 @@ public class FuelRegistryImpl implements FuelRegistry {
 		if (cookTime > 32767) {
 			LOGGER.warn("Tried to register an overly high cookTime: " + cookTime + " > 32767! (" + tag.getId() + ")");
 		}
+
 		tagCookTimes.put(tag, cookTime.intValue());
 	}
 
@@ -84,6 +86,7 @@ public class FuelRegistryImpl implements FuelRegistry {
 		// tags take precedence before blocks
 		for (Tag<Item> tag : tagCookTimes.keySet()) {
 			int time = tagCookTimes.getInt(tag);
+
 			if (time <= 0) {
 				for (Item i : tag.values()) {
 					map.remove(i);
@@ -97,6 +100,7 @@ public class FuelRegistryImpl implements FuelRegistry {
 
 		for (ItemConvertible item : itemCookTimes.keySet()) {
 			int time = itemCookTimes.getInt(item);
+
 			if (time <= 0) {
 				map.remove(item.asItem());
 			} else {

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/registry/LootEntryTypeRegistryImpl.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/registry/LootEntryTypeRegistryImpl.java
@@ -16,11 +16,12 @@
 
 package net.fabricmc.fabric.impl.registry;
 
-import net.fabricmc.fabric.api.registry.LootEntryTypeRegistry;
+import java.lang.reflect.Method;
+
 import net.minecraft.world.loot.entry.LootEntries;
 import net.minecraft.world.loot.entry.LootEntry;
 
-import java.lang.reflect.Method;
+import net.fabricmc.fabric.api.registry.LootEntryTypeRegistry;
 
 @Deprecated
 public final class LootEntryTypeRegistryImpl implements LootEntryTypeRegistry {
@@ -29,6 +30,7 @@ public final class LootEntryTypeRegistryImpl implements LootEntryTypeRegistry {
 
 	static {
 		Method target = null;
+
 		for (Method m : LootEntries.class.getDeclaredMethods()) {
 			if (m.getParameterCount() == 1 && m.getParameterTypes()[0] == LootEntry.Serializer.class) {
 				if (target != null) {
@@ -47,8 +49,7 @@ public final class LootEntryTypeRegistryImpl implements LootEntryTypeRegistry {
 		}
 	}
 
-	private LootEntryTypeRegistryImpl() {
-	}
+	private LootEntryTypeRegistryImpl() { }
 
 	@Override
 	public void register(LootEntry.Serializer<?> serializer) {

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/mixin/registryextras/MixinAbstractFurnaceBlockEntity.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/mixin/registryextras/MixinAbstractFurnaceBlockEntity.java
@@ -16,15 +16,17 @@
 
 package net.fabricmc.fabric.mixin.registryextras;
 
-import net.fabricmc.fabric.impl.registry.FuelRegistryImpl;
-import net.minecraft.block.entity.AbstractFurnaceBlockEntity;
-import net.minecraft.item.Item;
+import java.util.Map;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.Map;
+import net.minecraft.block.entity.AbstractFurnaceBlockEntity;
+import net.minecraft.item.Item;
+
+import net.fabricmc.fabric.impl.registry.FuelRegistryImpl;
 
 @Mixin(AbstractFurnaceBlockEntity.class)
 public class MixinAbstractFurnaceBlockEntity {

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/mixin/registryextras/MixinFireBlock.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/mixin/registryextras/MixinFireBlock.java
@@ -16,19 +16,21 @@
 
 package net.fabricmc.fabric.mixin.registryextras;
 
-import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
-import net.fabricmc.fabric.impl.registry.FireBlockHooks;
-import net.fabricmc.fabric.impl.registry.FlammableBlockRegistryImpl;
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.FireBlock;
-import net.minecraft.state.property.Properties;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.FireBlock;
+import net.minecraft.state.property.Properties;
+
+import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
+import net.fabricmc.fabric.impl.registry.FireBlockHooks;
+import net.fabricmc.fabric.impl.registry.FlammableBlockRegistryImpl;
 
 @Mixin(FireBlock.class)
 public class MixinFireBlock implements FireBlockHooks {
@@ -52,6 +54,7 @@ public class MixinFireBlock implements FireBlockHooks {
 	@Inject(at = @At("HEAD"), method = "getBurnChance", cancellable = true)
 	private void getFabricBurnChance(BlockState block, CallbackInfoReturnable info) {
 		FlammableBlockRegistry.Entry entry = fabric_registry.getFabric(block.getBlock());
+
 		if (entry != null) {
 			// TODO: use a (BlockState -> int) with this as the default impl
 			if (block.contains(Properties.WATERLOGGED) && block.get(Properties.WATERLOGGED)) {
@@ -65,6 +68,7 @@ public class MixinFireBlock implements FireBlockHooks {
 	@Inject(at = @At("HEAD"), method = "getSpreadChance", cancellable = true)
 	private void getFabricSpreadChance(BlockState block, CallbackInfoReturnable info) {
 		FlammableBlockRegistry.Entry entry = fabric_registry.getFabric(block.getBlock());
+
 		if (entry != null) {
 			// TODO: use a (BlockState -> int) with this as the default impl
 			if (block.contains(Properties.WATERLOGGED) && block.get(Properties.WATERLOGGED)) {

--- a/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/mixin/crash/MixinCrashReport.java
+++ b/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/mixin/crash/MixinCrashReport.java
@@ -16,18 +16,20 @@
 
 package net.fabricmc.fabric.mixin.crash;
 
-import net.fabricmc.loader.api.FabricLoader;
-import net.fabricmc.loader.api.ModContainer;
-import net.minecraft.util.crash.CrashReport;
-import net.minecraft.util.crash.CrashReportSection;
+import java.util.Map;
+import java.util.TreeMap;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Map;
-import java.util.TreeMap;
+import net.minecraft.util.crash.CrashReport;
+import net.minecraft.util.crash.CrashReportSection;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
 
 @Mixin(CrashReport.class)
 public abstract class MixinCrashReport {
@@ -38,6 +40,7 @@ public abstract class MixinCrashReport {
 	private void fillSystemDetails(CallbackInfo info) {
 		getSystemDetailsSection().add("Fabric Mods", () -> {
 			Map<String, String> mods = new TreeMap<>();
+
 			for (ModContainer container : FabricLoader.getInstance().getAllMods()) {
 				mods.put(container.getMetadata().getId(), container.getMetadata().getName() + " " + container.getMetadata().getVersion().getFriendlyString());
 			}

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/v1/EntityPlacer.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/v1/EntityPlacer.java
@@ -20,7 +20,6 @@ import net.minecraft.block.pattern.BlockPattern;
 import net.minecraft.entity.Entity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.Direction;
-import net.minecraft.world.dimension.DimensionType;
 
 /**
  * Responsible for placing an Entity once they have entered a dimension.
@@ -35,7 +34,7 @@ public interface EntityPlacer {
 	 * Handles the placement of an entity going to a dimension.
 	 * Utilized by {@link FabricDimensions#teleport(Entity, DimensionType, EntityPlacer)} to specify placement logic when needed.
 	 *
-	 * <p> This method may have side effects such as the creation of a portal in the target dimension,
+	 * <p>This method may have side effects such as the creation of a portal in the target dimension,
 	 * or the creation of a chunk loading ticket.
 	 *
 	 * @param portalDir        the direction the portal is facing, meaningless if no portal was used

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/v1/FabricDimensionType.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/v1/FabricDimensionType.java
@@ -16,7 +16,10 @@
 
 package net.fabricmc.fabric.api.dimension.v1;
 
+import java.util.function.BiFunction;
+
 import com.google.common.base.Preconditions;
+
 import net.minecraft.entity.Entity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Identifier;
@@ -25,8 +28,6 @@ import net.minecraft.util.registry.Registry;
 import net.minecraft.world.World;
 import net.minecraft.world.dimension.Dimension;
 import net.minecraft.world.dimension.DimensionType;
-
-import java.util.function.BiFunction;
 
 /**
  * An extended version of {@link DimensionType} with automatic raw id management and default placement settings.
@@ -39,7 +40,7 @@ import java.util.function.BiFunction;
 public final class FabricDimensionType extends DimensionType {
 	private final EntityPlacer defaultPlacement;
 	private int desiredRawId;
-	/** The fixed raw id for this dimension type, set through reflection */
+	/** The fixed raw id for this dimension type, set through reflection. */
 	private int fixedRawId;
 
 	/**
@@ -77,7 +78,7 @@ public final class FabricDimensionType extends DimensionType {
 	/**
 	 * Return the current raw id for this dimension type.
 	 *
-	 * <p> The returned id is guaranteed to be unique and persistent in a save,
+	 * <p>The returned id is guaranteed to be unique and persistent in a save,
 	 * as well as synchronized between a server and its connected clients.
 	 * It may change when connecting to a different server or opening a new save.
 	 *
@@ -130,7 +131,7 @@ public final class FabricDimensionType extends DimensionType {
 		 * Set the default placer used when teleporting entities to dimensions of the built type.
 		 * The default placer must be set before building a dimension type.
 		 *
-		 * <p> A dimension type's default placer must never return {@code null} when its
+		 * <p>A dimension type's default placer must never return {@code null} when its
 		 * {@link EntityPlacer#placeEntity(Entity, ServerWorld, Direction, double, double) placeEntity} method
 		 * is called.
 		 *
@@ -178,7 +179,7 @@ public final class FabricDimensionType extends DimensionType {
 		 * If this method is not called, the value defaults to the raw registry id
 		 * of the dimension type.
 		 *
-		 * <p> A Fabric Dimension's desired raw id is used as its actual raw id
+		 * <p>A Fabric Dimension's desired raw id is used as its actual raw id
 		 * when it does not conflict with any existing id, and the world
 		 * save does not map the dimension to a different raw id.
 		 *
@@ -196,7 +197,7 @@ public final class FabricDimensionType extends DimensionType {
 		/**
 		 * Build and register a {@code FabricDimensionType}.
 		 *
-		 * <p> The {@code dimensionId} is used as a registry ID, and as
+		 * <p>The {@code dimensionId} is used as a registry ID, and as
 		 * a unique name both for the dimension suffix and the save directory.
 		 *
 		 * @param dimensionId the id used to name and register the dimension

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/v1/FabricDimensions.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/v1/FabricDimensions.java
@@ -17,9 +17,11 @@
 package net.fabricmc.fabric.api.dimension.v1;
 
 import com.google.common.base.Preconditions;
-import net.fabricmc.fabric.impl.dimension.FabricDimensionInternals;
+
 import net.minecraft.entity.Entity;
 import net.minecraft.world.dimension.DimensionType;
+
+import net.fabricmc.fabric.impl.dimension.FabricDimensionInternals;
 
 /**
  * This class consists exclusively of static methods that operate on world dimensions.
@@ -32,10 +34,10 @@ public final class FabricDimensions {
 	/**
 	 * Teleports an entity to a different dimension, using custom placement logic.
 	 *
-	 * <p> This method behaves as if:
+	 * <p>This method behaves as if:
 	 * <pre>{@code teleported.changeDimension(destination)}</pre>
 	 *
-	 * <p> If {@code destination} is a {@link FabricDimensionType}, the placement logic used
+	 * <p>If {@code destination} is a {@link FabricDimensionType}, the placement logic used
 	 * is {@link FabricDimensionType#getDefaultPlacement()}. If {@code destination} is
 	 * the nether or the overworld, the default logic is the vanilla path.
 	 * For any other dimension, the default placement behaviour is undefined.
@@ -43,7 +45,7 @@ public final class FabricDimensions {
 	 * {@code lastPortalDirectionVector}, and {@code lastPortalDirection} fields should be updated
 	 * before calling this method.
 	 *
-	 * <p> After calling this method, {@code teleported} may be invalidated. Callers should use
+	 * <p>After calling this method, {@code teleported} may be invalidated. Callers should use
 	 * the returned entity for any further manipulation.
 	 *
 	 * @param teleported  the entity to teleport
@@ -58,12 +60,12 @@ public final class FabricDimensions {
 	/**
 	 * Teleports an entity to a different dimension, using custom placement logic.
 	 *
-	 * <p> If {@code customPlacement} is {@code null}, this method behaves as if:
+	 * <p>If {@code customPlacement} is {@code null}, this method behaves as if:
 	 * <pre>{@code teleported.changeDimension(destination)}</pre>
 	 * The {@code customPlacement} may itself return {@code null}, in which case
 	 * the default placement logic for that dimension will be run.
 	 *
-	 * <p> If {@code destination} is a {@link FabricDimensionType}, the default placement logic
+	 * <p>If {@code destination} is a {@link FabricDimensionType}, the default placement logic
 	 * is {@link FabricDimensionType#getDefaultPlacement()}. If {@code destination} is the nether
 	 * or the overworld, the default logic is the vanilla path.
 	 * For any other dimension, the default placement behaviour is undefined.
@@ -71,7 +73,7 @@ public final class FabricDimensions {
 	 * {@code lastPortalDirectionVector}, and {@code lastPortalDirection} fields should be updated
 	 * before calling this method.
 	 *
-	 * <p> After calling this method, {@code teleported} may be invalidated. Callers should use
+	 * <p>After calling this method, {@code teleported} may be invalidated. Callers should use
 	 * the returned entity for any further manipulation.
 	 *
 	 * @param teleported   the entity to teleport

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionIdsFixer.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionIdsFixer.java
@@ -16,12 +16,15 @@
 
 package net.fabricmc.fabric.impl.dimension;
 
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
 import io.netty.buffer.Unpooled;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import net.fabricmc.fabric.api.dimension.v1.FabricDimensionType;
-import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
-import net.fabricmc.fabric.impl.registry.RemapException;
+
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Packet;
 import net.minecraft.util.Identifier;
@@ -30,10 +33,9 @@ import net.minecraft.util.registry.Registry;
 import net.minecraft.world.dimension.DimensionType;
 import net.minecraft.world.level.LevelProperties;
 
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import net.fabricmc.fabric.api.dimension.v1.FabricDimensionType;
+import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
+import net.fabricmc.fabric.impl.registry.RemapException;
 
 /**
  * Handles fixing raw dimension ids between saves and servers,
@@ -72,6 +74,7 @@ public class DimensionIdsFixer {
 				setFixedRawId(fabricDimension, fabricDimension.getDesiredRawId());
 			} else {
 				Identifier existing = fixedIds.put(dimensionType.getRawId(), id);
+
 				if (existing != null) {
 					throw new RemapException("Two non-fabric dimensions have the same raw dim id (" + dimensionType.getRawId() + ") : " + existing + " and " + id);
 				}
@@ -89,6 +92,7 @@ public class DimensionIdsFixer {
 			}
 
 			DimensionType dim = DimensionType.byId(dimId);
+
 			if (dim instanceof FabricDimensionType) {
 				setFixedRawId((FabricDimensionType) dim, savedRawId);
 			} else {
@@ -100,6 +104,7 @@ public class DimensionIdsFixer {
 
 		// step 3: de-duplicate raw ids for dimensions which ids are not fixed yet
 		int nextFreeId = 0;
+
 		for (FabricDimensionType fabricDimension : fabricDimensions) {
 			int rawDimId = fabricDimension.getRawId();
 			Identifier dimId = Objects.requireNonNull(DimensionType.getId(fabricDimension));

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionIdsHolder.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionIdsHolder.java
@@ -19,7 +19,7 @@ package net.fabricmc.fabric.impl.dimension;
 import net.minecraft.nbt.CompoundTag;
 
 /**
- * An object holding a raw id -> full id map for fabric dimensions
+ * An object holding a raw id -> full id map for fabric dimensions.
  */
 public interface DimensionIdsHolder {
 	CompoundTag fabric_getDimensionIds();

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionClientInit.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionClientInit.java
@@ -16,18 +16,20 @@
 
 package net.fabricmc.fabric.impl.dimension;
 
-import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
-import net.fabricmc.fabric.api.network.PacketContext;
-import net.fabricmc.fabric.impl.registry.RemapException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.text.LiteralText;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+
+import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
+import net.fabricmc.fabric.api.network.PacketContext;
+import net.fabricmc.fabric.impl.registry.RemapException;
 
 /**
- * Client entry point for fabric-dimensions
+ * Client entry point for fabric-dimensions.
  */
 public final class FabricDimensionClientInit {
 	private static final Logger LOGGER = LogManager.getLogger();
@@ -55,8 +57,7 @@ public final class FabricDimensionClientInit {
 		LOGGER.error("Dimension id remapping failed!", e);
 
 		MinecraftClient.getInstance().execute(() -> ((ClientPlayerEntity) ctx.getPlayer()).networkHandler.getConnection().disconnect(
-			new LiteralText("Dimension id remapping failed: " + e)
+				new LiteralText("Dimension id remapping failed: " + e)
 		));
 	}
-
 }

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionInternals.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionInternals.java
@@ -17,17 +17,19 @@
 package net.fabricmc.fabric.impl.dimension;
 
 import com.google.common.base.Preconditions;
-import net.fabricmc.fabric.api.dimension.v1.EntityPlacer;
-import net.fabricmc.fabric.api.dimension.v1.FabricDimensionType;
-import net.fabricmc.fabric.api.dimension.v1.FabricDimensions;
-import net.fabricmc.fabric.mixin.EntityHooks;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import net.minecraft.block.pattern.BlockPattern;
 import net.minecraft.entity.Entity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.dimension.DimensionType;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+
+import net.fabricmc.fabric.api.dimension.v1.EntityPlacer;
+import net.fabricmc.fabric.api.dimension.v1.FabricDimensionType;
+import net.fabricmc.fabric.api.dimension.v1.FabricDimensions;
+import net.fabricmc.fabric.mixin.EntityHooks;
 
 public final class FabricDimensionInternals {
 	private FabricDimensionInternals() {
@@ -38,11 +40,11 @@ public final class FabricDimensionInternals {
 	public static final Logger LOGGER = LogManager.getLogger();
 
 	/**
-	 * The entity currently being transported to another dimension
+	 * The entity currently being transported to another dimension.
 	 */
 	private static final ThreadLocal<Entity> PORTAL_ENTITY = new ThreadLocal<>();
 	/**
-	 * The custom placement logic passed from {@link FabricDimensions#teleport(Entity, DimensionType, EntityPlacer)}
+	 * The custom placement logic passed from {@link FabricDimensions#teleport(Entity, DimensionType, EntityPlacer)}.
 	 */
 	private static EntityPlacer customPlacement;
 
@@ -65,9 +67,11 @@ public final class FabricDimensionInternals {
 
 		// Set values used by `PortalForcer#changeDimension` to prevent a NPE crash.
 		EntityHooks access = ((EntityHooks) entity);
+
 		if (entity.getLastPortalDirectionVector() == null) {
 			access.setLastPortalDirectionVector(entity.getRotationVector());
 		}
+
 		if (entity.getLastPortalDirection() == null) {
 			access.setLastPortalDirection(entity.getHorizontalFacing());
 		}
@@ -86,6 +90,7 @@ public final class FabricDimensionInternals {
 
 		// Custom placement logic, falls back to default dimension placement if no placement or target found
 		EntityPlacer customPlacement = FabricDimensionInternals.customPlacement;
+
 		if (customPlacement != null) {
 			BlockPattern.TeleportTarget customTarget = customPlacement.placeEntity(teleported, destination, portalDir, portalX, portalY);
 
@@ -96,12 +101,14 @@ public final class FabricDimensionInternals {
 
 		// Default placement logic, falls back to vanilla if not a fabric dimension
 		DimensionType dimType = destination.getDimension().getType();
+
 		if (dimType instanceof FabricDimensionType) {
 			BlockPattern.TeleportTarget defaultTarget = ((FabricDimensionType) dimType).getDefaultPlacement().placeEntity(teleported, destination, portalDir, portalX, portalY);
 
 			if (defaultTarget == null) {
 				throw new IllegalStateException("Mod dimension " + DimensionType.getId(dimType) + " returned an invalid teleport target");
 			}
+
 			return defaultTarget;
 		}
 
@@ -121,5 +128,4 @@ public final class FabricDimensionInternals {
 			customPlacement = null;
 		}
 	}
-
 }

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/EntityHooks.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/EntityHooks.java
@@ -16,11 +16,12 @@
 
 package net.fabricmc.fabric.mixin;
 
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
 import net.minecraft.entity.Entity;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(Entity.class)
 public interface EntityHooks {
@@ -29,5 +30,4 @@ public interface EntityHooks {
 
 	@Accessor
 	void setLastPortalDirection(Direction dir);
-
 }

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/MixinEntity.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/MixinEntity.java
@@ -16,17 +16,18 @@
 
 package net.fabricmc.fabric.mixin;
 
-import net.fabricmc.fabric.impl.dimension.FabricDimensionInternals;
-import net.minecraft.entity.Entity;
-import net.minecraft.world.dimension.DimensionType;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import net.minecraft.entity.Entity;
+import net.minecraft.world.dimension.DimensionType;
+
+import net.fabricmc.fabric.impl.dimension.FabricDimensionInternals;
+
 @Mixin(Entity.class)
 public abstract class MixinEntity {
-
 	// Inject right before the direction vector is retrieved by the game
 	@Inject(method = "changeDimension", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;getLastPortalDirectionVector()Lnet/minecraft/util/math/Vec3d;"))
 	private void onGetPortal(DimensionType dimension, CallbackInfoReturnable<Entity> cir) {

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/MixinPortalForcer.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/MixinPortalForcer.java
@@ -16,7 +16,13 @@
 
 package net.fabricmc.fabric.mixin;
 
-import net.fabricmc.fabric.impl.dimension.FabricDimensionInternals;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
 import net.minecraft.block.pattern.BlockPattern;
 import net.minecraft.entity.Entity;
 import net.minecraft.server.world.ServerWorld;
@@ -24,12 +30,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.PortalForcer;
-import org.spongepowered.asm.mixin.Final;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.fabricmc.fabric.impl.dimension.FabricDimensionInternals;
 
 @Mixin(PortalForcer.class)
 public abstract class MixinPortalForcer {

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinDimensionRawIndexFix.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinDimensionRawIndexFix.java
@@ -16,12 +16,13 @@
 
 package net.fabricmc.fabric.mixin.idremap;
 
-import net.minecraft.util.registry.Registry;
-import net.minecraft.world.dimension.DimensionType;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.util.registry.Registry;
+import net.minecraft.world.dimension.DimensionType;
 
 // NOTE: This probably goes into dimension-fixes
 @Mixin(DimensionType.class)

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinLevelProperties.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinLevelProperties.java
@@ -44,6 +44,7 @@ public abstract class MixinLevelProperties implements DimensionIdsHolder {
 	@Inject(method = "<init>(Lnet/minecraft/nbt/CompoundTag;Lcom/mojang/datafixers/DataFixer;ILnet/minecraft/nbt/CompoundTag;)V", at = @At("RETURN"))
 	private void readDimensionIds(CompoundTag data, DataFixer fixer, int version, CompoundTag player, CallbackInfo ci) {
 		CompoundTag savedIds = data.getCompound("fabric_DimensionIds");
+
 		try {
 			this.fabricDimensionIds = DimensionIdsFixer.apply(savedIds);
 		} catch (RemapException e) {

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinLevelProperties.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinLevelProperties.java
@@ -17,17 +17,19 @@
 package net.fabricmc.fabric.mixin.idremap;
 
 import com.mojang.datafixers.DataFixer;
-import net.fabricmc.fabric.impl.dimension.DimensionIdsFixer;
-import net.fabricmc.fabric.impl.dimension.DimensionIdsHolder;
-import net.fabricmc.fabric.impl.dimension.DimensionRemapException;
-import net.fabricmc.fabric.impl.registry.RemapException;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.level.LevelProperties;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.LevelProperties;
+
+import net.fabricmc.fabric.impl.dimension.DimensionIdsFixer;
+import net.fabricmc.fabric.impl.dimension.DimensionIdsHolder;
+import net.fabricmc.fabric.impl.dimension.DimensionRemapException;
+import net.fabricmc.fabric.impl.registry.RemapException;
 
 @Mixin(LevelProperties.class)
 public abstract class MixinLevelProperties implements DimensionIdsHolder {

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinLevelStorage.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinLevelStorage.java
@@ -16,11 +16,13 @@
 
 package net.fabricmc.fabric.mixin.idremap;
 
-import net.fabricmc.fabric.impl.dimension.DimensionRemapException;
-import net.minecraft.world.level.storage.LevelStorage;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import net.minecraft.world.level.storage.LevelStorage;
+
+import net.fabricmc.fabric.impl.dimension.DimensionRemapException;
 
 @Mixin(LevelStorage.class)
 public abstract class MixinLevelStorage {

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinPlayerManager.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinPlayerManager.java
@@ -16,20 +16,22 @@
 
 package net.fabricmc.fabric.mixin.idremap;
 
-import net.fabricmc.fabric.impl.dimension.DimensionIdsFixer;
-import net.fabricmc.fabric.impl.dimension.FabricDimensionInternals;
-import net.minecraft.network.ClientConnection;
-import net.minecraft.server.PlayerManager;
-import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import net.minecraft.network.ClientConnection;
+import net.minecraft.server.PlayerManager;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import net.fabricmc.fabric.impl.dimension.DimensionIdsFixer;
+import net.fabricmc.fabric.impl.dimension.FabricDimensionInternals;
+
 @Mixin(PlayerManager.class)
 public abstract class MixinPlayerManager {
 	/**
-	 * Synchronizes raw dimension ids to connecting players
+	 * Synchronizes raw dimension ids to connecting players.
 	 */
 	@Inject(method = "onPlayerConnect", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/packet/DifficultyS2CPacket;<init>(Lnet/minecraft/world/Difficulty;Z)V"))
 	private void onPlayerConnect(ClientConnection conn, ServerPlayerEntity player, CallbackInfo info) {

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinUnmodifiableLevelProperties.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinUnmodifiableLevelProperties.java
@@ -16,13 +16,15 @@
 
 package net.fabricmc.fabric.mixin.idremap;
 
-import net.fabricmc.fabric.impl.dimension.DimensionIdsHolder;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.level.LevelProperties;
-import net.minecraft.world.level.UnmodifiableLevelProperties;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.LevelProperties;
+import net.minecraft.world.level.UnmodifiableLevelProperties;
+
+import net.fabricmc.fabric.impl.dimension.DimensionIdsHolder;
 
 @Mixin(UnmodifiableLevelProperties.class)
 public abstract class MixinUnmodifiableLevelProperties implements DimensionIdsHolder {
@@ -31,7 +33,7 @@ public abstract class MixinUnmodifiableLevelProperties implements DimensionIdsHo
 	private LevelProperties properties;
 
 	/**
-	 * Delegates to the main level properties
+	 * Delegates to the main level properties.
 	 */
 	@Override
 	public CompoundTag fabric_getDimensionIds() {

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/client/player/ClientPickBlockApplyCallback.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/client/player/ClientPickBlockApplyCallback.java
@@ -16,11 +16,12 @@
 
 package net.fabricmc.fabric.api.event.client.player;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.hit.HitResult;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
 
 /**
  * This event is emitted during the block-picking process. It can be used to
@@ -28,19 +29,20 @@ import net.minecraft.util.hit.HitResult;
  * ItemStack will cause the event to leave, and no block to be picked.
  */
 public interface ClientPickBlockApplyCallback {
-	public static final Event<ClientPickBlockApplyCallback> EVENT = EventFactory.createArrayBacked(ClientPickBlockApplyCallback.class,
-		(listeners) -> (player, result, _stack) -> {
-			ItemStack stack = _stack;
+	Event<ClientPickBlockApplyCallback> EVENT = EventFactory.createArrayBacked(ClientPickBlockApplyCallback.class,
+			(listeners) -> (player, result, _stack) -> {
+				ItemStack stack = _stack;
 
-			for (ClientPickBlockApplyCallback event : listeners) {
-				stack = event.pick(player, result, stack);
-				if (stack.isEmpty()) {
-					return ItemStack.EMPTY;
+				for (ClientPickBlockApplyCallback event : listeners) {
+					stack = event.pick(player, result, stack);
+
+					if (stack.isEmpty()) {
+						return ItemStack.EMPTY;
+					}
 				}
-			}
 
-			return stack;
-		}
+				return stack;
+			}
 	);
 
 	ItemStack pick(PlayerEntity player, HitResult result, ItemStack stack);

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/client/player/ClientPickBlockCallback.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/client/player/ClientPickBlockCallback.java
@@ -16,11 +16,12 @@
 
 package net.fabricmc.fabric.api.event.client.player;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.hit.HitResult;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
 
 /**
  * This event handler has been deprecated due to not hooking nicely
@@ -32,7 +33,7 @@ import net.minecraft.util.hit.HitResult;
 @Deprecated
 public interface ClientPickBlockCallback {
 	@Deprecated
-	public static final class Container {
+	final class Container {
 		private ItemStack stack;
 
 		public Container(ItemStack stack) {
@@ -48,8 +49,7 @@ public interface ClientPickBlockCallback {
 		}
 	}
 
-	@Deprecated
-	public static final Event<ClientPickBlockCallback> EVENT = EventFactory.createArrayBacked(ClientPickBlockCallback.class,
+	@Deprecated Event<ClientPickBlockCallback> EVENT = EventFactory.createArrayBacked(ClientPickBlockCallback.class,
 		(listeners) -> (player, result, container) -> {
 			for (ClientPickBlockCallback event : listeners) {
 				if (!event.pick(player, result, container)) {

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/client/player/ClientPickBlockGatherCallback.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/client/player/ClientPickBlockGatherCallback.java
@@ -16,11 +16,12 @@
 
 package net.fabricmc.fabric.api.event.client.player;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.hit.HitResult;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
 
 /**
  * This event is emitted at the beginning of the block picking process in
@@ -28,17 +29,18 @@ import net.minecraft.util.hit.HitResult;
  * will be returned, overriding vanilla behaviour.
  */
 public interface ClientPickBlockGatherCallback {
-	public static final Event<ClientPickBlockGatherCallback> EVENT = EventFactory.createArrayBacked(ClientPickBlockGatherCallback.class,
-		(listeners) -> (player, result) -> {
-			for (ClientPickBlockGatherCallback event : listeners) {
-				ItemStack stack = event.pick(player, result);
-				if (stack != ItemStack.EMPTY && !stack.isEmpty()) {
-					return stack;
-				}
-			}
+	Event<ClientPickBlockGatherCallback> EVENT = EventFactory.createArrayBacked(ClientPickBlockGatherCallback.class,
+			(listeners) -> (player, result) -> {
+				for (ClientPickBlockGatherCallback event : listeners) {
+					ItemStack stack = event.pick(player, result);
 
-			return ItemStack.EMPTY;
-		}
+					if (stack != ItemStack.EMPTY && !stack.isEmpty()) {
+						return stack;
+					}
+				}
+
+				return ItemStack.EMPTY;
+			}
 	);
 
 	ItemStack pick(PlayerEntity player, HitResult result);

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/AttackBlockCallback.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/AttackBlockCallback.java
@@ -16,8 +16,6 @@
 
 package net.fabricmc.fabric.api.event.player;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
@@ -25,29 +23,33 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
 
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
 /**
  * Callback for left-clicking ("attacking") a block.
  * Is hooked in before the spectator check, so make sure to check for the player's game mode as well!
- * <p>
- * Upon return:
- * - SUCCESS cancels further processing and, on the client, sends a packet to the server.
- * - PASS falls back to further processing.
- * - FAIL cancels further processing and does not send a packet to the server.
- * <p>
- * ATTACK_BLOCK does not let you control the packet sending process yet.
+ *
+ * <p>Upon return:
+ * <ul><li>SUCCESS cancels further processing and, on the client, sends a packet to the server.
+ * <li>PASS falls back to further processing.
+ * <li>FAIL cancels further processing and does not send a packet to the server.</ul>
+ *
+ * <p>ATTACK_BLOCK does not let you control the packet sending process yet.
  */
 public interface AttackBlockCallback {
-	public static final Event<AttackBlockCallback> EVENT = EventFactory.createArrayBacked(AttackBlockCallback.class,
-		(listeners) -> (player, world, hand, pos, direction) -> {
-			for (AttackBlockCallback event : listeners) {
-				ActionResult result = event.interact(player, world, hand, pos, direction);
-				if (result != ActionResult.PASS) {
-					return result;
-				}
-			}
+	Event<AttackBlockCallback> EVENT = EventFactory.createArrayBacked(AttackBlockCallback.class,
+			(listeners) -> (player, world, hand, pos, direction) -> {
+				for (AttackBlockCallback event : listeners) {
+					ActionResult result = event.interact(player, world, hand, pos, direction);
 
-			return ActionResult.PASS;
-		}
+					if (result != ActionResult.PASS) {
+						return result;
+					}
+				}
+
+				return ActionResult.PASS;
+			}
 	);
 
 	ActionResult interact(PlayerEntity player, World world, Hand hand, BlockPos pos, Direction direction);

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/AttackEntityCallback.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/AttackEntityCallback.java
@@ -16,8 +16,6 @@
 
 package net.fabricmc.fabric.api.event.player;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.ActionResult;
@@ -25,27 +23,31 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.hit.EntityHitResult;
 import net.minecraft.world.World;
 
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
 /**
  * Callback for left-clicking ("attacking") an entity.
  * Is hooked in before the spectator check, so make sure to check for the player's game mode as well!
- * <p>
- * Upon return:
- * - SUCCESS cancels further processing and, on the client, sends a packet to the server.
- * - PASS falls back to further processing.
- * - FAIL cancels further processing and does not send a packet to the server.
+ *
+ * <p>Upon return:
+ * <ul><li>SUCCESS cancels further processing and, on the client, sends a packet to the server.
+ * <li>PASS falls back to further processing.
+ * <li>FAIL cancels further processing and does not send a packet to the server.</ul>
  */
 public interface AttackEntityCallback {
-	public static final Event<AttackEntityCallback> EVENT = EventFactory.createArrayBacked(AttackEntityCallback.class,
-		(listeners) -> (player, world, hand, entity, hitResult) -> {
-			for (AttackEntityCallback event : listeners) {
-				ActionResult result = event.interact(player, world, hand, entity, hitResult);
-				if (result != ActionResult.PASS) {
-					return result;
-				}
-			}
+	Event<AttackEntityCallback> EVENT = EventFactory.createArrayBacked(AttackEntityCallback.class,
+			(listeners) -> (player, world, hand, entity, hitResult) -> {
+				for (AttackEntityCallback event : listeners) {
+					ActionResult result = event.interact(player, world, hand, entity, hitResult);
 
-			return ActionResult.PASS;
-		}
+					if (result != ActionResult.PASS) {
+						return result;
+					}
+				}
+
+				return ActionResult.PASS;
+			}
 	);
 
 	ActionResult interact(PlayerEntity player, World world, Hand hand, Entity entity, /* Nullable */ EntityHitResult hitResult);

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/UseBlockCallback.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/UseBlockCallback.java
@@ -16,35 +16,37 @@
 
 package net.fabricmc.fabric.api.event.player;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.world.World;
 
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
 /**
  * Callback for right-clicking ("using") a block.
  * Is hooked in before the spectator check, so make sure to check for the player's game mode as well!
- * <p>
- * Upon return:
- * - SUCCESS cancels further processing and, on the client, sends a packet to the server.
- * - PASS falls back to further processing.
- * - FAIL cancels further processing and does not send a packet to the server.
+ *
+ * <p>Upon return:
+ * <ul><li>SUCCESS cancels further processing and, on the client, sends a packet to the server.
+ * <li>PASS falls back to further processing.
+ * <li>FAIL cancels further processing and does not send a packet to the server.</ul>
  */
 public interface UseBlockCallback {
-	public static final Event<UseBlockCallback> EVENT = EventFactory.createArrayBacked(UseBlockCallback.class,
-		(listeners) -> (player, world, hand, hitResult) -> {
-			for (UseBlockCallback event : listeners) {
-				ActionResult result = event.interact(player, world, hand, hitResult);
-				if (result != ActionResult.PASS) {
-					return result;
-				}
-			}
+	Event<UseBlockCallback> EVENT = EventFactory.createArrayBacked(UseBlockCallback.class,
+			(listeners) -> (player, world, hand, hitResult) -> {
+				for (UseBlockCallback event : listeners) {
+					ActionResult result = event.interact(player, world, hand, hitResult);
 
-			return ActionResult.PASS;
-		}
+					if (result != ActionResult.PASS) {
+						return result;
+					}
+				}
+
+				return ActionResult.PASS;
+			}
 	);
 
 	ActionResult interact(PlayerEntity player, World world, Hand hand, BlockHitResult hitResult);

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/UseEntityCallback.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/UseEntityCallback.java
@@ -16,8 +16,6 @@
 
 package net.fabricmc.fabric.api.event.player;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.ActionResult;
@@ -25,27 +23,31 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.hit.EntityHitResult;
 import net.minecraft.world.World;
 
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
 /**
  * Callback for right-clicking ("using") an entity.
  * Is hooked in before the spectator check, so make sure to check for the player's game mode as well!
- * <p>
- * Upon return:
- * - SUCCESS cancels further processing and, on the client, sends a packet to the server.
- * - PASS falls back to further processing.
- * - FAIL cancels further processing and does not send a packet to the server.
+ *
+ * <p>Upon return:
+ * <ul><li>SUCCESS cancels further processing and, on the client, sends a packet to the server.
+ * <li>PASS falls back to further processing.
+ * <li>FAIL cancels further processing and does not send a packet to the server.</ul>
  */
 public interface UseEntityCallback {
-	public static final Event<UseEntityCallback> EVENT = EventFactory.createArrayBacked(UseEntityCallback.class,
-		(listeners) -> (player, world, hand, entity, hitResult) -> {
-			for (UseEntityCallback event : listeners) {
-				ActionResult result = event.interact(player, world, hand, entity, hitResult);
-				if (result != ActionResult.PASS) {
-					return result;
-				}
-			}
+	Event<UseEntityCallback> EVENT = EventFactory.createArrayBacked(UseEntityCallback.class,
+			(listeners) -> (player, world, hand, entity, hitResult) -> {
+				for (UseEntityCallback event : listeners) {
+					ActionResult result = event.interact(player, world, hand, entity, hitResult);
 
-			return ActionResult.PASS;
-		}
+					if (result != ActionResult.PASS) {
+						return result;
+					}
+				}
+
+				return ActionResult.PASS;
+			}
 	);
 
 	ActionResult interact(PlayerEntity player, World world, Hand hand, Entity entity, /* Nullable */ EntityHitResult hitResult);

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/UseItemCallback.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/UseItemCallback.java
@@ -16,34 +16,36 @@
 
 package net.fabricmc.fabric.api.event.player;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.world.World;
 
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
 /**
  * Callback for right-clicking ("using") an item.
  * Is hooked in before the spectator check, so make sure to check for the player's game mode as well!
- * <p>
- * Upon return:
- * - SUCCESS cancels further processing and, on the client, sends a packet to the server.
- * - PASS falls back to further processing.
- * - FAIL cancels further processing and does not send a packet to the server.
+ *
+ * <p>Upon return:
+ * <ul><li>SUCCESS cancels further processing and, on the client, sends a packet to the server.
+ * <li>PASS falls back to further processing.
+ * <li>FAIL cancels further processing and does not send a packet to the server.</ul>
  */
 public interface UseItemCallback {
-	public static final Event<UseItemCallback> EVENT = EventFactory.createArrayBacked(UseItemCallback.class,
-		(listeners) -> (player, world, hand) -> {
-			for (UseItemCallback event : listeners) {
-				ActionResult result = event.interact(player, world, hand);
-				if (result != ActionResult.PASS) {
-					return result;
-				}
-			}
+	Event<UseItemCallback> EVENT = EventFactory.createArrayBacked(UseItemCallback.class,
+			(listeners) -> (player, world, hand) -> {
+				for (UseItemCallback event : listeners) {
+					ActionResult result = event.interact(player, world, hand);
 
-			return ActionResult.PASS;
-		}
+					if (result != ActionResult.PASS) {
+						return result;
+					}
+				}
+
+				return ActionResult.PASS;
+			}
 	);
 
 	ActionResult interact(PlayerEntity player, World world, Hand hand);

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/impl/event/InteractionEventsRouter.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/impl/event/InteractionEventsRouter.java
@@ -16,17 +16,19 @@
 
 package net.fabricmc.fabric.impl.event;
 
+import net.minecraft.block.BlockState;
+import net.minecraft.util.ActionResult;
+
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.block.BlockAttackInteractionAware;
 import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
-import net.minecraft.block.BlockState;
-import net.minecraft.util.ActionResult;
 
 public class InteractionEventsRouter implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		AttackBlockCallback.EVENT.register((player, world, hand, pos, direction) -> {
 			BlockState state = world.getBlockState(pos);
+
 			if (state instanceof BlockAttackInteractionAware) {
 				if (((BlockAttackInteractionAware) state).onAttackInteraction(state, world, pos, player, hand, direction)) {
 					return ActionResult.FAIL;

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/impl/event/InteractionEventsRouterClient.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/impl/event/InteractionEventsRouterClient.java
@@ -16,10 +16,6 @@
 
 package net.fabricmc.fabric.impl.event;
 
-import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.block.BlockPickInteractionAware;
-import net.fabricmc.fabric.api.entity.EntityPickInteractionAware;
-import net.fabricmc.fabric.api.event.client.player.ClientPickBlockGatherCallback;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
@@ -27,6 +23,11 @@ import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.EntityHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockView;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.block.BlockPickInteractionAware;
+import net.fabricmc.fabric.api.entity.EntityPickInteractionAware;
+import net.fabricmc.fabric.api.event.client.player.ClientPickBlockGatherCallback;
 
 public class InteractionEventsRouterClient implements ClientModInitializer {
 	@Override

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/eventsinteraction/MixinMinecraftClient.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/eventsinteraction/MixinMinecraftClient.java
@@ -16,9 +16,13 @@
 
 package net.fabricmc.fabric.mixin.eventsinteraction;
 
-import net.fabricmc.fabric.api.event.client.player.ClientPickBlockApplyCallback;
-import net.fabricmc.fabric.api.event.client.player.ClientPickBlockCallback;
-import net.fabricmc.fabric.api.event.client.player.ClientPickBlockGatherCallback;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
@@ -27,12 +31,10 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.HitResult;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.fabricmc.fabric.api.event.client.player.ClientPickBlockApplyCallback;
+import net.fabricmc.fabric.api.event.client.player.ClientPickBlockCallback;
+import net.fabricmc.fabric.api.event.client.player.ClientPickBlockGatherCallback;
 
 @Mixin(MinecraftClient.class)
 public abstract class MixinMinecraftClient {
@@ -52,6 +54,7 @@ public abstract class MixinMinecraftClient {
 
 		// Do a "best effort" emulation of the old events.
 		ItemStack stack = ClientPickBlockGatherCallback.EVENT.invoker().pick(client.player, client.hitResult);
+
 		// TODO: Remove in 0.3.0
 		if (stack.isEmpty()) {
 			stack = fabric_emulateOldPick();
@@ -67,12 +70,14 @@ public abstract class MixinMinecraftClient {
 
 			if (client.player.abilities.creativeMode && Screen.hasControlDown() && client.hitResult.getType() == HitResult.Type.BLOCK) {
 				BlockEntity be = client.world.getBlockEntity(((BlockHitResult) client.hitResult).getBlockPos());
+
 				if (be != null) {
 					stack = addBlockEntityNbt(stack, be);
 				}
 			}
 
 			stack = ClientPickBlockApplyCallback.EVENT.invoker().pick(client.player, client.hitResult, stack);
+
 			if (stack.isEmpty()) {
 				return;
 			}
@@ -82,6 +87,7 @@ public abstract class MixinMinecraftClient {
 				client.interactionManager.clickCreativeStack(client.player.getStackInHand(Hand.MAIN_HAND), 36 + playerInventory.selectedSlot);
 			} else {
 				int slot = playerInventory.getSlotWithStack(stack);
+
 				if (slot >= 0) {
 					if (PlayerInventory.isValidHotbarIndex(slot)) {
 						playerInventory.selectedSlot = slot;

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/eventsinteraction/MixinServerPlayNetworkHandler.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/eventsinteraction/MixinServerPlayNetworkHandler.java
@@ -16,7 +16,12 @@
 
 package net.fabricmc.fabric.mixin.eventsinteraction;
 
-import net.fabricmc.fabric.api.event.player.UseEntityCallback;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
 import net.minecraft.entity.Entity;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -24,11 +29,8 @@ import net.minecraft.server.network.packet.PlayerInteractEntityC2SPacket;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.hit.EntityHitResult;
 import net.minecraft.world.World;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.fabricmc.fabric.api.event.player.UseEntityCallback;
 
 @Mixin(ServerPlayNetworkHandler.class)
 public class MixinServerPlayNetworkHandler {
@@ -39,10 +41,11 @@ public class MixinServerPlayNetworkHandler {
 	public void onPlayerInteractEntity(PlayerInteractEntityC2SPacket packet, CallbackInfo info) {
 		World world = player.getEntityWorld();
 		Entity entity = packet.getEntity(world);
+
 		if (entity != null) {
 			EntityHitResult hitResult = new EntityHitResult(entity, packet.getHitPosition().add(entity.x, entity.y, entity.z));
-
 			ActionResult result = UseEntityCallback.EVENT.invoker().interact(player, world, packet.getHand(), entity, hitResult);
+
 			if (result != ActionResult.PASS) {
 				info.cancel();
 			}

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/eventsinteraction/MixinServerPlayerEntity.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/eventsinteraction/MixinServerPlayerEntity.java
@@ -16,15 +16,17 @@
 
 package net.fabricmc.fabric.mixin.eventsinteraction;
 
-import net.fabricmc.fabric.api.event.player.AttackEntityCallback;
-import net.minecraft.entity.Entity;
-import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.util.ActionResult;
-import net.minecraft.util.Hand;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+
+import net.fabricmc.fabric.api.event.player.AttackEntityCallback;
 
 @Mixin(ServerPlayerEntity.class)
 public class MixinServerPlayerEntity {
@@ -32,6 +34,7 @@ public class MixinServerPlayerEntity {
 	public void onPlayerInteractEntity(Entity target, CallbackInfo info) {
 		ServerPlayerEntity player = (ServerPlayerEntity) (Object) this;
 		ActionResult result = AttackEntityCallback.EVENT.invoker().interact(player, player.getEntityWorld(), Hand.MAIN_HAND, target, null);
+
 		if (result != ActionResult.PASS) {
 			info.cancel();
 		}

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/eventsinteraction/MixinServerPlayerInteractionManager.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/eventsinteraction/MixinServerPlayerInteractionManager.java
@@ -16,9 +16,13 @@
 
 package net.fabricmc.fabric.mixin.eventsinteraction;
 
-import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
-import net.fabricmc.fabric.api.event.player.UseBlockCallback;
-import net.fabricmc.fabric.api.event.player.UseItemCallback;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
 import net.minecraft.client.network.packet.BlockUpdateS2CPacket;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
@@ -32,12 +36,10 @@ import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
+import net.fabricmc.fabric.api.event.player.UseBlockCallback;
+import net.fabricmc.fabric.api.event.player.UseItemCallback;
 
 @Mixin(ServerPlayerInteractionManager.class)
 public class MixinServerPlayerInteractionManager {
@@ -49,6 +51,7 @@ public class MixinServerPlayerInteractionManager {
 	@Inject(at = @At("HEAD"), method = "method_14263", cancellable = true)
 	public void startBlockBreak(BlockPos pos, PlayerActionC2SPacket.Action playerAction, Direction direction, int i, CallbackInfo info) {
 		ActionResult result = AttackBlockCallback.EVENT.invoker().interact(player, world, Hand.MAIN_HAND, pos, direction);
+
 		if (result != ActionResult.PASS) {
 			// The client might have broken the block on its side, so make sure to let it know.
 			this.player.networkHandler.sendPacket(new BlockUpdateS2CPacket(world, pos));
@@ -59,6 +62,7 @@ public class MixinServerPlayerInteractionManager {
 	@Inject(at = @At("HEAD"), method = "interactBlock", cancellable = true)
 	public void interactBlock(PlayerEntity player, World world, ItemStack stack, Hand hand, BlockHitResult blockHitResult, CallbackInfoReturnable<ActionResult> info) {
 		ActionResult result = UseBlockCallback.EVENT.invoker().interact(player, world, hand, blockHitResult);
+
 		if (result != ActionResult.PASS) {
 			info.setReturnValue(result);
 			info.cancel();
@@ -69,6 +73,7 @@ public class MixinServerPlayerInteractionManager {
 	@Inject(at = @At("HEAD"), method = "interactItem", cancellable = true)
 	public void interactItem(PlayerEntity player, World world, ItemStack stack, Hand hand, CallbackInfoReturnable<ActionResult> info) {
 		ActionResult result = UseItemCallback.EVENT.invoker().interact(player, world, hand);
+
 		if (result != ActionResult.PASS) {
 			info.setReturnValue(result);
 			info.cancel();

--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/client/ClientTickCallback.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/client/ClientTickCallback.java
@@ -16,31 +16,34 @@
 
 package net.fabricmc.fabric.api.event.client;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.client.MinecraftClient;
 
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
 public interface ClientTickCallback {
-	public static final Event<ClientTickCallback> EVENT = EventFactory.createArrayBacked(ClientTickCallback.class,
-		(listeners) -> {
-			if (EventFactory.isProfilingEnabled()) {
-				return (client) -> {
-					client.getProfiler().push("fabricClientTick");
-					for (ClientTickCallback event : listeners) {
-						client.getProfiler().push(EventFactory.getHandlerName(event));
-						event.tick(client);
+	Event<ClientTickCallback> EVENT = EventFactory.createArrayBacked(ClientTickCallback.class,
+			(listeners) -> {
+				if (EventFactory.isProfilingEnabled()) {
+					return (client) -> {
+						client.getProfiler().push("fabricClientTick");
+
+						for (ClientTickCallback event : listeners) {
+							client.getProfiler().push(EventFactory.getHandlerName(event));
+							event.tick(client);
+							client.getProfiler().pop();
+						}
+
 						client.getProfiler().pop();
-					}
-					client.getProfiler().pop();
-				};
-			} else {
-				return (client) -> {
-					for (ClientTickCallback event : listeners) {
-						event.tick(client);
-					}
-				};
+					};
+				} else {
+					return (client) -> {
+						for (ClientTickCallback event : listeners) {
+							event.tick(client);
+						}
+					};
+				}
 			}
-		}
 	);
 
 	void tick(MinecraftClient client);

--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/client/ItemTooltipCallback.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/client/ItemTooltipCallback.java
@@ -16,24 +16,23 @@
 
 package net.fabricmc.fabric.api.event.client;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
+import java.util.List;
+
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
 
-import java.util.List;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
 
 public interface ItemTooltipCallback {
-
-	/** Fired after the game has appended all base tooltip lines to the list */
+	/** Fired after the game has appended all base tooltip lines to the list. */
 	Event<ItemTooltipCallback> EVENT = EventFactory.createArrayBacked(ItemTooltipCallback.class, (listeners) ->
-		(stack, tooltipContext, lines) -> {
-			for(ItemTooltipCallback callback : listeners){
-				callback.getTooltip(stack, tooltipContext, lines);
-			}
+			(stack, tooltipContext, lines) -> {
+		for (ItemTooltipCallback callback : listeners) {
+			callback.getTooltip(stack, tooltipContext, lines);
 		}
-	);
+	});
 
 	/**
 	 * Called when an item stack's tooltip is rendered. Text added to {@code lines} will be
@@ -41,5 +40,4 @@ public interface ItemTooltipCallback {
 	 * @param lines the list containing the lines of text displayed on the stack's tooltip
 	 */
 	void getTooltip(ItemStack stack, TooltipContext tooltipContext, List<Text> lines);
-
 }

--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/server/ServerStartCallback.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/server/ServerStartCallback.java
@@ -16,17 +16,18 @@
 
 package net.fabricmc.fabric.api.event.server;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.server.MinecraftServer;
 
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
 public interface ServerStartCallback {
-	public static final Event<ServerStartCallback> EVENT = EventFactory.createArrayBacked(ServerStartCallback.class,
-		(listeners) -> (server) -> {
-			for (ServerStartCallback event : listeners) {
-				event.onStartServer(server);
+	Event<ServerStartCallback> EVENT = EventFactory.createArrayBacked(ServerStartCallback.class,
+			(listeners) -> (server) -> {
+				for (ServerStartCallback event : listeners) {
+					event.onStartServer(server);
+				}
 			}
-		}
 	);
 
 	void onStartServer(MinecraftServer server);

--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/server/ServerStopCallback.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/server/ServerStopCallback.java
@@ -16,17 +16,18 @@
 
 package net.fabricmc.fabric.api.event.server;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.server.MinecraftServer;
 
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
 public interface ServerStopCallback {
-	public static final Event<ServerStopCallback> EVENT = EventFactory.createArrayBacked(ServerStopCallback.class,
-		(listeners) -> (server) -> {
-			for (ServerStopCallback event : listeners) {
-				event.onStopServer(server);
+	Event<ServerStopCallback> EVENT = EventFactory.createArrayBacked(ServerStopCallback.class,
+			(listeners) -> (server) -> {
+				for (ServerStopCallback event : listeners) {
+					event.onStopServer(server);
+				}
 			}
-		}
 	);
 
 	void onStopServer(MinecraftServer server);

--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/server/ServerTickCallback.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/server/ServerTickCallback.java
@@ -16,31 +16,34 @@
 
 package net.fabricmc.fabric.api.event.server;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.server.MinecraftServer;
 
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
 public interface ServerTickCallback {
-	public static final Event<ServerTickCallback> EVENT = EventFactory.createArrayBacked(ServerTickCallback.class,
-		(listeners) -> {
-			if (EventFactory.isProfilingEnabled()) {
-				return (server) -> {
-					server.getProfiler().push("fabricServerTick");
-					for (ServerTickCallback event : listeners) {
-						server.getProfiler().push(EventFactory.getHandlerName(event));
-						event.tick(server);
+	Event<ServerTickCallback> EVENT = EventFactory.createArrayBacked(ServerTickCallback.class,
+			(listeners) -> {
+				if (EventFactory.isProfilingEnabled()) {
+					return (server) -> {
+						server.getProfiler().push("fabricServerTick");
+
+						for (ServerTickCallback event : listeners) {
+							server.getProfiler().push(EventFactory.getHandlerName(event));
+							event.tick(server);
+							server.getProfiler().pop();
+						}
+
 						server.getProfiler().pop();
-					}
-					server.getProfiler().pop();
-				};
-			} else {
-				return (server) -> {
-					for (ServerTickCallback event : listeners) {
-						event.tick(server);
-					}
-				};
+					};
+				} else {
+					return (server) -> {
+						for (ServerTickCallback event : listeners) {
+							event.tick(server);
+						}
+					};
+				}
 			}
-		}
 	);
 
 	void tick(MinecraftServer server);

--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/world/WorldTickCallback.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/world/WorldTickCallback.java
@@ -16,31 +16,34 @@
 
 package net.fabricmc.fabric.api.event.world;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.world.World;
 
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
 public interface WorldTickCallback {
-	public static final Event<WorldTickCallback> EVENT = EventFactory.createArrayBacked(WorldTickCallback.class,
-		(listeners) -> {
-			if (EventFactory.isProfilingEnabled()) {
-				return (world) -> {
-					world.getProfiler().push("fabricWorldTick");
-					for (WorldTickCallback event : listeners) {
-						world.getProfiler().push(EventFactory.getHandlerName(event));
-						event.tick(world);
+	Event<WorldTickCallback> EVENT = EventFactory.createArrayBacked(WorldTickCallback.class,
+			(listeners) -> {
+				if (EventFactory.isProfilingEnabled()) {
+					return (world) -> {
+						world.getProfiler().push("fabricWorldTick");
+
+						for (WorldTickCallback event : listeners) {
+							world.getProfiler().push(EventFactory.getHandlerName(event));
+							event.tick(world);
+							world.getProfiler().pop();
+						}
+
 						world.getProfiler().pop();
-					}
-					world.getProfiler().pop();
-				};
-			} else {
-				return (world) -> {
-					for (WorldTickCallback event : listeners) {
-						event.tick(world);
-					}
-				};
+					};
+				} else {
+					return (world) -> {
+						for (WorldTickCallback event : listeners) {
+							event.tick(world);
+						}
+					};
+				}
 			}
-		}
 	);
 
 	void tick(World world);

--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/mixin/eventslifecycle/MixinItemStack.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/mixin/eventslifecycle/MixinItemStack.java
@@ -16,25 +16,24 @@
 
 package net.fabricmc.fabric.mixin.eventslifecycle;
 
-import net.fabricmc.fabric.api.event.client.ItemTooltipCallback;
-import net.minecraft.client.item.TooltipContext;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.ItemStack;
-import net.minecraft.text.Text;
+import java.util.List;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-import java.util.List;
+import net.minecraft.client.item.TooltipContext;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.Text;
+
+import net.fabricmc.fabric.api.event.client.ItemTooltipCallback;
 
 @Mixin(ItemStack.class)
 public class MixinItemStack {
-
 	@Inject(method = "getTooltip", at = @At("RETURN"))
-	private void getTooltip(PlayerEntity entity, TooltipContext tooltipContext, CallbackInfoReturnable<List<Text>> info){
+	private void getTooltip(PlayerEntity entity, TooltipContext tooltipContext, CallbackInfoReturnable<List<Text>> info) {
 		ItemTooltipCallback.EVENT.invoker().getTooltip((ItemStack) (Object)this, tooltipContext, info.getReturnValue());
 	}
-
 }

--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/mixin/eventslifecycle/MixinItemStack.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/mixin/eventslifecycle/MixinItemStack.java
@@ -34,6 +34,6 @@ import net.fabricmc.fabric.api.event.client.ItemTooltipCallback;
 public class MixinItemStack {
 	@Inject(method = "getTooltip", at = @At("RETURN"))
 	private void getTooltip(PlayerEntity entity, TooltipContext tooltipContext, CallbackInfoReturnable<List<Text>> info) {
-		ItemTooltipCallback.EVENT.invoker().getTooltip((ItemStack) (Object)this, tooltipContext, info.getReturnValue());
+		ItemTooltipCallback.EVENT.invoker().getTooltip((ItemStack) (Object) this, tooltipContext, info.getReturnValue());
 	}
 }

--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/mixin/eventslifecycle/MixinMinecraftClient.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/mixin/eventslifecycle/MixinMinecraftClient.java
@@ -16,12 +16,14 @@
 
 package net.fabricmc.fabric.mixin.eventslifecycle;
 
-import net.fabricmc.fabric.api.event.client.ClientTickCallback;
-import net.minecraft.client.MinecraftClient;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.MinecraftClient;
+
+import net.fabricmc.fabric.api.event.client.ClientTickCallback;
 
 @Mixin(MinecraftClient.class)
 public class MixinMinecraftClient {

--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/mixin/eventslifecycle/MixinMinecraftServer.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/mixin/eventslifecycle/MixinMinecraftServer.java
@@ -16,16 +16,18 @@
 
 package net.fabricmc.fabric.mixin.eventslifecycle;
 
-import net.fabricmc.fabric.api.event.server.ServerStartCallback;
-import net.fabricmc.fabric.api.event.server.ServerStopCallback;
-import net.fabricmc.fabric.api.event.server.ServerTickCallback;
-import net.minecraft.server.MinecraftServer;
+import java.util.function.BooleanSupplier;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.function.BooleanSupplier;
+import net.minecraft.server.MinecraftServer;
+
+import net.fabricmc.fabric.api.event.server.ServerStartCallback;
+import net.fabricmc.fabric.api.event.server.ServerStopCallback;
+import net.fabricmc.fabric.api.event.server.ServerTickCallback;
 
 @Mixin(MinecraftServer.class)
 public class MixinMinecraftServer {

--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/mixin/eventslifecycle/MixinWorld.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/mixin/eventslifecycle/MixinWorld.java
@@ -16,12 +16,14 @@
 
 package net.fabricmc.fabric.mixin.eventslifecycle;
 
-import net.fabricmc.fabric.api.event.world.WorldTickCallback;
-import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.world.World;
+
+import net.fabricmc.fabric.api.event.world.WorldTickCallback;
 
 @Mixin(World.class)
 public class MixinWorld {

--- a/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/api/client/itemgroup/FabricItemGroupBuilder.java
+++ b/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/api/client/itemgroup/FabricItemGroupBuilder.java
@@ -16,18 +16,18 @@
 
 package net.fabricmc.fabric.api.client.itemgroup;
 
-import net.fabricmc.fabric.impl.itemgroup.ItemGroupExtensions;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.DefaultedList;
 import net.minecraft.util.Identifier;
 
-import java.util.List;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
+import net.fabricmc.fabric.impl.itemgroup.ItemGroupExtensions;
 
 public final class FabricItemGroupBuilder {
-
 	private Identifier identifier;
 	private Supplier<ItemStack> stackSupplier = () -> ItemStack.EMPTY;
 	private Consumer<List<ItemStack>> stacksForDisplay;
@@ -37,7 +37,7 @@ public final class FabricItemGroupBuilder {
 	}
 
 	/**
-	 * Create a new Item Group Builder
+	 * Create a new Item Group Builder.
 	 *
 	 * @param identifier the id will become the name of the ItemGroup and will be used for the translation key
 	 * @return a FabricItemGroupBuilder
@@ -47,7 +47,7 @@ public final class FabricItemGroupBuilder {
 	}
 
 	/**
-	 * This is used to add an icon to to the item group
+	 * This is used to add an icon to to the item group.
 	 *
 	 * @param stackSupplier the supplier should return the item stack that you wish to show on the tab
 	 * @return a reference to the FabricItemGroupBuilder
@@ -58,7 +58,7 @@ public final class FabricItemGroupBuilder {
 	}
 
 	/**
-	 * This allows for a custom list of items to be displayed in a tab, this enabled tabs to be created with a custom set of items
+	 * This allows for a custom list of items to be displayed in a tab, this enabled tabs to be created with a custom set of items.
 	 *
 	 * @param appender Add ItemStack's to this list to show in the ItemGroup
 	 * @return a reference to the FabricItemGroupBuilder
@@ -70,7 +70,7 @@ public final class FabricItemGroupBuilder {
 	}
 
 	/**
-	 * This allows for a custom list of items to be displayed in a tab, this enabled tabs to be created with a custom set of items
+	 * This allows for a custom list of items to be displayed in a tab, this enabled tabs to be created with a custom set of items.
 	 *
 	 * @param stacksForDisplay Add ItemStack's to this list to show in the ItemGroup
 	 * @return a reference to the FabricItemGroupBuilder
@@ -81,7 +81,7 @@ public final class FabricItemGroupBuilder {
 	}
 
 	/**
-	 * This is a single method that makes creating an ItemGroup with an icon one call
+	 * This is a single method that makes creating an ItemGroup with an icon one call.
 	 *
 	 * @param identifier    the id will become the name of the ItemGroup and will be used for the translation key
 	 * @param stackSupplier the supplier should return the item stack that you wish to show on the tab
@@ -92,7 +92,7 @@ public final class FabricItemGroupBuilder {
 	}
 
 	/**
-	 * Create an instance of the ItemGroup
+	 * Create an instance of the ItemGroup.
 	 *
 	 * @return An instance of the built ItemGroup
 	 */
@@ -110,9 +110,9 @@ public final class FabricItemGroupBuilder {
 					stacksForDisplay.accept(stacks);
 					return;
 				}
+
 				super.appendStacks(stacks);
 			}
 		};
 	}
-
 }

--- a/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/impl/itemgroup/CreativeGuiExtensions.java
+++ b/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/impl/itemgroup/CreativeGuiExtensions.java
@@ -17,7 +17,6 @@
 package net.fabricmc.fabric.impl.itemgroup;
 
 public interface CreativeGuiExtensions {
-
 	void fabric_nextPage();
 
 	void fabric_previousPage();

--- a/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/impl/itemgroup/FabricCreativeGuiComponents.java
+++ b/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/impl/itemgroup/FabricCreativeGuiComponents.java
@@ -16,21 +16,20 @@
 
 package net.fabricmc.fabric.impl.itemgroup;
 
-import com.mojang.blaze3d.platform.GlStateManager;
-import net.minecraft.client.MinecraftClient;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
 
+import com.mojang.blaze3d.platform.GlStateManager;
+
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.util.Identifier;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.function.Consumer;
-
 public class FabricCreativeGuiComponents {
-
 	private static final Identifier BUTTON_TEX = new Identifier("fabric", "textures/gui/creative_buttons.png");
 	public static final Set<ItemGroup> COMMON_GROUPS = new HashSet<>();
 
@@ -41,7 +40,6 @@ public class FabricCreativeGuiComponents {
 	}
 
 	public static class ItemGroupButtonWidget extends ButtonWidget {
-
 		CreativeGuiExtensions extensions;
 		CreativeInventoryScreen gui;
 		Type type;
@@ -73,7 +71,6 @@ public class FabricCreativeGuiComponents {
 	}
 
 	public enum Type {
-
 		NEXT(">", CreativeGuiExtensions::fabric_nextPage),
 		PREVIOUS("<", CreativeGuiExtensions::fabric_previousPage);
 
@@ -85,5 +82,4 @@ public class FabricCreativeGuiComponents {
 			this.clickConsumer = clickConsumer;
 		}
 	}
-
 }

--- a/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/impl/itemgroup/ItemGroupExtensions.java
+++ b/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/impl/itemgroup/ItemGroupExtensions.java
@@ -17,7 +17,5 @@
 package net.fabricmc.fabric.impl.itemgroup;
 
 public interface ItemGroupExtensions {
-
 	void fabric_expandArray();
-
 }

--- a/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/mixin/itemgroup/MixinItemGroup.java
+++ b/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/mixin/itemgroup/MixinItemGroup.java
@@ -16,16 +16,17 @@
 
 package net.fabricmc.fabric.mixin.itemgroup;
 
-import net.fabricmc.fabric.impl.itemgroup.ItemGroupExtensions;
-import net.minecraft.item.ItemGroup;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Shadow;
 
+import net.minecraft.item.ItemGroup;
+
+import net.fabricmc.fabric.impl.itemgroup.ItemGroupExtensions;
+
 @Mixin(ItemGroup.class)
 public abstract class MixinItemGroup implements ItemGroupExtensions {
-
 	@Shadow
 	@Final
 	@Mutable
@@ -35,9 +36,9 @@ public abstract class MixinItemGroup implements ItemGroupExtensions {
 	public void fabric_expandArray() {
 		ItemGroup[] tempGroups = GROUPS;
 		GROUPS = new ItemGroup[GROUPS.length + 1];
+
 		for (int i = 0; i < tempGroups.length; i++) {
 			GROUPS[i] = tempGroups[i];
 		}
 	}
-
 }

--- a/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/mixin/itemgroup/client/MixinCreativePlayerInventoryGui.java
+++ b/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/mixin/itemgroup/client/MixinCreativePlayerInventoryGui.java
@@ -16,14 +16,6 @@
 
 package net.fabricmc.fabric.mixin.itemgroup.client;
 
-import net.fabricmc.fabric.impl.itemgroup.CreativeGuiExtensions;
-import net.fabricmc.fabric.impl.itemgroup.FabricCreativeGuiComponents;
-import net.minecraft.client.gui.screen.ingame.AbstractInventoryScreen;
-import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
-import net.minecraft.container.Container;
-import net.minecraft.entity.player.PlayerInventory;
-import net.minecraft.item.ItemGroup;
-import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -31,9 +23,18 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import net.minecraft.client.gui.screen.ingame.AbstractInventoryScreen;
+import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
+import net.minecraft.container.Container;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.text.Text;
+
+import net.fabricmc.fabric.impl.itemgroup.CreativeGuiExtensions;
+import net.fabricmc.fabric.impl.itemgroup.FabricCreativeGuiComponents;
+
 @Mixin(CreativeInventoryScreen.class)
 public abstract class MixinCreativePlayerInventoryGui extends AbstractInventoryScreen implements CreativeGuiExtensions {
-
 	public MixinCreativePlayerInventoryGui(Container container_1, PlayerInventory playerInventory_1, Text textComponent_1) {
 		super(container_1, playerInventory_1, textComponent_1);
 	}
@@ -49,12 +50,12 @@ public abstract class MixinCreativePlayerInventoryGui extends AbstractInventoryS
 
 	private int fabric_getPageOffset(int page) {
 		switch (page) {
-			case 0:
-				return 0;
-			case 1:
-				return 12;
-			default:
-				return 12 + ((12 - FabricCreativeGuiComponents.COMMON_GROUPS.size()) * (page - 1));
+		case 0:
+			return 0;
+		case 1:
+			return 12;
+		default:
+			return 12 + ((12 - FabricCreativeGuiComponents.COMMON_GROUPS.size()) * (page - 1));
 		}
 	}
 
@@ -71,6 +72,7 @@ public abstract class MixinCreativePlayerInventoryGui extends AbstractInventoryS
 		if (fabric_getPageOffset(fabric_currentPage + 1) >= ItemGroup.GROUPS.length) {
 			return;
 		}
+
 		fabric_currentPage++;
 		fabric_updateSelection();
 	}
@@ -80,6 +82,7 @@ public abstract class MixinCreativePlayerInventoryGui extends AbstractInventoryS
 		if (fabric_currentPage == 0) {
 			return;
 		}
+
 		fabric_currentPage--;
 		fabric_updateSelection();
 	}
@@ -94,9 +97,11 @@ public abstract class MixinCreativePlayerInventoryGui extends AbstractInventoryS
 		if (type == FabricCreativeGuiComponents.Type.NEXT) {
 			return !(fabric_getPageOffset(fabric_currentPage + 1) >= ItemGroup.GROUPS.length);
 		}
+
 		if (type == FabricCreativeGuiComponents.Type.PREVIOUS) {
 			return fabric_currentPage != 0;
 		}
+
 		return false;
 	}
 
@@ -119,7 +124,6 @@ public abstract class MixinCreativePlayerInventoryGui extends AbstractInventoryS
 
 		addButton(new FabricCreativeGuiComponents.ItemGroupButtonWidget(xpos + 10, ypos, FabricCreativeGuiComponents.Type.NEXT, this));
 		addButton(new FabricCreativeGuiComponents.ItemGroupButtonWidget(xpos, ypos, FabricCreativeGuiComponents.Type.PREVIOUS, this));
-
 	}
 
 	@Inject(method = "setSelectedTab", at = @At("HEAD"), cancellable = true)
@@ -154,8 +158,8 @@ public abstract class MixinCreativePlayerInventoryGui extends AbstractInventoryS
 		if (FabricCreativeGuiComponents.COMMON_GROUPS.contains(itemGroup)) {
 			return true;
 		}
-		return fabric_currentPage == fabric_getOffsetPage(itemGroup.getIndex());
 
+		return fabric_currentPage == fabric_getOffsetPage(itemGroup.getIndex());
 	}
 
 	@Override

--- a/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/mixin/itemgroup/client/MixinItemGroup.java
+++ b/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/mixin/itemgroup/client/MixinItemGroup.java
@@ -16,13 +16,15 @@
 
 package net.fabricmc.fabric.mixin.itemgroup.client;
 
-import net.fabricmc.fabric.impl.itemgroup.FabricCreativeGuiComponents;
-import net.minecraft.item.ItemGroup;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.item.ItemGroup;
+
+import net.fabricmc.fabric.impl.itemgroup.FabricCreativeGuiComponents;
 
 @Mixin(ItemGroup.class)
 public abstract class MixinItemGroup {
@@ -47,7 +49,6 @@ public abstract class MixinItemGroup {
 			} else {
 				info.setReturnValue((getIndex() - 12) % (12 - FabricCreativeGuiComponents.COMMON_GROUPS.size()) - 4);
 			}
-
 		}
 	}
 }

--- a/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/FabricKeyBinding.java
+++ b/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/FabricKeyBinding.java
@@ -16,15 +16,16 @@
 
 package net.fabricmc.fabric.api.client.keybinding;
 
-import net.fabricmc.fabric.mixin.client.keybinding.KeyCodeAccessor;
 import net.minecraft.client.options.KeyBinding;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.util.Identifier;
 
+import net.fabricmc.fabric.mixin.client.keybinding.KeyCodeAccessor;
+
 /**
  * Expanded version of {@link KeyBinding} for use by Fabric mods.
- * <p>
- * *ALL* instantiated FabricKeyBindings should be registered in
+ *
+ * <p>*ALL* instantiated FabricKeyBindings should be registered in
  * {@link KeyBindingRegistry#register(FabricKeyBinding)}!
  */
 public class FabricKeyBinding extends KeyBinding {

--- a/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/KeyBindingRegistry.java
+++ b/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/KeyBindingRegistry.java
@@ -16,8 +16,9 @@
 
 package net.fabricmc.fabric.api.client.keybinding;
 
-import net.fabricmc.fabric.impl.client.keybinding.KeyBindingRegistryImpl;
 import net.minecraft.client.options.KeyBinding;
+
+import net.fabricmc.fabric.impl.client.keybinding.KeyBindingRegistryImpl;
 
 /**
  * Interface for registering key bindings.
@@ -25,7 +26,7 @@ import net.minecraft.client.options.KeyBinding;
  * @see KeyBinding
  */
 public interface KeyBindingRegistry {
-	static KeyBindingRegistry INSTANCE = KeyBindingRegistryImpl.INSTANCE;
+	KeyBindingRegistry INSTANCE = KeyBindingRegistryImpl.INSTANCE;
 
 	/**
 	 * Add a new key binding category.

--- a/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
+++ b/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
@@ -16,17 +16,19 @@
 
 package net.fabricmc.fabric.impl.client.keybinding;
 
-import net.fabricmc.fabric.api.client.keybinding.FabricKeyBinding;
-import net.fabricmc.fabric.api.client.keybinding.KeyBindingRegistry;
-import net.minecraft.client.options.KeyBinding;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import net.minecraft.client.options.KeyBinding;
+
+import net.fabricmc.fabric.api.client.keybinding.FabricKeyBinding;
+import net.fabricmc.fabric.api.client.keybinding.KeyBindingRegistry;
 
 public class KeyBindingRegistryImpl implements KeyBindingRegistry {
 	public static final KeyBindingRegistryImpl INSTANCE = new KeyBindingRegistryImpl();
@@ -67,6 +69,7 @@ public class KeyBindingRegistryImpl implements KeyBindingRegistry {
 	@Override
 	public boolean addCategory(String categoryName) {
 		Map<String, Integer> map = getCategoryMap();
+
 		if (map.containsKey(categoryName)) {
 			return false;
 		}
@@ -98,6 +101,7 @@ public class KeyBindingRegistryImpl implements KeyBindingRegistry {
 
 	public KeyBinding[] process(KeyBinding[] keysAll) {
 		List<KeyBinding> newKeysAll = new ArrayList<>();
+
 		for (KeyBinding binding : keysAll) {
 			if (!(binding instanceof FabricKeyBinding)) {
 				newKeysAll.add(binding);

--- a/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/mixin/client/keybinding/KeyCodeAccessor.java
+++ b/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/mixin/client/keybinding/KeyCodeAccessor.java
@@ -16,10 +16,11 @@
 
 package net.fabricmc.fabric.mixin.client.keybinding;
 
-import net.minecraft.client.options.KeyBinding;
-import net.minecraft.client.util.InputUtil;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.client.options.KeyBinding;
+import net.minecraft.client.util.InputUtil;
 
 @Mixin(KeyBinding.class)
 public interface KeyCodeAccessor {

--- a/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/mixin/client/keybinding/MixinGameOptions.java
+++ b/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/mixin/client/keybinding/MixinGameOptions.java
@@ -16,14 +16,16 @@
 
 package net.fabricmc.fabric.mixin.client.keybinding;
 
-import net.fabricmc.fabric.impl.client.keybinding.KeyBindingRegistryImpl;
-import net.minecraft.client.options.GameOptions;
-import net.minecraft.client.options.KeyBinding;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.options.GameOptions;
+import net.minecraft.client.options.KeyBinding;
+
+import net.fabricmc.fabric.impl.client.keybinding.KeyBindingRegistryImpl;
 
 @Mixin(GameOptions.class)
 public class MixinGameOptions {

--- a/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/mixin/client/keybinding/MixinKeyBinding.java
+++ b/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/mixin/client/keybinding/MixinKeyBinding.java
@@ -16,11 +16,12 @@
 
 package net.fabricmc.fabric.mixin.client.keybinding;
 
-import net.minecraft.client.options.KeyBinding;
+import java.util.Map;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
-import java.util.Map;
+import net.minecraft.client.options.KeyBinding;
 
 @Mixin(KeyBinding.class)
 public class MixinKeyBinding {

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/FabricLootPool.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/FabricLootPool.java
@@ -16,13 +16,13 @@
 
 package net.fabricmc.fabric.api.loot.v1;
 
+import java.util.List;
+
 import net.minecraft.world.loot.LootPool;
 import net.minecraft.world.loot.LootTableRange;
 import net.minecraft.world.loot.condition.LootCondition;
 import net.minecraft.world.loot.entry.LootEntry;
 import net.minecraft.world.loot.function.LootFunction;
-
-import java.util.List;
 
 /**
  * An interface implemented by all {@code net.minecraft.world.loot.LootPool} instances when
@@ -32,6 +32,7 @@ public interface FabricLootPool {
 	default LootPool asVanilla() {
 		return (LootPool) this;
 	}
+
 	List<LootEntry> getEntries();
 	List<LootCondition> getConditions();
 	List<LootFunction> getFunctions();

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/FabricLootPoolBuilder.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/FabricLootPoolBuilder.java
@@ -16,17 +16,18 @@
 
 package net.fabricmc.fabric.api.loot.v1;
 
-import net.fabricmc.fabric.mixin.loot.LootPoolBuilderHooks;
 import net.minecraft.world.loot.LootPool;
 import net.minecraft.world.loot.LootTableRange;
 import net.minecraft.world.loot.condition.LootCondition;
 import net.minecraft.world.loot.entry.LootEntry;
 import net.minecraft.world.loot.function.LootFunction;
 
+import net.fabricmc.fabric.mixin.loot.LootPoolBuilderHooks;
+
 public class FabricLootPoolBuilder extends LootPool.Builder {
 	private final LootPoolBuilderHooks extended = (LootPoolBuilderHooks) this;
 
-	private FabricLootPoolBuilder() {}
+	private FabricLootPoolBuilder() { }
 
 	private FabricLootPoolBuilder(LootPool pool) {
 		copyFrom(pool, true);
@@ -75,7 +76,7 @@ public class FabricLootPoolBuilder extends LootPool.Builder {
 	 * Copies the entries, conditions and functions of the {@code pool} to this
 	 * builder.
 	 *
-	 * This is equal to {@code copyFrom(pool, false)}.
+	 * <p>This is equal to {@code copyFrom(pool, false)}.
 	 */
 	public FabricLootPoolBuilder copyFrom(LootPool pool) {
 		return copyFrom(pool, false);
@@ -85,7 +86,7 @@ public class FabricLootPoolBuilder extends LootPool.Builder {
 	 * Copies the entries, conditions and functions of the {@code pool} to this
 	 * builder.
 	 *
-	 * If {@code copyRolls} is true, the {@link FabricLootPool#getRollsRange rolls} of the pool are also copied.
+	 * <p>If {@code copyRolls} is true, the {@link FabricLootPool#getRollsRange rolls} of the pool are also copied.
 	 */
 	public FabricLootPoolBuilder copyFrom(LootPool pool, boolean copyRolls) {
 		FabricLootPool extendedPool = (FabricLootPool) pool;

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/FabricLootSupplier.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/FabricLootSupplier.java
@@ -16,12 +16,12 @@
 
 package net.fabricmc.fabric.api.loot.v1;
 
+import java.util.List;
+
 import net.minecraft.world.loot.LootPool;
 import net.minecraft.world.loot.LootSupplier;
 import net.minecraft.world.loot.context.LootContextType;
 import net.minecraft.world.loot.function.LootFunction;
-
-import java.util.List;
 
 /**
  * An interface implemented by all {@code net.minecraft.world.loot.LootSupplier} instances when
@@ -31,6 +31,7 @@ public interface FabricLootSupplier {
 	default LootSupplier asVanilla() {
 		return (LootSupplier) this;
 	}
+
 	List<LootPool> getPools();
 	List<LootFunction> getFunctions();
 	LootContextType getType();

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/FabricLootSupplierBuilder.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/FabricLootSupplierBuilder.java
@@ -16,18 +16,19 @@
 
 package net.fabricmc.fabric.api.loot.v1;
 
-import net.fabricmc.fabric.mixin.loot.LootSupplierBuilderHooks;
+import java.util.Collection;
+
 import net.minecraft.world.loot.LootPool;
 import net.minecraft.world.loot.LootSupplier;
 import net.minecraft.world.loot.context.LootContextType;
 import net.minecraft.world.loot.function.LootFunction;
 
-import java.util.Collection;
+import net.fabricmc.fabric.mixin.loot.LootSupplierBuilderHooks;
 
 public class FabricLootSupplierBuilder extends LootSupplier.Builder {
 	private final LootSupplierBuilderHooks extended = (LootSupplierBuilderHooks) this;
 
-	protected FabricLootSupplierBuilder() {}
+	protected FabricLootSupplierBuilder() { }
 
 	private FabricLootSupplierBuilder(LootSupplier supplier) {
 		copyFrom(supplier, true);

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/LootEntryTypeRegistry.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/LootEntryTypeRegistry.java
@@ -16,8 +16,9 @@
 
 package net.fabricmc.fabric.api.loot.v1;
 
-import net.fabricmc.fabric.impl.loot.LootEntryTypeRegistryImpl;
 import net.minecraft.world.loot.entry.LootEntry;
+
+import net.fabricmc.fabric.impl.loot.LootEntryTypeRegistryImpl;
 
 /**
  * Fabric's extensions to {@code net.minecraft.world.loot.entry.LootEntries} for registering
@@ -26,7 +27,7 @@ import net.minecraft.world.loot.entry.LootEntry;
  * @see #register
  */
 public interface LootEntryTypeRegistry {
-	final LootEntryTypeRegistry INSTANCE = LootEntryTypeRegistryImpl.INSTANCE;
+	LootEntryTypeRegistry INSTANCE = LootEntryTypeRegistryImpl.INSTANCE;
 
 	/**
 	 * Registers a loot entry type by its serializer.

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/LootJsonParser.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/LootJsonParser.java
@@ -16,13 +16,15 @@
 
 package net.fabricmc.fabric.api.loot.v1;
 
-import com.google.gson.Gson;
-import net.minecraft.util.JsonHelper;
-import net.minecraft.util.Lazy;
-import net.minecraft.world.loot.*;
 import java.io.Reader;
 import java.lang.reflect.Field;
 import java.util.stream.Stream;
+
+import com.google.gson.Gson;
+
+import net.minecraft.util.JsonHelper;
+import net.minecraft.util.Lazy;
+import net.minecraft.world.loot.LootManager;
 
 public final class LootJsonParser {
 	/* Reading this from LootManager to access all serializers from vanilla. */
@@ -39,9 +41,7 @@ public final class LootJsonParser {
 		}
 	});
 
-	private LootJsonParser() {
-
-	}
+	private LootJsonParser() { }
 
 	public static <T> T read(Reader json, Class<T> c) {
 		return JsonHelper.deserialize(GSON.get(), json, c);

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/event/LootTableLoadingCallback.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/event/LootTableLoadingCallback.java
@@ -16,13 +16,14 @@
 
 package net.fabricmc.fabric.api.loot.v1.event;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
-import net.fabricmc.fabric.api.loot.v1.FabricLootSupplierBuilder;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.loot.LootManager;
 import net.minecraft.world.loot.LootSupplier;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.fabricmc.fabric.api.loot.v1.FabricLootSupplierBuilder;
 
 /**
  * An event handler that is called when loot tables are loaded.
@@ -35,7 +36,7 @@ public interface LootTableLoadingCallback {
 		void set(LootSupplier supplier);
 	}
 
-	final Event<LootTableLoadingCallback> EVENT = EventFactory.createArrayBacked(
+	Event<LootTableLoadingCallback> EVENT = EventFactory.createArrayBacked(
 			LootTableLoadingCallback.class,
 			(listeners) -> (resourceManager, manager, id, supplier, setter) -> {
 				for (LootTableLoadingCallback callback : listeners) {

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/impl/loot/LootEntryTypeRegistryImpl.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/impl/loot/LootEntryTypeRegistryImpl.java
@@ -16,10 +16,10 @@
 
 package net.fabricmc.fabric.impl.loot;
 
+import java.lang.reflect.Method;
+
 import net.minecraft.world.loot.entry.LootEntries;
 import net.minecraft.world.loot.entry.LootEntry;
-
-import java.lang.reflect.Method;
 
 public final class LootEntryTypeRegistryImpl implements net.fabricmc.fabric.api.loot.v1.LootEntryTypeRegistry {
 	public static final LootEntryTypeRegistryImpl INSTANCE = new LootEntryTypeRegistryImpl();
@@ -27,6 +27,7 @@ public final class LootEntryTypeRegistryImpl implements net.fabricmc.fabric.api.
 
 	static {
 		Method target = null;
+
 		for (Method m : LootEntries.class.getDeclaredMethods()) {
 			if (m.getParameterCount() == 1 && m.getParameterTypes()[0] == LootEntry.Serializer.class) {
 				if (target != null) {
@@ -45,8 +46,7 @@ public final class LootEntryTypeRegistryImpl implements net.fabricmc.fabric.api.
 		}
 	}
 
-	private LootEntryTypeRegistryImpl() {
-	}
+	private LootEntryTypeRegistryImpl() { }
 
 	@Override
 	public void register(LootEntry.Serializer<?> serializer) {

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/mixin/loot/LootPoolBuilderHooks.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/mixin/loot/LootPoolBuilderHooks.java
@@ -16,14 +16,15 @@
 
 package net.fabricmc.fabric.mixin.loot;
 
+import java.util.List;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
 import net.minecraft.world.loot.LootPool;
 import net.minecraft.world.loot.condition.LootCondition;
 import net.minecraft.world.loot.entry.LootEntry;
 import net.minecraft.world.loot.function.LootFunction;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.gen.Accessor;
-
-import java.util.List;
 
 @Mixin(LootPool.Builder.class)
 public interface LootPoolBuilderHooks {

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/mixin/loot/LootSupplierBuilderHooks.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/mixin/loot/LootSupplierBuilderHooks.java
@@ -16,13 +16,14 @@
 
 package net.fabricmc.fabric.mixin.loot;
 
-import net.minecraft.world.loot.LootPool;
-import net.minecraft.world.loot.LootSupplier;
-import net.minecraft.world.loot.function.LootFunction;
+import java.util.List;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
-import java.util.List;
+import net.minecraft.world.loot.LootPool;
+import net.minecraft.world.loot.LootSupplier;
+import net.minecraft.world.loot.function.LootFunction;
 
 @Mixin(LootSupplier.Builder.class)
 public interface LootSupplierBuilderHooks {

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/mixin/loot/MixinLootManager.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/mixin/loot/MixinLootManager.java
@@ -16,23 +16,25 @@
 
 package net.fabricmc.fabric.mixin.loot;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonObject;
-import net.fabricmc.fabric.api.loot.v1.event.LootTableLoadingCallback;
-import net.fabricmc.fabric.api.loot.v1.FabricLootSupplierBuilder;
-import net.minecraft.resource.ResourceManager;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.profiler.Profiler;
-import net.minecraft.world.loot.LootManager;
-import net.minecraft.world.loot.LootSupplier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.HashMap;
-import java.util.Map;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.profiler.Profiler;
+import net.minecraft.world.loot.LootManager;
+import net.minecraft.world.loot.LootSupplier;
+
+import net.fabricmc.fabric.api.loot.v1.FabricLootSupplierBuilder;
+import net.fabricmc.fabric.api.loot.v1.event.LootTableLoadingCallback;
 
 @Mixin(LootManager.class)
 public class MixinLootManager {
@@ -47,7 +49,7 @@ public class MixinLootManager {
 
 			//noinspection ConstantConditions
 			LootTableLoadingCallback.EVENT.invoker().onLootTableLoading(
-				manager, (LootManager) (Object) this, id, builder, (s) -> newSuppliers.put(id, s)
+					manager, (LootManager) (Object) this, id, builder, (s) -> newSuppliers.put(id, s)
 			);
 
 			newSuppliers.computeIfAbsent(id, (i) -> builder.create());

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/mixin/loot/MixinLootPool.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/mixin/loot/MixinLootPool.java
@@ -16,27 +16,35 @@
 
 package net.fabricmc.fabric.mixin.loot;
 
-import net.fabricmc.fabric.api.loot.v1.FabricLootPool;
-import net.minecraft.world.loot.LootPool;
-import net.minecraft.world.loot.LootTableRange;
-import net.minecraft.world.loot.condition.LootCondition;
-import net.minecraft.world.loot.entry.LootEntry;
-import net.minecraft.world.loot.function.LootFunction;
+import java.util.Arrays;
+import java.util.List;
+
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
-import java.util.Arrays;
-import java.util.List;
+import net.minecraft.world.loot.LootPool;
+import net.minecraft.world.loot.LootTableRange;
+import net.minecraft.world.loot.condition.LootCondition;
+import net.minecraft.world.loot.entry.LootEntry;
+import net.minecraft.world.loot.function.LootFunction;
+
+import net.fabricmc.fabric.api.loot.v1.FabricLootPool;
 
 @Mixin(LootPool.class)
 public abstract class MixinLootPool implements FabricLootPool {
-	@Shadow @Final private LootEntry[] entries;
+	@Shadow
+	@Final
+	private LootEntry[] entries;
 
-	@Shadow @Final private LootCondition[] conditions;
+	@Shadow
+	@Final
+	private LootCondition[] conditions;
 
-	@Shadow @Final private LootFunction[] functions;
+	@Shadow
+	@Final
+	private LootFunction[] functions;
 
 	@Override
 	public List<LootEntry> getEntries() {

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/mixin/loot/MixinLootSupplier.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/mixin/loot/MixinLootSupplier.java
@@ -16,23 +16,29 @@
 
 package net.fabricmc.fabric.mixin.loot;
 
-import net.fabricmc.fabric.api.loot.v1.FabricLootSupplier;
-import net.minecraft.world.loot.LootPool;
-import net.minecraft.world.loot.LootSupplier;
-import net.minecraft.world.loot.context.LootContextType;
-import net.minecraft.world.loot.function.LootFunction;
+import java.util.Arrays;
+import java.util.List;
+
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
-import java.util.Arrays;
-import java.util.List;
+import net.minecraft.world.loot.LootPool;
+import net.minecraft.world.loot.LootSupplier;
+import net.minecraft.world.loot.context.LootContextType;
+import net.minecraft.world.loot.function.LootFunction;
+
+import net.fabricmc.fabric.api.loot.v1.FabricLootSupplier;
 
 @Mixin(LootSupplier.class)
 public abstract class MixinLootSupplier implements FabricLootSupplier {
-	@Shadow @Final private LootPool[] pools;
-	@Shadow @Final private LootFunction[] functions;
+	@Shadow
+	@Final
+	private LootPool[] pools;
+	@Shadow
+	@Final
+	private LootFunction[] functions;
 
 	@Override
 	public List<LootPool> getPools() {

--- a/fabric-mining-levels-v0/src/main/java/net/fabricmc/fabric/api/tag/FabricItemTags.java
+++ b/fabric-mining-levels-v0/src/main/java/net/fabricmc/fabric/api/tag/FabricItemTags.java
@@ -16,10 +16,11 @@
 
 package net.fabricmc.fabric.api.tag;
 
-import net.fabricmc.fabric.api.tools.FabricToolTags;
 import net.minecraft.item.Item;
 import net.minecraft.tag.Tag;
 import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.api.tools.FabricToolTags;
 
 /**
  * Item tags provided by Fabric.
@@ -34,9 +35,7 @@ public class FabricItemTags {
 	public static final Tag<Item> SHOVELS = FabricToolTags.SHOVELS;
 	public static final Tag<Item> SWORDS = FabricToolTags.SWORDS;
 
-	private FabricItemTags() {
-
-	}
+	private FabricItemTags() { }
 
 	private static Tag<Item> register(String id) {
 		return TagRegistry.item(new Identifier("fabric", id));

--- a/fabric-mining-levels-v0/src/main/java/net/fabricmc/fabric/api/tools/FabricToolTags.java
+++ b/fabric-mining-levels-v0/src/main/java/net/fabricmc/fabric/api/tools/FabricToolTags.java
@@ -16,10 +16,11 @@
 
 package net.fabricmc.fabric.api.tools;
 
-import net.fabricmc.fabric.api.tag.TagRegistry;
 import net.minecraft.item.Item;
 import net.minecraft.tag.Tag;
 import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.api.tag.TagRegistry;
 
 /**
  * Tool item tags provided by Fabric.
@@ -31,9 +32,7 @@ public class FabricToolTags {
 	public static final Tag<Item> SHOVELS = register("shovels");
 	public static final Tag<Item> SWORDS = register("swords");
 
-	private FabricToolTags() {
-
-	}
+	private FabricToolTags() { }
 
 	private static Tag<Item> register(String id) {
 		return TagRegistry.item(new Identifier("fabric", id));

--- a/fabric-mining-levels-v0/src/main/java/net/fabricmc/fabric/impl/tools/ToolManager.java
+++ b/fabric-mining-levels-v0/src/main/java/net/fabricmc/fabric/impl/tools/ToolManager.java
@@ -16,7 +16,9 @@
 
 package net.fabricmc.fabric.impl.tools;
 
-import net.fabricmc.fabric.api.util.TriState;
+import java.util.HashMap;
+import java.util.Map;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -24,8 +26,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.ToolItem;
 import net.minecraft.tag.Tag;
 
-import java.util.HashMap;
-import java.util.Map;
+import net.fabricmc.fabric.api.util.TriState;
 
 public final class ToolManager {
 	public interface Entry {
@@ -36,7 +37,7 @@ public final class ToolManager {
 
 	private static class EntryImpl implements Entry {
 		@SuppressWarnings("unchecked")
-		private Tag<Item>[] tags = (Tag<Item>[]) new Tag[0];
+		private Tag<Item>[] tags = new Tag[0];
 		private int[] tagLevels = new int[0];
 		private TriState defaultValue = TriState.DEFAULT;
 
@@ -55,7 +56,7 @@ public final class ToolManager {
 			}
 
 			//noinspection unchecked
-			Tag<Item>[] newTags = (Tag<Item>[]) new Tag[tags.length + 1];
+			Tag<Item>[] newTags = new Tag[tags.length + 1];
 			int[] newTagLevels = new int[tagLevels.length + 1];
 			System.arraycopy(tags, 0, newTags, 0, tags.length);
 			System.arraycopy(tagLevels, 0, newTagLevels, 0, tagLevels.length);
@@ -68,9 +69,7 @@ public final class ToolManager {
 
 	private static final Map<Block, EntryImpl> entries = new HashMap<>();
 
-	private ToolManager() {
-
-	}
+	private ToolManager() { }
 
 	public static Entry entry(Block block) {
 		return entries.computeIfAbsent(block, (bb) -> new EntryImpl());
@@ -99,8 +98,10 @@ public final class ToolManager {
 	 */
 	public static TriState handleIsEffectiveOn(ItemStack stack, BlockState state) {
 		EntryImpl entry = entries.get(state.getBlock());
+
 		if (entry != null) {
 			Item item = stack.getItem();
+
 			for (int i = 0; i < entry.tags.length; i++) {
 				if (item.isIn(entry.tags[i])) {
 					return TriState.of(getMiningLevel(stack) >= entry.tagLevels[i]);

--- a/fabric-mining-levels-v0/src/main/java/net/fabricmc/fabric/mixin/tools/MiningToolItemAccessor.java
+++ b/fabric-mining-levels-v0/src/main/java/net/fabricmc/fabric/mixin/tools/MiningToolItemAccessor.java
@@ -16,9 +16,10 @@
 
 package net.fabricmc.fabric.mixin.tools;
 
-import net.minecraft.item.MiningToolItem;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.item.MiningToolItem;
 
 @Mixin(MiningToolItem.class)
 public interface MiningToolItemAccessor {

--- a/fabric-mining-levels-v0/src/main/java/net/fabricmc/fabric/mixin/tools/MixinItemStack.java
+++ b/fabric-mining-levels-v0/src/main/java/net/fabricmc/fabric/mixin/tools/MixinItemStack.java
@@ -16,16 +16,18 @@
 
 package net.fabricmc.fabric.mixin.tools;
 
-import net.fabricmc.fabric.api.util.TriState;
-import net.fabricmc.fabric.impl.tools.ToolManager;
-import net.minecraft.block.BlockState;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+import net.fabricmc.fabric.api.util.TriState;
+import net.fabricmc.fabric.impl.tools.ToolManager;
 
 @Mixin(ItemStack.class)
 public abstract class MixinItemStack {
@@ -35,6 +37,7 @@ public abstract class MixinItemStack {
 	@Inject(at = @At("HEAD"), method = "isEffectiveOn", cancellable = true)
 	public void isEffectiveOn(BlockState state, CallbackInfoReturnable<Boolean> info) {
 		TriState triState = ToolManager.handleIsEffectiveOn((ItemStack) (Object) this, state);
+
 		if (triState != TriState.DEFAULT) {
 			info.setReturnValue(triState.get());
 			info.cancel();
@@ -45,11 +48,11 @@ public abstract class MixinItemStack {
 	public void getBlockBreakingSpeed(BlockState state, CallbackInfoReturnable<Float> info) {
 		if (this.getItem() instanceof MiningToolItemAccessor) {
 			TriState triState = ToolManager.handleIsEffectiveOn((ItemStack) (Object) this, state);
+
 			if (triState != TriState.DEFAULT) {
 				info.setReturnValue(triState.get() ? ((MiningToolItemAccessor) this.getItem()).getMiningSpeed() : 1.0F);
 				info.cancel();
 			}
 		}
 	}
-
 }

--- a/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/ModelAppender.java
+++ b/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/ModelAppender.java
@@ -16,10 +16,10 @@
 
 package net.fabricmc.fabric.api.client.model;
 
+import java.util.function.Consumer;
+
 import net.minecraft.client.util.ModelIdentifier;
 import net.minecraft.resource.ResourceManager;
-
-import java.util.function.Consumer;
 
 @FunctionalInterface
 public interface ModelAppender {

--- a/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/ModelLoadingRegistry.java
+++ b/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/ModelLoadingRegistry.java
@@ -16,10 +16,11 @@
 
 package net.fabricmc.fabric.api.client.model;
 
-import net.fabricmc.fabric.impl.client.model.ModelLoadingRegistryImpl;
+import java.util.function.Function;
+
 import net.minecraft.resource.ResourceManager;
 
-import java.util.function.Function;
+import net.fabricmc.fabric.impl.client.model.ModelLoadingRegistryImpl;
 
 public interface ModelLoadingRegistry {
 	ModelLoadingRegistry INSTANCE = ModelLoadingRegistryImpl.INSTANCE;

--- a/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/ModelProviderContext.java
+++ b/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/ModelProviderContext.java
@@ -26,8 +26,8 @@ import net.minecraft.util.Identifier;
 public interface ModelProviderContext {
 	/**
 	 * Load a model using a {@link Identifier}, {@link ModelIdentifier}, ...
-	 * <p>
-	 * Please note that the game engine keeps track of circular model loading calls on its own.
+	 *
+	 * <p>Please note that the game engine keeps track of circular model loading calls on its own.
 	 *
 	 * @param id The model identifier.
 	 * @return The UnbakedModel. Can return a missing model if it's not present!

--- a/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/ModelResourceProvider.java
+++ b/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/ModelResourceProvider.java
@@ -21,27 +21,26 @@ import net.minecraft.util.Identifier;
 
 /**
  * Interface for model resource providers.
- * <p>
- * Model resource providers hook the loading of model *files* from the resource tree;
+ *
+ * <p>Model resource providers hook the loading of model *files* from the resource tree;
  * that is, in vanilla, it handles going from "minecraft:block/stone" to a
  * "assets/minecraft/models/block/stone.json" file.
- * <p>
- * This is where you want to add your own custom model formats.
- * <p>
- * As providers are instantiated with a new provider, it is safe
+ *
+ * <p>This is where you want to add your own custom model formats.
+ *
+ * <p>As providers are instantiated with a new provider, it is safe
  * (and recommended!) to cache information inside a loader.
- * <p>
- * Keep in mind that only *one* ModelResourceProvider may respond to a given model
+ *
+ * <p>Keep in mind that only *one* ModelResourceProvider may respond to a given model
  * at any time. If you're writing, say, an OBJ loader, this means you could
  * easily conflict with another OBJ loader unless you take some precautions,
  * for example:
- * <p>
- * a) Only load files with a mod-suffixed name, such as .architect.obj,
- * b) Only load files from an explicit list of namespaces, registered elsewhere.
+ *
+ * <ul><li>Only load files with a mod-suffixed name, such as .architect.obj,
+ * <li>Only load files from an explicit list of namespaces, registered elsewhere.</ul>
  */
 @FunctionalInterface
 public interface ModelResourceProvider {
-
 	/**
 	 * @param resourceId The resource identifier to be loaded.
 	 * @return The loaded UnbakedModel, or null if this ModelResourceProvider doesn't handle a specific Identifier

--- a/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/ModelVariantProvider.java
+++ b/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/ModelVariantProvider.java
@@ -21,24 +21,23 @@ import net.minecraft.client.util.ModelIdentifier;
 
 /**
  * Interface for model variant providers.
- * <p>
- * Model variant providers hook the resolution of ModelIdentifiers. In vanilla, this is
+ *
+ * <p>Model variant providers hook the resolution of ModelIdentifiers. In vanilla, this is
  * the part where a "minecraft:stone#normal" identifier triggers the loading of a
  * "minecraft:models/stone" model ({@link ModelResourceProvider} handles the later step).
- * <p>
- * The most common use of this is to cooperate with a {@link ModelAppender}, but it can
+ *
+ * <p>The most common use of this is to cooperate with a {@link ModelAppender}, but it can
  * also allow you to add your own block- or item-state formats. To trigger the loading
  * of another model, use the passed {@link ModelProviderContext}.
- * <p>
- * As every model loading is instantiated with a new provider, it is safe
+ *
+ * <p>As every model loading is instantiated with a new provider, it is safe
  * (and recommended!) to cache information.
- * <p>
- * Keep in mind that only *one* ModelVariantProvider may respond to a given model
+ *
+ * <p>Keep in mind that only *one* ModelVariantProvider may respond to a given model
  * at any time.
  */
 @FunctionalInterface
 public interface ModelVariantProvider {
-
 	/**
 	 * @param modelId The model identifier, complete with variant.
 	 * @return The loaded UnbakedModel, or null if this ModelVariantProvider doesn't handle a specific Identifier

--- a/fabric-models-v0/src/main/java/net/fabricmc/fabric/impl/client/model/ModelLoadingRegistryImpl.java
+++ b/fabric-models-v0/src/main/java/net/fabricmc/fabric/impl/client/model/ModelLoadingRegistryImpl.java
@@ -16,17 +16,6 @@
 
 package net.fabricmc.fabric.impl.client.model;
 
-import com.google.common.collect.Lists;
-import net.fabricmc.fabric.api.client.model.*;
-import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.client.render.model.ModelLoader;
-import net.minecraft.client.render.model.UnbakedModel;
-import net.minecraft.client.util.ModelIdentifier;
-import net.minecraft.resource.ResourceManager;
-import net.minecraft.util.Identifier;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -35,9 +24,27 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.Lists;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import net.minecraft.client.render.model.ModelLoader;
+import net.minecraft.client.render.model.UnbakedModel;
+import net.minecraft.client.util.ModelIdentifier;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.api.client.model.ModelAppender;
+import net.fabricmc.fabric.api.client.model.ModelLoadingRegistry;
+import net.fabricmc.fabric.api.client.model.ModelProviderContext;
+import net.fabricmc.fabric.api.client.model.ModelProviderException;
+import net.fabricmc.fabric.api.client.model.ModelResourceProvider;
+import net.fabricmc.fabric.api.client.model.ModelVariantProvider;
+import net.fabricmc.loader.api.FabricLoader;
+
 public class ModelLoadingRegistryImpl implements ModelLoadingRegistry {
 	private static final boolean DEBUG_MODEL_LOADING = FabricLoader.getInstance().isDevelopmentEnvironment()
-		|| Boolean.valueOf(System.getProperty("fabric.debugModelLoading", "false"));
+			|| Boolean.valueOf(System.getProperty("fabric.debugModelLoading", "false"));
 
 	@FunctionalInterface
 	private interface CustomModelItf<T> {
@@ -81,6 +88,7 @@ public class ModelLoadingRegistryImpl implements ModelLoadingRegistry {
 				for (T provider : loaders) {
 					try {
 						UnbakedModel model = function.load(provider);
+
 						if (model != null) {
 							return model;
 						}
@@ -100,6 +108,7 @@ public class ModelLoadingRegistryImpl implements ModelLoadingRegistry {
 			for (T provider : loaders) {
 				try {
 					UnbakedModel model = function.load(provider);
+
 					if (model != null) {
 						if (providersApplied != null) {
 							providersApplied.add(provider);
@@ -118,9 +127,11 @@ public class ModelLoadingRegistryImpl implements ModelLoadingRegistry {
 
 			if (providersApplied != null) {
 				StringBuilder builder = new StringBuilder("Conflict - multiple " + debugName + "s claimed the same unbaked model:");
+
 				for (T loader : providersApplied) {
 					builder.append("\n\t - ").append(loader.getClass().getName());
 				}
+
 				logger.error(builder.toString());
 				return null;
 			} else {
@@ -140,6 +151,7 @@ public class ModelLoadingRegistryImpl implements ModelLoadingRegistry {
 			} else {
 				ModelIdentifier modelId = (ModelIdentifier) variantId;
 				UnbakedModel model = loadCustomModel((r) -> r.loadModelVariant((ModelIdentifier) variantId, this), modelVariantProviders, "resource provider");
+
 				if (model != null) {
 					return model;
 				}
@@ -148,6 +160,7 @@ public class ModelLoadingRegistryImpl implements ModelLoadingRegistry {
 				if (Objects.equals(modelId.getVariant(), "inventory")) {
 					Identifier resourceId = new Identifier(modelId.getNamespace(), "item/" + modelId.getPath());
 					model = loadModelFromResource(resourceId);
+
 					if (model != null) {
 						return model;
 					}

--- a/fabric-models-v0/src/main/java/net/fabricmc/fabric/mixin/client/model/MixinModelLoader.java
+++ b/fabric-models-v0/src/main/java/net/fabricmc/fabric/mixin/client/model/MixinModelLoader.java
@@ -16,21 +16,23 @@
 
 package net.fabricmc.fabric.mixin.client.model;
 
-import net.fabricmc.fabric.impl.client.model.ModelLoaderHooks;
-import net.fabricmc.fabric.impl.client.model.ModelLoadingRegistryImpl;
-import net.minecraft.client.render.model.ModelLoader;
-import net.minecraft.client.render.model.UnbakedModel;
-import net.minecraft.client.util.ModelIdentifier;
-import net.minecraft.resource.ResourceManager;
-import net.minecraft.util.Identifier;
+import java.util.Map;
+import java.util.Set;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Map;
-import java.util.Set;
+import net.minecraft.client.render.model.ModelLoader;
+import net.minecraft.client.render.model.UnbakedModel;
+import net.minecraft.client.util.ModelIdentifier;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.impl.client.model.ModelLoaderHooks;
+import net.fabricmc.fabric.impl.client.model.ModelLoadingRegistryImpl;
 
 @Mixin(ModelLoader.class)
 public class MixinModelLoader implements ModelLoaderHooks {
@@ -47,23 +49,18 @@ public class MixinModelLoader implements ModelLoaderHooks {
 	private ModelLoadingRegistryImpl.LoaderInstance fabric_mlrLoaderInstance;
 
 	@Shadow
-	private void addModel(ModelIdentifier id) {
-
-	}
+	private void addModel(ModelIdentifier id) { }
 
 	@Shadow
-	private void putModel(Identifier id, UnbakedModel unbakedModel) {
-
-	}
+	private void putModel(Identifier id, UnbakedModel unbakedModel) { }
 
 	@Shadow
-	private void loadModel(Identifier id) {
-
-	}
+	private void loadModel(Identifier id) { }
 
 	@Inject(at = @At("HEAD"), method = "loadModel", cancellable = true)
 	private void loadModelHook(Identifier id, CallbackInfo ci) {
 		UnbakedModel customModel = fabric_mlrLoaderInstance.loadModelFromVariant(id);
+
 		if (customModel != null) {
 			putModel(id, customModel);
 			ci.cancel();
@@ -74,7 +71,7 @@ public class MixinModelLoader implements ModelLoaderHooks {
 	private void addModelHook(ModelIdentifier id, CallbackInfo info) {
 		if (id == MISSING) {
 			//noinspection RedundantCast
-			ModelLoaderHooks hooks = (ModelLoaderHooks) (Object) this;
+			ModelLoaderHooks hooks = this;
 
 			fabric_mlrLoaderInstance = ModelLoadingRegistryImpl.begin((ModelLoader) (Object) this, resourceManager);
 			fabric_mlrLoaderInstance.onModelPopulation(hooks::fabric_addModel);
@@ -97,6 +94,7 @@ public class MixinModelLoader implements ModelLoaderHooks {
 		if (!modelsToLoad.add(id)) {
 			throw new IllegalStateException("Circular reference while loading " + id);
 		}
+
 		loadModel(id);
 		modelsToLoad.remove(id);
 		return unbakedModels.get(id);

--- a/fabric-networking-blockentity-v0/src/main/java/net/fabricmc/fabric/api/block/entity/BlockEntityClientSerializable.java
+++ b/fabric-networking-blockentity-v0/src/main/java/net/fabricmc/fabric/api/block/entity/BlockEntityClientSerializable.java
@@ -37,7 +37,7 @@ public interface BlockEntityClientSerializable {
 	 * This will cause {@link #toClientTag(CompoundTag)} to be called on the
 	 * server to generate the packet data, and then
 	 * {@link #fromClientTag(CompoundTag)} on the client to decode that data.
-	 * 
+	 *
 	 * <p>This is preferable to
 	 * {@link World#updateListeners(net.minecraft.util.math.BlockPos, net.minecraft.block.BlockState, net.minecraft.block.BlockState, int)}
 	 * because it does not cause entities to update their pathing as a side effect.

--- a/fabric-networking-blockentity-v0/src/main/java/net/fabricmc/fabric/mixin/networkingblockentity/MixinBlockEntity.java
+++ b/fabric-networking-blockentity-v0/src/main/java/net/fabricmc/fabric/mixin/networkingblockentity/MixinBlockEntity.java
@@ -16,18 +16,20 @@
 
 package net.fabricmc.fabric.mixin.networkingblockentity;
 
-import net.fabricmc.fabric.api.block.entity.BlockEntityClientSerializable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.client.network.packet.BlockEntityUpdateS2CPacket;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.fabricmc.fabric.api.block.entity.BlockEntityClientSerializable;
 
 @Mixin(BlockEntity.class)
 public abstract class MixinBlockEntity {
@@ -39,7 +41,7 @@ public abstract class MixinBlockEntity {
 
 	@Inject(at = @At("HEAD"), method = "toUpdatePacket", cancellable = true)
 	public void toUpdatePacket(CallbackInfoReturnable<BlockEntityUpdateS2CPacket> info) {
-		Object self = (Object) this;
+		Object self = this;
 
 		if (self instanceof BlockEntityClientSerializable) {
 			// Mojang's serialization of x/y/z into the update packet is redundant,
@@ -50,6 +52,7 @@ public abstract class MixinBlockEntity {
 
 			CompoundTag tag = new CompoundTag();
 			Identifier entityId = BlockEntityType.getId(getType());
+
 			if (entityId == null) {
 				throw new RuntimeException(this.getClass() + " is missing a mapping! This is a bug!");
 			}
@@ -63,7 +66,7 @@ public abstract class MixinBlockEntity {
 
 	@Inject(at = @At("RETURN"), method = "toInitialChunkDataTag", cancellable = true)
 	public void toInitialChunkDataTag(CallbackInfoReturnable<CompoundTag> info) {
-		Object self = (Object) this;
+		Object self = this;
 
 		if (self instanceof BlockEntityClientSerializable && info.getReturnValue() != null) {
 			info.setReturnValue(((BlockEntityClientSerializable) self).toClientTag(info.getReturnValue()));

--- a/fabric-networking-blockentity-v0/src/main/java/net/fabricmc/fabric/mixin/networkingblockentity/MixinClientPlayNetworkHandler.java
+++ b/fabric-networking-blockentity-v0/src/main/java/net/fabricmc/fabric/mixin/networkingblockentity/MixinClientPlayNetworkHandler.java
@@ -16,13 +16,6 @@
 
 package net.fabricmc.fabric.mixin.networkingblockentity;
 
-import net.fabricmc.fabric.api.block.entity.BlockEntityClientSerializable;
-import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.block.entity.BlockEntityType;
-import net.minecraft.client.network.ClientPlayNetworkHandler;
-import net.minecraft.client.network.packet.BlockEntityUpdateS2CPacket;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.util.Identifier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Mixin;
@@ -32,6 +25,15 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.client.network.packet.BlockEntityUpdateS2CPacket;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.api.block.entity.BlockEntityClientSerializable;
 
 @Mixin(ClientPlayNetworkHandler.class)
 public class MixinClientPlayNetworkHandler {
@@ -44,14 +46,16 @@ public class MixinClientPlayNetworkHandler {
 			if (packet.getActionId() == 127) {
 				BlockEntityClientSerializable serializable = (BlockEntityClientSerializable) entity;
 				String id = packet.getCompoundTag().getString("id");
+
 				if (id != null) {
 					Identifier otherIdObj = BlockEntityType.getId(entity.getType());
-					;
+
 					if (otherIdObj == null) {
 						FABRIC_LOGGER.error(entity.getClass() + " is missing a mapping! This is a bug!");
 						info.cancel();
 						return;
 					}
+
 					String otherId = otherIdObj.toString();
 
 					if (otherId.equals(id)) {

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/event/network/C2SPacketTypeCallback.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/event/network/C2SPacketTypeCallback.java
@@ -16,12 +16,13 @@
 
 package net.fabricmc.fabric.api.event.network;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
+import java.util.Collection;
+
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.Identifier;
 
-import java.util.Collection;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
 
 /**
  * Event for listening to packet type registrations and unregistrations
@@ -29,22 +30,22 @@ import java.util.Collection;
  * in the client -&gt; server direction.
  */
 public interface C2SPacketTypeCallback {
-	static final Event<C2SPacketTypeCallback> REGISTERED = EventFactory.createArrayBacked(
-		C2SPacketTypeCallback.class,
-		(callbacks) -> (client, types) -> {
-			for (C2SPacketTypeCallback callback : callbacks) {
-				callback.accept(client, types);
+	Event<C2SPacketTypeCallback> REGISTERED = EventFactory.createArrayBacked(
+			C2SPacketTypeCallback.class,
+			(callbacks) -> (client, types) -> {
+				for (C2SPacketTypeCallback callback : callbacks) {
+					callback.accept(client, types);
+				}
 			}
-		}
 	);
 
-	static final Event<C2SPacketTypeCallback> UNREGISTERED = EventFactory.createArrayBacked(
-		C2SPacketTypeCallback.class,
-		(callbacks) -> (client, types) -> {
-			for (C2SPacketTypeCallback callback : callbacks) {
-				callback.accept(client, types);
+	Event<C2SPacketTypeCallback> UNREGISTERED = EventFactory.createArrayBacked(
+			C2SPacketTypeCallback.class,
+			(callbacks) -> (client, types) -> {
+				for (C2SPacketTypeCallback callback : callbacks) {
+					callback.accept(client, types);
+				}
 			}
-		}
 	);
 
 	/**

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/event/network/S2CPacketTypeCallback.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/event/network/S2CPacketTypeCallback.java
@@ -16,11 +16,12 @@
 
 package net.fabricmc.fabric.api.event.network;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
+import java.util.Collection;
+
 import net.minecraft.util.Identifier;
 
-import java.util.Collection;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
 
 /**
  * Event for listening to packet type registrations and unregistrations
@@ -28,22 +29,22 @@ import java.util.Collection;
  * in the server -&gt; client direction.
  */
 public interface S2CPacketTypeCallback {
-	static final Event<S2CPacketTypeCallback> REGISTERED = EventFactory.createArrayBacked(
-		S2CPacketTypeCallback.class,
-		(callbacks) -> (types) -> {
-			for (S2CPacketTypeCallback callback : callbacks) {
-				callback.accept(types);
+	Event<S2CPacketTypeCallback> REGISTERED = EventFactory.createArrayBacked(
+			S2CPacketTypeCallback.class,
+			(callbacks) -> (types) -> {
+				for (S2CPacketTypeCallback callback : callbacks) {
+					callback.accept(types);
+				}
 			}
-		}
 	);
 
-	static final Event<S2CPacketTypeCallback> UNREGISTERED = EventFactory.createArrayBacked(
-		S2CPacketTypeCallback.class,
-		(callbacks) -> (types) -> {
-			for (S2CPacketTypeCallback callback : callbacks) {
-				callback.accept(types);
+	Event<S2CPacketTypeCallback> UNREGISTERED = EventFactory.createArrayBacked(
+			S2CPacketTypeCallback.class,
+			(callbacks) -> (types) -> {
+				for (S2CPacketTypeCallback callback : callbacks) {
+					callback.accept(types);
+				}
 			}
-		}
 	);
 
 	/**

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/network/ClientSidePacketRegistry.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/network/ClientSidePacketRegistry.java
@@ -18,21 +18,23 @@ package net.fabricmc.fabric.api.network;
 
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
-import net.fabricmc.fabric.impl.network.ClientSidePacketRegistryImpl;
+
 import net.minecraft.network.Packet;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.PacketByteBuf;
 
+import net.fabricmc.fabric.impl.network.ClientSidePacketRegistryImpl;
+
 /**
  * The client-side packet registry.
- * <p>
- * It is used for:
- * <p>
- * - registering client-side packet receivers (server -&gt; client packets)
- * - sending packets to the server (client -&gt; server packets).
+ *
+ * <p>It is used for:
+ *
+ * <ul><li>registering client-side packet receivers (server -&gt; client packets)
+ * <li>sending packets to the server (client -&gt; server packets).</ul>
  */
 public interface ClientSidePacketRegistry extends PacketRegistry {
-	static final ClientSidePacketRegistry INSTANCE = new ClientSidePacketRegistryImpl();
+	ClientSidePacketRegistry INSTANCE = new ClientSidePacketRegistryImpl();
 
 	/**
 	 * Check if the server declared the ability to receive a given packet ID

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/network/PacketConsumer.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/network/PacketConsumer.java
@@ -26,11 +26,11 @@ public interface PacketConsumer {
 	/**
 	 * Receive a CustomPayload-based packet.
 	 *
-	 * The PacketByteBuf received will be released as soon as the method exits,
+	 * <p>The PacketByteBuf received will be released as soon as the method exits,
 	 * meaning that you have to call .retain()/.release() on it if you want to
 	 * keep it around after that.
 	 *
-	 * Please keep in mind that this CAN be called OUTSIDE of the main thread!
+	 * <p>Please keep in mind that this CAN be called OUTSIDE of the main thread!
 	 * Most game operations are not thread-safe, so you should look into using
 	 * the thread task queue ({@link PacketContext#getTaskQueue()}) to split
 	 * the "reading" (which should happen within this method's execution)

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/network/PacketContext.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/network/PacketContext.java
@@ -16,9 +16,10 @@
 
 package net.fabricmc.fabric.api.network;
 
-import net.fabricmc.api.EnvType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.ThreadExecutor;
+
+import net.fabricmc.api.EnvType;
 
 /**
  * Interface defining a context used during packet processing. Allows access
@@ -36,8 +37,8 @@ public interface PacketContext {
 
 	/**
 	 * Get the player associated with the packet.
-	 * <p>
-	 * On the client side, this always returns the client-side player instance.
+	 *
+	 * <p>On the client side, this always returns the client-side player instance.
 	 * On the server side, it returns the player belonging to the client this
 	 * packet was sent by.
 	 *
@@ -47,15 +48,15 @@ public interface PacketContext {
 
 	/**
 	 * Get the task queue for a given side.
-	 * <p>
-	 * As Minecraft networking I/O is asynchronous, but a lot of its logic is
+	 *
+	 * <p>As Minecraft networking I/O is asynchronous, but a lot of its logic is
 	 * not thread-safe, it is recommended to do the following:
-	 * <p>
-	 * - read and parse the PacketByteBuf,
-	 * - run the packet response logic through the main thread task queue via
+	 *
+	 * <ul><li>read and parse the PacketByteBuf,
+	 * <li>run the packet response logic through the main thread task queue via
 	 * ThreadTaskQueue.execute(). The method will check if it's not already
 	 * on the main thread in order to avoid unnecessary delays, so don't
-	 * worry about that!
+	 * worry about that!</ul>
 	 *
 	 * @return The thread task queue.
 	 */

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/network/ServerSidePacketRegistry.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/network/ServerSidePacketRegistry.java
@@ -18,25 +18,27 @@ package net.fabricmc.fabric.api.network;
 
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
-import net.fabricmc.fabric.api.server.PlayerStream;
-import net.fabricmc.fabric.impl.network.ServerSidePacketRegistryImpl;
+
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.Packet;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.PacketByteBuf;
 
+import net.fabricmc.fabric.api.server.PlayerStream;
+import net.fabricmc.fabric.impl.network.ServerSidePacketRegistryImpl;
+
 /**
  * The server-side packet registry.
- * <p>
- * It is used for:
- * <p>
- * - registering server-side packet receivers (client -&gt; server packets)
- * - sending packets to clients (server -&gt; client packets).
- * <p>
- * For iterating over clients in a server, see {@link PlayerStream}.
+ *
+ * <p>It is used for:
+ *
+ * <ul><li>registering server-side packet receivers (client -&gt; server packets)
+ * <li>sending packets to clients (server -&gt; client packets).</ul>
+ *
+ * <p>For iterating over clients in a server, see {@link PlayerStream}.
  */
 public interface ServerSidePacketRegistry extends PacketRegistry {
-	static final ServerSidePacketRegistry INSTANCE = new ServerSidePacketRegistryImpl();
+	ServerSidePacketRegistry INSTANCE = new ServerSidePacketRegistryImpl();
 
 	/**
 	 * Check if a given client declared the ability to receive a given packet ID

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/server/PlayerStream.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/server/PlayerStream.java
@@ -16,7 +16,8 @@
 
 package net.fabricmc.fabric.api.server;
 
-import net.fabricmc.fabric.impl.server.EntityTrackerStorageAccessor;
+import java.util.stream.Stream;
+
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -31,17 +32,15 @@ import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.ChunkManager;
 
-import java.util.stream.Stream;
+import net.fabricmc.fabric.impl.server.EntityTrackerStorageAccessor;
 
 /**
  * Helper streams for looking up players on a server.
- * <p>
- * In general, most of these methods will only function with a {@link ServerWorld} instance.
+ *
+ * <p>In general, most of these methods will only function with a {@link ServerWorld} instance.
  */
 public final class PlayerStream {
-	private PlayerStream() {
-
-	}
+	private PlayerStream() { }
 
 	public static Stream<ServerPlayerEntity> all(MinecraftServer server) {
 		if (server.getPlayerManager() != null) {
@@ -54,7 +53,7 @@ public final class PlayerStream {
 	public static Stream<PlayerEntity> world(World world) {
 		if (world instanceof ServerWorld) {
 			// noinspection unchecked
-			return ((Stream<PlayerEntity>) (Stream) ((ServerWorld) world).getPlayers().stream());
+			return ((Stream) ((ServerWorld) world).getPlayers().stream());
 		} else {
 			throw new RuntimeException("Only supported on ServerWorld!");
 		}
@@ -62,11 +61,12 @@ public final class PlayerStream {
 
 	public static Stream<PlayerEntity> watching(World world, ChunkPos pos) {
 		ChunkManager manager = world.getChunkManager();
+
 		if (!(manager instanceof ServerChunkManager)) {
 			throw new RuntimeException("Only supported on ServerWorld!");
 		} else {
 			//noinspection unchecked
-			return ((Stream<PlayerEntity>) (Stream) ((ServerChunkManager) manager).threadedAnvilChunkStorage.getPlayersWatchingChunk(pos, false));
+			return ((Stream) ((ServerChunkManager) manager).threadedAnvilChunkStorage.getPlayersWatchingChunk(pos, false));
 		}
 	}
 
@@ -81,9 +81,10 @@ public final class PlayerStream {
 
 		if (manager instanceof ServerChunkManager) {
 			ThreadedAnvilChunkStorage storage = ((ServerChunkManager) manager).threadedAnvilChunkStorage;
+
 			if (storage instanceof EntityTrackerStorageAccessor) {
 				//noinspection unchecked
-				return ((Stream<PlayerEntity>) (Stream) ((EntityTrackerStorageAccessor) storage).fabric_getTrackingPlayers(entity));
+				return ((Stream) ((EntityTrackerStorageAccessor) storage).fabric_getTrackingPlayers(entity));
 			}
 		}
 

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/impl/network/ClientSidePacketRegistryImpl.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/impl/network/ClientSidePacketRegistryImpl.java
@@ -16,11 +16,13 @@
 
 package net.fabricmc.fabric.impl.network;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
-import net.fabricmc.fabric.api.event.network.S2CPacketTypeCallback;
-import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
-import net.fabricmc.fabric.api.network.PacketContext;
+
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.network.Packet;
@@ -28,9 +30,9 @@ import net.minecraft.server.network.packet.CustomPayloadC2SPacket;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.PacketByteBuf;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
+import net.fabricmc.fabric.api.event.network.S2CPacketTypeCallback;
+import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
+import net.fabricmc.fabric.api.network.PacketContext;
 
 public class ClientSidePacketRegistryImpl extends PacketRegistryImpl implements ClientSidePacketRegistry {
 	private final Collection<Identifier> serverPayloadIds = new HashSet<>();
@@ -47,6 +49,7 @@ public class ClientSidePacketRegistryImpl extends PacketRegistryImpl implements 
 	@Override
 	public void sendToServer(Packet<?> packet, GenericFutureListener<? extends Future<? super Void>> completionListener) {
 		ClientPlayNetworkHandler handler = MinecraftClient.getInstance().getNetworkHandler();
+
 		if (handler != null) {
 			if (completionListener == null) {
 				// stay closer to the vanilla codepath
@@ -67,6 +70,7 @@ public class ClientSidePacketRegistryImpl extends PacketRegistryImpl implements 
 	@Override
 	protected void onRegister(Identifier id) {
 		ClientPlayNetworkHandler handler = MinecraftClient.getInstance().getNetworkHandler();
+
 		if (handler != null) {
 			createRegisterTypePacket(PacketTypes.REGISTER, Collections.singleton(id)).ifPresent(handler::sendPacket);
 		}
@@ -75,6 +79,7 @@ public class ClientSidePacketRegistryImpl extends PacketRegistryImpl implements 
 	@Override
 	protected void onUnregister(Identifier id) {
 		ClientPlayNetworkHandler handler = MinecraftClient.getInstance().getNetworkHandler();
+
 		if (handler != null) {
 			createRegisterTypePacket(PacketTypes.UNREGISTER, Collections.singleton(id)).ifPresent(handler::sendPacket);
 		}

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/impl/network/PacketDebugOptions.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/impl/network/PacketDebugOptions.java
@@ -19,7 +19,5 @@ package net.fabricmc.fabric.impl.network;
 public final class PacketDebugOptions {
 	public static final boolean DISABLE_BUFFER_RELEASES = System.getProperty("fabric.networking.broken.disableBufferReleases", "false").equalsIgnoreCase("true");
 
-	private PacketDebugOptions() {
-
-	}
+	private PacketDebugOptions() { }
 }

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/impl/network/PacketRegistryImpl.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/impl/network/PacketRegistryImpl.java
@@ -187,6 +187,7 @@ public abstract class PacketRegistryImpl implements PacketRegistry {
 
 		if (consumer != null) {
 			PacketByteBuf buf = bufSupplier.get();
+
 			try {
 				consumer.accept(context, buf);
 			} catch (Throwable t) {

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/impl/network/PacketRegistryImpl.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/impl/network/PacketRegistryImpl.java
@@ -16,20 +16,26 @@
 
 package net.fabricmc.fabric.impl.network;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
 import io.netty.buffer.Unpooled;
-import net.fabricmc.fabric.api.network.PacketConsumer;
-import net.fabricmc.fabric.api.network.PacketContext;
-import net.fabricmc.fabric.api.network.PacketRegistry;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import net.minecraft.network.Packet;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.InvalidIdentifierException;
 import net.minecraft.util.PacketByteBuf;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.function.Supplier;
+import net.fabricmc.fabric.api.network.PacketConsumer;
+import net.fabricmc.fabric.api.network.PacketContext;
+import net.fabricmc.fabric.api.network.PacketRegistry;
 
 public abstract class PacketRegistryImpl implements PacketRegistry {
 	protected static final Logger LOGGER = LogManager.getLogger();
@@ -47,6 +53,7 @@ public abstract class PacketRegistryImpl implements PacketRegistry {
 	@Override
 	public void register(Identifier id, PacketConsumer consumer) {
 		boolean isNew = true;
+
 		if (consumerMap.containsKey(id)) {
 			LOGGER.warn("Registered duplicate packet " + id + "!");
 			LOGGER.trace(new Throwable());
@@ -54,6 +61,7 @@ public abstract class PacketRegistryImpl implements PacketRegistry {
 		}
 
 		consumerMap.put(id, consumer);
+
 		if (isNew) {
 			onRegister(id);
 		}
@@ -86,14 +94,17 @@ public abstract class PacketRegistryImpl implements PacketRegistry {
 
 		PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
 		boolean first = true;
+
 		for (Identifier a : ids) {
 			if (!first) {
 				buf.writeByte(0);
 			} else {
 				first = false;
 			}
+
 			buf.writeBytes(a.toString().getBytes(StandardCharsets.US_ASCII));
 		}
+
 		return Optional.of(toPacket(id, buf));
 	}
 
@@ -108,8 +119,10 @@ public abstract class PacketRegistryImpl implements PacketRegistry {
 			try {
 				while (buf.readerIndex() < buf.writerIndex()) {
 					c = (char) buf.readByte();
+
 					if (c == 0) {
 						String s = sb.toString();
+
 						if (!s.isEmpty()) {
 							try {
 								ids.add(new Identifier(s));
@@ -118,6 +131,7 @@ public abstract class PacketRegistryImpl implements PacketRegistry {
 								LOGGER.trace(e);
 							}
 						}
+
 						sb = new StringBuilder();
 					} else {
 						sb.append(c);
@@ -128,6 +142,7 @@ public abstract class PacketRegistryImpl implements PacketRegistry {
 			}
 
 			String s = sb.toString();
+
 			if (!s.isEmpty()) {
 				try {
 					ids.add(new Identifier(s));
@@ -139,6 +154,7 @@ public abstract class PacketRegistryImpl implements PacketRegistry {
 		}
 
 		Collection<Identifier> target = getIdCollectionFor(context);
+
 		if (id.equals(PacketTypes.UNREGISTER)) {
 			target.removeAll(ids);
 			onReceivedUnregisterPacket(context, ids);
@@ -146,13 +162,14 @@ public abstract class PacketRegistryImpl implements PacketRegistry {
 			target.addAll(ids);
 			onReceivedRegisterPacket(context, ids);
 		}
+
 		return false; // continue execution for other mods
 	}
 
 	/**
 	 * Hook for accepting packets used in Fabric mixins.
 	 *
-	 * As PacketByteBuf getters in vanilla create a copy (to allow releasing the original packet buffer without
+	 * <p>As PacketByteBuf getters in vanilla create a copy (to allow releasing the original packet buffer without
 	 * breaking other, potentially delayed accesses), we use a Supplier to generate those copies and release them
 	 * when needed.
 	 *
@@ -167,6 +184,7 @@ public abstract class PacketRegistryImpl implements PacketRegistry {
 		}
 
 		PacketConsumer consumer = consumerMap.get(id);
+
 		if (consumer != null) {
 			PacketByteBuf buf = bufSupplier.get();
 			try {
@@ -178,6 +196,7 @@ public abstract class PacketRegistryImpl implements PacketRegistry {
 					buf.release();
 				}
 			}
+
 			return true;
 		} else {
 			return false;

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/impl/network/ServerSidePacketRegistryImpl.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/impl/network/ServerSidePacketRegistryImpl.java
@@ -16,11 +16,18 @@
 
 package net.fabricmc.fabric.impl.network;
 
+import java.lang.ref.WeakReference;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.function.Consumer;
+
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
-import net.fabricmc.fabric.api.event.network.C2SPacketTypeCallback;
-import net.fabricmc.fabric.api.network.PacketContext;
-import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
+
 import net.minecraft.client.network.packet.CustomPayloadS2CPacket;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.Packet;
@@ -30,9 +37,9 @@ import net.minecraft.server.network.packet.LoginQueryResponseC2SPacket;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.PacketByteBuf;
 
-import java.lang.ref.WeakReference;
-import java.util.*;
-import java.util.function.Consumer;
+import net.fabricmc.fabric.api.event.network.C2SPacketTypeCallback;
+import net.fabricmc.fabric.api.network.PacketContext;
+import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
 
 public class ServerSidePacketRegistryImpl extends PacketRegistryImpl implements ServerSidePacketRegistry {
 	private final WeakHashMap<PlayerEntity, Collection<Identifier>> playerPayloadIds = new WeakHashMap<>();
@@ -47,8 +54,10 @@ public class ServerSidePacketRegistryImpl extends PacketRegistryImpl implements 
 
 	protected void forEachHandler(Consumer<ServerPlayNetworkHandler> consumer) {
 		Iterator<WeakReference<ServerPlayNetworkHandler>> it = handlers.iterator();
+
 		while (it.hasNext()) {
 			ServerPlayNetworkHandler server = it.next().get();
+
 			if (server != null) {
 				consumer.accept(server);
 			} else {
@@ -60,6 +69,7 @@ public class ServerSidePacketRegistryImpl extends PacketRegistryImpl implements 
 	@Override
 	public boolean canPlayerReceive(PlayerEntity player, Identifier id) {
 		Collection<Identifier> ids = playerPayloadIds.get(player);
+
 		if (ids != null) {
 			return ids.contains(id);
 		} else {

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/impl/server/EntityTrackerStorageAccessor.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/impl/server/EntityTrackerStorageAccessor.java
@@ -16,10 +16,10 @@
 
 package net.fabricmc.fabric.impl.server;
 
+import java.util.stream.Stream;
+
 import net.minecraft.entity.Entity;
 import net.minecraft.server.network.ServerPlayerEntity;
-
-import java.util.stream.Stream;
 
 public interface EntityTrackerStorageAccessor {
 	Stream<ServerPlayerEntity> fabric_getTrackingPlayers(Entity entity);

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/impl/server/EntityTrackerStreamAccessor.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/impl/server/EntityTrackerStreamAccessor.java
@@ -16,9 +16,9 @@
 
 package net.fabricmc.fabric.impl.server;
 
-import net.minecraft.server.network.ServerPlayerEntity;
-
 import java.util.stream.Stream;
+
+import net.minecraft.server.network.ServerPlayerEntity;
 
 public interface EntityTrackerStreamAccessor {
 	Stream<ServerPlayerEntity> fabric_getTrackingPlayers();

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/mixin/network/MixinClientPlayNetworkHandler.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/mixin/network/MixinClientPlayNetworkHandler.java
@@ -16,12 +16,15 @@
 
 package net.fabricmc.fabric.mixin.network;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
-import net.fabricmc.fabric.api.network.PacketContext;
-import net.fabricmc.fabric.impl.network.ClientSidePacketRegistryImpl;
-import net.fabricmc.fabric.impl.network.PacketRegistryImpl;
-import net.fabricmc.fabric.impl.network.PacketTypes;
+import java.util.Optional;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.network.packet.CustomPayloadS2CPacket;
@@ -31,14 +34,13 @@ import net.minecraft.network.Packet;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.PacketByteBuf;
 import net.minecraft.util.ThreadExecutor;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-import java.util.Optional;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
+import net.fabricmc.fabric.api.network.PacketContext;
+import net.fabricmc.fabric.impl.network.ClientSidePacketRegistryImpl;
+import net.fabricmc.fabric.impl.network.PacketRegistryImpl;
+import net.fabricmc.fabric.impl.network.PacketTypes;
 
 @Mixin(ClientPlayNetworkHandler.class)
 public abstract class MixinClientPlayNetworkHandler implements PacketContext {
@@ -51,6 +53,7 @@ public abstract class MixinClientPlayNetworkHandler implements PacketContext {
 	@Inject(at = @At("RETURN"), method = "onGameJoin")
 	public void onGameJoin(GameJoinS2CPacket packet, CallbackInfo info) {
 		Optional<Packet<?>> optionalPacket = PacketRegistryImpl.createInitialRegisterPacket(ClientSidePacketRegistry.INSTANCE);
+
 		//noinspection OptionalIsPresent
 		if (optionalPacket.isPresent()) {
 			sendPacket(optionalPacket.get());

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/mixin/network/MixinCustomPayloadC2SPacket.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/mixin/network/MixinCustomPayloadC2SPacket.java
@@ -16,12 +16,14 @@
 
 package net.fabricmc.fabric.mixin.network;
 
-import net.fabricmc.fabric.impl.network.CustomPayloadC2SPacketAccessor;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
 import net.minecraft.server.network.packet.CustomPayloadC2SPacket;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.PacketByteBuf;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+
+import net.fabricmc.fabric.impl.network.CustomPayloadC2SPacketAccessor;
 
 @Mixin(CustomPayloadC2SPacket.class)
 public class MixinCustomPayloadC2SPacket implements CustomPayloadC2SPacketAccessor {

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/mixin/network/MixinEntityTracker.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/mixin/network/MixinEntityTracker.java
@@ -16,14 +16,16 @@
 
 package net.fabricmc.fabric.mixin.network;
 
-import net.fabricmc.fabric.impl.server.EntityTrackerStreamAccessor;
-import net.minecraft.server.network.ServerPlayerEntity;
+import java.util.Set;
+import java.util.stream.Stream;
+
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
-import java.util.Set;
-import java.util.stream.Stream;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import net.fabricmc.fabric.impl.server.EntityTrackerStreamAccessor;
 
 @Mixin(targets = "net.minecraft.server.world.ThreadedAnvilChunkStorage$EntityTracker")
 public class MixinEntityTracker implements EntityTrackerStreamAccessor {

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/mixin/network/MixinMinecraftClient.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/mixin/network/MixinMinecraftClient.java
@@ -16,13 +16,15 @@
 
 package net.fabricmc.fabric.mixin.network;
 
-import net.fabricmc.fabric.impl.network.ClientSidePacketRegistryImpl;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.Screen;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+
+import net.fabricmc.fabric.impl.network.ClientSidePacketRegistryImpl;
 
 @Mixin(MinecraftClient.class)
 public class MixinMinecraftClient {

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/mixin/network/MixinPlayerManager.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/mixin/network/MixinPlayerManager.java
@@ -16,25 +16,28 @@
 
 package net.fabricmc.fabric.mixin.network;
 
-import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
-import net.fabricmc.fabric.impl.network.PacketRegistryImpl;
-import net.fabricmc.fabric.impl.network.ServerSidePacketRegistryImpl;
-import net.minecraft.network.ClientConnection;
-import net.minecraft.network.Packet;
-import net.minecraft.server.PlayerManager;
-import net.minecraft.server.network.ServerPlayerEntity;
+import java.util.Optional;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Optional;
+import net.minecraft.network.ClientConnection;
+import net.minecraft.network.Packet;
+import net.minecraft.server.PlayerManager;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
+import net.fabricmc.fabric.impl.network.PacketRegistryImpl;
+import net.fabricmc.fabric.impl.network.ServerSidePacketRegistryImpl;
 
 @Mixin(priority = 500, value = PlayerManager.class)
 public abstract class MixinPlayerManager {
 	@Inject(method = "onPlayerConnect", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/packet/DifficultyS2CPacket;<init>(Lnet/minecraft/world/Difficulty;Z)V"))
 	public void onPlayerConnect(ClientConnection connection, ServerPlayerEntity player, CallbackInfo info) {
 		Optional<Packet<?>> optionalPacket = PacketRegistryImpl.createInitialRegisterPacket(ServerSidePacketRegistry.INSTANCE);
+
 		//noinspection OptionalIsPresent
 		if (optionalPacket.isPresent()) {
 			player.networkHandler.sendPacket(optionalPacket.get());

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/mixin/network/MixinServerPlayNetworkHandler.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/mixin/network/MixinServerPlayNetworkHandler.java
@@ -16,11 +16,12 @@
 
 package net.fabricmc.fabric.mixin.network;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.fabric.api.network.PacketContext;
-import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
-import net.fabricmc.fabric.impl.network.CustomPayloadC2SPacketAccessor;
-import net.fabricmc.fabric.impl.network.ServerSidePacketRegistryImpl;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
@@ -28,11 +29,12 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.network.packet.CustomPayloadC2SPacket;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.ThreadExecutor;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.fabric.api.network.PacketContext;
+import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
+import net.fabricmc.fabric.impl.network.CustomPayloadC2SPacketAccessor;
+import net.fabricmc.fabric.impl.network.ServerSidePacketRegistryImpl;
 
 @Mixin(ServerPlayNetworkHandler.class)
 public class MixinServerPlayNetworkHandler implements PacketContext {

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/mixin/network/MixinThreadedAnvilChunkStorage.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/mixin/network/MixinThreadedAnvilChunkStorage.java
@@ -16,17 +16,19 @@
 
 package net.fabricmc.fabric.mixin.network;
 
+import java.util.stream.Stream;
+
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import net.fabricmc.fabric.impl.server.EntityTrackerStorageAccessor;
-import net.fabricmc.fabric.impl.server.EntityTrackerStreamAccessor;
-import net.minecraft.entity.Entity;
-import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.server.world.ThreadedAnvilChunkStorage;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
-import java.util.stream.Stream;
+import net.minecraft.entity.Entity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ThreadedAnvilChunkStorage;
+
+import net.fabricmc.fabric.impl.server.EntityTrackerStorageAccessor;
+import net.fabricmc.fabric.impl.server.EntityTrackerStreamAccessor;
 
 @Mixin(ThreadedAnvilChunkStorage.class)
 public class MixinThreadedAnvilChunkStorage implements EntityTrackerStorageAccessor {

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/block/BlockSettingsExtensions.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/block/BlockSettingsExtensions.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.fabric.api.block;
 
-import net.fabricmc.fabric.mixin.builders.BlockSettingsHooks;
 import net.minecraft.block.Block.Settings;
 import net.minecraft.block.MaterialColor;
 import net.minecraft.item.Item;
@@ -24,63 +23,65 @@ import net.minecraft.sound.BlockSoundGroup;
 import net.minecraft.tag.Tag;
 import net.minecraft.util.Identifier;
 
+import net.fabricmc.fabric.mixin.builders.BlockSettingsHooks;
+
 public final class BlockSettingsExtensions {
-    private BlockSettingsExtensions() {
-    }
+	private BlockSettingsExtensions() {
+	}
 
-    public static void breakByHand(Settings settings, boolean breakByHand) {
-        FabricBlockSettings.computeExtraData(settings).breakByHand(breakByHand);
-    }
+	public static void breakByHand(Settings settings, boolean breakByHand) {
+		FabricBlockSettings.computeExtraData(settings).breakByHand(breakByHand);
+	}
 
-    public static void breakByTool(Settings settings, Tag<Item> tag, int miningLevel) {
-        FabricBlockSettings.computeExtraData(settings).addMiningLevel(tag, miningLevel);
-    }
+	public static void breakByTool(Settings settings, Tag<Item> tag, int miningLevel) {
+		FabricBlockSettings.computeExtraData(settings).addMiningLevel(tag, miningLevel);
+	}
 
-    public static void hardness(Settings settings, float hardness) {
-        ((BlockSettingsHooks) settings).setHardness(hardness);
-    }
+	public static void hardness(Settings settings, float hardness) {
+		((BlockSettingsHooks) settings).setHardness(hardness);
+	}
 
-    public static void resistance(Settings settings, float resistance) {
-        ((BlockSettingsHooks) settings).setResistance(Math.max(0.0F, resistance));
-    }
+	public static void resistance(Settings settings, float resistance) {
+		((BlockSettingsHooks) settings).setResistance(Math.max(0.0F, resistance));
+	}
 
-    public static void collidable(Settings settings, boolean collidable) {
-        ((BlockSettingsHooks) settings).setCollidable(collidable);
-    }
+	public static void collidable(Settings settings, boolean collidable) {
+		((BlockSettingsHooks) settings).setCollidable(collidable);
+	}
 
-    public static void materialColor(Settings settings, MaterialColor materialColor) {
-        ((BlockSettingsHooks) settings).setMaterialColor(materialColor);
-    }
+	public static void materialColor(Settings settings, MaterialColor materialColor) {
+		((BlockSettingsHooks) settings).setMaterialColor(materialColor);
+	}
 
-    public static void drops(Settings settings, Identifier dropTableId) {
-        ((BlockSettingsHooks) settings).setDropTableId(dropTableId);
-    }
+	public static void drops(Settings settings, Identifier dropTableId) {
+		((BlockSettingsHooks) settings).setDropTableId(dropTableId);
+	}
 
-    public static void sounds(Settings settings, BlockSoundGroup soundGroup) {
-        ((BlockSettingsHooks) settings).invokeSounds(soundGroup);
-    }
+	public static void sounds(Settings settings, BlockSoundGroup soundGroup) {
+		((BlockSettingsHooks) settings).invokeSounds(soundGroup);
+	}
 
-    public static void lightLevel(Settings settings, int lightLevel) { 
-        ((BlockSettingsHooks) settings).invokeLightLevel(lightLevel);
-    }
+	public static void lightLevel(Settings settings, int lightLevel) {
+		((BlockSettingsHooks) settings).invokeLightLevel(lightLevel);
+	}
 
-    public static void breakInstantly(Settings settings) {
-        ((BlockSettingsHooks) settings).invokeBreakInstantly();
-    }
+	public static void breakInstantly(Settings settings) {
+		((BlockSettingsHooks) settings).invokeBreakInstantly();
+	}
 
-    public static void strength(Settings settings, float strength) {
-        ((BlockSettingsHooks) settings).invokeStrength(strength);
-    }
+	public static void strength(Settings settings, float strength) {
+		((BlockSettingsHooks) settings).invokeStrength(strength);
+	}
 
-    public static void ticksRandomly(Settings settings) {
-        ((BlockSettingsHooks) settings).invokeTicksRandomly();
-    }
+	public static void ticksRandomly(Settings settings) {
+		((BlockSettingsHooks) settings).invokeTicksRandomly();
+	}
 
-    public static void dynamicBounds(Settings settings) {
-        ((BlockSettingsHooks) settings).invokeHasDynamicBounds();
-    }
+	public static void dynamicBounds(Settings settings) {
+		((BlockSettingsHooks) settings).invokeHasDynamicBounds();
+	}
 
-    public static void dropsNothing(Settings settings) {
-        ((BlockSettingsHooks) settings).invokeDropsNothing();
-    }
+	public static void dropsNothing(Settings settings) {
+		((BlockSettingsHooks) settings).invokeDropsNothing();
+	}
 }

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/block/FabricBlockSettings.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/block/FabricBlockSettings.java
@@ -16,8 +16,12 @@
 
 package net.fabricmc.fabric.api.block;
 
-import net.fabricmc.fabric.api.event.registry.BlockConstructedCallback;
-import net.fabricmc.fabric.impl.tools.ToolManager;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.Material;
 import net.minecraft.block.MaterialColor;
@@ -27,17 +31,14 @@ import net.minecraft.tag.Tag;
 import net.minecraft.util.DyeColor;
 import net.minecraft.util.Identifier;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
+import net.fabricmc.fabric.api.event.registry.BlockConstructedCallback;
+import net.fabricmc.fabric.impl.tools.ToolManager;
 
 /**
  * Fabric's version of Block.Settings. Adds additional methods and hooks
  * not found in the original class.
- * <p>
- * To use it, simply replace Block.Settings.create() with
+ *
+ * <p>To use it, simply replace Block.Settings.create() with
  * FabricBlockSettings.create() and add .build() at the end to return the
  * vanilla Block.Settings instance beneath.
  */
@@ -46,47 +47,49 @@ public class FabricBlockSettings {
 		BlockConstructedCallback.EVENT.register(FabricBlockSettings::onBuild);
 	}
 
-    private static final Map<Block.Settings, ExtraData> EXTRA_DATA = new HashMap<>();
+	private static final Map<Block.Settings, ExtraData> EXTRA_DATA = new HashMap<>();
 
-    protected final Block.Settings delegate;
+	protected final Block.Settings delegate;
 
 	static final class ExtraData {
-        private final List<MiningLevel> miningLevels = new ArrayList<>();
-        /* @Nullable */ private Boolean breakByHand;
+		private final List<MiningLevel> miningLevels = new ArrayList<>();
+		/* @Nullable */ private Boolean breakByHand;
 
 		private ExtraData(Block.Settings settings) {
-        }
+		}
 
 		void breakByHand(boolean breakByHand) {
-		    this.breakByHand = breakByHand;
-        }
+			this.breakByHand = breakByHand;
+		}
 
 		void addMiningLevel(Tag<Item> tag, int level) {
-		    miningLevels.add(new MiningLevel(tag, level));
-        }
+			miningLevels.add(new MiningLevel(tag, level));
+		}
 	}
 
-    private static final class MiningLevel {
-        private final Tag<Item> tag;
-        private final int level;
+	private static final class MiningLevel {
+		private final Tag<Item> tag;
+		private final int level;
 
-        MiningLevel(Tag<Item> tag, int level) {
-            this.tag = tag;
-            this.level = level;
-        }
-    }
+		MiningLevel(Tag<Item> tag, int level) {
+			this.tag = tag;
+			this.level = level;
+		}
+	}
 
 	static ExtraData computeExtraData(Block.Settings settings) {
-	    return EXTRA_DATA.computeIfAbsent(settings, ExtraData::new);
-    }
+		return EXTRA_DATA.computeIfAbsent(settings, ExtraData::new);
+	}
 
 	private static void onBuild(Block.Settings settings, Block block) {
 		// TODO: Load only if fabric-mining-levels present
 		ExtraData data = EXTRA_DATA.get(settings);
+
 		if (data != null) {
 			if (data.breakByHand != null) {
 				ToolManager.entry(block).setBreakByHand(data.breakByHand);
 			}
+
 			for (MiningLevel tml : data.miningLevels) {
 				ToolManager.entry(block).putBreakByTool(tml.tag, tml.level);
 			}
@@ -121,9 +124,9 @@ public class FabricBlockSettings {
 		return new FabricBlockSettings(base);
 	}
 
-    public static FabricBlockSettings copyOf(Block.Settings settings) {
-        return new FabricBlockSettings(settings);
-    }
+	public static FabricBlockSettings copyOf(Block.Settings settings) {
+		return new FabricBlockSettings(settings);
+	}
 
 	/* FABRIC HELPERS */
 
@@ -137,9 +140,9 @@ public class FabricBlockSettings {
 		return this;
 	}
 
-    public FabricBlockSettings breakByTool(Tag<Item> tag) {
-        return breakByTool(tag, 0);
-    }
+	public FabricBlockSettings breakByTool(Tag<Item> tag) {
+		return breakByTool(tag, 0);
+	}
 
 	/* DELEGATE WRAPPERS */
 
@@ -214,7 +217,7 @@ public class FabricBlockSettings {
 
 	@Deprecated
 	public FabricBlockSettings friction(float friction) {
-	    delegate.slipperiness(friction);
+		delegate.slipperiness(friction);
 		return this;
 	}
 

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/block/FabricMaterialBuilder.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/block/FabricMaterialBuilder.java
@@ -16,11 +16,12 @@
 
 package net.fabricmc.fabric.api.block;
 
-import net.fabricmc.fabric.mixin.builders.MaterialBuilderHooks;
 import net.minecraft.block.Material;
 import net.minecraft.block.MaterialColor;
 import net.minecraft.block.piston.PistonBehavior;
 import net.minecraft.util.DyeColor;
+
+import net.fabricmc.fabric.mixin.builders.MaterialBuilderHooks;
 
 public class FabricMaterialBuilder extends Material.Builder {
 	public FabricMaterialBuilder(MaterialColor color) {

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/entity/EntityTrackingRegistry.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/entity/EntityTrackingRegistry.java
@@ -16,13 +16,14 @@
 
 package net.fabricmc.fabric.api.entity;
 
-import net.minecraft.entity.EntityType;
-import net.minecraft.util.registry.Registry;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.HashMap;
-import java.util.Map;
+import net.minecraft.entity.EntityType;
+import net.minecraft.util.registry.Registry;
 
 /**
  * Registry for server-&gt;client entity tracking values.
@@ -63,9 +64,7 @@ public class EntityTrackingRegistry {
 	public static final EntityTrackingRegistry INSTANCE = new EntityTrackingRegistry();
 	private final Map<EntityType, Entry> entries = new HashMap<>();
 
-	private EntityTrackingRegistry() {
-
-	}
+	private EntityTrackingRegistry() { }
 
 	@Deprecated
 	public Entry get(EntityType type) {

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/entity/FabricEntityTypeBuilder.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/entity/FabricEntityTypeBuilder.java
@@ -16,16 +16,18 @@
 
 package net.fabricmc.fabric.api.entity;
 
-import net.fabricmc.fabric.impl.entity.FabricEntityType;
+import java.util.function.Function;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityCategory;
 import net.minecraft.entity.EntityDimensions;
 import net.minecraft.entity.EntityType;
 import net.minecraft.world.World;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
-import java.util.function.Function;
+import net.fabricmc.fabric.impl.entity.FabricEntityType;
 
 /**
  * Extended version of {@link EntityType.Builder} with added registration for

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/event/registry/BlockConstructedCallback.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/event/registry/BlockConstructedCallback.java
@@ -16,17 +16,18 @@
 
 package net.fabricmc.fabric.api.event.registry;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.block.Block;
 
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
 public interface BlockConstructedCallback {
-	public static Event<BlockConstructedCallback> EVENT = EventFactory.createArrayBacked(BlockConstructedCallback.class,
-		(listeners) -> (settings, builtBlock) -> {
-			for (BlockConstructedCallback callback : listeners) {
-				callback.building(settings, builtBlock);
+	Event<BlockConstructedCallback> EVENT = EventFactory.createArrayBacked(BlockConstructedCallback.class,
+			(listeners) -> (settings, builtBlock) -> {
+				for (BlockConstructedCallback callback : listeners) {
+					callback.building(settings, builtBlock);
+				}
 			}
-		}
 	);
 
 	void building(Block.Settings settings, Block builtBlock);

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/event/registry/ItemConstructedCallback.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/event/registry/ItemConstructedCallback.java
@@ -16,17 +16,18 @@
 
 package net.fabricmc.fabric.api.event.registry;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.item.Item;
 
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
 public interface ItemConstructedCallback {
-	public static Event<ItemConstructedCallback> EVENT = EventFactory.createArrayBacked(ItemConstructedCallback.class,
-		(listeners) -> (settings, builtItem) -> {
-			for (ItemConstructedCallback callback : listeners) {
-				callback.building(settings, builtItem);
+	Event<ItemConstructedCallback> EVENT = EventFactory.createArrayBacked(ItemConstructedCallback.class,
+			(listeners) -> (settings, builtItem) -> {
+				for (ItemConstructedCallback callback : listeners) {
+					callback.building(settings, builtItem);
+				}
 			}
-		}
 	);
 
 	void building(Item.Settings settings, Item builtItem);

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/mixin/builders/BlockSettingsHooks.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/mixin/builders/BlockSettingsHooks.java
@@ -16,49 +16,50 @@
 
 package net.fabricmc.fabric.mixin.builders;
 
-import net.minecraft.block.Block;
-import net.minecraft.block.MaterialColor;
-import net.minecraft.sound.BlockSoundGroup;
-import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.gen.Invoker;
 
+import net.minecraft.block.Block;
+import net.minecraft.block.MaterialColor;
+import net.minecraft.sound.BlockSoundGroup;
+import net.minecraft.util.Identifier;
+
 @Mixin(Block.Settings.class)
 public interface BlockSettingsHooks {
-    @Accessor
-    void setHardness(float hardness);
+	@Accessor
+	void setHardness(float hardness);
 
-    @Accessor
-    void setResistance(float resistance);
+	@Accessor
+	void setResistance(float resistance);
 
-    @Accessor
-    void setCollidable(boolean collidable);
+	@Accessor
+	void setCollidable(boolean collidable);
 
-    @Accessor
-    void setMaterialColor(MaterialColor materialColor);
+	@Accessor
+	void setMaterialColor(MaterialColor materialColor);
 
-    @Accessor
-    void setDropTableId(Identifier dropTableId);
+	@Accessor
+	void setDropTableId(Identifier dropTableId);
 
-    @Invoker
-    Block.Settings invokeSounds(BlockSoundGroup group);
+	@Invoker
+	Block.Settings invokeSounds(BlockSoundGroup group);
 
-    @Invoker
-    Block.Settings invokeLightLevel(int lightLevel);
+	@Invoker
+	Block.Settings invokeLightLevel(int lightLevel);
 
-    @Invoker
-    Block.Settings invokeBreakInstantly();
+	@Invoker
+	Block.Settings invokeBreakInstantly();
 
-    @Invoker
-    Block.Settings invokeStrength(float strength);
+	@Invoker
+	Block.Settings invokeStrength(float strength);
 
-    @Invoker
-    Block.Settings invokeTicksRandomly();
+	@Invoker
+	Block.Settings invokeTicksRandomly();
 
-    @Invoker
-    Block.Settings invokeHasDynamicBounds();
+	@Invoker
+	Block.Settings invokeHasDynamicBounds();
 
-    @Invoker
-    Block.Settings invokeDropsNothing();
+	@Invoker
+	Block.Settings invokeDropsNothing();
 }

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/mixin/builders/MaterialBuilderHooks.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/mixin/builders/MaterialBuilderHooks.java
@@ -16,11 +16,12 @@
 
 package net.fabricmc.fabric.mixin.builders;
 
-import net.minecraft.block.Material;
-import net.minecraft.block.piston.PistonBehavior;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.gen.Invoker;
+
+import net.minecraft.block.Material;
+import net.minecraft.block.piston.PistonBehavior;
 
 @Mixin(Material.Builder.class)
 public interface MaterialBuilderHooks {

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/mixin/builders/MixinBlock.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/mixin/builders/MixinBlock.java
@@ -16,12 +16,14 @@
 
 package net.fabricmc.fabric.mixin.builders;
 
-import net.fabricmc.fabric.api.event.registry.BlockConstructedCallback;
-import net.minecraft.block.Block;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.block.Block;
+
+import net.fabricmc.fabric.api.event.registry.BlockConstructedCallback;
 
 @Mixin(Block.class)
 public class MixinBlock {

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/mixin/builders/MixinItem.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/mixin/builders/MixinItem.java
@@ -16,12 +16,14 @@
 
 package net.fabricmc.fabric.mixin.builders;
 
-import net.fabricmc.fabric.api.event.registry.ItemConstructedCallback;
-import net.minecraft.item.Item;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.item.Item;
+
+import net.fabricmc.fabric.api.event.registry.ItemConstructedCallback;
 
 @Mixin(Item.class)
 public class MixinItem {

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/api/client/particle/v1/FabricSpriteProvider.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/api/client/particle/v1/FabricSpriteProvider.java
@@ -22,27 +22,27 @@ import net.minecraft.client.particle.SpriteProvider;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.texture.SpriteAtlasTexture;
 
-/*
+/**
  * FabricSpriteProvider. It does the same thing as vanilla's SpriteProvider,
  * but in a way that's accessible to mods, and that exposes the atlas as well.
  *
- * Custom sprites registered using ParticleFactoryRegistry have the options
+ * <p>Custom sprites registered using ParticleFactoryRegistry have the options
  * to supply a particle factory which will recieve an instance of this
  * interface containing the sprites set loaded for their particle from the
  * active resourcepacks.
  *
- * @see ParticleFactoryRegistry.register(type, constructor)
- * @see ParticleFactoryRegistry.PendingParticleFactory<T>
+ * @see ParticleFactoryRegistry#register(type, constructor)
+ * @see ParticleFactoryRegistry.PendingParticleFactory
  */
 public interface FabricSpriteProvider extends SpriteProvider {
 	/**
 	 * Returns the entire particles texture atlas.
 	 */
-	public SpriteAtlasTexture getAtlas();
+	SpriteAtlasTexture getAtlas();
 
 	/**
 	 * Gets the list of all sprites available for this particle to use.
 	 * This is defined in your resourcepack.
 	 */
-	public List<Sprite> getSprites();
+	List<Sprite> getSprites();
 }

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/api/client/particle/v1/ParticleFactoryRegistry.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/api/client/particle/v1/ParticleFactoryRegistry.java
@@ -16,10 +16,12 @@
 
 package net.fabricmc.fabric.api.client.particle.v1;
 
-import net.fabricmc.fabric.impl.client.particle.ParticleFactoryRegistryImpl;
 import net.minecraft.client.particle.ParticleFactory;
 import net.minecraft.particle.ParticleEffect;
 import net.minecraft.particle.ParticleType;
+
+import net.fabricmc.fabric.api.particle.v1.FabricParticleTypes;
+import net.fabricmc.fabric.impl.client.particle.ParticleFactoryRegistryImpl;
 
 /**
  * Registry for adding particle factories on the client for
@@ -28,23 +30,23 @@ import net.minecraft.particle.ParticleType;
  * @see FabricParticleTypes
  */
 public interface ParticleFactoryRegistry {
-	public static ParticleFactoryRegistry getInstance() {
+	static ParticleFactoryRegistry getInstance() {
 		return ParticleFactoryRegistryImpl.INSTANCE;
 	}
 
 	/**
 	 * Registers a factory for constructing particles of the given type.
 	 */
-	public <T extends ParticleEffect> void register(ParticleType<T> type, ParticleFactory<T> factory);
+	<T extends ParticleEffect> void register(ParticleType<T> type, ParticleFactory<T> factory);
 
 	/**
 	 * Registers a delayed factory for constructing particles of the given type.
 	 *
-	 * The factory method will be called with a sprite provider to use for that particle when it comes time.
+	 * <p>The factory method will be called with a sprite provider to use for that particle when it comes time.
 	 *
-	 * Particle sprites will be loaded from domain:/particles/particle_name.json as per vanilla minecraft behaviour.
+	 * <p>Particle sprites will be loaded from domain:/particles/particle_name.json as per vanilla minecraft behaviour.
 	 */
-	public <T extends ParticleEffect> void register(ParticleType<T> type, PendingParticleFactory<T> constructor);
+	<T extends ParticleEffect> void register(ParticleType<T> type, PendingParticleFactory<T> constructor);
 
 	/**
 	 * A pending particle factory.
@@ -56,12 +58,12 @@ public interface ParticleFactoryRegistry {
 		/**
 		 * Called to create a new particle factory.
 		 *
-		 * Particle sprites will be loaded from domain:/particles/particle_name.json as per vanilla minecraft behaviour.
+		 * <p>Particle sprites will be loaded from domain:/particles/particle_name.json as per vanilla minecraft behaviour.
 		 *
 		 * @param provider The sprite provider used to supply sprite textures when drawing the mod's particle.
 		 *
 		 * @return A new particle factory.
 		 */
-		public ParticleFactory<T> create(FabricSpriteProvider provider);
+		ParticleFactory<T> create(FabricSpriteProvider provider);
 	}
 }

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/api/particle/v1/FabricParticleTypes.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/api/particle/v1/FabricParticleTypes.java
@@ -23,16 +23,16 @@ import net.minecraft.particle.ParticleType;
 /**
  * Methods for creating particle types, both simple and using an existing attribute factory.
  *
- * Usage:
+ * <p>Usage:
+ * <pre> {@code
+ * public static final DefaultParticleType SIMPLE_TEST_PARTICLE = FabricParticleTypes.simple();
+ * public static final DefaultParticleType CUSTOM_TEST_PARTICLE = FabricParticleTypes.simple();
  *
- *	public static final DefaultParticleType SIMPLE_TEST_PARTICLE = FabricParticleTypes.simple();
- *	public static final DefaultParticleType CUSTOM_TEST_PARTICLE = FabricParticleTypes.simple();
- *
- *	@Override
- *	public void onInitialize() {
- *		Registry.register(Registry.PARTICLE_TYPE, new Identifier("testmod", "simple"), SIMPLE_TEST_PARTICLE);
- *		Registry.register(Registry.PARTICLE_TYPE, new Identifier("testmod", "custom"), CUSTOM_TEST_PARTICLE);
- *	}
+ * @Override
+ * public void onInitialize() {
+ *     Registry.register(Registry.PARTICLE_TYPE, new Identifier("testmod", "simple"), SIMPLE_TEST_PARTICLE);
+ *     Registry.register(Registry.PARTICLE_TYPE, new Identifier("testmod", "custom"), CUSTOM_TEST_PARTICLE);
+ * }}</pre>
  *
  * @see ParticleModClient in the fabric example mods for a more complete usage.
  */
@@ -55,7 +55,7 @@ public final class FabricParticleTypes {
 	 * @param alwaysSpawn True to always spawn the particle regardless of distance.
 	 */
 	public static DefaultParticleType simple(boolean alwaysSpawn) {
-		return new DefaultParticleType(alwaysSpawn) {};
+		return new DefaultParticleType(alwaysSpawn) { };
 	}
 
 	/**
@@ -76,6 +76,6 @@ public final class FabricParticleTypes {
 	 * @param factory	 A factory for serializing packet data and string command parameters into a particle effect.
 	 */
 	public static <T extends ParticleEffect> ParticleType<T> complex(boolean alwaysSpawn, ParticleEffect.Factory<T> factory) {
-		return new ParticleType<T>(alwaysSpawn, factory) {};
+		return new ParticleType<T>(alwaysSpawn, factory) { };
 	}
 }

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/impl/client/particle/FabricParticleManager.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/impl/client/particle/FabricParticleManager.java
@@ -25,16 +25,17 @@ import java.util.Random;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
-
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import net.fabricmc.fabric.api.client.particle.v1.FabricSpriteProvider;
+
 import net.minecraft.client.particle.ParticleTextureData;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.texture.SpriteAtlasTexture;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.JsonHelper;
+
+import net.fabricmc.fabric.api.client.particle.v1.FabricSpriteProvider;
 
 public final class FabricParticleManager {
 	private final VanillaParticleManager manager;
@@ -114,6 +115,7 @@ public final class FabricParticleManager {
 			if (sprites == null) {
 				sprites = spriteIds.stream().map(getAtlas()::getSprite).collect(Collectors.toList());
 			}
+
 			return sprites;
 		}
 

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/impl/client/particle/FabricParticleManager.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/impl/client/particle/FabricParticleManager.java
@@ -51,8 +51,8 @@ public final class FabricParticleManager {
 		ParticleFactoryRegistryImpl.INSTANCE.constructors.forEach((id, factory) -> {
 			FabricSpriteProviderImpl provider = new FabricSpriteProviderImpl();
 
-			providers.put((int)id, provider);
-			manager.getFactories().put((int)id, factory.create(provider));
+			providers.put((int) id, provider);
+			manager.getFactories().put((int) id, factory.create(provider));
 		});
 	}
 
@@ -61,7 +61,7 @@ public final class FabricParticleManager {
 			return null;
 		}
 
-		return providers.get((int)ParticleFactoryRegistryImpl.INSTANCE.constructorsIdsMap.get(id));
+		return providers.get((int) ParticleFactoryRegistryImpl.INSTANCE.constructorsIdsMap.get(id));
 	}
 
 	public boolean loadParticle(ResourceManager manager, Identifier id) {

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/impl/client/particle/ParticleFactoryRegistryImpl.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/impl/client/particle/ParticleFactoryRegistryImpl.java
@@ -21,12 +21,14 @@ import java.util.Map;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import net.fabricmc.fabric.api.client.particle.v1.ParticleFactoryRegistry;
+
 import net.minecraft.client.particle.ParticleFactory;
 import net.minecraft.particle.ParticleEffect;
 import net.minecraft.particle.ParticleType;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
+
+import net.fabricmc.fabric.api.client.particle.v1.ParticleFactoryRegistry;
 
 public final class ParticleFactoryRegistryImpl implements ParticleFactoryRegistry {
 	public static final ParticleFactoryRegistryImpl INSTANCE = new ParticleFactoryRegistryImpl();

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/impl/client/particle/VanillaParticleManager.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/impl/client/particle/VanillaParticleManager.java
@@ -17,17 +17,20 @@
 package net.fabricmc.fabric.impl.client.particle;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+
 import net.minecraft.client.particle.ParticleFactory;
 import net.minecraft.client.texture.SpriteAtlasTexture;
 
 /**
  * Accessors for some private members of ParticleManager.
  *
- * Usage:
- *  SpriteAtlasTexture atlas = ((VanillaParticleManager)MinecraftClient.getInstance().particleManager).getAtlas()
+ * <p>Usage:
+ * <pre> {@code
+ * SpriteAtlasTexture atlas = ((VanillaParticleManager)MinecraftClient.getInstance().particleManager).getAtlas()
+ * }</pre>
  */
 public interface VanillaParticleManager {
-	public SpriteAtlasTexture getAtlas();
+	SpriteAtlasTexture getAtlas();
 
-	public Int2ObjectMap<ParticleFactory<?>> getFactories();
+	Int2ObjectMap<ParticleFactory<?>> getFactories();
 }

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/client/particle/MixinParticleManager.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/client/particle/MixinParticleManager.java
@@ -19,20 +19,21 @@ package net.fabricmc.fabric.mixin.client.particle;
 import java.util.List;
 import java.util.Map;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import net.fabricmc.fabric.impl.client.particle.FabricParticleManager;
-import net.fabricmc.fabric.impl.client.particle.VanillaParticleManager;
 import net.minecraft.client.particle.ParticleFactory;
 import net.minecraft.client.particle.ParticleManager;
 import net.minecraft.client.texture.SpriteAtlasTexture;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.impl.client.particle.FabricParticleManager;
+import net.fabricmc.fabric.impl.client.particle.VanillaParticleManager;
 
 @Mixin(ParticleManager.class)
 public abstract class MixinParticleManager implements VanillaParticleManager {

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/RegistryEntryAddedCallback.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/RegistryEntryAddedCallback.java
@@ -16,10 +16,11 @@
 
 package net.fabricmc.fabric.api.event.registry;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.impl.registry.ListenableRegistry;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.impl.registry.ListenableRegistry;
 
 @FunctionalInterface
 public interface RegistryEntryAddedCallback<T> {

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/RegistryEntryRemovedCallback.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/RegistryEntryRemovedCallback.java
@@ -16,10 +16,11 @@
 
 package net.fabricmc.fabric.api.event.registry;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.impl.registry.ListenableRegistry;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.impl.registry.ListenableRegistry;
 
 @FunctionalInterface
 public interface RegistryEntryRemovedCallback<T> {

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/RegistryIdRemapCallback.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/RegistryIdRemapCallback.java
@@ -17,22 +17,24 @@
 package net.fabricmc.fabric.api.event.registry;
 
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.impl.registry.ListenableRegistry;
+
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.impl.registry.ListenableRegistry;
 
 /**
  * The remapping process functions as follows:
  *
- * - RegistryEntryRemovedCallbacks are called to remove any objects culled in the process, with the old numeric ID.
- * - RegistryIdRemapCallback is emitted to allow remapping the IDs of objects still present.
- * - RegistryEntryAddedCallbacks are called to add any objects added in the process, with the new numeric ID.
+ * <ul><li>RegistryEntryRemovedCallbacks are called to remove any objects culled in the process, with the old numeric ID.
+ * <li>RegistryIdRemapCallback is emitted to allow remapping the IDs of objects still present.
+ * <li>RegistryEntryAddedCallbacks are called to add any objects added in the process, with the new numeric ID.</ul>
  *
- * RegistryIdRemapCallback is called on every remapping operation, if you want to do your own processing in one swoop
+ * <p>RegistryIdRemapCallback is called on every remapping operation, if you want to do your own processing in one swoop
  * (say, rebuild the ID map from scratch).
  *
- * Generally speaking, a remap can only cause object *removals*; object *additions* are necessary to reverse remaps.
+ * <p>Generally speaking, a remap can only cause object *removals*; object *additions* are necessary to reverse remaps.
  *
  * @param <T> The registry type.
  */
@@ -52,6 +54,6 @@ public interface RegistryIdRemapCallback<T> {
 		}
 
 		//noinspection unchecked
-		return (Event<RegistryIdRemapCallback<T>>) ((ListenableRegistry) registry).fabric_getRemapEvent();
+		return ((ListenableRegistry) registry).fabric_getRemapEvent();
 	}
 }

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/FabricRegistryClientInit.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/FabricRegistryClientInit.java
@@ -16,13 +16,15 @@
 
 package net.fabricmc.fabric.impl.registry;
 
-import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.text.LiteralText;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
 
 public class FabricRegistryClientInit implements ClientModInitializer {
 	private static final Logger LOGGER = LogManager.getLogger();
@@ -35,7 +37,7 @@ public class FabricRegistryClientInit implements ClientModInitializer {
 				LOGGER.error("Registry remapping failed!", e);
 				MinecraftClient.getInstance().execute(() -> {
 					((ClientPlayerEntity) ctx.getPlayer()).networkHandler.getConnection().disconnect(
-						new LiteralText("Registry remapping failed: " + e.getMessage())
+							new LiteralText("Registry remapping failed: " + e.getMessage())
 					);
 				});
 			});

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/ListenableRegistry.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/ListenableRegistry.java
@@ -18,8 +18,8 @@ package net.fabricmc.fabric.impl.registry;
 
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
-import net.fabricmc.fabric.api.event.registry.RegistryIdRemapCallback;
 import net.fabricmc.fabric.api.event.registry.RegistryEntryRemovedCallback;
+import net.fabricmc.fabric.api.event.registry.RegistryIdRemapCallback;
 
 public interface ListenableRegistry<T> {
 	Event<RegistryEntryAddedCallback<T>> fabric_getAddObjectEvent();

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/RegistrySyncManager.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/RegistrySyncManager.java
@@ -108,6 +108,7 @@ public final class RegistrySyncManager {
 
 				if (c && registry != null) {
 					File file = new File(location, registryId.toString().replace(':', '.').replace('/', '.') + ".csv");
+
 					try (FileOutputStream stream = new FileOutputStream(file)) {
 						StringBuilder builder = new StringBuilder("Raw ID,String ID,Class Type\n");
 

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/RegistrySyncManager.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/RegistrySyncManager.java
@@ -16,25 +16,6 @@
 
 package net.fabricmc.fabric.impl.registry;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
-import io.netty.buffer.Unpooled;
-import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
-import it.unimi.dsi.fastutil.ints.IntSet;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
-import net.fabricmc.fabric.api.network.PacketContext;
-import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.Packet;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.PacketByteBuf;
-import net.minecraft.util.registry.MutableRegistry;
-import net.minecraft.util.registry.Registry;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -45,6 +26,27 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import io.netty.buffer.Unpooled;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.Packet;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.PacketByteBuf;
+import net.minecraft.util.registry.MutableRegistry;
+import net.minecraft.util.registry.Registry;
+
+import net.fabricmc.fabric.api.network.PacketContext;
+import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
+
 public final class RegistrySyncManager {
 	static final boolean DEBUG = System.getProperty("fabric.registry.debug", "false").equalsIgnoreCase("true");
 	static final Identifier ID = new Identifier("fabric", "registry/sync");
@@ -53,9 +55,7 @@ public final class RegistrySyncManager {
 	private static final Set<Identifier> REGISTRY_BLACKLIST = ImmutableSet.of();
 	private static final Set<Identifier> REGISTRY_BLACKLIST_NETWORK = ImmutableSet.of();
 
-	private RegistrySyncManager() {
-
-	}
+	private RegistrySyncManager() { }
 
 	public static Packet<?> createPacket() {
 		PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
@@ -80,6 +80,7 @@ public final class RegistrySyncManager {
 					} catch (RemapException e) {
 						errorHandler.accept(e);
 					}
+
 					return null;
 				}).get(30, TimeUnit.SECONDS);
 			} catch (ExecutionException | InterruptedException | TimeoutException e) {
@@ -95,6 +96,7 @@ public final class RegistrySyncManager {
 			if (DEBUG_WRITE_REGISTRY_DATA) {
 				File location = new File(".fabric" + File.separatorChar + "debug" + File.separatorChar + "registry");
 				boolean c = true;
+
 				if (!location.exists()) {
 					if (!location.mkdirs()) {
 						LOGGER.warn("[fabric-registry-sync debug] Could not create " + location.getAbsolutePath() + " directory!");
@@ -103,10 +105,12 @@ public final class RegistrySyncManager {
 				}
 
 				MutableRegistry registry = Registry.REGISTRIES.get(registryId);
+
 				if (c && registry != null) {
 					File file = new File(location, registryId.toString().replace(':', '.').replace('/', '.') + ".csv");
 					try (FileOutputStream stream = new FileOutputStream(file)) {
 						StringBuilder builder = new StringBuilder("Raw ID,String ID,Class Type\n");
+
 						for (Object o : registry) {
 							String classType = (o == null) ? "null" : o.getClass().getName();
 							//noinspection unchecked
@@ -118,6 +122,7 @@ public final class RegistrySyncManager {
 							String stringId = id.toString();
 							builder.append("\"").append(rawId).append("\",\"").append(stringId).append("\",\"").append(classType).append("\"\n");
 						}
+
 						stream.write(builder.toString().getBytes(StandardCharsets.UTF_8));
 					} catch (IOException e) {
 						LOGGER.warn("[fabric-registry-sync debug] Could not write to " + file.getAbsolutePath() + "!", e);
@@ -132,6 +137,7 @@ public final class RegistrySyncManager {
 			}
 
 			MutableRegistry registry = Registry.REGISTRIES.get(registryId);
+
 			if (registry instanceof RemappableRegistry) {
 				CompoundTag registryTag = new CompoundTag();
 				IntSet rawIdsFound = DEBUG ? new IntOpenHashSet() : null;
@@ -186,6 +192,7 @@ public final class RegistrySyncManager {
 
 			if (registry instanceof RemappableRegistry) {
 				Object2IntMap<Identifier> idMap = new Object2IntOpenHashMap<>();
+
 				for (String key : registryTag.getKeys()) {
 					idMap.put(new Identifier(key), registryTag.getInt(key));
 				}
@@ -202,6 +209,7 @@ public final class RegistrySyncManager {
 	public static void unmap() throws RemapException {
 		for (Identifier registryId : Registry.REGISTRIES.getIds()) {
 			MutableRegistry registry = Registry.REGISTRIES.get(registryId);
+
 			if (registry instanceof RemappableRegistry) {
 				((RemappableRegistry) registry).unmap(registryId.toString());
 			}

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/RemapStateImpl.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/RemapStateImpl.java
@@ -19,9 +19,11 @@ package net.fabricmc.fabric.impl.registry;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import net.fabricmc.fabric.api.event.registry.RegistryIdRemapCallback;
+
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
+
+import net.fabricmc.fabric.api.event.registry.RegistryIdRemapCallback;
 
 public class RemapStateImpl<T> implements RegistryIdRemapCallback.RemapState<T> {
 	private final Int2IntMap rawIdChangeMap;

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/RemappableRegistry.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/RemappableRegistry.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.impl.registry;
 
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
+
 import net.minecraft.util.Identifier;
 
 public interface RemappableRegistry {

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/trackers/IdListTracker.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/trackers/IdListTracker.java
@@ -16,16 +16,17 @@
 
 package net.fabricmc.fabric.impl.registry.trackers;
 
-import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
-import net.fabricmc.fabric.api.event.registry.RegistryIdRemapCallback;
-import net.fabricmc.fabric.api.event.registry.RegistryEntryRemovedCallback;
-import net.fabricmc.fabric.impl.registry.RemovableIdList;
+import java.util.HashMap;
+import java.util.Map;
+
 import net.minecraft.util.IdList;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 
-import java.util.HashMap;
-import java.util.Map;
+import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
+import net.fabricmc.fabric.api.event.registry.RegistryEntryRemovedCallback;
+import net.fabricmc.fabric.api.event.registry.RegistryIdRemapCallback;
+import net.fabricmc.fabric.impl.registry.RemovableIdList;
 
 public class IdListTracker<V, OV> implements RegistryEntryAddedCallback<V>, RegistryIdRemapCallback<V>, RegistryEntryRemovedCallback<V> {
 	private final String name;

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/trackers/Int2ObjectMapTracker.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/trackers/Int2ObjectMapTracker.java
@@ -16,22 +16,24 @@
 
 package net.fabricmc.fabric.impl.registry.trackers;
 
-import com.google.common.base.Joiner;
-import it.unimi.dsi.fastutil.ints.Int2IntMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
-import net.fabricmc.fabric.api.event.registry.RegistryIdRemapCallback;
-import net.fabricmc.fabric.api.event.registry.RegistryEntryRemovedCallback;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.google.common.base.Joiner;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
+import net.fabricmc.fabric.api.event.registry.RegistryEntryRemovedCallback;
+import net.fabricmc.fabric.api.event.registry.RegistryIdRemapCallback;
 
 public class Int2ObjectMapTracker<V, OV> implements RegistryEntryAddedCallback<V>, RegistryIdRemapCallback<V>, RegistryEntryRemovedCallback<V> {
 	private static final Logger LOGGER = LogManager.getLogger();
@@ -65,8 +67,10 @@ public class Int2ObjectMapTracker<V, OV> implements RegistryEntryAddedCallback<V
 		List<String> errors = null;
 
 		mappers.clear();
+
 		for (int i : oldMappers.keySet()) {
 			int newI = remapMap.getOrDefault(i, Integer.MIN_VALUE);
+
 			if (newI >= 0) {
 				if (mappers.containsKey(newI)) {
 					if (errors == null) {
@@ -91,6 +95,7 @@ public class Int2ObjectMapTracker<V, OV> implements RegistryEntryAddedCallback<V
 	@Override
 	public void onEntryRemoved(int rawId, Identifier id, V object) {
 		OV mapper = mappers.remove(rawId);
+
 		if (mapper != null) {
 			removedMapperCache.put(id, mapper);
 		}

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/trackers/StateIdTracker.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/trackers/StateIdTracker.java
@@ -16,19 +16,21 @@
 
 package net.fabricmc.fabric.impl.registry.trackers;
 
+import java.util.Collection;
+import java.util.function.Function;
+
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectRBTreeMap;
-import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
-import net.fabricmc.fabric.api.event.registry.RegistryIdRemapCallback;
-import net.fabricmc.fabric.impl.registry.RemovableIdList;
-import net.minecraft.util.IdList;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Collection;
-import java.util.function.Function;
+import net.minecraft.util.IdList;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
+import net.fabricmc.fabric.api.event.registry.RegistryIdRemapCallback;
+import net.fabricmc.fabric.impl.registry.RemovableIdList;
 
 public final class StateIdTracker<T, S> implements RegistryIdRemapCallback<T>, RegistryEntryAddedCallback<T> {
 	private final Logger logger = LogManager.getLogger();
@@ -86,6 +88,7 @@ public final class StateIdTracker<T, S> implements RegistryIdRemapCallback<T>, R
 
 	private void recalcHighestId() {
 		currentHighestId = 0;
+
 		for (T object : registry) {
 			currentHighestId = Math.max(currentHighestId, registry.getRawId(object));
 		}

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/trackers/vanilla/BiomeParentTracker.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/trackers/vanilla/BiomeParentTracker.java
@@ -16,16 +16,18 @@
 
 package net.fabricmc.fabric.impl.registry.trackers.vanilla;
 
+import java.util.Objects;
+
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
-import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
-import net.fabricmc.fabric.api.event.registry.RegistryIdRemapCallback;
-import net.fabricmc.fabric.api.event.registry.RegistryEntryRemovedCallback;
-import net.fabricmc.fabric.impl.registry.RemovableIdList;
+
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biome;
 
-import java.util.Objects;
+import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
+import net.fabricmc.fabric.api.event.registry.RegistryEntryRemovedCallback;
+import net.fabricmc.fabric.api.event.registry.RegistryIdRemapCallback;
+import net.fabricmc.fabric.impl.registry.RemovableIdList;
 
 public final class BiomeParentTracker implements RegistryEntryAddedCallback<Biome>, RegistryEntryRemovedCallback<Biome>, RegistryIdRemapCallback<Biome> {
 	private final Registry<Biome> registry;

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/trackers/vanilla/BlockInitTracker.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/trackers/vanilla/BlockInitTracker.java
@@ -16,11 +16,12 @@
 
 package net.fabricmc.fabric.impl.registry.trackers.vanilla;
 
-import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
+
+import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
 
 public final class BlockInitTracker implements RegistryEntryAddedCallback<Block> {
 	private final Registry<Block> registry;

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/trackers/vanilla/BlockItemTracker.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/trackers/vanilla/BlockItemTracker.java
@@ -16,16 +16,15 @@
 
 package net.fabricmc.fabric.impl.registry.trackers.vanilla;
 
-import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 
-public final class BlockItemTracker implements RegistryEntryAddedCallback<Item> {
-	private BlockItemTracker() {
+import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
 
-	}
+public final class BlockItemTracker implements RegistryEntryAddedCallback<Item> {
+	private BlockItemTracker() { }
 
 	public static void register(Registry<Item> registry) {
 		BlockItemTracker tracker = new BlockItemTracker();

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/MixinBootstrap.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/MixinBootstrap.java
@@ -16,10 +16,11 @@
 
 package net.fabricmc.fabric.mixin.registry;
 
-import net.fabricmc.fabric.impl.registry.trackers.*;
-import net.fabricmc.fabric.impl.registry.trackers.vanilla.BiomeParentTracker;
-import net.fabricmc.fabric.impl.registry.trackers.vanilla.BlockInitTracker;
-import net.fabricmc.fabric.impl.registry.trackers.vanilla.BlockItemTracker;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
 import net.minecraft.Bootstrap;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
@@ -28,10 +29,11 @@ import net.minecraft.fluid.Fluids;
 import net.minecraft.item.Items;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biomes;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.fabricmc.fabric.impl.registry.trackers.StateIdTracker;
+import net.fabricmc.fabric.impl.registry.trackers.vanilla.BiomeParentTracker;
+import net.fabricmc.fabric.impl.registry.trackers.vanilla.BlockInitTracker;
+import net.fabricmc.fabric.impl.registry.trackers.vanilla.BlockItemTracker;
 
 @Mixin(Bootstrap.class)
 public class MixinBootstrap {

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/MixinIdList.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/MixinIdList.java
@@ -16,17 +16,19 @@
 
 package net.fabricmc.fabric.mixin.registry;
 
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntMaps;
-import net.fabricmc.fabric.impl.registry.RemovableIdList;
-import net.minecraft.util.IdList;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 
-import java.util.ArrayList;
-import java.util.IdentityHashMap;
-import java.util.List;
+import net.minecraft.util.IdList;
+
+import net.fabricmc.fabric.impl.registry.RemovableIdList;
 
 @Mixin(IdList.class)
 public class MixinIdList implements RemovableIdList<Object> {
@@ -48,6 +50,7 @@ public class MixinIdList implements RemovableIdList<Object> {
 	private void fabric_removeInner(Object o) {
 		int value = idMap.remove(o);
 		list.set(value, null);
+
 		while (nextId > 1 && list.get(nextId - 1) == null) {
 			nextId--;
 		}
@@ -66,6 +69,7 @@ public class MixinIdList implements RemovableIdList<Object> {
 
 		for (Object o : idMap.keySet()) {
 			int j = idMap.get(o);
+
 			if (i == j) {
 				removals.add(o);
 			}
@@ -91,6 +95,7 @@ public class MixinIdList implements RemovableIdList<Object> {
 
 		for (int k = 0; k < oldList.size(); k++) {
 			Object o = oldList.get(k);
+
 			if (o != null) {
 				int i = map.getOrDefault(k, k);
 
@@ -99,6 +104,7 @@ public class MixinIdList implements RemovableIdList<Object> {
 				}
 
 				list.set(i, o);
+
 				if (nextId <= i) {
 					nextId = i + 1;
 				}

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/MixinIdRegistry.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/MixinIdRegistry.java
@@ -16,23 +16,20 @@
 
 package net.fabricmc.fabric.mixin.registry;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
-import it.unimi.dsi.fastutil.ints.*;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
-import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
-import net.fabricmc.fabric.api.event.registry.RegistryIdRemapCallback;
-import net.fabricmc.fabric.api.event.registry.RegistryEntryRemovedCallback;
-import net.fabricmc.fabric.impl.registry.ListenableRegistry;
-import net.fabricmc.fabric.impl.registry.RemapStateImpl;
-import net.fabricmc.fabric.impl.registry.RemapException;
-import net.fabricmc.fabric.impl.registry.RemappableRegistry;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.Int2ObjectBiMap;
-import net.minecraft.util.registry.SimpleRegistry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Mixin;
@@ -42,7 +39,19 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.*;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.Int2ObjectBiMap;
+import net.minecraft.util.registry.SimpleRegistry;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
+import net.fabricmc.fabric.api.event.registry.RegistryEntryRemovedCallback;
+import net.fabricmc.fabric.api.event.registry.RegistryIdRemapCallback;
+import net.fabricmc.fabric.impl.registry.ListenableRegistry;
+import net.fabricmc.fabric.impl.registry.RemapException;
+import net.fabricmc.fabric.impl.registry.RemapStateImpl;
+import net.fabricmc.fabric.impl.registry.RemappableRegistry;
 
 @Mixin(SimpleRegistry.class)
 public abstract class MixinIdRegistry<T> implements RemappableRegistry, ListenableRegistry {
@@ -57,32 +66,32 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 
 	@Unique
 	private final Event<RegistryEntryAddedCallback> fabric_addObjectEvent = EventFactory.createArrayBacked(RegistryEntryAddedCallback.class,
-		(callbacks) -> (rawId, id, object) -> {
-			for (RegistryEntryAddedCallback callback : callbacks) {
-				//noinspection unchecked
-				callback.onEntryAdded(rawId, id, object);
+			(callbacks) -> (rawId, id, object) -> {
+				for (RegistryEntryAddedCallback callback : callbacks) {
+					//noinspection unchecked
+					callback.onEntryAdded(rawId, id, object);
+				}
 			}
-		}
 	);
 
 	@Unique
 	private final Event<RegistryEntryRemovedCallback> fabric_removeObjectEvent = EventFactory.createArrayBacked(RegistryEntryRemovedCallback.class,
-		(callbacks) -> (rawId, id, object) -> {
-			for (RegistryEntryRemovedCallback callback : callbacks) {
-				//noinspection unchecked
-				callback.onEntryRemoved(rawId, id, object);
+			(callbacks) -> (rawId, id, object) -> {
+				for (RegistryEntryRemovedCallback callback : callbacks) {
+					//noinspection unchecked
+					callback.onEntryRemoved(rawId, id, object);
+				}
 			}
-		}
 	);
 
 	@Unique
 	private final Event<RegistryIdRemapCallback> fabric_postRemapEvent = EventFactory.createArrayBacked(RegistryIdRemapCallback.class,
-		(callbacks) -> (a) -> {
-			for (RegistryIdRemapCallback callback : callbacks) {
-				//noinspection unchecked
-				callback.onRemap(a);
+			(callbacks) -> (a) -> {
+				for (RegistryIdRemapCallback callback : callbacks) {
+					//noinspection unchecked
+					callback.onRemap(a);
+				}
 			}
-		}
 	);
 
 	@Unique
@@ -93,19 +102,19 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 	@Override
 	public Event<RegistryEntryAddedCallback<T>> fabric_getAddObjectEvent() {
 		//noinspection unchecked
-		return (Event<RegistryEntryAddedCallback<T>>) (Event) fabric_addObjectEvent;
+		return (Event) fabric_addObjectEvent;
 	}
 
 	@Override
 	public Event<RegistryEntryRemovedCallback<T>> fabric_getRemoveObjectEvent() {
 		//noinspection unchecked
-		return (Event<RegistryEntryRemovedCallback<T>>) (Event) fabric_removeObjectEvent;
+		return (Event) fabric_removeObjectEvent;
 	}
 
 	@Override
 	public Event<RegistryIdRemapCallback<T>> fabric_getRemapEvent() {
 		//noinspection unchecked
-		return (Event<RegistryIdRemapCallback<T>>) (Event) fabric_postRemapEvent;
+		return (Event) fabric_postRemapEvent;
 	}
 
 	// The rest of the registry isn't thread-safe, so this one need not be either.
@@ -116,6 +125,7 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 	@Inject(method = "set", at = @At("HEAD"))
 	public void setPre(int id, Identifier identifier, Object object, CallbackInfoReturnable info) {
 		int indexedEntriesId = indexedEntries.getId((T) object);
+
 		if (indexedEntriesId >= 0) {
 			throw new RuntimeException("Attempted to register object " + object + " twice! (at raw IDs " + indexedEntriesId + " and " + id + " )");
 		}
@@ -124,8 +134,10 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 			fabric_isObjectNew = true;
 		} else {
 			T oldObject = entries.get(identifier);
+
 			if (oldObject != null && oldObject != object) {
 				int oldId = indexedEntries.getId(oldObject);
+
 				if (oldId != id) {
 					throw new RuntimeException("Attempted to register ID " + identifier + " at different raw IDs (" + oldId + ", " + id + ")! If you're trying to override an item, use .set(), not .register()!");
 				}
@@ -153,50 +165,60 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 
 		// Throw on invalid conditions.
 		switch (mode) {
-			case AUTHORITATIVE:
-				break;
-			case REMOTE: {
-				List<String> strings = null;
+		case AUTHORITATIVE:
+			break;
+		case REMOTE: {
+			List<String> strings = null;
+
+			for (Identifier remoteId : remoteIndexedEntries.keySet()) {
+				if (!entries.keySet().contains(remoteId)) {
+					if (strings == null) {
+						strings = new ArrayList<>();
+					}
+
+					strings.add(" - " + remoteId);
+				}
+			}
+
+			if (strings != null) {
+				StringBuilder builder = new StringBuilder("Received ID map for " + name + " contains IDs unknown to the receiver!");
+
+				for (String s : strings) {
+					builder.append('\n').append(s);
+				}
+
+				throw new RemapException(builder.toString());
+			}
+
+			break;
+		}
+		case EXACT: {
+			if (!entries.keySet().equals(remoteIndexedEntries.keySet())) {
+				List<String> strings = new ArrayList<>();
+
 				for (Identifier remoteId : remoteIndexedEntries.keySet()) {
 					if (!entries.keySet().contains(remoteId)) {
-						if (strings == null) {
-							strings = new ArrayList<>();
-						}
-
-						strings.add(" - " + remoteId);
+						strings.add(" - " + remoteId + " (missing on local)");
 					}
 				}
 
-				if (strings != null) {
-					StringBuilder builder = new StringBuilder("Received ID map for " + name + " contains IDs unknown to the receiver!");
-					for (String s : strings) {
-						builder.append('\n').append(s);
+				for (Identifier localId : registry.getIds()) {
+					if (!remoteIndexedEntries.keySet().contains(localId)) {
+						strings.add(" - " + localId + " (missing on remote)");
 					}
-					throw new RemapException(builder.toString());
 				}
-			} break;
-			case EXACT: {
-				if (!entries.keySet().equals(remoteIndexedEntries.keySet())) {
-					List<String> strings = new ArrayList<>();
-					for (Identifier remoteId : remoteIndexedEntries.keySet()) {
-						if (!entries.keySet().contains(remoteId)) {
-							strings.add(" - " + remoteId + " (missing on local)");
-						}
-					}
 
-					for (Identifier localId : registry.getIds()) {
-						if (!remoteIndexedEntries.keySet().contains(localId)) {
-							strings.add(" - " + localId + " (missing on remote)");
-						}
-					}
+				StringBuilder builder = new StringBuilder("Local and remote ID sets for " + name + " do not match!");
 
-					StringBuilder builder = new StringBuilder("Local and remote ID sets for " + name + " do not match!");
-					for (String s : strings) {
-						builder.append('\n').append(s);
-					}
-					throw new RemapException(builder.toString());
+				for (String s : strings) {
+					builder.append('\n').append(s);
 				}
-			} break;
+
+				throw new RemapException(builder.toString());
+			}
+
+			break;
+		}
 		}
 
 		// Make a copy of the previous maps.
@@ -208,12 +230,14 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 		if (fabric_prevIndexedEntries == null) {
 			fabric_prevIndexedEntries = new Object2IntOpenHashMap<>();
 			fabric_prevEntries = HashBiMap.create(entries);
+
 			for (Object o : registry) {
 				fabric_prevIndexedEntries.put(registry.getId(o), registry.getRawId(o));
 			}
 		}
 
 		Int2ObjectMap<Identifier> oldIdMap = new Int2ObjectOpenHashMap<>();
+
 		for (Object o : registry) {
 			oldIdMap.put(registry.getRawId(o), registry.getId(o));
 		}
@@ -221,47 +245,53 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 		// If we're AUTHORITATIVE, we append entries which only exist on the
 		// local side to the new entry list. For REMOTE, we instead drop them.
 		switch (mode) {
-			case AUTHORITATIVE: {
-				int maxValue = 0;
+		case AUTHORITATIVE: {
+			int maxValue = 0;
 
-				Object2IntMap<Identifier> oldRemoteIndexedEntries = remoteIndexedEntries;
-				remoteIndexedEntries = new Object2IntOpenHashMap<>();
-				for (Identifier id : oldRemoteIndexedEntries.keySet()) {
-					int v = oldRemoteIndexedEntries.getInt(id);
-					remoteIndexedEntries.put(id, v);
-					if (v > maxValue) maxValue = v;
+			Object2IntMap<Identifier> oldRemoteIndexedEntries = remoteIndexedEntries;
+			remoteIndexedEntries = new Object2IntOpenHashMap<>();
+
+			for (Identifier id : oldRemoteIndexedEntries.keySet()) {
+				int v = oldRemoteIndexedEntries.getInt(id);
+				remoteIndexedEntries.put(id, v);
+				if (v > maxValue) maxValue = v;
+			}
+
+			for (Identifier id : registry.getIds()) {
+				if (!remoteIndexedEntries.containsKey(id)) {
+					FABRIC_LOGGER.warn("Adding " + id + " to saved/remote registry.");
+					remoteIndexedEntries.put(id, ++maxValue);
 				}
+			}
 
-				for (Identifier id : registry.getIds()) {
-					if (!remoteIndexedEntries.containsKey(id)) {
-						FABRIC_LOGGER.warn("Adding " + id + " to saved/remote registry.");
-						remoteIndexedEntries.put(id, ++maxValue);
-					}
+			break;
+		}
+		case REMOTE: {
+			// TODO: Is this what mods really want?
+			Set<Identifier> droppedIds = new HashSet<>();
+
+			for (Identifier id : registry.getIds()) {
+				if (!remoteIndexedEntries.containsKey(id)) {
+					Object object = registry.get(id);
+					int rid = registry.getRawId(object);
+
+					droppedIds.add(id);
+
+					// Emit RemoveObject events for removed objects.
+					//noinspection unchecked
+					fabric_getRemoveObjectEvent().invoker().onEntryRemoved(rid, id, (T) object);
 				}
-			} break;
-			case REMOTE: {
-				// TODO: Is this what mods really want?
-				Set<Identifier> droppedIds = new HashSet<>();
+			}
 
-				for (Identifier id : registry.getIds()) {
-					if (!remoteIndexedEntries.containsKey(id)) {
-						Object object = registry.get(id);
-						int rid = registry.getRawId(object);
+			// note: indexedEntries cannot be safely remove()d from
+			entries.keySet().removeAll(droppedIds);
 
-						droppedIds.add(id);
-
-						// Emit RemoveObject events for removed objects.
-						//noinspection unchecked
-						fabric_getRemoveObjectEvent().invoker().onEntryRemoved(rid, id, (T) object);
-					}
-				}
-
-				// note: indexedEntries cannot be safely remove()d from
-				entries.keySet().removeAll(droppedIds);
-			} break;
+			break;
+		}
 		}
 
 		Int2IntMap idMap = new Int2IntOpenHashMap();
+
 		for (Object o : indexedEntries) {
 			Identifier id = registry.getId(o);
 			int rid = registry.getRawId(o);
@@ -292,11 +322,13 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 				} else {
 					FABRIC_LOGGER.warn(identifier + " missing from registry, but requested!");
 				}
+
 				continue;
 			}
 
 			// Add the new object, increment nextId to match.
 			indexedEntries.put(object, id);
+
 			if (nextId <= id) {
 				nextId = id + 1;
 			}

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/MixinPlayerManager.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/MixinPlayerManager.java
@@ -16,14 +16,16 @@
 
 package net.fabricmc.fabric.mixin.registry;
 
-import net.fabricmc.fabric.impl.registry.RegistrySyncManager;
-import net.minecraft.network.ClientConnection;
-import net.minecraft.server.PlayerManager;
-import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.network.ClientConnection;
+import net.minecraft.server.PlayerManager;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import net.fabricmc.fabric.impl.registry.RegistrySyncManager;
 
 @Mixin(PlayerManager.class)
 public abstract class MixinPlayerManager {

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/MixinWorldSaveHandler.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/MixinWorldSaveHandler.java
@@ -128,6 +128,7 @@ public class MixinWorldSaveHandler {
 		// Load
 		for (int i = 0; i < FABRIC_ID_REGISTRY_BACKUPS; i++) {
 			FABRIC_LOGGER.trace("[fabric-registry-sync] Loading Fabric registry [file " + (i + 1) + "/" + (FABRIC_ID_REGISTRY_BACKUPS + 1) + "]");
+
 			try {
 				if (fabric_readIdMapFile(fabric_getWorldIdMapFile(i))) {
 					FABRIC_LOGGER.info("[fabric-registry-sync] Loaded registry data [file " + (i + 1) + "/" + (FABRIC_ID_REGISTRY_BACKUPS + 1) + "]");

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/MixinWorldSaveHandler.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/MixinWorldSaveHandler.java
@@ -16,13 +16,12 @@
 
 package net.fabricmc.fabric.mixin.registry;
 
-import net.fabricmc.fabric.impl.registry.RegistrySyncManager;
-import net.fabricmc.fabric.impl.registry.RemapException;
-import net.fabricmc.fabric.impl.registry.RemappableRegistry;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.NbtIo;
-import net.minecraft.world.WorldSaveHandler;
-import net.minecraft.world.level.LevelProperties;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Mixin;
@@ -33,7 +32,14 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.io.*;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.world.WorldSaveHandler;
+import net.minecraft.world.level.LevelProperties;
+
+import net.fabricmc.fabric.impl.registry.RegistrySyncManager;
+import net.fabricmc.fabric.impl.registry.RemapException;
+import net.fabricmc.fabric.impl.registry.RemappableRegistry;
 
 @Mixin(WorldSaveHandler.class)
 public class MixinWorldSaveHandler {
@@ -53,6 +59,7 @@ public class MixinWorldSaveHandler {
 			FileInputStream fileInputStream = new FileInputStream(file);
 			CompoundTag tag = NbtIo.readCompressed(fileInputStream);
 			fileInputStream.close();
+
 			if (tag != null) {
 				RegistrySyncManager.apply(tag, RemappableRegistry.RemapMode.AUTHORITATIVE);
 				return true;
@@ -70,9 +77,11 @@ public class MixinWorldSaveHandler {
 	@Unique
 	private void fabric_saveRegistryData() {
 		CompoundTag newIdMap = RegistrySyncManager.toTag(false);
+
 		if (!newIdMap.equals(fabric_lastSavedIdMap)) {
 			for (int i = FABRIC_ID_REGISTRY_BACKUPS - 1; i >= 0; i--) {
 				File file = fabric_getWorldIdMapFile(i);
+
 				if (file.exists()) {
 					if (i == FABRIC_ID_REGISTRY_BACKUPS - 1) {
 						file.delete();
@@ -86,6 +95,7 @@ public class MixinWorldSaveHandler {
 			try {
 				File file = fabric_getWorldIdMapFile(0);
 				File parentFile = file.getParentFile();
+
 				if (!parentFile.exists()) {
 					if (!parentFile.mkdirs()) {
 						FABRIC_LOGGER.warn("[fabric-registry-sync] Could not create directory " + parentFile + "!");

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/client/MixinBlockColorMap.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/client/MixinBlockColorMap.java
@@ -16,16 +16,18 @@
 
 package net.fabricmc.fabric.mixin.registry.client;
 
-import net.fabricmc.fabric.impl.registry.trackers.IdListTracker;
-import net.minecraft.client.color.block.BlockColorProvider;
-import net.minecraft.client.color.block.BlockColors;
-import net.minecraft.util.IdList;
-import net.minecraft.util.registry.Registry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.color.block.BlockColorProvider;
+import net.minecraft.client.color.block.BlockColors;
+import net.minecraft.util.IdList;
+import net.minecraft.util.registry.Registry;
+
+import net.fabricmc.fabric.impl.registry.trackers.IdListTracker;
 
 @Mixin(BlockColors.class)
 public class MixinBlockColorMap {

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/client/MixinItemColorMap.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/client/MixinItemColorMap.java
@@ -16,16 +16,18 @@
 
 package net.fabricmc.fabric.mixin.registry.client;
 
-import net.fabricmc.fabric.impl.registry.trackers.IdListTracker;
-import net.minecraft.client.color.item.ItemColorProvider;
-import net.minecraft.client.color.item.ItemColors;
-import net.minecraft.util.IdList;
-import net.minecraft.util.registry.Registry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.color.item.ItemColorProvider;
+import net.minecraft.client.color.item.ItemColors;
+import net.minecraft.util.IdList;
+import net.minecraft.util.registry.Registry;
+
+import net.fabricmc.fabric.impl.registry.trackers.IdListTracker;
 
 @Mixin(ItemColors.class)
 public class MixinItemColorMap {

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/client/MixinItemModelMap.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/client/MixinItemModelMap.java
@@ -17,17 +17,19 @@
 package net.fabricmc.fabric.mixin.registry.client;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import net.fabricmc.fabric.impl.registry.trackers.Int2ObjectMapTracker;
-import net.minecraft.client.render.item.ItemModels;
-import net.minecraft.client.render.model.BakedModel;
-import net.minecraft.client.render.model.BakedModelManager;
-import net.minecraft.client.util.ModelIdentifier;
-import net.minecraft.util.registry.Registry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.render.item.ItemModels;
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.render.model.BakedModelManager;
+import net.minecraft.client.util.ModelIdentifier;
+import net.minecraft.util.registry.Registry;
+
+import net.fabricmc.fabric.impl.registry.trackers.Int2ObjectMapTracker;
 
 @Mixin(ItemModels.class)
 public class MixinItemModelMap {

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/client/MixinMinecraftClient.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/client/MixinMinecraftClient.java
@@ -16,10 +16,6 @@
 
 package net.fabricmc.fabric.mixin.registry.client;
 
-import net.fabricmc.fabric.impl.registry.RegistrySyncManager;
-import net.fabricmc.fabric.impl.registry.RemapException;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.Screen;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Mixin;
@@ -27,6 +23,12 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+
+import net.fabricmc.fabric.impl.registry.RegistrySyncManager;
+import net.fabricmc.fabric.impl.registry.RemapException;
 
 @Mixin(MinecraftClient.class)
 public class MixinMinecraftClient {

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/client/MixinParticleManager.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/client/MixinParticleManager.java
@@ -17,17 +17,19 @@
 package net.fabricmc.fabric.mixin.registry.client;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import net.fabricmc.fabric.impl.registry.trackers.Int2ObjectMapTracker;
-import net.minecraft.client.particle.ParticleFactory;
-import net.minecraft.client.particle.ParticleManager;
-import net.minecraft.client.texture.TextureManager;
-import net.minecraft.util.registry.Registry;
-import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.particle.ParticleFactory;
+import net.minecraft.client.particle.ParticleManager;
+import net.minecraft.client.texture.TextureManager;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.world.World;
+
+import net.fabricmc.fabric.impl.registry.trackers.Int2ObjectMapTracker;
 
 @Mixin(ParticleManager.class)
 public class MixinParticleManager {

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/Renderer.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/Renderer.java
@@ -16,48 +16,49 @@
 
 package net.fabricmc.fabric.api.renderer.v1;
 
+import net.minecraft.util.Identifier;
+
 import net.fabricmc.fabric.api.renderer.v1.material.MaterialFinder;
 import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
 import net.fabricmc.fabric.api.renderer.v1.mesh.MeshBuilder;
-import net.minecraft.util.Identifier;
 
 /**
  * Interface for rendering plug-ins that provide enhanced capabilities
  * for model lighting, buffering and rendering. Such plug-ins implement the
- * enhanced model rendering interfaces specified by the Fabric API.<p>
+ * enhanced model rendering interfaces specified by the Fabric API.
  */
 public interface Renderer {
-    /**
-     * Obtain a new {@link MeshBuilder} instance used to create 
-     * baked models with enhanced features.<p>
-     * 
-     * Renderer does not retain a reference to returned instances and they should be re-used for 
-     * multiple models when possible to avoid memory allocation overhead.
-     */
-    MeshBuilder meshBuilder();
-    
-    /**
-     * Obtain a new {@link MaterialFinder} instance used to retrieve
-     * standard {@link RenderMaterial} instances.<p>
-     * 
-     * Renderer does not retain a reference to returned instances and they should be re-used for 
-     * multiple materials when possible to avoid memory allocation overhead.
-     */
-    MaterialFinder materialFinder();
+	/**
+	 * Obtain a new {@link MeshBuilder} instance used to create
+	 * baked models with enhanced features.
+	 *
+	 * <p>Renderer does not retain a reference to returned instances and they should be re-used for
+	 * multiple models when possible to avoid memory allocation overhead.
+	 */
+	MeshBuilder meshBuilder();
 
-    /**
-     * Return a material previously registered via {@link #registerMaterial(Identifier, RenderMaterial)}.
-     * Will return null if no material was found matching the given identifier.
-     */
-    RenderMaterial materialById(Identifier id);
-    
-    /**
-     * Register a material for re-use by other mods or models within a mod.
-     * The registry does not persist registrations - mods must create and register 
-     * all materials at game initialization.<p>
-     * 
-     * Returns false if a material with the given identifier is already present,
-     * leaving the existing material intact.
-     */
-    boolean registerMaterial(Identifier id, RenderMaterial material);
+	/**
+	 * Obtain a new {@link MaterialFinder} instance used to retrieve
+	 * standard {@link RenderMaterial} instances.
+	 *
+	 * <p>Renderer does not retain a reference to returned instances and they should be re-used for
+	 * multiple materials when possible to avoid memory allocation overhead.
+	 */
+	MaterialFinder materialFinder();
+
+	/**
+	 * Return a material previously registered via {@link #registerMaterial(Identifier, RenderMaterial)}.
+	 * Will return null if no material was found matching the given identifier.
+	 */
+	RenderMaterial materialById(Identifier id);
+
+	/**
+	 * Register a material for re-use by other mods or models within a mod.
+	 * The registry does not persist registrations - mods must create and register
+	 * all materials at game initialization.
+	 *
+	 * <p>Returns false if a material with the given identifier is already present,
+	 * leaving the existing material intact.
+	 */
+	boolean registerMaterial(Identifier id, RenderMaterial material);
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/RendererAccess.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/RendererAccess.java
@@ -22,25 +22,25 @@ import net.fabricmc.fabric.impl.renderer.RendererAccessImpl;
  * Registration and access for rendering extensions.
  */
 public interface RendererAccess {
-    RendererAccess INSTANCE = RendererAccessImpl.INSTANCE;
+	RendererAccess INSTANCE = RendererAccessImpl.INSTANCE;
 
-    /**
-     * Rendering extension mods must implement {@link Renderer} and 
-     * call this method during initialization.<p>
-     * 
-     * Only one {@link Renderer} plug-in can be active in any game instance.
-     * If a second mod attempts to register this method will throw an UnsupportedOperationException.
-     */
-    void registerRenderer(Renderer plugin);
+	/**
+	 * Rendering extension mods must implement {@link Renderer} and
+	 * call this method during initialization.
+	 *
+	 * <p>Only one {@link Renderer} plug-in can be active in any game instance.
+	 * If a second mod attempts to register this method will throw an UnsupportedOperationException.
+	 */
+	void registerRenderer(Renderer plugin);
 
-    /**
-     * Access to the current {@link Renderer} for creating and retrieving model builders 
-     * and materials. Will return null if no render plug in is active.
-     */
-    Renderer getRenderer();
+	/**
+	 * Access to the current {@link Renderer} for creating and retrieving model builders
+	 * and materials. Will return null if no render plug in is active.
+	 */
+	Renderer getRenderer();
 
-    /**
-     * Performant test for {@link #getRenderer()} != null;
-     */
-    boolean hasRenderer();
+	/**
+	 * Performant test for {@link #getRenderer()} != null.
+	 */
+	boolean hasRenderer();
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/material/MaterialFinder.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/material/MaterialFinder.java
@@ -16,81 +16,81 @@
 
 package net.fabricmc.fabric.api.renderer.v1.material;
 
-import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
-import net.fabricmc.fabric.api.renderer.v1.Renderer;
-import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockRenderLayer;
 
+import net.fabricmc.fabric.api.renderer.v1.Renderer;
+import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
+import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
+
 /**
  * Finds standard {@link RenderMaterial} instances used to communicate
- * quad rendering characteristics to a {@link RenderContext}.<p>
+ * quad rendering characteristics to a {@link RenderContext}.
  *
- * Must be obtained via {@link Renderer#materialFinder()}.
+ * <p>Must be obtained via {@link Renderer#materialFinder()}.
  */
 public interface MaterialFinder {
-    /**
-     * Returns the standard material encoding all
-     * of the current settings in this finder. The settings in
-     * this finder are not changed.<p>
-     * 
-     * Resulting instances can and should be re-used to prevent
-     * needless memory allocation. {@link Renderer} implementations
-     * may or may not cache standard material instances.
-     */
-    RenderMaterial find();
+	/**
+	 * Returns the standard material encoding all
+	 * of the current settings in this finder. The settings in
+	 * this finder are not changed.
+	 *
+	 * <p>Resulting instances can and should be re-used to prevent
+	 * needless memory allocation. {@link Renderer} implementations
+	 * may or may not cache standard material instances.
+	 */
+	RenderMaterial find();
 
-    /**
-     * Resets this instance to default values. Values will match those
-     * in effect when an instance is newly obtained via {@link Renderer#materialFinder()}.
-     */
-    MaterialFinder clear();
-    
-    /**
-     * 
-     * Reserved for future use.  Behavior for values &gt; 1 is currently undefined.
-     */
-    MaterialFinder spriteDepth(int depth);
+	/**
+	 * Resets this instance to default values. Values will match those
+	 * in effect when an instance is newly obtained via {@link Renderer#materialFinder()}.
+	 */
+	MaterialFinder clear();
 
-    /**
-     * Defines how sprite pixels will be blended with the scene.
-     * Accepts {link @BlockRenderLayer} values and blending behavior
-     * will emulate the way that Minecraft renders each pass. But this does 
-     * NOT mean the sprite will be rendered in a specific render pass - some
-     * implementations may not use the standard Minecraft render passes.<p>
-     * 
-     * CAN be null and is null by default. A null value means the renderer
-     * will use {@link Block#getRenderLayer()} for the associate block, or
-     * {@link BlockRenderLayer#TRANSLUCENT} for item renders. (Normal Minecraft rendering)
-     */
-    MaterialFinder blendMode(int spriteIndex, BlockRenderLayer blendMode);
+	/**
+	 * Reserved for future use.  Behavior for values &gt; 1 is currently undefined.
+	 */
+	MaterialFinder spriteDepth(int depth);
 
-    /**
-     * Vertex color(s) will be modified for quad color index unless disabled.<p>
-     */
-    MaterialFinder disableColorIndex(int spriteIndex, boolean disable);
-    
-    /**
-     * Vertex color(s) will be modified for diffuse shading unless disabled.
-     */
-    MaterialFinder disableDiffuse(int spriteIndex, boolean disable);
-    
-    /**
-     * Vertex color(s) will be modified for ambient occlusion unless disabled.
-     */
-    MaterialFinder disableAo(int spriteIndex, boolean disable);
-    
-    /**
-     * When true, sprite texture and color will be rendered at full brightness.
-     * Lightmap values provided via {@link QuadEmitter#lightmap(int)} will be ignored.
-     * False by default<p>
-     * 
-     * This is the preferred method for emissive lighting effects.  Some renderers
-     * with advanced lighting models may not use block lightmaps and this method will
-     * allow per-sprite emissive lighting in future extensions that support overlay sprites.<p>
-     * 
-     * Note that color will still be modified by diffuse shading and ambient occlusion,
-     * unless disabled via {@link #disableAo(int, boolean)} and {@link #disableDiffuse(int, boolean)}.
-     */
-    MaterialFinder emissive(int spriteIndex, boolean isEmissive);
+	/**
+	 * Defines how sprite pixels will be blended with the scene.
+	 * Accepts {link @BlockRenderLayer} values and blending behavior
+	 * will emulate the way that Minecraft renders each pass. But this does
+	 * NOT mean the sprite will be rendered in a specific render pass - some
+	 * implementations may not use the standard Minecraft render passes.
+	 *
+	 * <p>CAN be null and is null by default. A null value means the renderer
+	 * will use {@link Block#getRenderLayer()} for the associate block, or
+	 * {@link BlockRenderLayer#TRANSLUCENT} for item renders. (Normal Minecraft rendering)
+	 */
+	MaterialFinder blendMode(int spriteIndex, BlockRenderLayer blendMode);
+
+	/**
+	 * Vertex color(s) will be modified for quad color index unless disabled.
+	 */
+	MaterialFinder disableColorIndex(int spriteIndex, boolean disable);
+
+	/**
+	 * Vertex color(s) will be modified for diffuse shading unless disabled.
+	 */
+	MaterialFinder disableDiffuse(int spriteIndex, boolean disable);
+
+	/**
+	 * Vertex color(s) will be modified for ambient occlusion unless disabled.
+	 */
+	MaterialFinder disableAo(int spriteIndex, boolean disable);
+
+	/**
+	 * When true, sprite texture and color will be rendered at full brightness.
+	 * Lightmap values provided via {@link QuadEmitter#lightmap(int)} will be ignored.
+	 * False by default
+	 *
+	 * <p>This is the preferred method for emissive lighting effects.  Some renderers
+	 * with advanced lighting models may not use block lightmaps and this method will
+	 * allow per-sprite emissive lighting in future extensions that support overlay sprites.
+	 *
+	 * <p>Note that color will still be modified by diffuse shading and ambient occlusion,
+	 * unless disabled via {@link #disableAo(int, boolean)} and {@link #disableDiffuse(int, boolean)}.
+	 */
+	MaterialFinder emissive(int spriteIndex, boolean isEmissive);
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/material/RenderMaterial.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/material/RenderMaterial.java
@@ -16,67 +16,68 @@
 
 package net.fabricmc.fabric.api.renderer.v1.material;
 
-import net.fabricmc.fabric.api.renderer.v1.Renderer;
-import net.fabricmc.fabric.api.renderer.v1.mesh.MeshBuilder;
-import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
 import net.minecraft.block.Block;
 import net.minecraft.util.Identifier;
 
+import net.fabricmc.fabric.api.renderer.v1.Renderer;
+import net.fabricmc.fabric.api.renderer.v1.mesh.MeshBuilder;
+import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
+
 /**
  * All model quads have an associated render material governing
- * how the quad will be rendered.<p>
- * 
- * A material instance is always immutable and thread-safe.  References to a material 
- * remain valid until the end of the current game session.<p>
- * 
- * Materials can be registered and shared between mods using {@link Renderer#registerMaterial(net.minecraft.util.Identifier, RenderMaterial)}.
- * The registering mod is responsible for creating each registered material at startup.<p>
- * 
- * Materials are not required to know their registration identity, and two materials
- * with the same attributes may or may not satisfy equality and identity tests. Model 
+ * how the quad will be rendered.
+ *
+ * <p>A material instance is always immutable and thread-safe.  References to a material
+ * remain valid until the end of the current game session.
+ *
+ * <p>Materials can be registered and shared between mods using {@link Renderer#registerMaterial(net.minecraft.util.Identifier, RenderMaterial)}.
+ * The registering mod is responsible for creating each registered material at startup.
+ *
+ * <p>Materials are not required to know their registration identity, and two materials
+ * with the same attributes may or may not satisfy equality and identity tests. Model
  * implementations should never attempt to analyze materials or implement control logic based on them.
- * They are only tokens for communicating quad attributes to the ModelRenderer.<p>
- * 
- * There are three classes of materials... <p>
- * 
- * <b>STANDARD MATERIALS</b><p>
- * 
- * Standard materials have "normal" rendering with control over lighting,
+ * They are only tokens for communicating quad attributes to the ModelRenderer.
+ *
+ * <p>There are three classes of materials...
+ *
+ * <p><b>STANDARD MATERIALS</b>
+ *
+ * <p>Standard materials have "normal" rendering with control over lighting,
  * color, and texture blending. In the default renderer, "normal" rendering
- * emulates unmodified Minecraft. Other renderers may offer a different aesthetic.<p>
- * 
- * The number of standard materials is finite, but not necessarily small. 
- * To find a standard material, use {@link Renderer#materialFinder()}.<p>
- * 
- * All renderer implementations should support standard materials.<p>
- * 
- * <b>SPECIAL MATERIALS</b><p>
- * 
- * Special materials are implemented directly by the Renderer implementation, typically
+ * emulates unmodified Minecraft. Other renderers may offer a different aesthetic.
+ *
+ * <p>The number of standard materials is finite, but not necessarily small.
+ * To find a standard material, use {@link Renderer#materialFinder()}.
+ *
+ * <p>All renderer implementations should support standard materials.
+ *
+ * <p><b>SPECIAL MATERIALS</b>
+ *
+ * <p>Special materials are implemented directly by the Renderer implementation, typically
  * with the aim of providing advanced/extended features. Such materials may offer additional
- * vertex attributes via extensions to {@link MeshBuilder} and {@link MutableQuadView}.<p>
- * 
- * Special materials can be obtained using {@link Renderer#materialById(Identifier)}
- * with a known identifier. Renderers may provide other means of access. Popular 
- * special materials could be implemented by multiple renderers, however there is 
+ * vertex attributes via extensions to {@link MeshBuilder} and {@link MutableQuadView}.
+ *
+ * <p>Special materials can be obtained using {@link Renderer#materialById(Identifier)}
+ * with a known identifier. Renderers may provide other means of access. Popular
+ * special materials could be implemented by multiple renderers, however there is
  * no requirement that special materials be cross-compatible.
  */
 public interface RenderMaterial {
-    /**
-     * This will be identical to the material that would be obtained by calling {@link MaterialFinder#find()}
-     * on a new, unaltered, {@link MaterialFinder} instance.  It is defined here for clarity and convenience.
-     * 
-     * Quads using this material use {@link Block#getRenderLayer()} of the associated block to determine texture blending, 
-     * honor block color index, are non-emissive, and apply both diffuse and ambient occlusion shading to vertex colors.<p>
-     * 
-     * All standard, non-fluid baked models are rendered using this material.
-     */
-    Identifier MATERIAL_STANDARD = new Identifier("fabric", "standard");
-    
-    /**
-     * How many sprite color/uv coordinates are in the material. 
-     * Behavior for values &gt; 1 is currently undefined.
-     * See {@link MaterialFinder#spriteDepth(int)}
-     */
-    int spriteDepth();
+	/**
+	 * This will be identical to the material that would be obtained by calling {@link MaterialFinder#find()}
+	 * on a new, unaltered, {@link MaterialFinder} instance.  It is defined here for clarity and convenience.
+	 *
+	 * <p>Quads using this material use {@link Block#getRenderLayer()} of the associated block to determine texture blending,
+	 * honor block color index, are non-emissive, and apply both diffuse and ambient occlusion shading to vertex colors.
+	 *
+	 * <p>All standard, non-fluid baked models are rendered using this material.
+	 */
+	Identifier MATERIAL_STANDARD = new Identifier("fabric", "standard");
+
+	/**
+	 * How many sprite color/uv coordinates are in the material.
+	 * Behavior for values &gt; 1 is currently undefined.
+	 * See {@link MaterialFinder#spriteDepth(int)}
+	 */
+	int spriteDepth();
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/Mesh.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/Mesh.java
@@ -22,19 +22,19 @@ import net.fabricmc.fabric.api.renderer.v1.Renderer;
 
 /**
  * A bundle of one or more {@link QuadView} instances encoded by the renderer,
- * typically via {@link Renderer#meshBuilder()}.<p>
- * 
- * Similar in purpose to the {@code List<BakedQuad>} instances returned by BakedModel, but 
+ * typically via {@link Renderer#meshBuilder()}.
+ *
+ * <p>Similar in purpose to the {@code List<BakedQuad>} instances returned by BakedModel, but
  * affords the renderer the ability to optimize the format for performance
- * and memory allocation.<p>
- * 
- * Only the renderer should implement or extend this interface.
+ * and memory allocation.
+ *
+ * <p>Only the renderer should implement or extend this interface.
  */
 public interface Mesh {
-    /**
-     * Use to access all of the quads encoded in this mesh. The quad instances
-     * sent to the consumer will likely be threadlocal/reused and should never
-     * be retained by the consumer.
-     */
-    public void forEach(Consumer<QuadView> consumer);
+	/**
+	 * Use to access all of the quads encoded in this mesh. The quad instances
+	 * sent to the consumer will likely be threadlocal/reused and should never
+	 * be retained by the consumer.
+	 */
+	void forEach(Consumer<QuadView> consumer);
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MeshBuilder.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MeshBuilder.java
@@ -21,22 +21,22 @@ import net.minecraft.client.render.BufferBuilder;
 /**
  * Similar in purpose to {@link BufferBuilder} but simpler
  * and not tied to NIO or any other specific implementation,
- * plus designed to handle both static and dynamic building.<p>
- * 
- * Decouples models from the vertex format(s) used by
- * ModelRenderer to allow compatibility across diverse implementations.<p>
+ * plus designed to handle both static and dynamic building.
+ *
+ * <p>Decouples models from the vertex format(s) used by
+ * ModelRenderer to allow compatibility across diverse implementations.
  */
 public interface MeshBuilder {
-    /**
-     * Returns the {@link QuadEmitter} used to append quad to this mesh. 
-     * Calling this method a second time invalidates any prior result.
-     * Do not retain references outside the context of building the mesh.
-     */
-    QuadEmitter getEmitter();
-    
-    /**
-     * Returns a new {@link Mesh} instance containing all
-     * quads added to this builder and resets the builder to an empty state<p>
-     */
-    Mesh build();
+	/**
+	 * Returns the {@link QuadEmitter} used to append quad to this mesh.
+	 * Calling this method a second time invalidates any prior result.
+	 * Do not retain references outside the context of building the mesh.
+	 */
+	QuadEmitter getEmitter();
+
+	/**
+	 * Returns a new {@link Mesh} instance containing all
+	 * quads added to this builder and resets the builder to an empty state.
+	 */
+	Mesh build();
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
@@ -16,225 +16,226 @@
 
 package net.fabricmc.fabric.api.renderer.v1.mesh;
 
-import net.fabricmc.fabric.api.renderer.v1.Renderer;
-import net.fabricmc.fabric.api.renderer.v1.material.MaterialFinder;
-import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
 import net.minecraft.client.render.model.BakedQuad;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.util.math.Direction;
 
+import net.fabricmc.fabric.api.renderer.v1.Renderer;
+import net.fabricmc.fabric.api.renderer.v1.material.MaterialFinder;
+import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
+
 /**
- * A mutable {@link QuadView} instance. The base interface for 
- * {@link QuadEmitter} and for dynamic renders/mesh transforms.<p>
- * 
- * Instances of {@link MutableQuadView} will practically always be
- * threadlocal and/or reused - do not retain references.<p>
- * 
- * Only the renderer should implement or extend this interface.
+ * A mutable {@link QuadView} instance. The base interface for
+ * {@link QuadEmitter} and for dynamic renders/mesh transforms.
+ *
+ * <p>Instances of {@link MutableQuadView} will practically always be
+ * threadlocal and/or reused - do not retain references.
+ *
+ * <p>Only the renderer should implement or extend this interface.
  */
 public interface MutableQuadView extends QuadView {
-    /**
-     * Causes texture to appear with no rotation.
-     * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
-     */
-    int BAKE_ROTATE_NONE = 0;
-    
-    /**
-     * Causes texture to appear rotated 90 deg. relative to nominal face.
-     * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
-     */
-    int BAKE_ROTATE_90 = 1;
-    
-    /**
-     * Causes texture to appear rotated 180 deg. relative to nominal face.
-     * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
-     */
-    int BAKE_ROTATE_180 = 2;
-    
-    /**
-     * Causes texture to appear rotated 270 deg. relative to nominal face.
-     * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
-     */
-    int BAKE_ROTATE_270 = 3;
-    
-    /**
-     * When enabled, texture coordinate are assigned based on vertex position.
-     * Any existing uv coordinates will be replaced.
-     * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.<p>
-     * 
-     * UV lock always derives texture coordinates based on nominal face, even
-     * when the quad is not co-planar with that face, and the result is
-     * the same as if the quad were projected onto the nominal face, which
-     * is usually the desired result.<p>
-     */
-    int BAKE_LOCK_UV = 4;
-    
-    /**
-     * When set, U texture coordinates for the given sprite are 
-     * flipped as part of baking. Can be useful for some randomization
-     * and texture mapping scenarios. Results are different than what
-     * can be obtained via rotation and both can be applied.
-     * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
-     */
-    int BAKE_FLIP_U = 8;
-    
-    /**
-     * Same as {@link MutableQuadView#BAKE_FLIP_U} but for V coordinate.
-     */
-    int BAKE_FLIP_V = 16;
-    
-    /**
-     * UV coordinates by default are assumed to be 0-16 scale for consistency
-     * with conventional Minecraft model format. This is scaled to 0-1 during
-     * baking before interpolation. Model loaders that already have 0-1 coordinates
-     * can avoid wasteful multiplication/division by passing 0-1 coordinates directly.
-     * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
-     */
-    int BAKE_NORMALIZED = 32;
-    
-    /**
-     * Assigns a different material to this quad. Useful for transformation of 
-     * existing meshes because lighting and texture blending are controlled by material.<p>
-     */
-    MutableQuadView material(RenderMaterial material);
-        
-    /**
-     * If non-null, quad is coplanar with a block face which, if known, simplifies
-     * or shortcuts geometric analysis that might otherwise be needed.
-     * Set to null if quad is not coplanar or if this is not known. 
-     * Also controls face culling during block rendering.<p>
-     * 
-     * Null by default.<p>
-     * 
-     * When called with a non-null value, also sets {@link #nominalFace(Direction)}
-     * to the same value.<p>
-     * 
-     * This is different than the value reported by {@link BakedQuad#getFace()}. That value
-     * is computed based on face geometry and must be non-null in vanilla quads.
-     * That computed value is returned by {@link #lightFace()}.
-     */
-    MutableQuadView cullFace(Direction face);
-    
-    /**
-     * Provides a hint to renderer about the facing of this quad. Not required,
-     * but if provided can shortcut some geometric analysis if the quad is parallel to a block face. 
-     * Should be the expected value of {@link #lightFace()}. Value will be confirmed
-     * and if invalid the correct light face will be calculated.<p>
-     * 
-     * Null by default, and set automatically by {@link #cullFace()}.<p>
-     * 
-     * Models may also find this useful as the face for texture UV locking and rotation semantics.<p>
-     * 
-     * NOTE: This value is not persisted independently when the quad is encoded.
-     * When reading encoded quads, this value will always be the same as {@link #lightFace()}.
-     */
-    MutableQuadView nominalFace(Direction face);
-    
-    /**
-     * Value functions identically to {@link BakedQuad#getColorIndex()} and is
-     * used by renderer / model builder in same way. Default value is -1.
-     */
-    MutableQuadView colorIndex(int colorIndex);
-    
-    /**
-     * Enables bulk vertex data transfer using the standard Minecraft vertex formats.
-     * This method should be performant whenever caller's vertex representation makes it feasible.<p>
-     * 
-     * Calling this method does not emit the quad.  
-     */
-    MutableQuadView fromVanilla(int[] quadData, int startIndex, boolean isItem);
-    
-    /**
-     * Encodes an integer tag with this quad that can later be retrieved via
-     * {@link QuadView#tag()}.  Useful for models that want to perform conditional
-     * transformation or filtering on static meshes.
-     */
-    MutableQuadView tag(int tag);
-    
-    /**
-     * Sets the geometric vertex position for the given vertex, 
-     * relative to block origin. (0,0,0).  Minecraft rendering is designed
-     * for models that fit within a single block space and is recommended 
-     * that coordinates remain in the 0-1 range, with multi-block meshes
-     * split into multiple per-block models.
-     */
-    MutableQuadView pos(int vertexIndex, float x, float y, float z);
-    
-    /**
-     * Same as {@link #pos(int, float, float, float)} but accepts vector type.
-     */
-    default MutableQuadView pos(int vertexIndex, Vector3f vec) {
-        return pos(vertexIndex, vec.getX(), vec.getY(), vec.getZ());
-    }
-    
-    /**
-     * Adds a vertex normal. Models that have per-vertex
-     * normals should include them to get correct lighting when it matters.
-     * Computed face normal is used when no vertex normal is provided.<p>
-     * 
-     * {@link Renderer} implementations should honor vertex normals for
-     * diffuse lighting - modifying vertex color(s) or packing normals in the vertex 
-     * buffer as appropriate for the rendering method/vertex format in effect.
-     */
-    MutableQuadView normal(int vertexIndex, float x, float y, float z);
-    
-    /**
-     * Same as {@link #normal(int, float, float, float)} but accepts vector type.
-     */
-    default MutableQuadView normal(int vertexIndex, Vector3f vec) {
-        return normal(vertexIndex, vec.getX(), vec.getY(), vec.getZ());
-    }
-    
-    /**
-     * Accept vanilla lightmap values.  Input values will override lightmap values
-     * computed from world state if input values are higher. Exposed for completeness
-     * but some rendering implementations with non-standard lighting model may not honor it. <p>
-     * 
-     * For emissive rendering, it is better to use {@link MaterialFinder#emissive(int, boolean)}.
-     */
-    MutableQuadView lightmap(int vertexIndex, int lightmap);
-    
-    /** 
-     * Convenience: set lightmap for all vertices at once. <p>
-     * 
-     * For emissive rendering, it is better to use {@link MaterialFinder#emissive(int, boolean)}.
-     * See {@link #lightmap(int, int)}. 
-     */
-    default MutableQuadView lightmap(int b0, int b1, int b2, int b3) {
-        lightmap(0, b0);
-        lightmap(1, b1);
-        lightmap(2, b2);
-        lightmap(3, b3);
-        return this;
-    }
-    
-    /**
-     * Set sprite color. Behavior for {@code spriteIndex > 0} is currently undefined.
-     */
-    MutableQuadView spriteColor(int vertexIndex, int spriteIndex, int color);
-    
-    /** 
-     * Convenience: set sprite color for all vertices at once. Behavior for {@code spriteIndex > 0} is currently undefined.
-     */
-    default MutableQuadView spriteColor(int spriteIndex, int c0, int c1, int c2, int c3) {
-        spriteColor(0, spriteIndex, c0);
-        spriteColor(1, spriteIndex, c1);
-        spriteColor(2, spriteIndex, c2);
-        spriteColor(3, spriteIndex, c3);
-        return this;
-    }
-    
-    /**
-     * Set sprite atlas coordinates. Behavior for {@code spriteIndex > 0} is currently undefined.
-     */
-    MutableQuadView sprite(int vertexIndex, int spriteIndex, float u, float v);
-    
-    /**
-     * Assigns sprite atlas u,v coordinates to this quad for the given sprite.
-     * Can handle UV locking, rotation, interpolation, etc. Control this behavior
-     * by passing additive combinations of the BAKE_ flags defined in this interface.  
-     * Behavior for {@code spriteIndex > 0} is currently undefined.
-     */
-    MutableQuadView spriteBake(int spriteIndex, Sprite sprite, int bakeFlags);
+	/**
+	 * Causes texture to appear with no rotation.
+	 * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
+	 */
+	int BAKE_ROTATE_NONE = 0;
+
+	/**
+	 * Causes texture to appear rotated 90 deg. relative to nominal face.
+	 * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
+	 */
+	int BAKE_ROTATE_90 = 1;
+
+	/**
+	 * Causes texture to appear rotated 180 deg. relative to nominal face.
+	 * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
+	 */
+	int BAKE_ROTATE_180 = 2;
+
+	/**
+	 * Causes texture to appear rotated 270 deg. relative to nominal face.
+	 * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
+	 */
+	int BAKE_ROTATE_270 = 3;
+
+	/**
+	 * When enabled, texture coordinate are assigned based on vertex position.
+	 * Any existing uv coordinates will be replaced.
+	 * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
+	 *
+	 * <p>UV lock always derives texture coordinates based on nominal face, even
+	 * when the quad is not co-planar with that face, and the result is
+	 * the same as if the quad were projected onto the nominal face, which
+	 * is usually the desired result.
+	 */
+	int BAKE_LOCK_UV = 4;
+
+	/**
+	 * When set, U texture coordinates for the given sprite are
+	 * flipped as part of baking. Can be useful for some randomization
+	 * and texture mapping scenarios. Results are different than what
+	 * can be obtained via rotation and both can be applied.
+	 * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
+	 */
+	int BAKE_FLIP_U = 8;
+
+	/**
+	 * Same as {@link MutableQuadView#BAKE_FLIP_U} but for V coordinate.
+	 */
+	int BAKE_FLIP_V = 16;
+
+	/**
+	 * UV coordinates by default are assumed to be 0-16 scale for consistency
+	 * with conventional Minecraft model format. This is scaled to 0-1 during
+	 * baking before interpolation. Model loaders that already have 0-1 coordinates
+	 * can avoid wasteful multiplication/division by passing 0-1 coordinates directly.
+	 * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
+	 */
+	int BAKE_NORMALIZED = 32;
+
+	/**
+	 * Assigns a different material to this quad. Useful for transformation of
+	 * existing meshes because lighting and texture blending are controlled by material.
+	 */
+	MutableQuadView material(RenderMaterial material);
+
+	/**
+	 * If non-null, quad is coplanar with a block face which, if known, simplifies
+	 * or shortcuts geometric analysis that might otherwise be needed.
+	 * Set to null if quad is not coplanar or if this is not known.
+	 * Also controls face culling during block rendering.
+	 *
+	 * <p>Null by default.
+	 *
+	 * <p>When called with a non-null value, also sets {@link #nominalFace(Direction)}
+	 * to the same value.
+	 *
+	 * <p>This is different than the value reported by {@link BakedQuad#getFace()}. That value
+	 * is computed based on face geometry and must be non-null in vanilla quads.
+	 * That computed value is returned by {@link #lightFace()}.
+	 */
+	MutableQuadView cullFace(Direction face);
+
+	/**
+	 * Provides a hint to renderer about the facing of this quad. Not required,
+	 * but if provided can shortcut some geometric analysis if the quad is parallel to a block face.
+	 * Should be the expected value of {@link #lightFace()}. Value will be confirmed
+	 * and if invalid the correct light face will be calculated.
+	 *
+	 * <p>Null by default, and set automatically by {@link #cullFace()}.
+	 *
+	 * <p>Models may also find this useful as the face for texture UV locking and rotation semantics.
+	 *
+	 * @note This value is not persisted independently when the quad is encoded.
+	 * When reading encoded quads, this value will always be the same as {@link #lightFace()}.
+	 */
+	MutableQuadView nominalFace(Direction face);
+
+	/**
+	 * Value functions identically to {@link BakedQuad#getColorIndex()} and is
+	 * used by renderer / model builder in same way. Default value is -1.
+	 */
+	MutableQuadView colorIndex(int colorIndex);
+
+	/**
+	 * Enables bulk vertex data transfer using the standard Minecraft vertex formats.
+	 * This method should be performant whenever caller's vertex representation makes it feasible.
+	 *
+	 * <p>Calling this method does not emit the quad.
+	 */
+	MutableQuadView fromVanilla(int[] quadData, int startIndex, boolean isItem);
+
+	/**
+	 * Encodes an integer tag with this quad that can later be retrieved via
+	 * {@link QuadView#tag()}.  Useful for models that want to perform conditional
+	 * transformation or filtering on static meshes.
+	 */
+	MutableQuadView tag(int tag);
+
+	/**
+	 * Sets the geometric vertex position for the given vertex,
+	 * relative to block origin. (0,0,0).  Minecraft rendering is designed
+	 * for models that fit within a single block space and is recommended
+	 * that coordinates remain in the 0-1 range, with multi-block meshes
+	 * split into multiple per-block models.
+	 */
+	MutableQuadView pos(int vertexIndex, float x, float y, float z);
+
+	/**
+	 * Same as {@link #pos(int, float, float, float)} but accepts vector type.
+	 */
+	default MutableQuadView pos(int vertexIndex, Vector3f vec) {
+		return pos(vertexIndex, vec.getX(), vec.getY(), vec.getZ());
+	}
+
+	/**
+	 * Adds a vertex normal. Models that have per-vertex
+	 * normals should include them to get correct lighting when it matters.
+	 * Computed face normal is used when no vertex normal is provided.
+	 *
+	 * <p>{@link Renderer} implementations should honor vertex normals for
+	 * diffuse lighting - modifying vertex color(s) or packing normals in the vertex
+	 * buffer as appropriate for the rendering method/vertex format in effect.
+	 */
+	MutableQuadView normal(int vertexIndex, float x, float y, float z);
+
+	/**
+	 * Same as {@link #normal(int, float, float, float)} but accepts vector type.
+	 */
+	default MutableQuadView normal(int vertexIndex, Vector3f vec) {
+		return normal(vertexIndex, vec.getX(), vec.getY(), vec.getZ());
+	}
+
+	/**
+	 * Accept vanilla lightmap values.  Input values will override lightmap values
+	 * computed from world state if input values are higher. Exposed for completeness
+	 * but some rendering implementations with non-standard lighting model may not honor it.
+	 *
+	 * <p>For emissive rendering, it is better to use {@link MaterialFinder#emissive(int, boolean)}.
+	 */
+	MutableQuadView lightmap(int vertexIndex, int lightmap);
+
+	/**
+	 * Convenience: set lightmap for all vertices at once.
+	 *
+	 * <p>For emissive rendering, it is better to use {@link MaterialFinder#emissive(int, boolean)}.
+	 * See {@link #lightmap(int, int)}.
+	 */
+	default MutableQuadView lightmap(int b0, int b1, int b2, int b3) {
+		lightmap(0, b0);
+		lightmap(1, b1);
+		lightmap(2, b2);
+		lightmap(3, b3);
+		return this;
+	}
+
+	/**
+	 * Set sprite color. Behavior for {@code spriteIndex > 0} is currently undefined.
+	 */
+	MutableQuadView spriteColor(int vertexIndex, int spriteIndex, int color);
+
+	/**
+	 * Convenience: set sprite color for all vertices at once. Behavior for {@code spriteIndex > 0} is currently undefined.
+	 */
+	default MutableQuadView spriteColor(int spriteIndex, int c0, int c1, int c2, int c3) {
+		spriteColor(0, spriteIndex, c0);
+		spriteColor(1, spriteIndex, c1);
+		spriteColor(2, spriteIndex, c2);
+		spriteColor(3, spriteIndex, c3);
+		return this;
+	}
+
+	/**
+	 * Set sprite atlas coordinates. Behavior for {@code spriteIndex > 0} is currently undefined.
+	 */
+	MutableQuadView sprite(int vertexIndex, int spriteIndex, float u, float v);
+
+	/**
+	 * Assigns sprite atlas u,v coordinates to this quad for the given sprite.
+	 * Can handle UV locking, rotation, interpolation, etc. Control this behavior
+	 * by passing additive combinations of the BAKE_ flags defined in this interface.
+	 * Behavior for {@code spriteIndex > 0} is currently undefined.
+	 */
+	MutableQuadView spriteBake(int spriteIndex, Sprite sprite, int bakeFlags);
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
@@ -16,161 +16,161 @@
 
 package net.fabricmc.fabric.api.renderer.v1.mesh;
 
-import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
-import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.util.math.Direction;
-import net.minecraft.util.math.MathHelper;
+
+import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
+import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
 
 /**
  * Specialized {@link MutableQuadView} obtained via {@link MeshBuilder#getEmitter()}
- * to append quads during mesh building.<p>
- * 
- * Also obtained from {@link RenderContext#getEmitter()} to submit
- * dynamic quads one-by-one at render time.<p>
- * 
- * Instances of {@link QuadEmitter} will practically always be
- * threadlocal and/or reused - do not retain references.<p>
- * 
- * Only the renderer should implement or extend this interface. 
+ * to append quads during mesh building.
+ *
+ * <p>Also obtained from {@link RenderContext#getEmitter()} to submit
+ * dynamic quads one-by-one at render time.
+ *
+ * <p>Instances of {@link QuadEmitter} will practically always be
+ * threadlocal and/or reused - do not retain references.
+ *
+ * <p>Only the renderer should implement or extend this interface.
  */
 public interface QuadEmitter extends MutableQuadView {
-    @Override
-    QuadEmitter material(RenderMaterial material);
+	@Override
+	QuadEmitter material(RenderMaterial material);
 
-    @Override
-    QuadEmitter cullFace(Direction face);
+	@Override
+	QuadEmitter cullFace(Direction face);
 
-    @Override
-    QuadEmitter nominalFace(Direction face);
+	@Override
+	QuadEmitter nominalFace(Direction face);
 
-    @Override
-    QuadEmitter colorIndex(int colorIndex);
+	@Override
+	QuadEmitter colorIndex(int colorIndex);
 
-    @Override
-    QuadEmitter fromVanilla(int[] quadData, int startIndex, boolean isItem);
+	@Override
+	QuadEmitter fromVanilla(int[] quadData, int startIndex, boolean isItem);
 
-    @Override
-    QuadEmitter tag(int tag);
+	@Override
+	QuadEmitter tag(int tag);
 
-    @Override
-    QuadEmitter pos(int vertexIndex, float x, float y, float z);
+	@Override
+	QuadEmitter pos(int vertexIndex, float x, float y, float z);
 
-    @Override
-    default QuadEmitter pos(int vertexIndex, Vector3f vec) {
-        MutableQuadView.super.pos(vertexIndex, vec);
-        return this;
-    }
+	@Override
+	default QuadEmitter pos(int vertexIndex, Vector3f vec) {
+		MutableQuadView.super.pos(vertexIndex, vec);
+		return this;
+	}
 
-    @Override
-    default QuadEmitter normal(int vertexIndex, Vector3f vec) {
-        MutableQuadView.super.normal(vertexIndex, vec);
-        return this;
-    }
+	@Override
+	default QuadEmitter normal(int vertexIndex, Vector3f vec) {
+		MutableQuadView.super.normal(vertexIndex, vec);
+		return this;
+	}
 
-    @Override
-    QuadEmitter lightmap(int vertexIndex, int lightmap);
+	@Override
+	QuadEmitter lightmap(int vertexIndex, int lightmap);
 
-    @Override
-    default QuadEmitter lightmap(int b0, int b1, int b2, int b3) {
-        MutableQuadView.super.lightmap(b0, b1, b2, b3);
-        return this;
-    }
+	@Override
+	default QuadEmitter lightmap(int b0, int b1, int b2, int b3) {
+		MutableQuadView.super.lightmap(b0, b1, b2, b3);
+		return this;
+	}
 
-    @Override
-    QuadEmitter spriteColor(int vertexIndex, int spriteIndex, int color);
+	@Override
+	QuadEmitter spriteColor(int vertexIndex, int spriteIndex, int color);
 
-    @Override
-    default QuadEmitter spriteColor(int spriteIndex, int c0, int c1, int c2, int c3) {
-        MutableQuadView.super.spriteColor(spriteIndex, c0, c1, c2, c3);
-        return this;
-    }
+	@Override
+	default QuadEmitter spriteColor(int spriteIndex, int c0, int c1, int c2, int c3) {
+		MutableQuadView.super.spriteColor(spriteIndex, c0, c1, c2, c3);
+		return this;
+	}
 
-    @Override
-    QuadEmitter sprite(int vertexIndex, int spriteIndex, float u, float v);
+	@Override
+	QuadEmitter sprite(int vertexIndex, int spriteIndex, float u, float v);
 
-    default QuadEmitter spriteUnitSquare(int spriteIndex) {
-        sprite(0, spriteIndex, 0, 0);
-        sprite(1, spriteIndex, 0, 1);
-        sprite(2, spriteIndex, 1, 1);
-        sprite(3, spriteIndex, 1, 0);
-        return this;
-    }
-    
-    @Override
-    QuadEmitter spriteBake(int spriteIndex, Sprite sprite, int bakeFlags);
-    
-    /**
-     * Tolerance for determining if the depth parameter to {@link #square(Direction, float, float, float, float, float)} 
-     * is effectively zero - meaning the face is a cull face.
-     */
-    final float CULL_FACE_EPSILON = 0.00001f;
-    
-    /**
-     * Helper method to assign vertex coordinates for a square aligned with the given face.
-     * Ensures that vertex order is consistent with vanilla convention. (Incorrect order can
-     * lead to bad AO lighting unless enhanced lighting logic is available/enabled.)<p>
-     * 
-     * Square will be parallel to the given face and coplanar with the face (and culled if the
-     * face is occluded) if the depth parameter is approximately zero. See {@link #CULL_FACE_EPSILON}.<p>
-     * 
-     * All coordinates should be normalized (0-1).
-     */
-    default QuadEmitter square(Direction nominalFace, float left, float bottom, float right, float top, float depth) {
-        if(Math.abs(depth) < CULL_FACE_EPSILON) {
-            cullFace(nominalFace);
-            depth = 0; // avoid any inconsistency for face quads
-        } else {
-            cullFace(null);
-        }
-        
-        nominalFace(nominalFace);
-        switch(nominalFace)
-        {
-        case UP:
-            depth = 1 - depth;
-            top = 1 - top;
-            bottom = 1 - bottom;
+	default QuadEmitter spriteUnitSquare(int spriteIndex) {
+		sprite(0, spriteIndex, 0, 0);
+		sprite(1, spriteIndex, 0, 1);
+		sprite(2, spriteIndex, 1, 1);
+		sprite(3, spriteIndex, 1, 0);
+		return this;
+	}
 
-        case DOWN:   
-            pos(0, left, depth, top);
-            pos(1, left, depth, bottom);
-            pos(2, right, depth, bottom);
-            pos(3, right, depth, top);
-            break;
+	@Override
+	QuadEmitter spriteBake(int spriteIndex, Sprite sprite, int bakeFlags);
 
-        case EAST:
-            depth = 1 - depth;
-            left = 1 - left;
-            right = 1 - right;
+	/**
+	 * Tolerance for determining if the depth parameter to {@link #square(Direction, float, float, float, float, float)}
+	 * is effectively zero - meaning the face is a cull face.
+	 */
+	float CULL_FACE_EPSILON = 0.00001f;
 
-        case WEST:
-            pos(0, depth, top, left);
-            pos(1, depth, bottom, left);
-            pos(2, depth, bottom, right);
-            pos(3, depth, top, right);
-            break;
+	/**
+	 * Helper method to assign vertex coordinates for a square aligned with the given face.
+	 * Ensures that vertex order is consistent with vanilla convention. (Incorrect order can
+	 * lead to bad AO lighting unless enhanced lighting logic is available/enabled.)
+	 *
+	 * <p>Square will be parallel to the given face and coplanar with the face (and culled if the
+	 * face is occluded) if the depth parameter is approximately zero. See {@link #CULL_FACE_EPSILON}.
+	 *
+	 * <p>All coordinates should be normalized (0-1).
+	 */
+	default QuadEmitter square(Direction nominalFace, float left, float bottom, float right, float top, float depth) {
+		if (Math.abs(depth) < CULL_FACE_EPSILON) {
+			cullFace(nominalFace);
+			depth = 0; // avoid any inconsistency for face quads
+		} else {
+			cullFace(null);
+		}
 
-        case SOUTH:
-            depth = 1 - depth;
-            left = 1 - left;
-            right = 1 - right;
-            
-        case NORTH:
-            pos(0, right, top, depth);
-            pos(1, right, bottom, depth);
-            pos(2, left, bottom, depth);
-            pos(3, left, top, depth);
-            break;
-        }
-        return this;
-    }
-    
-    /**
-     * In static mesh building, causes quad to be appended to the mesh being built.
-     * In a dynamic render context, create a new quad to be output to rendering.
-     * In both cases, current instance is reset to default values.
-     */
-    QuadEmitter emit();
+		nominalFace(nominalFace);
+		switch (nominalFace) {
+		case UP:
+			depth = 1 - depth;
+			top = 1 - top;
+			bottom = 1 - bottom;
+
+		case DOWN:
+			pos(0, left, depth, top);
+			pos(1, left, depth, bottom);
+			pos(2, right, depth, bottom);
+			pos(3, right, depth, top);
+			break;
+
+		case EAST:
+			depth = 1 - depth;
+			left = 1 - left;
+			right = 1 - right;
+
+		case WEST:
+			pos(0, depth, top, left);
+			pos(1, depth, bottom, left);
+			pos(2, depth, bottom, right);
+			pos(3, depth, top, right);
+			break;
+
+		case SOUTH:
+			depth = 1 - depth;
+			left = 1 - left;
+			right = 1 - right;
+
+		case NORTH:
+			pos(0, right, top, depth);
+			pos(1, right, bottom, depth);
+			pos(2, left, bottom, depth);
+			pos(3, left, top, depth);
+			break;
+		}
+
+		return this;
+	}
+
+	/**
+	 * In static mesh building, causes quad to be appended to the mesh being built.
+	 * In a dynamic render context, create a new quad to be output to rendering.
+	 * In both cases, current instance is reset to default values.
+	 */
+	QuadEmitter emit();
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadView.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadView.java
@@ -16,187 +16,184 @@
 
 package net.fabricmc.fabric.api.renderer.v1.mesh;
 
-import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
 import net.minecraft.client.render.model.BakedQuad;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.util.math.Direction;
 
+import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
+
 /**
  * Interface for reading quad data encoded by {@link MeshBuilder}.
  * Enables models to do analysis, re-texturing or translation without knowing the
- * renderer's vertex formats and without retaining redundant information.<p>
- * 
- * Only the renderer should implement or extend this interface.
+ * renderer's vertex formats and without retaining redundant information.
+ *
+ * <p>Only the renderer should implement or extend this interface.
  */
 public interface QuadView {
-    /**
-     * Reads baked vertex data and outputs standard baked quad 
-     * vertex data in the given array and location.<p>
-     * 
-     * @param spriteIndex The sprite to be used for the quad.
-     * Behavior for values &gt; 0 is currently undefined.
-     * 
-     * @param target Target array for the baked quad data.
-     * 
-     * @param targetIndex Starting position in target array - array must have
-     * at least 28 elements available at this index.
-     * 
-     * @param isItem If true, will output vertex normals. Otherwise will output
-     * lightmaps, per Minecraft vertex formats for baked models.
-     */
-    void toVanilla(int spriteIndex, int[] target, int targetIndex, boolean isItem);
-    
-    /**
-     * Extracts all quad properties except material to the given {@link MutableQuadView} instance.
-     * Must be used before calling {link QuadEmitter#emit()} on the target instance.
-     * Meant for re-texturing, analysis and static transformation use cases.
-     */   
-    void copyTo(MutableQuadView target);
-    
-    /**
-     * Retrieves the material serialized with the quad.
-     */
-    RenderMaterial material();
-    
-    /**
-     * Retrieves the quad color index serialized with the quad.
-     */
-    int colorIndex();
-    
-    /**
-     * Equivalent to {@link BakedQuad#getFace()}. This is the face used for vanilla lighting
-     * calculations and will be the block face to which the quad is most closely aligned. Always
-     * the same as cull face for quads that are on a block face, but never null.<p>
-     */
-    Direction lightFace();
-    
-    /**
-     * If non-null, quad should not be rendered in-world if the 
-     * opposite face of a neighbor block occludes it.<p>
-     * 
-     * See {@link MutableQuadView#cullFace(Direction)}.
-     */
-    Direction cullFace();
-    
-    /**
-     * See {@link MutableQuadView#nominalFace(Direction)}.
-     */
-    Direction nominalFace();
-    
-    /**
-     * Normal of the quad as implied by geometry. Will be invalid
-     * if quad vertices are not co-planar.  Typically computed lazily
-     * on demand and not encoded.<p>
-     * 
-     * Not typically needed by models. Exposed to enable standard lighting
-     * utility functions for use by renderers.
-     */
-    Vector3f faceNormal();
-    
-    /**
-     * Generates a new BakedQuad instance with texture
-     * coordinates and colors from the given sprite.<p>
-     * 
-     * param source Data previously packed by {@link MeshBuilder}.
-     * 
-     * param sourceIndex Index where packed data starts.
-     * 
-     * @param spriteIndex The sprite to be used for the quad.
-     * Behavior for {@code spriteIndex > 0} is currently undefined.
-     * 
-     * @param sprite  {@link MutableQuadView} does not serialize sprites
-     * so the sprite must be provided by the caller.
-     * 
-     * @param isItem If true, will output vertex normals. Otherwise will output
-     * lightmaps, per Minecraft vertex formats for baked models.
-     * 
-     * @return A new baked quad instance with the closest-available appearance
-     * supported by vanilla features. Will retain emissive light maps, for example,
-     * but the standard Minecraft renderer will not use them.
-     */
-    default BakedQuad toBakedQuad(int spriteIndex, Sprite sprite, boolean isItem) {
-        int vertexData[] = new int[28];
-        toVanilla(spriteIndex, vertexData, 0, isItem);
-        return new BakedQuad(vertexData, colorIndex(), lightFace(), sprite);
-    }
-    
-    /**
-     * Retrieves the integer tag encoded with this quad via {@link MutableQuadView#tag(int)}.
-     * Will return zero if no tag was set.  For use by models.
-     */
-    int tag();
-    
-    /**
-     * Pass a non-null target to avoid allocation - will be returned with values.
-     * Otherwise returns a new instance.
-     */
-    Vector3f copyPos(int vertexIndex, Vector3f target);
-    
-    /**
-     * Convenience: access x, y, z by index 0-2
-     */
-    float posByIndex(int vertexIndex, int coordinateIndex);
-    
-    /**
-     * Geometric position, x coordinate.
-     */
-    float x(int vertexIndex);
-    
-    /**
-     * Geometric position, y coordinate.
-     */
-    float y(int vertexIndex);
-    
-    /**
-     * Geometric position, z coordinate.
-     */
-    float z(int vertexIndex);
-   
-    /**
-     * If false, no vertex normal was provided.
-     * Lighting should use face normal in that case.
-     */
-    boolean hasNormal(int vertexIndex);
-    
-    /**
-     * Pass a non-null target to avoid allocation - will be returned with values.
-     * Otherwise returns a new instance. Returns null if normal not present.
-     */
-    Vector3f copyNormal(int vertexIndex, Vector3f target);
-    
-    /**
-     * Will return {@link Float#NaN} if normal not present.
-     */
-    float normalX(int vertexIndex);
-    
-    /**
-     * Will return {@link Float#NaN} if normal not present.
-     */
-    float normalY(int vertexIndex);
-    
-    /**
-     * Will return {@link Float#NaN} if normal not present.
-     */
-    float normalZ(int vertexIndex);
-    
-    /**
-     * Minimum block brightness. Zero if not set.
-     */
-    int lightmap(int vertexIndex);
+	/**
+	 * Reads baked vertex data and outputs standard baked quad
+	 * vertex data in the given array and location.
+	 *
+	 * @param spriteIndex The sprite to be used for the quad.
+	 * Behavior for values &gt; 0 is currently undefined.
+	 *
+	 * @param target Target array for the baked quad data.
+	 *
+	 * @param targetIndex Starting position in target array - array must have
+	 * at least 28 elements available at this index.
+	 *
+	 * @param isItem If true, will output vertex normals. Otherwise will output
+	 * lightmaps, per Minecraft vertex formats for baked models.
+	 */
+	void toVanilla(int spriteIndex, int[] target, int targetIndex, boolean isItem);
 
-    /**
-     * Retrieve vertex color.
-     */
-    int spriteColor(int vertexIndex, int spriteIndex);
-    
-    /**
-     * Retrieve horizontal sprite atlas coordinates.
-     */
-    float spriteU(int vertexIndex, int spriteIndex);
-    
-    /**
-     * Retrieve vertical sprite atlas coordinates
-     */
-    float spriteV(int vertexIndex, int spriteIndex);
+	/**
+	 * Extracts all quad properties except material to the given {@link MutableQuadView} instance.
+	 * Must be used before calling {link QuadEmitter#emit()} on the target instance.
+	 * Meant for re-texturing, analysis and static transformation use cases.
+	 */
+	void copyTo(MutableQuadView target);
+
+	/**
+	 * Retrieves the material serialized with the quad.
+	 */
+	RenderMaterial material();
+
+	/**
+	 * Retrieves the quad color index serialized with the quad.
+	 */
+	int colorIndex();
+
+	/**
+	 * Equivalent to {@link BakedQuad#getFace()}. This is the face used for vanilla lighting
+	 * calculations and will be the block face to which the quad is most closely aligned. Always
+	 * the same as cull face for quads that are on a block face, but never null.
+	 */
+	Direction lightFace();
+
+	/**
+	 * If non-null, quad should not be rendered in-world if the
+	 * opposite face of a neighbor block occludes it.
+	 *
+	 * @see MutableQuadView#cullFace(Direction)
+	 */
+	Direction cullFace();
+
+	/**
+	 * See {@link MutableQuadView#nominalFace(Direction)}.
+	 */
+	Direction nominalFace();
+
+	/**
+	 * Normal of the quad as implied by geometry. Will be invalid
+	 * if quad vertices are not co-planar.  Typically computed lazily
+	 * on demand and not encoded.
+	 *
+	 * <p>Not typically needed by models. Exposed to enable standard lighting
+	 * utility functions for use by renderers.
+	 */
+	Vector3f faceNormal();
+
+	/**
+	 * Generates a new BakedQuad instance with texture
+	 * coordinates and colors from the given sprite.
+	 *
+	 * @param spriteIndex The sprite to be used for the quad.
+	 * Behavior for {@code spriteIndex > 0} is currently undefined.
+	 *
+	 * @param sprite  {@link MutableQuadView} does not serialize sprites
+	 * so the sprite must be provided by the caller.
+	 *
+	 * @param isItem If true, will output vertex normals. Otherwise will output
+	 * lightmaps, per Minecraft vertex formats for baked models.
+	 *
+	 * @return A new baked quad instance with the closest-available appearance
+	 * supported by vanilla features. Will retain emissive light maps, for example,
+	 * but the standard Minecraft renderer will not use them.
+	 */
+	default BakedQuad toBakedQuad(int spriteIndex, Sprite sprite, boolean isItem) {
+		int[] vertexData = new int[28];
+		toVanilla(spriteIndex, vertexData, 0, isItem);
+		return new BakedQuad(vertexData, colorIndex(), lightFace(), sprite);
+	}
+
+	/**
+	 * Retrieves the integer tag encoded with this quad via {@link MutableQuadView#tag(int)}.
+	 * Will return zero if no tag was set.  For use by models.
+	 */
+	int tag();
+
+	/**
+	 * Pass a non-null target to avoid allocation - will be returned with values.
+	 * Otherwise returns a new instance.
+	 */
+	Vector3f copyPos(int vertexIndex, Vector3f target);
+
+	/**
+	 * Convenience: access x, y, z by index 0-2.
+	 */
+	float posByIndex(int vertexIndex, int coordinateIndex);
+
+	/**
+	 * Geometric position, x coordinate.
+	 */
+	float x(int vertexIndex);
+
+	/**
+	 * Geometric position, y coordinate.
+	 */
+	float y(int vertexIndex);
+
+	/**
+	 * Geometric position, z coordinate.
+	 */
+	float z(int vertexIndex);
+
+	/**
+	 * If false, no vertex normal was provided.
+	 * Lighting should use face normal in that case.
+	 */
+	boolean hasNormal(int vertexIndex);
+
+	/**
+	 * Pass a non-null target to avoid allocation - will be returned with values.
+	 * Otherwise returns a new instance. Returns null if normal not present.
+	 */
+	Vector3f copyNormal(int vertexIndex, Vector3f target);
+
+	/**
+	 * Will return {@link Float#NaN} if normal not present.
+	 */
+	float normalX(int vertexIndex);
+
+	/**
+	 * Will return {@link Float#NaN} if normal not present.
+	 */
+	float normalY(int vertexIndex);
+
+	/**
+	 * Will return {@link Float#NaN} if normal not present.
+	 */
+	float normalZ(int vertexIndex);
+
+	/**
+	 * Minimum block brightness. Zero if not set.
+	 */
+	int lightmap(int vertexIndex);
+
+	/**
+	 * Retrieve vertex color.
+	 */
+	int spriteColor(int vertexIndex, int spriteIndex);
+
+	/**
+	 * Retrieve horizontal sprite atlas coordinates.
+	 */
+	float spriteU(int vertexIndex, int spriteIndex);
+
+	/**
+	 * Retrieve vertical sprite atlas coordinates.
+	 */
+	float spriteV(int vertexIndex, int spriteIndex);
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/model/FabricBakedModel.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/model/FabricBakedModel.java
@@ -19,8 +19,6 @@ package net.fabricmc.fabric.api.renderer.v1.model;
 import java.util.Random;
 import java.util.function.Supplier;
 
-import net.fabricmc.fabric.api.renderer.v1.Renderer;
-import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.render.block.BlockModelRenderer;
 import net.minecraft.client.render.model.BakedModel;
@@ -28,97 +26,100 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.ExtendedBlockView;
 
+import net.fabricmc.fabric.api.renderer.v1.Renderer;
+import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
+
 /**
  * Interface for baked models that output meshes with enhanced rendering features.
  * Can also be used to generate or customize outputs based on world state instead of
- * or in addition to block state when render chunks are rebuilt.<p>
- * 
- * Note for {@link Renderer} implementors: Fabric causes BakedModel to extend this
- * interface with {@link #isVanillaAdapter()} == true and to produce standard vertex data. 
+ * or in addition to block state when render chunks are rebuilt.
+ *
+ * <p>Note for {@link Renderer} implementors: Fabric causes BakedModel to extend this
+ * interface with {@link #isVanillaAdapter()} == true and to produce standard vertex data.
  * This means any BakedModel instance can be safely cast to this interface without an instanceof check.
  */
 public interface FabricBakedModel {
-    /**
-     * When true, signals renderer this producer is implemented through {@link BakedModel#getQuads(BlockState, net.minecraft.util.math.Direction, Random)}.
-     * Also means the model does not rely on any non-vanilla features. 
-     * Allows the renderer to optimize or route vanilla models through the unmodified vanilla pipeline if desired.<p>
+	/**
+	 * When true, signals renderer this producer is implemented through {@link BakedModel#getQuads(BlockState, net.minecraft.util.math.Direction, Random)}.
+	 * Also means the model does not rely on any non-vanilla features.
+	 * Allows the renderer to optimize or route vanilla models through the unmodified vanilla pipeline if desired.
+	 *
+	 * <p>Fabric overrides to true for vanilla baked models.
+	 * Enhanced models that use this API should return false,
+	 * otherwise the API will not recognize the model.
+	 */
+	boolean isVanillaAdapter();
 
-     * Fabric overrides to true for vanilla baked models.  
-     * Enhanced models that use this API should return false,
-     * otherwise the API will not recognize the model. <p>
-     */
-    boolean isVanillaAdapter(); 
-    
-    /**
-     * This method will be called during chunk rebuilds to generate both the static and
-     * dynamic portions of a block model when the model implements this interface and
-     * {@link #isVanillaAdapter()} returns false. <p>
-     * 
-     * During chunk rebuild, this method will always be called exactly one time per block
-     * position, irrespective of which or how many faces or block render layers are included 
-     * in the model. Models must output all quads/meshes in a single pass.<p>
-     * 
-     * Also called to render block models outside of chunk rebuild or block entity rendering.
-     * Typically this happens when the block is being rendered as an entity, not as a block placed in the world.
-     * Currently this happens for falling blocks and blocks being pushed by a piston, but renderers
-     * should invoke this for all calls to {@link BlockModelRenderer#tesselate(ExtendedBlockView, BakedModel, BlockState, BlockPos, net.minecraft.client.render.BufferBuilder, boolean, Random, long)}
-     * that occur outside of chunk rebuilds to allow for features added by mods, unless 
-     * {@link #isVanillaAdapter()} returns true.<p>
-     * 
-     * Outside of chunk rebuilds, this method will be called every frame. Model implementations should 
-     * rely on pre-baked meshes as much as possible and keep transformation to a minimum.  The provided 
-     * block position may be the <em>nearest</em> block position and not actual. For this reason, neighbor
-     * state lookups are best avoided or will require special handling. Block entity lookups are 
-     * likely to fail and/or give meaningless results.<p>
-     * 
-     * In all cases, renderer will handle face occlusion and filter quads on faces obscured by 
-     * neighboring blocks (if appropriate).  Models only need to consider "sides" to the
-     * extent the model is driven by connection with neighbor blocks or other world state.<p>
-     * 
-     * Note: with {@link BakedModel#getQuads(BlockState, net.minecraft.util.math.Direction, Random)}, the random 
-     * parameter is normally initialized with the same seed prior to each face layer.
-     * Model authors should note this method is called only once per block, and call the provided
-     * Random supplier multiple times if re-seeding is necessary. For wrapped vanilla baked models, 
-     * it will probably be easier to use {@link RenderContext#fallbackConsumer} which handles
-     * re-seeding per face automatically.<p>
-     * 
-     * @param blockView Access to world state. Using {@link net.fabricmc.fabric.api.rendering.data.v1.RenderAttachedBlockView#getBlockEntityRenderAttachment(BlockPos)} to
-     * retrieve block entity state unless thread safety can be guaranteed.
-     * param safeBlockEntityAccessor Thread-safe access to block entity data 
-     * @param state Block state for model being rendered.
-     * @param pos Position of block for model being rendered.
-     * @param randomSupplier  Random object seeded per vanilla conventions. Call multiple times to re-seed.
-     * Will not be thread-safe. Do not cache or retain a reference.
-     * @param context Accepts model output.
-     */
-    void emitBlockQuads(ExtendedBlockView blockView, BlockState state, BlockPos pos, Supplier<Random> randomSupplier, RenderContext context);
+	/**
+	 * This method will be called during chunk rebuilds to generate both the static and
+	 * dynamic portions of a block model when the model implements this interface and
+	 * {@link #isVanillaAdapter()} returns false.
+	 *
+	 * <p>During chunk rebuild, this method will always be called exactly one time per block
+	 * position, irrespective of which or how many faces or block render layers are included
+	 * in the model. Models must output all quads/meshes in a single pass.
+	 *
+	 * <p>Also called to render block models outside of chunk rebuild or block entity rendering.
+	 * Typically this happens when the block is being rendered as an entity, not as a block placed in the world.
+	 * Currently this happens for falling blocks and blocks being pushed by a piston, but renderers
+	 * should invoke this for all calls to {@link BlockModelRenderer#tesselate(ExtendedBlockView, BakedModel, BlockState, BlockPos, net.minecraft.client.render.BufferBuilder, boolean, Random, long)}
+	 * that occur outside of chunk rebuilds to allow for features added by mods, unless
+	 * {@link #isVanillaAdapter()} returns true.
+	 *
+	 * <p>Outside of chunk rebuilds, this method will be called every frame. Model implementations should
+	 * rely on pre-baked meshes as much as possible and keep transformation to a minimum.  The provided
+	 * block position may be the <em>nearest</em> block position and not actual. For this reason, neighbor
+	 * state lookups are best avoided or will require special handling. Block entity lookups are
+	 * likely to fail and/or give meaningless results.
+	 *
+	 * <p>In all cases, renderer will handle face occlusion and filter quads on faces obscured by
+	 * neighboring blocks (if appropriate).  Models only need to consider "sides" to the
+	 * extent the model is driven by connection with neighbor blocks or other world state.
+	 *
+	 * @note with {@link BakedModel#getQuads(BlockState, net.minecraft.util.math.Direction, Random)}, the random
+	 * parameter is normally initialized with the same seed prior to each face layer.
+	 * Model authors should note this method is called only once per block, and call the provided
+	 * Random supplier multiple times if re-seeding is necessary. For wrapped vanilla baked models,
+	 * it will probably be easier to use {@link RenderContext#fallbackConsumer} which handles
+	 * re-seeding per face automatically.
+	 *
+	 * @param blockView Access to world state. Using {@link net.fabricmc.fabric.api.rendering.data.v1.RenderAttachedBlockView#getBlockEntityRenderAttachment(BlockPos)} to
+	 * retrieve block entity state unless thread safety can be guaranteed.
+	 * param safeBlockEntityAccessor Thread-safe access to block entity data
+	 * @param state Block state for model being rendered.
+	 * @param pos Position of block for model being rendered.
+	 * @param randomSupplier  Random object seeded per vanilla conventions. Call multiple times to re-seed.
+	 * Will not be thread-safe. Do not cache or retain a reference.
+	 * @param context Accepts model output.
+	 */
+	void emitBlockQuads(ExtendedBlockView blockView, BlockState state, BlockPos pos, Supplier<Random> randomSupplier, RenderContext context);
 
-    /**
-     * This method will be called during item rendering to generate both the static and
-     * dynamic portions of an item model when the model implements this interface and
-     * {@link #isVanillaAdapter()} returns false.<p>
-     * 
-     * Vanilla item rendering is normally very limited. It ignores lightmaps, vertex colors,
-     * and vertex normals. Renderers are expected to implement enhanced features for item 
-     * models. If a feature is impractical due to performance or other concerns, then the
-     * renderer must at least give acceptable visual results without the need for special-
-     * case handling in model implementations.<p>
-     * 
-     * Calls to this method will generally happen on the main client thread but nothing 
-     * prevents a mod or renderer from calling this method concurrently. Implementations 
-     * should not mutate the ItemStack parameter, and best practice will be to make the 
-     * method thread-safe.<p>
-     * 
-     * Implementing this method does NOT mitigate the need to implement a functional 
-     * {@link BakedModel#getItemPropertyOverrides()} method, because this method will be called 
-     * on the <em>result</em> of  {@link BakedModel#getItemPropertyOverrides}.  However, that 
-     * method can simply return the base model because the output from this method will
-     * be used for rendering.<p>
-     * 
-     * Renderer implementations should also use this method to obtain the quads used
-     * for item enchantment glint rendering.  This means models can put geometric variation
-     * logic here, instead of returning every possible shape from {@link BakedModel#getItemPropertyOverrides}
-     * as vanilla baked models.
-     */
-    void emitItemQuads(ItemStack stack, Supplier<Random> randomSupplier, RenderContext context);
+	/**
+	 * This method will be called during item rendering to generate both the static and
+	 * dynamic portions of an item model when the model implements this interface and
+	 * {@link #isVanillaAdapter()} returns false.
+	 *
+	 * <p>Vanilla item rendering is normally very limited. It ignores lightmaps, vertex colors,
+	 * and vertex normals. Renderers are expected to implement enhanced features for item
+	 * models. If a feature is impractical due to performance or other concerns, then the
+	 * renderer must at least give acceptable visual results without the need for special-
+	 * case handling in model implementations.
+	 *
+	 * <p>Calls to this method will generally happen on the main client thread but nothing
+	 * prevents a mod or renderer from calling this method concurrently. Implementations
+	 * should not mutate the ItemStack parameter, and best practice will be to make the
+	 * method thread-safe.
+	 *
+	 * <p>Implementing this method does NOT mitigate the need to implement a functional
+	 * {@link BakedModel#getItemPropertyOverrides()} method, because this method will be called
+	 * on the <em>result</em> of  {@link BakedModel#getItemPropertyOverrides}.  However, that
+	 * method can simply return the base model because the output from this method will
+	 * be used for rendering.
+	 *
+	 * <p>Renderer implementations should also use this method to obtain the quads used
+	 * for item enchantment glint rendering.  This means models can put geometric variation
+	 * logic here, instead of returning every possible shape from {@link BakedModel#getItemPropertyOverrides}
+	 * as vanilla baked models.
+	 */
+	void emitItemQuads(ItemStack stack, Supplier<Random> randomSupplier, RenderContext context);
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/model/ForwardingBakedModel.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/model/ForwardingBakedModel.java
@@ -20,8 +20,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.function.Supplier;
 
-import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
-import net.fabricmc.fabric.impl.renderer.DamageModel;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.client.render.model.BakedQuad;
@@ -33,61 +31,64 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.ExtendedBlockView;
 
+import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
+import net.fabricmc.fabric.impl.renderer.DamageModel;
+
 /**
  * Base class for specialized model implementations that need to wrap other baked models.
  * Avoids boilerplate code for pass-through methods. For example usage see {@link DamageModel}.
  */
 public abstract class ForwardingBakedModel implements BakedModel, FabricBakedModel {
-    /** implementations must set this somehow */
-    protected BakedModel wrapped;
-    
-    @Override
-    public void emitBlockQuads(ExtendedBlockView blockView, BlockState state, BlockPos pos, Supplier<Random> randomSupplier, RenderContext context) {
-        ((FabricBakedModel)wrapped).emitBlockQuads(blockView, state, pos, randomSupplier, context);
-    }
+	/** implementations must set this somehow. */
+	protected BakedModel wrapped;
 
-    @Override
-    public boolean isVanillaAdapter() {
-        return ((FabricBakedModel)wrapped).isVanillaAdapter();
-    }
+	@Override
+	public void emitBlockQuads(ExtendedBlockView blockView, BlockState state, BlockPos pos, Supplier<Random> randomSupplier, RenderContext context) {
+		((FabricBakedModel) wrapped).emitBlockQuads(blockView, state, pos, randomSupplier, context);
+	}
 
-    @Override
-    public void emitItemQuads(ItemStack stack, Supplier<Random> randomSupplier, RenderContext context) {
-        ((FabricBakedModel)wrapped).emitItemQuads(stack, randomSupplier, context);
-    }
+	@Override
+	public boolean isVanillaAdapter() {
+		return ((FabricBakedModel) wrapped).isVanillaAdapter();
+	}
 
-    @Override
-    public List<BakedQuad> getQuads(BlockState blockState, Direction face, Random rand) {
-        return wrapped.getQuads(blockState, face, rand);
-    }
+	@Override
+	public void emitItemQuads(ItemStack stack, Supplier<Random> randomSupplier, RenderContext context) {
+		((FabricBakedModel) wrapped).emitItemQuads(stack, randomSupplier, context);
+	}
 
-    @Override
-    public boolean useAmbientOcclusion() {
-        return wrapped.useAmbientOcclusion();
-    }
+	@Override
+	public List<BakedQuad> getQuads(BlockState blockState, Direction face, Random rand) {
+		return wrapped.getQuads(blockState, face, rand);
+	}
 
-    @Override
-    public boolean hasDepthInGui() {
-        return wrapped.hasDepthInGui();
-    }
+	@Override
+	public boolean useAmbientOcclusion() {
+		return wrapped.useAmbientOcclusion();
+	}
 
-    @Override
-    public boolean isBuiltin() {
-        return wrapped.isBuiltin();
-    }
+	@Override
+	public boolean hasDepthInGui() {
+		return wrapped.hasDepthInGui();
+	}
 
-    @Override
-    public Sprite getSprite() {
-        return wrapped.getSprite();
-    }
+	@Override
+	public boolean isBuiltin() {
+		return wrapped.isBuiltin();
+	}
 
-    @Override
-    public ModelTransformation getTransformation() {
-        return wrapped.getTransformation();
-    }
+	@Override
+	public Sprite getSprite() {
+		return wrapped.getSprite();
+	}
 
-    @Override
-    public ModelItemPropertyOverrideList getItemPropertyOverrides() {
-        return wrapped.getItemPropertyOverrides();
-    }
+	@Override
+	public ModelTransformation getTransformation() {
+		return wrapped.getTransformation();
+	}
+
+	@Override
+	public ModelItemPropertyOverrideList getItemPropertyOverrides() {
+		return wrapped.getItemPropertyOverrides();
+	}
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/model/ModelHelper.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/model/ModelHelper.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import com.google.common.collect.ImmutableList;
 
-import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.model.BakedQuad;
 import net.minecraft.client.render.model.json.ModelTransformation;
@@ -29,108 +28,114 @@ import net.minecraft.client.render.model.json.Transformation;
 import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.util.math.Direction;
 
+import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
+
 /**
  * Collection of utilities for model implementations.
  */
 public abstract class ModelHelper {
-    private ModelHelper() {}
-    
-    /** Result from {@link #toFaceIndex(Direction)} for null values. */
-    public static final int NULL_FACE_ID = 6;
-    
-    /**
-     * Convenient way to encode faces that may be null.
-     * Null is returned as {@link #NULL_FACE_ID}. 
-     * Use {@link #faceFromIndex(int)} to retrieve encoded face.
-     */
-    public static int toFaceIndex(Direction face) {
-        return face == null ? NULL_FACE_ID : face.getId();
-    }
-    
-    /**
-     * Use to decode a result from {@link #toFaceIndex(Direction)}. 
-     * Return value will be null if encoded value was null.
-     * Can also be used for no-allocation iteration of {@link Direction#values()},
-     * optionally including the null face. (Use &lt; or  &lt;= {@link #NULL_FACE_ID}
-     * to exclude or include the null value, respectively.)
-     */
-    public static Direction faceFromIndex(int faceIndex) {
-        return FACES[faceIndex];
-    }
-   
-    /** see {@link #faceFromIndex(int)} */
-    private static final Direction[] FACES = Arrays.copyOf(Direction.values(), 7);
-    
-    /**
-     * Converts a mesh into an array of lists of vanilla baked quads.
-     * Useful for creating vanilla baked models when required for compatibility.
-     * The array indexes correspond to {@link Direction#getId()} with the 
-     * addition of {@link #NULL_FACE_ID}.<p>
-     * 
-     * Retrieves sprites from the block texture atlas via {@link SpriteFinder}. 
-     */
-    public static List<BakedQuad>[] toQuadLists(Mesh mesh) {
-        SpriteFinder finder = SpriteFinder.get(MinecraftClient.getInstance().getSpriteAtlas());
-        
-        @SuppressWarnings("unchecked")
-        final ImmutableList.Builder<BakedQuad>[] builders = new ImmutableList.Builder[7];
-        for(int i = 0; i < 7; i++) {
-            builders[i] = ImmutableList.builder();
-        }
-        
-        mesh.forEach(q -> {
-            final int limit = q.material().spriteDepth();
-            for(int l = 0; l < limit; l++) {
-                Direction face = q.cullFace();
-                builders[face == null ? 6 : face.getId()].add(q.toBakedQuad(l, finder.find(q, l), false));
-            }
-        }) ;
-        
-        @SuppressWarnings("unchecked")
-        List<BakedQuad>[] result = new List[7];
-        for(int i = 0; i < 7; i++) {
-            result[i] = builders[i].build();
-        }
-        return result;
-    }
+	private ModelHelper() { }
 
-    /**
-     * The vanilla model transformation logic is closely coupled with model deserialization.
-     * That does little good for modded model loaders and procedurally generated models.
-     * This convenient construction method applies the same scaling factors used for vanilla models.  
-     * This means you can use values from a vanilla JSON file as inputs to this method.
-     */
-    private static Transformation makeTransform(
-            float rotationX, float rotationY, float rotationZ,
-            float translationX, float translationY, float translationZ,
-            float scaleX, float scaleY, float scaleZ) {
-        Vector3f translation = new Vector3f(translationX, translationY, translationZ);
-        translation.scale(0.0625f);
-        translation.clamp(-5.0F, 5.0F);
-        return new Transformation(
-                new Vector3f(rotationX, rotationY, rotationZ),
-                translation, 
-                new Vector3f(scaleX, scaleY, scaleZ));
-    }
-    
-    public static final Transformation TRANSFORM_BLOCK_GUI = makeTransform(30, 225, 0, 0, 0, 0, 0.625f, 0.625f, 0.625f);
-    public static final Transformation TRANSFORM_BLOCK_GROUND = makeTransform(0, 0, 0, 0, 3, 0, 0.25f, 0.25f, 0.25f);
-    public static final Transformation TRANSFORM_BLOCK_FIXED = makeTransform(0, 0, 0, 0, 0, 0, 0.5f, 0.5f, 0.5f);
-    public static final Transformation TRANSFORM_BLOCK_3RD_PERSON_RIGHT = makeTransform(75, 45, 0, 0, 2.5f, 0, 0.375f, 0.375f, 0.375f);
-    public static final Transformation TRANSFORM_BLOCK_1ST_PERSON_RIGHT = makeTransform(0, 45, 0, 0, 0, 0, 0.4f, 0.4f, 0.4f);
-    public static final Transformation TRANSFORM_BLOCK_1ST_PERSON_LEFT = makeTransform(0, 225, 0, 0, 0, 0, 0.4f, 0.4f, 0.4f);
-    
-    /**
-     * Mimics the vanilla model transformation used for most vanilla blocks,
-     * and should be suitable for most custom block-like models. 
-     */
-    public static final ModelTransformation MODEL_TRANSFORM_BLOCK = new ModelTransformation(
-            TRANSFORM_BLOCK_3RD_PERSON_RIGHT,
-            TRANSFORM_BLOCK_3RD_PERSON_RIGHT,
-            TRANSFORM_BLOCK_1ST_PERSON_LEFT,
-            TRANSFORM_BLOCK_1ST_PERSON_RIGHT,
-            Transformation.NONE,
-            TRANSFORM_BLOCK_GUI,
-            TRANSFORM_BLOCK_GROUND,
-            TRANSFORM_BLOCK_FIXED);
+	/** Result from {@link #toFaceIndex(Direction)} for null values. */
+	public static final int NULL_FACE_ID = 6;
+
+	/**
+	 * Convenient way to encode faces that may be null.
+	 * Null is returned as {@link #NULL_FACE_ID}.
+	 * Use {@link #faceFromIndex(int)} to retrieve encoded face.
+	 */
+	public static int toFaceIndex(Direction face) {
+		return face == null ? NULL_FACE_ID : face.getId();
+	}
+
+	/**
+	 * Use to decode a result from {@link #toFaceIndex(Direction)}.
+	 * Return value will be null if encoded value was null.
+	 * Can also be used for no-allocation iteration of {@link Direction#values()},
+	 * optionally including the null face. (Use &lt; or  &lt;= {@link #NULL_FACE_ID}
+	 * to exclude or include the null value, respectively.)
+	 */
+	public static Direction faceFromIndex(int faceIndex) {
+		return FACES[faceIndex];
+	}
+
+	/** @see #faceFromIndex(int) */
+	private static final Direction[] FACES = Arrays.copyOf(Direction.values(), 7);
+
+	/**
+	 * Converts a mesh into an array of lists of vanilla baked quads.
+	 * Useful for creating vanilla baked models when required for compatibility.
+	 * The array indexes correspond to {@link Direction#getId()} with the
+	 * addition of {@link #NULL_FACE_ID}.
+	 *
+	 * <p>Retrieves sprites from the block texture atlas via {@link SpriteFinder}.
+	 */
+	public static List<BakedQuad>[] toQuadLists(Mesh mesh) {
+		SpriteFinder finder = SpriteFinder.get(MinecraftClient.getInstance().getSpriteAtlas());
+
+		@SuppressWarnings("unchecked")
+		final ImmutableList.Builder<BakedQuad>[] builders = new ImmutableList.Builder[7];
+
+		for (int i = 0; i < 7; i++) {
+			builders[i] = ImmutableList.builder();
+		}
+
+		mesh.forEach(q -> {
+			final int limit = q.material().spriteDepth();
+
+			for (int l = 0; l < limit; l++) {
+				Direction face = q.cullFace();
+				builders[face == null ? 6 : face.getId()].add(q.toBakedQuad(l, finder.find(q, l), false));
+			}
+		}) ;
+
+		@SuppressWarnings("unchecked")
+		List<BakedQuad>[] result = new List[7];
+
+		for (int i = 0; i < 7; i++) {
+			result[i] = builders[i].build();
+		}
+
+		return result;
+	}
+
+	/**
+	 * The vanilla model transformation logic is closely coupled with model deserialization.
+	 * That does little good for modded model loaders and procedurally generated models.
+	 * This convenient construction method applies the same scaling factors used for vanilla models.
+	 * This means you can use values from a vanilla JSON file as inputs to this method.
+	 */
+	private static Transformation makeTransform(
+			float rotationX, float rotationY, float rotationZ,
+			float translationX, float translationY, float translationZ,
+			float scaleX, float scaleY, float scaleZ) {
+		Vector3f translation = new Vector3f(translationX, translationY, translationZ);
+		translation.scale(0.0625f);
+		translation.clamp(-5.0F, 5.0F);
+		return new Transformation(
+				new Vector3f(rotationX, rotationY, rotationZ),
+				translation,
+				new Vector3f(scaleX, scaleY, scaleZ));
+	}
+
+	public static final Transformation TRANSFORM_BLOCK_GUI = makeTransform(30, 225, 0, 0, 0, 0, 0.625f, 0.625f, 0.625f);
+	public static final Transformation TRANSFORM_BLOCK_GROUND = makeTransform(0, 0, 0, 0, 3, 0, 0.25f, 0.25f, 0.25f);
+	public static final Transformation TRANSFORM_BLOCK_FIXED = makeTransform(0, 0, 0, 0, 0, 0, 0.5f, 0.5f, 0.5f);
+	public static final Transformation TRANSFORM_BLOCK_3RD_PERSON_RIGHT = makeTransform(75, 45, 0, 0, 2.5f, 0, 0.375f, 0.375f, 0.375f);
+	public static final Transformation TRANSFORM_BLOCK_1ST_PERSON_RIGHT = makeTransform(0, 45, 0, 0, 0, 0, 0.4f, 0.4f, 0.4f);
+	public static final Transformation TRANSFORM_BLOCK_1ST_PERSON_LEFT = makeTransform(0, 225, 0, 0, 0, 0, 0.4f, 0.4f, 0.4f);
+
+	/**
+	 * Mimics the vanilla model transformation used for most vanilla blocks,
+	 * and should be suitable for most custom block-like models.
+	 */
+	public static final ModelTransformation MODEL_TRANSFORM_BLOCK = new ModelTransformation(
+			TRANSFORM_BLOCK_3RD_PERSON_RIGHT,
+			TRANSFORM_BLOCK_3RD_PERSON_RIGHT,
+			TRANSFORM_BLOCK_1ST_PERSON_LEFT,
+			TRANSFORM_BLOCK_1ST_PERSON_RIGHT,
+			Transformation.NONE,
+			TRANSFORM_BLOCK_GUI,
+			TRANSFORM_BLOCK_GROUND,
+			TRANSFORM_BLOCK_FIXED);
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/model/ModelHelper.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/model/ModelHelper.java
@@ -87,7 +87,7 @@ public abstract class ModelHelper {
 				Direction face = q.cullFace();
 				builders[face == null ? 6 : face.getId()].add(q.toBakedQuad(l, finder.find(q, l), false));
 			}
-		}) ;
+		});
 
 		@SuppressWarnings("unchecked")
 		List<BakedQuad>[] result = new List[7];

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/model/SpriteFinder.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/model/SpriteFinder.java
@@ -16,52 +16,53 @@
 
 package net.fabricmc.fabric.api.renderer.v1.model;
 
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.client.texture.SpriteAtlasTexture;
+
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
 import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadView;
 import net.fabricmc.fabric.impl.renderer.SpriteFinderImpl;
-import net.minecraft.client.texture.Sprite;
-import net.minecraft.client.texture.SpriteAtlasTexture;
 
 /**
  * Indexes a texture atlas to allow fast lookup of Sprites from
  * baked vertex coordinates.  Main use is for {@link Mesh}-based models
  * to generate vanilla quads on demand without tracking and retaining
- * the sprites that were baked into the mesh. In other words, this class 
+ * the sprites that were baked into the mesh. In other words, this class
  * supplies the sprite parameter for {@link QuadView#toBakedQuad(int, Sprite, boolean)}.
  */
 public interface SpriteFinder {
-    /**
-     * Retrieves or creates the finder for the given atlas.
-     * Instances should not be retained as fields or they must be
-     * refreshed whenever there is a resource reload or other event
-     * that causes atlas textures to be re-stitched.
-     */
-    public static SpriteFinder get(SpriteAtlasTexture atlas) {
-        return SpriteFinderImpl.get(atlas);
-    }
-    
-    /**
-     * Finds the atlas sprite containing the vertex centroid of the quad.
-     * Vertex centroid is essentially the mean u,v coordinate - the intent being
-     * to find a point that is unambiguously inside the sprite (vs on an edge.)<p>
-     * 
-     * Should be reliable for any convex quad or triangle. May fail for non-convex quads.
-     * Note that all the above refers to u,v coordinates. Geometric vertex does not matter,
-     * except to the extent it was used to determine u,v.
-     */
-    Sprite find(QuadView quad, int textureIndex);
+	/**
+	 * Retrieves or creates the finder for the given atlas.
+	 * Instances should not be retained as fields or they must be
+	 * refreshed whenever there is a resource reload or other event
+	 * that causes atlas textures to be re-stitched.
+	 */
+	static SpriteFinder get(SpriteAtlasTexture atlas) {
+		return SpriteFinderImpl.get(atlas);
+	}
 
-    /**
-     * Alternative to {@link #find(QuadView, int)} when vertex centroid is already
-     * known or unsuitable.  Expects normalized (0-1) coordinates on the atlas texture,
-     * which should already be the case for u,v values in vanilla baked quads and in 
-     * {@link QuadView} after calling {@link MutableQuadView#spriteBake(int, Sprite, int)}.<p>
-     * 
-     * Coordinates must be in the sprite interior for reliable results. Generally will
-     * be easier to use {@link #find(QuadView, int)} unless you know the vertex
-     * centroid will somehow not be in the quad interior. This method will be slightly 
-     * faster if you already have the centroid or another appropriate value.
-     */
-    Sprite find(float u, float v);
+	/**
+	 * Finds the atlas sprite containing the vertex centroid of the quad.
+	 * Vertex centroid is essentially the mean u,v coordinate - the intent being
+	 * to find a point that is unambiguously inside the sprite (vs on an edge.)
+	 *
+	 * <p>Should be reliable for any convex quad or triangle. May fail for non-convex quads.
+	 * Note that all the above refers to u,v coordinates. Geometric vertex does not matter,
+	 * except to the extent it was used to determine u,v.
+	 */
+	Sprite find(QuadView quad, int textureIndex);
+
+	/**
+	 * Alternative to {@link #find(QuadView, int)} when vertex centroid is already
+	 * known or unsuitable.  Expects normalized (0-1) coordinates on the atlas texture,
+	 * which should already be the case for u,v values in vanilla baked quads and in
+	 * {@link QuadView} after calling {@link MutableQuadView#spriteBake(int, Sprite, int)}.
+	 *
+	 * <p>Coordinates must be in the sprite interior for reliable results. Generally will
+	 * be easier to use {@link #find(QuadView, int)} unless you know the vertex
+	 * centroid will somehow not be in the quad interior. This method will be slightly
+	 * faster if you already have the centroid or another appropriate value.
+	 */
+	Sprite find(float u, float v);
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/render/RenderContext.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/render/RenderContext.java
@@ -18,74 +18,75 @@ package net.fabricmc.fabric.api.renderer.v1.render;
 
 import java.util.function.Consumer;
 
+import net.minecraft.client.render.model.BakedModel;
+
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
 import net.fabricmc.fabric.api.renderer.v1.mesh.MeshBuilder;
 import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
-import net.minecraft.client.render.model.BakedModel;
 
 /**
  * This defines the instance made available to models for buffering vertex data at render time.
  */
 public interface RenderContext {
-    /**
-     * Used by models to send vertex data previously baked via {@link MeshBuilder}. 
-     * The fastest option and preferred whenever feasible.
-     */
-    Consumer<Mesh> meshConsumer();
-    
-    /**
-     * Fabric causes vanilla baked models to send themselves 
-     * via this interface. Can also be used by compound models that contain a mix
-     * of vanilla baked models, packaged quads and/or dynamic elements.
-     */
-    Consumer<BakedModel> fallbackConsumer();
-    
-    /**
-     * Returns a {@link QuadEmitter} instance that emits directly to the render buffer.
-     * It remains necessary to call {@link QuadEmitter#emit()} to output the quad.<p>
-     * 
-     * This method will always be less performant than passing pre-baked meshes
-     * via {@link #meshConsumer()}. It should be used sparingly for model components that
-     * demand it - text, icons, dynamic indicators, or other elements that vary too 
-     * much for static baking to be feasible.<p>
-     * 
-     * Calling this method invalidates any {@link QuadEmitter} returned earlier.  
-     * Will be threadlocal/re-used - do not retain references.
-     */
-    QuadEmitter getEmitter();
-    
-    /**
-     * Causes all models/quads/meshes sent to this consumer to be transformed by the provided
-     * {@link QuadTransform} that edits each quad before buffering. Quads in the mesh will 
-     * be passed to the {@link QuadTransform} for modification before offsets, face culling or lighting are applied.  
-     * Meant for animation and mesh customization.<p>
-     * 
-     * You MUST call {@link #popTransform()} after model is done outputting quads.
-     * 
-     * More than one transformer can be added to the context.  Transformers are applied in reverse order. 
-     * (Last pushed is applied first.)<p>
-     * 
-     * Meshes are never mutated by the transformer - only buffered quads. This ensures thread-safe
-     * use of meshes/models across multiple chunk builders.<p>
-     * 
-     * Only the renderer should implement or extend this interface.
-     */
-    void pushTransform(QuadTransform transform);
-    
-    /**
-     * Removes the transformation added by the last call to {@link #pushTransform(QuadTransform)}.
-     * MUST be called before exiting from {@link FabricBakedModel} .emit... methods.
-     */
-    void popTransform();
-    
-    @FunctionalInterface
-    public static interface QuadTransform {
-        /**
-         * Return false to filter out quads from rendering. When more than one transform
-         * is in effect, returning false means unapplied transforms will not receive the quad.
-         */
-        boolean transform(MutableQuadView quad);
-    }
+	/**
+	 * Used by models to send vertex data previously baked via {@link MeshBuilder}.
+	 * The fastest option and preferred whenever feasible.
+	 */
+	Consumer<Mesh> meshConsumer();
+
+	/**
+	 * Fabric causes vanilla baked models to send themselves
+	 * via this interface. Can also be used by compound models that contain a mix
+	 * of vanilla baked models, packaged quads and/or dynamic elements.
+	 */
+	Consumer<BakedModel> fallbackConsumer();
+
+	/**
+	 * Returns a {@link QuadEmitter} instance that emits directly to the render buffer.
+	 * It remains necessary to call {@link QuadEmitter#emit()} to output the quad.
+	 *
+	 * <p>This method will always be less performant than passing pre-baked meshes
+	 * via {@link #meshConsumer()}. It should be used sparingly for model components that
+	 * demand it - text, icons, dynamic indicators, or other elements that vary too
+	 * much for static baking to be feasible.
+	 *
+	 * <p>Calling this method invalidates any {@link QuadEmitter} returned earlier.
+	 * Will be threadlocal/re-used - do not retain references.
+	 */
+	QuadEmitter getEmitter();
+
+	/**
+	 * Causes all models/quads/meshes sent to this consumer to be transformed by the provided
+	 * {@link QuadTransform} that edits each quad before buffering. Quads in the mesh will
+	 * be passed to the {@link QuadTransform} for modification before offsets, face culling or lighting are applied.
+	 * Meant for animation and mesh customization.
+	 *
+	 * <p>You MUST call {@link #popTransform()} after model is done outputting quads.
+	 *
+	 * <p>More than one transformer can be added to the context.  Transformers are applied in reverse order.
+	 * (Last pushed is applied first.)
+	 *
+	 * <p>Meshes are never mutated by the transformer - only buffered quads. This ensures thread-safe
+	 * use of meshes/models across multiple chunk builders.
+	 *
+	 * <p>Only the renderer should implement or extend this interface.
+	 */
+	void pushTransform(QuadTransform transform);
+
+	/**
+	 * Removes the transformation added by the last call to {@link #pushTransform(QuadTransform)}.
+	 * MUST be called before exiting from {@link FabricBakedModel} .emit... methods.
+	 */
+	void popTransform();
+
+	@FunctionalInterface
+	public interface QuadTransform {
+		/**
+		 * Return false to filter out quads from rendering. When more than one transform
+		 * is in effect, returning false means unapplied transforms will not receive the quad.
+		 */
+		boolean transform(MutableQuadView quad);
+	}
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/impl/renderer/DamageModel.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/impl/renderer/DamageModel.java
@@ -19,51 +19,52 @@ package net.fabricmc.fabric.impl.renderer;
 import java.util.Random;
 import java.util.function.Supplier;
 
-import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
-import net.fabricmc.fabric.api.renderer.v1.RendererAccess;
-import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
-import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
-import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
-import net.fabricmc.fabric.api.renderer.v1.model.ForwardingBakedModel;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.ExtendedBlockView;
 
+import net.fabricmc.fabric.api.renderer.v1.RendererAccess;
+import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
+import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
+import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
+import net.fabricmc.fabric.api.renderer.v1.model.ForwardingBakedModel;
+import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
+
 /**
- * Specialized model wrapper that implements a general-purpose 
- * block-breaking render for enhanced models.<p>
- * 
- * Works by intercepting all model output and redirecting to dynamic
+ * Specialized model wrapper that implements a general-purpose
+ * block-breaking render for enhanced models.
+ *
+ * <p>Works by intercepting all model output and redirecting to dynamic
  * quads that are baked with single-layer, UV-locked damage texture.
  */
 public class DamageModel extends ForwardingBakedModel {
-    static final RenderMaterial DAMAGE_MATERIAL = RendererAccess.INSTANCE.hasRenderer() ? RendererAccess.INSTANCE.getRenderer().materialFinder().find() : null;
-    
-    private DamageTransform damageTransform = new DamageTransform();
-    
-    public void prepare(BakedModel wrappedModel, Sprite sprite, BlockState blockState, BlockPos blockPos) {
-        this.damageTransform.damageSprite = sprite;
-        this.wrapped = wrappedModel;
-    }
-    
-    @Override
-    public void emitBlockQuads(ExtendedBlockView blockView, BlockState state, BlockPos pos, Supplier<Random> randomSupplier, RenderContext context) {
-        context.pushTransform(damageTransform);
-        ((FabricBakedModel)wrapped).emitBlockQuads(blockView, state, pos, randomSupplier, context);
-        context.popTransform();
-    }
-    
-    private static class DamageTransform implements RenderContext.QuadTransform {
-        private Sprite damageSprite;
-        
-        @Override
-        public boolean transform(MutableQuadView quad) {
-            quad.material(DAMAGE_MATERIAL);
-            quad.spriteBake(0, damageSprite, MutableQuadView.BAKE_LOCK_UV);
-            quad.colorIndex(-1);
-            return true;
-        }
-    }
+	static final RenderMaterial DAMAGE_MATERIAL = RendererAccess.INSTANCE.hasRenderer() ? RendererAccess.INSTANCE.getRenderer().materialFinder().find() : null;
+
+	private DamageTransform damageTransform = new DamageTransform();
+
+	public void prepare(BakedModel wrappedModel, Sprite sprite, BlockState blockState, BlockPos blockPos) {
+		this.damageTransform.damageSprite = sprite;
+		this.wrapped = wrappedModel;
+	}
+
+	@Override
+	public void emitBlockQuads(ExtendedBlockView blockView, BlockState state, BlockPos pos, Supplier<Random> randomSupplier, RenderContext context) {
+		context.pushTransform(damageTransform);
+		((FabricBakedModel) wrapped).emitBlockQuads(blockView, state, pos, randomSupplier, context);
+		context.popTransform();
+	}
+
+	private static class DamageTransform implements RenderContext.QuadTransform {
+		private Sprite damageSprite;
+
+		@Override
+		public boolean transform(MutableQuadView quad) {
+			quad.material(DAMAGE_MATERIAL);
+			quad.spriteBake(0, damageSprite, MutableQuadView.BAKE_LOCK_UV);
+			quad.colorIndex(-1);
+			return true;
+		}
+	}
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/impl/renderer/RendererAccessImpl.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/impl/renderer/RendererAccessImpl.java
@@ -19,36 +19,36 @@ package net.fabricmc.fabric.impl.renderer;
 import net.fabricmc.fabric.api.renderer.v1.Renderer;
 import net.fabricmc.fabric.api.renderer.v1.RendererAccess;
 
-public final class RendererAccessImpl implements RendererAccess{
-    public static final RendererAccessImpl INSTANCE = new RendererAccessImpl();
+public final class RendererAccessImpl implements RendererAccess {
+	public static final RendererAccessImpl INSTANCE = new RendererAccessImpl();
 
-    // private constructor
-    private RendererAccessImpl() { };
+	// private constructor
+	private RendererAccessImpl() { }
 
-    @Override
-    public final void registerRenderer(Renderer renderer) {
-        if(renderer == null) {
-            throw new NullPointerException("Attempt to register a NULL rendering plug-in.");
-        } else if(activeRenderer != null) {
-            throw new UnsupportedOperationException("A second rendering plug-in attempted to register. Multiple rendering plug-ins are not supported.");
-        } else {
-            activeRenderer = renderer;
-            hasActiveRenderer = true;
-        }
-    }
+	@Override
+	public void registerRenderer(Renderer renderer) {
+		if (renderer == null) {
+			throw new NullPointerException("Attempt to register a NULL rendering plug-in.");
+		} else if (activeRenderer != null) {
+			throw new UnsupportedOperationException("A second rendering plug-in attempted to register. Multiple rendering plug-ins are not supported.");
+		} else {
+			activeRenderer = renderer;
+			hasActiveRenderer = true;
+		}
+	}
 
-    private Renderer activeRenderer = null;
+	private Renderer activeRenderer = null;
 
-    /** avoids null test every call to {@link #hasRenderer()} */
-    private boolean hasActiveRenderer = false;
+	/** avoids null test every call to {@link #hasRenderer()}. */
+	private boolean hasActiveRenderer = false;
 
-    @Override
-    public final Renderer getRenderer() {
-        return activeRenderer;
-    }
+	@Override
+	public Renderer getRenderer() {
+		return activeRenderer;
+	}
 
-    @Override
-    public final boolean hasRenderer() {
-        return hasActiveRenderer;
-    }
+	@Override
+	public boolean hasRenderer() {
+		return hasActiveRenderer;
+	}
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/impl/renderer/SpriteFinderImpl.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/impl/renderer/SpriteFinderImpl.java
@@ -19,16 +19,17 @@ package net.fabricmc.fabric.impl.renderer;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import net.fabricmc.fabric.api.renderer.v1.model.SpriteFinder;
-import net.fabricmc.fabric.api.renderer.v1.mesh.QuadView;
 import net.minecraft.client.texture.MissingSprite;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.texture.SpriteAtlasTexture;
 import net.minecraft.util.Identifier;
 
+import net.fabricmc.fabric.api.renderer.v1.mesh.QuadView;
+import net.fabricmc.fabric.api.renderer.v1.model.SpriteFinder;
+
 /**
  * Indexes an atlas sprite to allow fast lookup of Sprites from
- * baked vertex coordinates.  Implementation is a straightforward 
+ * baked vertex coordinates.  Implementation is a straightforward
  * quad tree. Other options that were considered were linear search
  * (slow) and direct indexing of fixed-size cells. Direct indexing
  * would be fastest but would be memory-intensive for large atlases
@@ -36,104 +37,112 @@ import net.minecraft.util.Identifier;
  * a fixed cell size.
  */
 public class SpriteFinderImpl implements SpriteFinder {
-    private final Node root;
-    
-    public SpriteFinderImpl(Map<Identifier, Sprite> sprites) {
-        root = new Node(0.5f, 0.5f, 0.25f);
-        sprites.values().forEach(root::add);
-    }
+	private final Node root;
 
-    @Override
-    public Sprite find(QuadView quad, int textureIndex) {
-        float u = 0; 
-        float v = 0;
-        for(int i = 0; i < 4; i++) {
-            u += quad.spriteU(i, textureIndex);
-            v += quad.spriteV(i, textureIndex);
-        }
-        return find(u * 0.25f, v * 0.25f);
-    }
-    
-    @Override
-    public Sprite find(float u, float v) {
-        return root.find(u, v);
-    }
-    
-    private static class Node {
-        final float midU;
-        final float midV;
-        final float cellRadius;
-        Object lowLow = null;
-        Object lowHigh = null;
-        Object highLow = null;
-        Object highHigh = null;
-        
-        Node(float midU, float midV, float radius) {
-            this.midU = midU;
-            this.midV = midV;
-            this.cellRadius = radius;
-        }
-        
-        static final float EPS = 0.00001f;
-        
-        void add(Sprite sprite) {
-            final boolean lowU = sprite.getMinU() < midU - EPS;
-            final boolean highU = sprite.getMaxU() > midU + EPS;
-            final boolean lowV = sprite.getMinV() < midV - EPS;
-            final boolean highV = sprite.getMaxV() > midV + EPS;
-            if(lowU && lowV) {
-                addInner(sprite, lowLow, -1, -1, q -> lowLow = q);
-            }
-            if(lowU && highV) {
-                addInner(sprite, lowHigh, -1, 1, q -> lowHigh = q);
-            }
-            if(highU && lowV) {
-                addInner(sprite, highLow, 1, -1, q -> highLow = q);
-            }
-            if(highU && highV) {
-                addInner(sprite, highHigh, 1, 1, q -> highHigh = q);
-            }
-        }
-        
-        private void addInner(Sprite sprite, Object quadrant, int uStep, int vStep, Consumer<Object> setter) {
-            if(quadrant == null) {
-                setter.accept(sprite);
-            } else if (quadrant instanceof Node) {
-                ((Node)quadrant).add(sprite);
-            } else {
-                Node n = new Node(midU + cellRadius * uStep, midV + cellRadius * vStep, cellRadius * 0.5f);
-                if(quadrant instanceof Sprite) {
-                    n.add((Sprite)quadrant);
-                }
-                n.add(sprite);
-                setter.accept(n);
-            }
-        }
-        
-        private Sprite find(float u, float v) {
-            if(u < midU) {
-                return v < midV ? findInner(lowLow, u, v) : findInner(lowHigh, u, v);
-            } else {
-                return v < midV ? findInner(highLow, u, v) : findInner(highHigh, u, v);
-            }
-        }
-        
-        private Sprite findInner(Object quadrant, float u, float v) {
-            if(quadrant instanceof Sprite) {
-                return (Sprite)quadrant;
-            } else if (quadrant instanceof Node) {
-                return ((Node)quadrant).find(u, v);
-            } else {
-                return MissingSprite.getMissingSprite();
-            }
-        }
-    }
+	public SpriteFinderImpl(Map<Identifier, Sprite> sprites) {
+		root = new Node(0.5f, 0.5f, 0.25f);
+		sprites.values().forEach(root::add);
+	}
 
-    public static SpriteFinderImpl get(SpriteAtlasTexture atlas) {
-        return ((SpriteFinderAccess)atlas).fabric_spriteFinder();
-    }
-    
-    public static interface SpriteFinderAccess {
-        SpriteFinderImpl fabric_spriteFinder();
-    }
+	@Override
+	public Sprite find(QuadView quad, int textureIndex) {
+		float u = 0;
+		float v = 0;
+
+		for (int i = 0; i < 4; i++) {
+			u += quad.spriteU(i, textureIndex);
+			v += quad.spriteV(i, textureIndex);
+		}
+
+		return find(u * 0.25f, v * 0.25f);
+	}
+
+	@Override
+	public Sprite find(float u, float v) {
+		return root.find(u, v);
+	}
+
+	private static class Node {
+		final float midU;
+		final float midV;
+		final float cellRadius;
+		Object lowLow = null;
+		Object lowHigh = null;
+		Object highLow = null;
+		Object highHigh = null;
+
+		Node(float midU, float midV, float radius) {
+			this.midU = midU;
+			this.midV = midV;
+			this.cellRadius = radius;
+		}
+
+		static final float EPS = 0.00001f;
+
+		void add(Sprite sprite) {
+			final boolean lowU = sprite.getMinU() < midU - EPS;
+			final boolean highU = sprite.getMaxU() > midU + EPS;
+			final boolean lowV = sprite.getMinV() < midV - EPS;
+			final boolean highV = sprite.getMaxV() > midV + EPS;
+
+			if (lowU && lowV) {
+				addInner(sprite, lowLow, -1, -1, q -> lowLow = q);
+			}
+
+			if (lowU && highV) {
+				addInner(sprite, lowHigh, -1, 1, q -> lowHigh = q);
+			}
+
+			if (highU && lowV) {
+				addInner(sprite, highLow, 1, -1, q -> highLow = q);
+			}
+
+			if (highU && highV) {
+				addInner(sprite, highHigh, 1, 1, q -> highHigh = q);
+			}
+		}
+
+		private void addInner(Sprite sprite, Object quadrant, int uStep, int vStep, Consumer<Object> setter) {
+			if (quadrant == null) {
+				setter.accept(sprite);
+			} else if (quadrant instanceof Node) {
+				((Node) quadrant).add(sprite);
+			} else {
+				Node n = new Node(midU + cellRadius * uStep, midV + cellRadius * vStep, cellRadius * 0.5f);
+
+				if (quadrant instanceof Sprite) {
+					n.add((Sprite) quadrant);
+				}
+
+				n.add(sprite);
+				setter.accept(n);
+			}
+		}
+
+		private Sprite find(float u, float v) {
+			if (u < midU) {
+				return v < midV ? findInner(lowLow, u, v) : findInner(lowHigh, u, v);
+			} else {
+				return v < midV ? findInner(highLow, u, v) : findInner(highHigh, u, v);
+			}
+		}
+
+		private Sprite findInner(Object quadrant, float u, float v) {
+			if (quadrant instanceof Sprite) {
+				return (Sprite) quadrant;
+			} else if (quadrant instanceof Node) {
+				return ((Node) quadrant).find(u, v);
+			} else {
+				return MissingSprite.getMissingSprite();
+			}
+		}
+	}
+
+	public static SpriteFinderImpl get(SpriteAtlasTexture atlas) {
+		return ((SpriteFinderAccess) atlas).fabric_spriteFinder();
+	}
+
+	public interface SpriteFinderAccess {
+		SpriteFinderImpl fabric_spriteFinder();
+	}
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinBakedModel.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinBakedModel.java
@@ -19,33 +19,34 @@ package net.fabricmc.fabric.mixin.renderer.client;
 import java.util.Random;
 import java.util.function.Supplier;
 
-import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
-import net.minecraft.world.ExtendedBlockView;
 import org.spongepowered.asm.mixin.Mixin;
 
-import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.ExtendedBlockView;
+
+import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
+import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
 
 /**
  * Avoids instanceof checks and enables consistent code path for all baked models.
  */
 @Mixin(BakedModel.class)
 public interface MixinBakedModel extends FabricBakedModel {
-    @Override
-    public default boolean isVanillaAdapter() {
-        return true;
-    }
-    
-    @Override
-    public default void emitBlockQuads(ExtendedBlockView blockView, BlockState state, BlockPos pos, Supplier<Random> randomSupplier, RenderContext context) {
-        context.fallbackConsumer().accept((BakedModel)this);
-    }
-    
-    @Override
-    default void emitItemQuads(ItemStack stack, Supplier<Random> randomSupplier, RenderContext context) {
-        context.fallbackConsumer().accept((BakedModel)this);        
-    }
+	@Override
+	default boolean isVanillaAdapter() {
+		return true;
+	}
+
+	@Override
+	default void emitBlockQuads(ExtendedBlockView blockView, BlockState state, BlockPos pos, Supplier<Random> randomSupplier, RenderContext context) {
+		context.fallbackConsumer().accept((BakedModel) this);
+	}
+
+	@Override
+	default void emitItemQuads(ItemStack stack, Supplier<Random> randomSupplier, RenderContext context) {
+		context.fallbackConsumer().accept((BakedModel) this);
+	}
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinBlockRenderManager.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinBlockRenderManager.java
@@ -67,7 +67,7 @@ public abstract class MixinBlockRenderManager {
 	private void hookTesselateDamage(BlockState blockState, BlockPos blockPos, Sprite sprite, ExtendedBlockView blockView, CallbackInfo ci) {
 		MutablePair<DamageModel, BakedModel> damageState = DAMAGE_STATE.get();
 
-		if (damageState.right != null && !((FabricBakedModel)damageState.right).isVanillaAdapter()) {
+		if (damageState.right != null && !((FabricBakedModel) damageState.right).isVanillaAdapter()) {
 			damageState.left.prepare(damageState.right, sprite, blockState, blockPos);
 			this.renderer.tesselate(blockView, damageState.left, blockState, blockPos, Tessellator.getInstance().getBufferBuilder(), true, this.random, blockState.getRenderingSeed(blockPos));
 			ci.cancel();

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinBlockRenderManager.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinBlockRenderManager.java
@@ -18,7 +18,6 @@ package net.fabricmc.fabric.mixin.renderer.client;
 
 import java.util.Random;
 
-import net.fabricmc.fabric.impl.renderer.DamageModel;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -27,7 +26,6 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.render.Tessellator;
 import net.minecraft.client.render.block.BlockModelRenderer;
@@ -37,38 +35,42 @@ import net.minecraft.client.texture.Sprite;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.ExtendedBlockView;
 
+import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
+import net.fabricmc.fabric.impl.renderer.DamageModel;
+
 /**
  * Implements hook for block-breaking render.
  */
 @Mixin(BlockRenderManager.class)
 public abstract class MixinBlockRenderManager {
-    @Shadow private BlockModelRenderer renderer;
-    @Shadow private Random random;
-    
-    private static final ThreadLocal<MutablePair<DamageModel, BakedModel>> DAMAGE_STATE = ThreadLocal.withInitial(() -> MutablePair.of(new DamageModel(), null));
-    
-    /**
-     * Intercept the model assignment from getModel() - simpler than capturing entire LVT.
-     */
-    @ModifyVariable(method = "tesselateDamage", at = @At(value = "STORE", ordinal = 0), allow = 1, require = 1)
-    private BakedModel hookTesselateDamageModel(BakedModel modelIn) {
-        DAMAGE_STATE.get().right = modelIn;
-        return modelIn;
-    }
-    
-    /**
-     * If the model we just captured is a fabric model, render it using a specialized 
-     * damage render context and cancel rest of the logic. Avoids creating a bunch of
-     * vanilla quads for complex meshes and honors dynamic model geometry.
-     */
-    @Inject(method = "tesselateDamage", cancellable = true, 
-            at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/client/render/block/BlockModels;getModel(Lnet/minecraft/block/BlockState;)Lnet/minecraft/client/render/model/BakedModel;"))
-    private void hookTesselateDamage(BlockState blockState, BlockPos blockPos, Sprite sprite, ExtendedBlockView blockView, CallbackInfo ci) {
-        MutablePair<DamageModel, BakedModel> damageState = DAMAGE_STATE.get();
-        if(damageState.right != null && !((FabricBakedModel)damageState.right).isVanillaAdapter()) {
-            damageState.left.prepare(damageState.right, sprite, blockState, blockPos);
-            this.renderer.tesselate(blockView, damageState.left, blockState, blockPos, Tessellator.getInstance().getBufferBuilder(), true, this.random, blockState.getRenderingSeed(blockPos));
-            ci.cancel();
-        }
-    }
+	@Shadow private BlockModelRenderer renderer;
+	@Shadow private Random random;
+
+	private static final ThreadLocal<MutablePair<DamageModel, BakedModel>> DAMAGE_STATE = ThreadLocal.withInitial(() -> MutablePair.of(new DamageModel(), null));
+
+	/**
+	 * Intercept the model assignment from getModel() - simpler than capturing entire LVT.
+	 */
+	@ModifyVariable(method = "tesselateDamage", at = @At(value = "STORE", ordinal = 0), allow = 1, require = 1)
+	private BakedModel hookTesselateDamageModel(BakedModel modelIn) {
+		DAMAGE_STATE.get().right = modelIn;
+		return modelIn;
+	}
+
+	/**
+	 * If the model we just captured is a fabric model, render it using a specialized
+	 * damage render context and cancel rest of the logic. Avoids creating a bunch of
+	 * vanilla quads for complex meshes and honors dynamic model geometry.
+	 */
+	@Inject(method = "tesselateDamage", cancellable = true,
+			at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/client/render/block/BlockModels;getModel(Lnet/minecraft/block/BlockState;)Lnet/minecraft/client/render/model/BakedModel;"))
+	private void hookTesselateDamage(BlockState blockState, BlockPos blockPos, Sprite sprite, ExtendedBlockView blockView, CallbackInfo ci) {
+		MutablePair<DamageModel, BakedModel> damageState = DAMAGE_STATE.get();
+
+		if (damageState.right != null && !((FabricBakedModel)damageState.right).isVanillaAdapter()) {
+			damageState.left.prepare(damageState.right, sprite, blockState, blockPos);
+			this.renderer.tesselate(blockView, damageState.left, blockState, blockPos, Tessellator.getInstance().getBufferBuilder(), true, this.random, blockState.getRenderingSeed(blockPos));
+			ci.cancel();
+		}
+	}
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinDebugHud.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinDebugHud.java
@@ -16,14 +16,16 @@
 
 package net.fabricmc.fabric.mixin.renderer.client;
 
-import net.fabricmc.fabric.api.renderer.v1.RendererAccess;
-import net.minecraft.client.gui.hud.DebugHud;
+import java.util.List;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.List;
+import net.minecraft.client.gui.hud.DebugHud;
+
+import net.fabricmc.fabric.api.renderer.v1.RendererAccess;
 
 @Mixin(DebugHud.class)
 public class MixinDebugHud {

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinSpriteAtlasTexture.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinSpriteAtlasTexture.java
@@ -18,7 +18,6 @@ package net.fabricmc.fabric.mixin.renderer.client;
 
 import java.util.Map;
 
-import net.fabricmc.fabric.impl.renderer.SpriteFinderImpl;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -29,24 +28,29 @@ import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.texture.SpriteAtlasTexture;
 import net.minecraft.util.Identifier;
 
+import net.fabricmc.fabric.impl.renderer.SpriteFinderImpl;
+
 @Mixin(SpriteAtlasTexture.class)
 public class MixinSpriteAtlasTexture implements SpriteFinderImpl.SpriteFinderAccess {
-    @Shadow private Map<Identifier, Sprite> sprites;
-    
-    private SpriteFinderImpl fabric_spriteFinder = null;
-    
-    @Inject(at = @At("RETURN"), method = "upload")
-    private void uploadHook(SpriteAtlasTexture.Data input, CallbackInfo info) {
-        fabric_spriteFinder = null;
-    }
+	@Shadow
+	private Map<Identifier, Sprite> sprites;
 
-    @Override
-    public SpriteFinderImpl fabric_spriteFinder() {
-        SpriteFinderImpl result = fabric_spriteFinder;
-        if(result == null) {
-            result = new SpriteFinderImpl(sprites);
-            fabric_spriteFinder = result;
-        }
-        return result;
-    }
+	private SpriteFinderImpl fabric_spriteFinder = null;
+
+	@Inject(at = @At("RETURN"), method = "upload")
+	private void uploadHook(SpriteAtlasTexture.Data input, CallbackInfo info) {
+		fabric_spriteFinder = null;
+	}
+
+	@Override
+	public SpriteFinderImpl fabric_spriteFinder() {
+		SpriteFinderImpl result = fabric_spriteFinder;
+
+		if (result == null) {
+			result = new SpriteFinderImpl(sprites);
+			fabric_spriteFinder = result;
+		}
+
+		return result;
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/Indigo.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/Indigo.java
@@ -16,15 +16,6 @@
 
 package net.fabricmc.indigo;
 
-import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.renderer.v1.RendererAccess;
-import net.fabricmc.fabric.api.util.TriState;
-import net.fabricmc.indigo.renderer.IndigoRenderer;
-import net.fabricmc.indigo.renderer.aocalc.AoConfig;
-import net.fabricmc.loader.api.FabricLoader;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -32,31 +23,41 @@ import java.io.IOException;
 import java.util.Locale;
 import java.util.Properties;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.renderer.v1.RendererAccess;
+import net.fabricmc.fabric.api.util.TriState;
+import net.fabricmc.indigo.renderer.IndigoRenderer;
+import net.fabricmc.indigo.renderer.aocalc.AoConfig;
+import net.fabricmc.loader.api.FabricLoader;
+
 public class Indigo implements ClientModInitializer {
 	public static final boolean ALWAYS_TESSELATE_INDIGO;
 	public static final boolean ENSURE_VERTEX_FORMAT_COMPATIBILITY;
 	public static final AoConfig AMBIENT_OCCLUSION_MODE;
-	/** Set true in dev env to confirm results match vanilla when they should */
+	/** Set true in dev env to confirm results match vanilla when they should. */
 	public static final boolean DEBUG_COMPARE_LIGHTING;
 	public static final boolean FIX_SMOOTH_LIGHTING_OFFSET;
 	public static final boolean FIX_EXTERIOR_VERTEX_LIGHTING;
 	public static final boolean FIX_LUMINOUS_AO_SHADE;
-	
+
 	public static final Logger LOGGER = LogManager.getLogger();
 
 	private static boolean asBoolean(String property, boolean defValue) {
 		switch (asTriState(property)) {
-			case TRUE:
-				return true;
-			case FALSE:
-				return false;
-			default:
-				return defValue;
+		case TRUE:
+			return true;
+		case FALSE:
+			return false;
+		default:
+			return defValue;
 		}
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
-    private static <T extends Enum> T asEnum(String property, T defValue) {
+	private static <T extends Enum> T asEnum(String property, T defValue) {
 		if (property == null || property.isEmpty()) {
 			return defValue;
 		} else {
@@ -76,19 +77,20 @@ public class Indigo implements ClientModInitializer {
 			return TriState.DEFAULT;
 		} else {
 			switch (property.toLowerCase(Locale.ROOT)) {
-				case "true":
-					return TriState.TRUE;
-				case "false":
-					return TriState.FALSE;
-				case "auto":
-				default:
-					return TriState.DEFAULT;
+			case "true":
+				return TriState.TRUE;
+			case "false":
+				return TriState.FALSE;
+			case "auto":
+			default:
+				return TriState.DEFAULT;
 			}
 		}
 	}
 
 	static {
 		File configDir = new File(FabricLoader.getInstance().getConfigDirectory(), "fabric");
+
 		if (!configDir.exists()) {
 			if (!configDir.mkdir()) {
 				LOGGER.warn("[Indigo] Could not create configuration directory: " + configDir.getAbsolutePath());
@@ -97,6 +99,7 @@ public class Indigo implements ClientModInitializer {
 
 		File configFile = new File(configDir, "indigo-renderer.properties");
 		Properties properties = new Properties();
+
 		if (configFile.exists()) {
 			try (FileInputStream stream = new FileInputStream(configFile)) {
 				properties.load(stream);
@@ -114,7 +117,7 @@ public class Indigo implements ClientModInitializer {
 		FIX_SMOOTH_LIGHTING_OFFSET = asBoolean((String) properties.computeIfAbsent("fix-smooth-lighting-offset", (a) -> "auto"), true);
 		FIX_EXTERIOR_VERTEX_LIGHTING = asBoolean((String) properties.computeIfAbsent("fix-exterior-vertex-lighting", (a) -> "auto"), true);
 		FIX_LUMINOUS_AO_SHADE = asBoolean((String) properties.computeIfAbsent("fix-luminous-block-ambient-occlusion", (a) -> "auto"), false);
-		
+
 		try (FileOutputStream stream = new FileOutputStream(configFile)) {
 			properties.store(stream, "Indigo properties file");
 		} catch (IOException e) {
@@ -122,16 +125,18 @@ public class Indigo implements ClientModInitializer {
 		}
 	}
 
-    @Override
-    public void onInitializeClient() {
-    	if (IndigoMixinConfigPlugin.shouldApplyIndigo()) {
-		    LOGGER.info("[Indigo] Registering Indigo renderer!");
-		    if(IndigoMixinConfigPlugin.shouldForceCompatibility()) {
-		    	LOGGER.info("[Indigo] Compatibility mode enabled.");
-		    }
-		    RendererAccess.INSTANCE.registerRenderer(IndigoRenderer.INSTANCE);
-	    } else {
-    		LOGGER.info("[Indigo] Different rendering plugin detected; not applying Indigo.");
-	    }
-    }
+	@Override
+	public void onInitializeClient() {
+		if (IndigoMixinConfigPlugin.shouldApplyIndigo()) {
+			LOGGER.info("[Indigo] Registering Indigo renderer!");
+
+			if (IndigoMixinConfigPlugin.shouldForceCompatibility()) {
+				LOGGER.info("[Indigo] Compatibility mode enabled.");
+			}
+
+			RendererAccess.INSTANCE.registerRenderer(IndigoRenderer.INSTANCE);
+		} else {
+			LOGGER.info("[Indigo] Different rendering plugin detected; not applying Indigo.");
+		}
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/IndigoConfig.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/IndigoConfig.java
@@ -16,6 +16,4 @@
 
 package net.fabricmc.indigo;
 
-public class IndigoConfig {
-
-}
+public class IndigoConfig { }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/IndigoMixinConfigPlugin.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/IndigoMixinConfigPlugin.java
@@ -16,55 +16,56 @@
 
 package net.fabricmc.indigo;
 
-import net.fabricmc.loader.api.FabricLoader;
-import net.fabricmc.loader.api.ModContainer;
-import net.fabricmc.loader.api.metadata.ModMetadata;
+import java.util.List;
+import java.util.Set;
 
 import org.spongepowered.asm.lib.tree.ClassNode;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 
-import java.util.List;
-import java.util.Set;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.metadata.ModMetadata;
 
 public class IndigoMixinConfigPlugin implements IMixinConfigPlugin {
-    /** Set by other renderers to disable loading of Indigo */
+	/** Set by other renderers to disable loading of Indigo. */
 	private static final String JSON_KEY_DISABLE_INDIGO = "fabric-renderer-api-v1:contains_renderer";
-	/** Disables vanilla block tesselation and ensures vertex format compatibility */
+	/** Disables vanilla block tesselation and ensures vertex format compatibility. */
 	private static final String JSON_KEY_FORCE_COMPATIBILITY = "fabric-renderer-indigo:force_compatibility";
-	
+
 	private static boolean needsLoad = true;
-	
+
 	private static boolean indigoApplicable = true;
 	private static boolean forceCompatibility = false;
 
 	private static void loadIfNeeded() {
-	    if(needsLoad) {
-	        for (ModContainer container : FabricLoader.getInstance().getAllMods()) {
-	            final ModMetadata meta = container.getMetadata();
-	            if (meta.containsCustomValue(JSON_KEY_DISABLE_INDIGO)) {
-	                indigoApplicable = false;
-	            } else if (meta.containsCustomValue(JSON_KEY_FORCE_COMPATIBILITY)) {
-	                forceCompatibility = true;
-	            }
-	        }
-	        needsLoad = false;
-	    }
+		if (needsLoad) {
+			for (ModContainer container : FabricLoader.getInstance().getAllMods()) {
+				final ModMetadata meta = container.getMetadata();
+
+				if (meta.containsCustomValue(JSON_KEY_DISABLE_INDIGO)) {
+					indigoApplicable = false;
+				} else if (meta.containsCustomValue(JSON_KEY_FORCE_COMPATIBILITY)) {
+					forceCompatibility = true;
+				}
+			}
+
+			needsLoad = false;
+		}
 	}
+
 	static boolean shouldApplyIndigo() {
-	    loadIfNeeded();
+		loadIfNeeded();
 		return indigoApplicable;
 	}
 
-   static boolean shouldForceCompatibility() {
-        loadIfNeeded();
-        return forceCompatibility;
-    }
-	   
-	@Override
-	public void onLoad(String mixinPackage) {
-
+	static boolean shouldForceCompatibility() {
+		loadIfNeeded();
+		return forceCompatibility;
 	}
+
+	@Override
+	public void onLoad(String mixinPackage) { }
 
 	@Override
 	public String getRefMapperConfig() {
@@ -77,9 +78,7 @@ public class IndigoMixinConfigPlugin implements IMixinConfigPlugin {
 	}
 
 	@Override
-	public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
-
-	}
+	public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) { }
 
 	@Override
 	public List<String> getMixins() {
@@ -87,12 +86,8 @@ public class IndigoMixinConfigPlugin implements IMixinConfigPlugin {
 	}
 
 	@Override
-	public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
-
-	}
+	public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) { }
 
 	@Override
-	public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
-
-	}
+	public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) { }
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/IndigoRenderer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/IndigoRenderer.java
@@ -18,52 +18,53 @@ package net.fabricmc.indigo.renderer;
 
 import java.util.HashMap;
 
+import net.minecraft.util.Identifier;
+
 import net.fabricmc.fabric.api.renderer.v1.Renderer;
 import net.fabricmc.fabric.api.renderer.v1.material.MaterialFinder;
 import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
 import net.fabricmc.fabric.api.renderer.v1.mesh.MeshBuilder;
 import net.fabricmc.indigo.renderer.RenderMaterialImpl.Value;
 import net.fabricmc.indigo.renderer.mesh.MeshBuilderImpl;
-import net.minecraft.util.Identifier;
 
 /**
  * The Fabric default renderer implementation. Supports all
  * features defined in the API except shaders and offers no special materials.
  */
 public class IndigoRenderer implements Renderer {
-    public static final IndigoRenderer INSTANCE = new IndigoRenderer();
-    
-    public static final RenderMaterialImpl.Value MATERIAL_STANDARD = (Value) INSTANCE.materialFinder().find();
-    
-    static {
-        INSTANCE.registerMaterial(RenderMaterial.MATERIAL_STANDARD, MATERIAL_STANDARD);
-    }
-    
-    private final HashMap<Identifier, RenderMaterial> materialMap = new HashMap<>();
-    
-    private IndigoRenderer() { };
+	public static final IndigoRenderer INSTANCE = new IndigoRenderer();
 
-    @Override
-    public MeshBuilder meshBuilder() {
-        return new MeshBuilderImpl();
-    }
-  
-    @Override
-    public MaterialFinder materialFinder() {
-        return new RenderMaterialImpl.Finder();
-    }
+	public static final RenderMaterialImpl.Value MATERIAL_STANDARD = (Value) INSTANCE.materialFinder().find();
 
-    @Override
-    public RenderMaterial materialById(Identifier id) {
-        return materialMap.get(id);
-    }
+	static {
+		INSTANCE.registerMaterial(RenderMaterial.MATERIAL_STANDARD, MATERIAL_STANDARD);
+	}
 
-    @Override
-    public boolean registerMaterial(Identifier id, RenderMaterial material) {
-        if(materialMap.containsKey(id))
-            return false;
-        // cast to prevent acceptance of impostor implementations
-        materialMap.put(id, material);
-        return true;
-    }
+	private final HashMap<Identifier, RenderMaterial> materialMap = new HashMap<>();
+
+	private IndigoRenderer() { }
+
+	@Override
+	public MeshBuilder meshBuilder() {
+		return new MeshBuilderImpl();
+	}
+
+	@Override
+	public MaterialFinder materialFinder() {
+		return new RenderMaterialImpl.Finder();
+	}
+
+	@Override
+	public RenderMaterial materialById(Identifier id) {
+		return materialMap.get(id);
+	}
+
+	@Override
+	public boolean registerMaterial(Identifier id, RenderMaterial material) {
+		if (materialMap.containsKey(id)) return false;
+
+		// cast to prevent acceptance of impostor implementations
+		materialMap.put(id, material);
+		return true;
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/RenderMaterialImpl.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/RenderMaterialImpl.java
@@ -18,9 +18,11 @@ package net.fabricmc.indigo.renderer;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+
+import net.minecraft.block.BlockRenderLayer;
+
 import net.fabricmc.fabric.api.renderer.v1.material.MaterialFinder;
 import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
-import net.minecraft.block.BlockRenderLayer;
 
 /**
  * Default implementation of the standard render materials.
@@ -29,157 +31,160 @@ import net.minecraft.block.BlockRenderLayer;
  * easy/fast interning via int/object hashmap.
  */
 public abstract class RenderMaterialImpl {
-	/** zero position (default value) will be NULL */
-    private static final BlockRenderLayer[] BLEND_MODES = new BlockRenderLayer[5];
+	/** zero position (default value) will be NULL. */
+	private static final BlockRenderLayer[] BLEND_MODES = new BlockRenderLayer[5];
 
-    
-    /**
-     * Indigo currently support up to 3 sprite layers but is configured to recognize only one.
-     */
-    public static final int MAX_SPRITE_DEPTH = 1;
-    
-    private static final int TEXTURE_DEPTH_MASK = 3;
-    private static final int TEXTURE_DEPTH_SHIFT = 0;
-    
-    private static final int BLEND_MODE_MASK = 7;
-    private static final int[] BLEND_MODE_SHIFT = new int[3];
-    private static final int[] COLOR_DISABLE_FLAGS = new int[3];
-    private static final int[] EMISSIVE_FLAGS = new int[3];
-    private static final int[] DIFFUSE_FLAGS = new int[3];
-    private static final int[] AO_FLAGS = new int[3];
-    
-    static {
-	    System.arraycopy(BlockRenderLayer.values(), 0, BLEND_MODES, 1, 4);
+	/**
+	 * Indigo currently support up to 3 sprite layers but is configured to recognize only one.
+	 */
+	public static final int MAX_SPRITE_DEPTH = 1;
 
-        int shift = Integer.bitCount(TEXTURE_DEPTH_MASK);
-        for(int i = 0; i < 3; i++) {
-            BLEND_MODE_SHIFT[i] = shift;
-            shift += Integer.bitCount(BLEND_MODE_MASK);
-            COLOR_DISABLE_FLAGS[i] = 1 << shift++;
-            EMISSIVE_FLAGS[i] = 1 << shift++;
-            DIFFUSE_FLAGS[i] = 1 << shift++;
-            AO_FLAGS[i] = 1 << shift++;
-        }
-    }
-    
-    static private final ObjectArrayList<Value> LIST = new ObjectArrayList<>();
-    static private final Int2ObjectOpenHashMap<Value> MAP = new Int2ObjectOpenHashMap<>();
-    
-    public static RenderMaterialImpl.Value byIndex(int index) {
-        return LIST.get(index);
-    }
-    
-    protected int bits;
-    
-    public BlockRenderLayer blendMode(int textureIndex) {
-        return BLEND_MODES[(bits >> BLEND_MODE_SHIFT[textureIndex]) & BLEND_MODE_MASK];
-    }
-    
-    public boolean disableColorIndex(int textureIndex) {
-        return (bits & COLOR_DISABLE_FLAGS[textureIndex]) != 0;
-    }
-    
-    public int spriteDepth() {
-        return 1 + ((bits >> TEXTURE_DEPTH_SHIFT) & TEXTURE_DEPTH_MASK);
-    }
-    
-    public boolean emissive(int textureIndex) {
-        return (bits & EMISSIVE_FLAGS[textureIndex]) != 0;
-    }
-    
-    public boolean disableDiffuse(int textureIndex) {
-        return (bits & DIFFUSE_FLAGS[textureIndex]) != 0;
-    }
+	private static final int TEXTURE_DEPTH_MASK = 3;
+	private static final int TEXTURE_DEPTH_SHIFT = 0;
 
-    public boolean disableAo(int textureIndex) {
-        return (bits & AO_FLAGS[textureIndex]) != 0;
-    }
-    
-    public static class Value extends RenderMaterialImpl implements RenderMaterial {
-        private final int index;
-        
-        /** True if any texture wants AO shading.  Simplifies check made by renderer at buffer-time. */
-        public final boolean hasAo;
-        
-        /** True if any texture wants emissive lighting.  Simplifies check made by renderer at buffer-time. */
-        public final boolean hasEmissive;
-        
-        private Value(int index, int bits) {
-            this.index = index;
-            this.bits = bits;
-            hasAo = !disableAo(0) 
-                    || (spriteDepth() > 1 && !disableAo(1))
-                    || (spriteDepth() == 3 && !disableAo(2));
-            hasEmissive = emissive(0) || emissive(1) || emissive(2);
-        }   
-        
-        public int index() {
-            return index;
-        }
-    }
-    
-    public static class Finder extends RenderMaterialImpl implements MaterialFinder {
-        @Override
-        public synchronized RenderMaterial find() {
-            Value result = MAP.get(bits);
-            if(result == null) {
-                result = new Value(LIST.size(), bits);
-                LIST.add(result);
-                MAP.put(bits, result);
-            }
-            return result;
-        }
+	private static final int BLEND_MODE_MASK = 7;
+	private static final int[] BLEND_MODE_SHIFT = new int[3];
+	private static final int[] COLOR_DISABLE_FLAGS = new int[3];
+	private static final int[] EMISSIVE_FLAGS = new int[3];
+	private static final int[] DIFFUSE_FLAGS = new int[3];
+	private static final int[] AO_FLAGS = new int[3];
 
-        @Override
-        public MaterialFinder clear() {
-            bits = 0;
-            return this;
-        }
-        
-        @Override
-        public MaterialFinder blendMode(int textureIndex, BlockRenderLayer blendMode) {
-            final int shift = BLEND_MODE_SHIFT[textureIndex];
-            // zero position is null (default) value
-            final int ordinal = blendMode == null ? 0 : blendMode.ordinal() + 1;
-            bits = (bits & ~(BLEND_MODE_MASK << shift)) | (ordinal << shift);
-            return this;
-        }
+	static {
+		System.arraycopy(BlockRenderLayer.values(), 0, BLEND_MODES, 1, 4);
 
-        @Override
-        public MaterialFinder disableColorIndex(int textureIndex, boolean disable) {
-            final int flag = COLOR_DISABLE_FLAGS[textureIndex];
-            bits = disable ? (bits | flag) : (bits & ~flag);
-            return this;
-        }
+		int shift = Integer.bitCount(TEXTURE_DEPTH_MASK);
 
-        @Override
-        public MaterialFinder spriteDepth(int depth) {
-            if(depth < 1 || depth > MAX_SPRITE_DEPTH) {
-                throw new IndexOutOfBoundsException("Invalid sprite depth: " + depth);
-            }
-            bits = (bits & ~(TEXTURE_DEPTH_MASK << TEXTURE_DEPTH_SHIFT)) | (--depth << TEXTURE_DEPTH_SHIFT);
-            return this;
-        }
+		for (int i = 0; i < 3; i++) {
+			BLEND_MODE_SHIFT[i] = shift;
+			shift += Integer.bitCount(BLEND_MODE_MASK);
+			COLOR_DISABLE_FLAGS[i] = 1 << shift++;
+			EMISSIVE_FLAGS[i] = 1 << shift++;
+			DIFFUSE_FLAGS[i] = 1 << shift++;
+			AO_FLAGS[i] = 1 << shift++;
+		}
+	}
 
-        @Override
-        public MaterialFinder emissive(int textureIndex, boolean isEmissive) {
-            final int flag = EMISSIVE_FLAGS[textureIndex];
-            bits = isEmissive ? (bits | flag) : (bits & ~flag);
-            return this;
-        }
+	private static final ObjectArrayList<Value> LIST = new ObjectArrayList<>();
+	private static final Int2ObjectOpenHashMap<Value> MAP = new Int2ObjectOpenHashMap<>();
 
-        @Override
-        public MaterialFinder disableDiffuse(int textureIndex, boolean disable) {
-            final int flag = DIFFUSE_FLAGS[textureIndex];
-            bits = disable ? (bits | flag) : (bits & ~flag);
-            return this;
-        }
+	public static RenderMaterialImpl.Value byIndex(int index) {
+		return LIST.get(index);
+	}
 
-        @Override
-        public MaterialFinder disableAo(int textureIndex, boolean disable) {
-            final int flag = AO_FLAGS[textureIndex];
-            bits = disable ? (bits | flag) : (bits & ~flag);
-            return this;
-        }
-    }
+	protected int bits;
+
+	public BlockRenderLayer blendMode(int textureIndex) {
+		return BLEND_MODES[(bits >> BLEND_MODE_SHIFT[textureIndex]) & BLEND_MODE_MASK];
+	}
+
+	public boolean disableColorIndex(int textureIndex) {
+		return (bits & COLOR_DISABLE_FLAGS[textureIndex]) != 0;
+	}
+
+	public int spriteDepth() {
+		return 1 + ((bits >> TEXTURE_DEPTH_SHIFT) & TEXTURE_DEPTH_MASK);
+	}
+
+	public boolean emissive(int textureIndex) {
+		return (bits & EMISSIVE_FLAGS[textureIndex]) != 0;
+	}
+
+	public boolean disableDiffuse(int textureIndex) {
+		return (bits & DIFFUSE_FLAGS[textureIndex]) != 0;
+	}
+
+	public boolean disableAo(int textureIndex) {
+		return (bits & AO_FLAGS[textureIndex]) != 0;
+	}
+
+	public static class Value extends RenderMaterialImpl implements RenderMaterial {
+		private final int index;
+
+		/** True if any texture wants AO shading.  Simplifies check made by renderer at buffer-time. */
+		public final boolean hasAo;
+
+		/** True if any texture wants emissive lighting.  Simplifies check made by renderer at buffer-time. */
+		public final boolean hasEmissive;
+
+		private Value(int index, int bits) {
+			this.index = index;
+			this.bits = bits;
+			hasAo = !disableAo(0)
+					|| (spriteDepth() > 1 && !disableAo(1))
+					|| (spriteDepth() == 3 && !disableAo(2));
+			hasEmissive = emissive(0) || emissive(1) || emissive(2);
+		}
+
+		public int index() {
+			return index;
+		}
+	}
+
+	public static class Finder extends RenderMaterialImpl implements MaterialFinder {
+		@Override
+		public synchronized RenderMaterial find() {
+			Value result = MAP.get(bits);
+
+			if (result == null) {
+				result = new Value(LIST.size(), bits);
+				LIST.add(result);
+				MAP.put(bits, result);
+			}
+
+			return result;
+		}
+
+		@Override
+		public MaterialFinder clear() {
+			bits = 0;
+			return this;
+		}
+
+		@Override
+		public MaterialFinder blendMode(int textureIndex, BlockRenderLayer blendMode) {
+			final int shift = BLEND_MODE_SHIFT[textureIndex];
+			// zero position is null (default) value
+			final int ordinal = blendMode == null ? 0 : blendMode.ordinal() + 1;
+			bits = (bits & ~(BLEND_MODE_MASK << shift)) | (ordinal << shift);
+			return this;
+		}
+
+		@Override
+		public MaterialFinder disableColorIndex(int textureIndex, boolean disable) {
+			final int flag = COLOR_DISABLE_FLAGS[textureIndex];
+			bits = disable ? (bits | flag) : (bits & ~flag);
+			return this;
+		}
+
+		@Override
+		public MaterialFinder spriteDepth(int depth) {
+			if (depth < 1 || depth > MAX_SPRITE_DEPTH) {
+				throw new IndexOutOfBoundsException("Invalid sprite depth: " + depth);
+			}
+
+			bits = (bits & ~(TEXTURE_DEPTH_MASK << TEXTURE_DEPTH_SHIFT)) | (--depth << TEXTURE_DEPTH_SHIFT);
+			return this;
+		}
+
+		@Override
+		public MaterialFinder emissive(int textureIndex, boolean isEmissive) {
+			final int flag = EMISSIVE_FLAGS[textureIndex];
+			bits = isEmissive ? (bits | flag) : (bits & ~flag);
+			return this;
+		}
+
+		@Override
+		public MaterialFinder disableDiffuse(int textureIndex, boolean disable) {
+			final int flag = DIFFUSE_FLAGS[textureIndex];
+			bits = disable ? (bits | flag) : (bits & ~flag);
+			return this;
+		}
+
+		@Override
+		public MaterialFinder disableAo(int textureIndex, boolean disable) {
+			final int flag = AO_FLAGS[textureIndex];
+			bits = disable ? (bits | flag) : (bits & ~flag);
+			return this;
+		}
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/accessor/AccessBufferBuilder.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/accessor/AccessBufferBuilder.java
@@ -19,5 +19,5 @@ package net.fabricmc.indigo.renderer.accessor;
 import net.fabricmc.indigo.renderer.mesh.QuadViewImpl;
 
 public interface AccessBufferBuilder {
-    void fabric_putQuad(QuadViewImpl quad);
+	void fabric_putQuad(QuadViewImpl quad);
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/accessor/AccessChunkRenderer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/accessor/AccessChunkRenderer.java
@@ -20,5 +20,5 @@ import net.minecraft.client.render.BufferBuilder;
 import net.minecraft.util.math.BlockPos;
 
 public interface AccessChunkRenderer {
-    void fabric_beginBufferBuilding(BufferBuilder bufferBuilder_1, BlockPos blockPos_1);
+	void fabric_beginBufferBuilding(BufferBuilder bufferBuilder_1, BlockPos blockPos_1);
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/accessor/AccessChunkRendererRegion.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/accessor/AccessChunkRendererRegion.java
@@ -23,6 +23,6 @@ import net.fabricmc.indigo.renderer.render.TerrainRenderContext;
  * chunk rebuild, thus avoiding repeated thread-local lookups.
  */
 public interface AccessChunkRendererRegion {
-    TerrainRenderContext fabric_getRenderer();
-    void fabric_setRenderer(TerrainRenderContext renderer);
+	TerrainRenderContext fabric_getRenderer();
+	void fabric_setRenderer(TerrainRenderContext renderer);
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/aocalc/AoCalculator.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/aocalc/AoCalculator.java
@@ -32,6 +32,13 @@ import java.util.function.ToIntFunction;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import net.minecraft.block.Block;
+import net.minecraft.client.util.math.Vector3f;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.ExtendedBlockView;
+
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.indigo.Indigo;
@@ -39,450 +46,453 @@ import net.fabricmc.indigo.renderer.aocalc.AoFace.WeightFunction;
 import net.fabricmc.indigo.renderer.mesh.MutableQuadViewImpl;
 import net.fabricmc.indigo.renderer.mesh.QuadViewImpl;
 import net.fabricmc.indigo.renderer.render.BlockRenderInfo;
-import net.minecraft.block.Block;
-import net.minecraft.client.util.math.Vector3f;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Direction;
-import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.Vec3i;
-import net.minecraft.world.ExtendedBlockView;
 
 /**
  * Adaptation of inner, non-static class in BlockModelRenderer that serves same purpose.
  */
 @Environment(EnvType.CLIENT)
 public class AoCalculator {
-    /** Used to receive a method reference in constructor for ao value lookup. */
-    @FunctionalInterface
-    public static interface AoFunc {
-        float apply(BlockPos pos);
-    }
-    
-    /** 
-     * Vanilla models with cubic quads have vertices in a certain order, which allows
-     * us to map them using a lookup. Adapted from enum in vanilla AoCalculator.
-     */
-    private static final int[][] VERTEX_MAP = new int[6][4];
-    static {
-        VERTEX_MAP[DOWN.getId()] = new int[] {0, 1, 2, 3};
-        VERTEX_MAP[UP.getId()] = new int[] {2, 3, 0, 1};
-        VERTEX_MAP[NORTH.getId()] = new int[] {3, 0, 1, 2};
-        VERTEX_MAP[SOUTH.getId()] = new int[] {0, 1, 2, 3};
-        VERTEX_MAP[WEST.getId()] = new int[] {3, 0, 1, 2};
-        VERTEX_MAP[EAST.getId()] = new int[] {1, 2, 3, 0};
-    }
-    
-    private static final Logger LOGGER = LogManager.getLogger();
+	/** Used to receive a method reference in constructor for ao value lookup. */
+	@FunctionalInterface
+	public interface AoFunc {
+		float apply(BlockPos pos);
+	}
 
-    private final VanillaAoCalc vanillaCalc;
-    private final BlockPos.Mutable lightPos = new BlockPos.Mutable();
-    private final BlockPos.Mutable searchPos = new BlockPos.Mutable();
-    private final BlockRenderInfo blockInfo;
-    private final ToIntFunction<BlockPos> brightnessFunc;
-    private final AoFunc aoFunc;
-    
-    /** caches results of {@link #computeFace(Direction, boolean)} for the current block */
-    private final AoFaceData[] faceData = new AoFaceData[12];
-    
-    /** indicates which elements of {@link #faceData} have been computed for the current block*/
-    private int completionFlags = 0;
-    
-    /** holds per-corner weights - used locally to avoid new allocation */
-    private final float[] w = new float[4];
-    
-    // outputs
-    public final float[] ao = new float[4];
-    public final int[] light = new int[4];
-    
-    public AoCalculator(BlockRenderInfo blockInfo, ToIntFunction<BlockPos> brightnessFunc, AoFunc aoFunc) {
-        this.blockInfo = blockInfo;
-        this.brightnessFunc = brightnessFunc;
-        this.aoFunc = aoFunc;
-        this.vanillaCalc = new VanillaAoCalc(brightnessFunc, aoFunc);
-        for(int i = 0; i < 12; i++) {
-            faceData[i] = new AoFaceData();
-        }
-    }
-    
-    /** call at start of each new block */
-    public void clear() {
-        completionFlags = 0;
-    }
-    
-    public void compute(MutableQuadViewImpl quad, boolean isVanilla) {
-        final AoConfig config = Indigo.AMBIENT_OCCLUSION_MODE;
-        final boolean shouldCompare;
-        
-        switch(config) {
-        case VANILLA:
-            calcVanilla(quad);
-            // no point in comparing vanilla with itself
-            shouldCompare = false;
-            break;
-            
-        case EMULATE:
-            calcFastVanilla(quad);
-            shouldCompare = Indigo.DEBUG_COMPARE_LIGHTING && isVanilla;
-            break;
-            
-        default:
-        case HYBRID:
-            if(isVanilla) {
-                shouldCompare = Indigo.DEBUG_COMPARE_LIGHTING;
-                calcFastVanilla(quad);
-            } else {
-                shouldCompare = false;
-                calcEnhanced(quad);
-            }
-            break;
-        
-        case ENHANCED:
-            shouldCompare = false;
-            calcEnhanced(quad);
-        }
-        
-        if (shouldCompare) {
-            float[] vanillaAo = new float[4];
-            int[] vanillaLight = new int[4];
-            
-            vanillaCalc.compute(blockInfo, quad, vanillaAo, vanillaLight);
-            for (int i = 0; i < 4; i++) {
-                if (light[i] != vanillaLight[i] || !MathHelper.equalsApproximate(ao[i], vanillaAo[i])) {
-                    LOGGER.info(String.format("Mismatch for %s @ %s", blockInfo.blockState.toString(), blockInfo.blockPos.toString()));
-                    LOGGER.info(String.format("Flags = %d, LightFace = %s", quad.geometryFlags(), quad.lightFace().toString()));
-                    LOGGER.info(String.format("    Old Multiplier: %.2f, %.2f, %.2f, %.2f",
-                            vanillaAo[0], vanillaAo[1], vanillaAo[2],vanillaAo[3]));
-                    LOGGER.info(String.format("    New Multiplier: %.2f, %.2f, %.2f, %.2f", ao[0], ao[1], ao[2], ao[3]));
-                    LOGGER.info(String.format("    Old Brightness: %s, %s, %s, %s",
-                            Integer.toHexString(vanillaLight[0]), Integer.toHexString(vanillaLight[1]),
-                            Integer.toHexString(vanillaLight[2]), Integer.toHexString(vanillaLight[3])));
-                    LOGGER.info(String.format("    New Brightness: %s, %s, %s, %s", Integer.toHexString(light[0]),
-                            Integer.toHexString(light[1]), Integer.toHexString(light[2]), Integer.toHexString(light[3])));
-                    break;
-                }
-            }
-        }
-    }
+	/**
+	 * Vanilla models with cubic quads have vertices in a certain order, which allows
+	 * us to map them using a lookup. Adapted from enum in vanilla AoCalculator.
+	 */
+	private static final int[][] VERTEX_MAP = new int[6][4];
 
-    private void calcVanilla(MutableQuadViewImpl quad) {
-        vanillaCalc.compute(blockInfo, quad, ao, light);
-    }
-    
-    private void calcFastVanilla(MutableQuadViewImpl quad) {
-        int flags = quad.geometryFlags();
-        
-        // force to block face if shape is full cube - matches vanilla logic
-        if((flags & LIGHT_FACE_FLAG) == 0 && (flags & AXIS_ALIGNED_FLAG) == AXIS_ALIGNED_FLAG && Block.isShapeFullCube(blockInfo.blockState.getCollisionShape(blockInfo.blockView, blockInfo.blockPos))) {
-            flags |= LIGHT_FACE_FLAG;
-        }
+	static {
+		VERTEX_MAP[DOWN.getId()] = new int[] {0, 1, 2, 3};
+		VERTEX_MAP[UP.getId()] = new int[] {2, 3, 0, 1};
+		VERTEX_MAP[NORTH.getId()] = new int[] {3, 0, 1, 2};
+		VERTEX_MAP[SOUTH.getId()] = new int[] {0, 1, 2, 3};
+		VERTEX_MAP[WEST.getId()] = new int[] {3, 0, 1, 2};
+		VERTEX_MAP[EAST.getId()] = new int[] {1, 2, 3, 0};
+	}
 
-        if((flags & CUBIC_FLAG) == 0) {
+	private static final Logger LOGGER = LogManager.getLogger();
+
+	private final VanillaAoCalc vanillaCalc;
+	private final BlockPos.Mutable lightPos = new BlockPos.Mutable();
+	private final BlockPos.Mutable searchPos = new BlockPos.Mutable();
+	private final BlockRenderInfo blockInfo;
+	private final ToIntFunction<BlockPos> brightnessFunc;
+	private final AoFunc aoFunc;
+
+	/** caches results of {@link #computeFace(Direction, boolean)} for the current block. */
+	private final AoFaceData[] faceData = new AoFaceData[12];
+
+	/** indicates which elements of {@link #faceData} have been computed for the current block. */
+	private int completionFlags = 0;
+
+	/** holds per-corner weights - used locally to avoid new allocation. */
+	private final float[] w = new float[4];
+
+	// outputs
+	public final float[] ao = new float[4];
+	public final int[] light = new int[4];
+
+	public AoCalculator(BlockRenderInfo blockInfo, ToIntFunction<BlockPos> brightnessFunc, AoFunc aoFunc) {
+		this.blockInfo = blockInfo;
+		this.brightnessFunc = brightnessFunc;
+		this.aoFunc = aoFunc;
+		this.vanillaCalc = new VanillaAoCalc(brightnessFunc, aoFunc);
+
+		for (int i = 0; i < 12; i++) {
+			faceData[i] = new AoFaceData();
+		}
+	}
+
+	/** call at start of each new block. */
+	public void clear() {
+		completionFlags = 0;
+	}
+
+	public void compute(MutableQuadViewImpl quad, boolean isVanilla) {
+		final AoConfig config = Indigo.AMBIENT_OCCLUSION_MODE;
+		final boolean shouldCompare;
+
+		switch (config) {
+		case VANILLA:
+			calcVanilla(quad);
+			// no point in comparing vanilla with itself
+			shouldCompare = false;
+			break;
+
+		case EMULATE:
+			calcFastVanilla(quad);
+			shouldCompare = Indigo.DEBUG_COMPARE_LIGHTING && isVanilla;
+			break;
+
+		case HYBRID:
+		default:
+			if (isVanilla) {
+				shouldCompare = Indigo.DEBUG_COMPARE_LIGHTING;
+				calcFastVanilla(quad);
+			} else {
+				shouldCompare = false;
+				calcEnhanced(quad);
+			}
+
+			break;
+
+		case ENHANCED:
+			shouldCompare = false;
+			calcEnhanced(quad);
+		}
+
+		if (shouldCompare) {
+			float[] vanillaAo = new float[4];
+			int[] vanillaLight = new int[4];
+
+			vanillaCalc.compute(blockInfo, quad, vanillaAo, vanillaLight);
+
+			for (int i = 0; i < 4; i++) {
+				if (light[i] != vanillaLight[i] || !MathHelper.equalsApproximate(ao[i], vanillaAo[i])) {
+					LOGGER.info(String.format("Mismatch for %s @ %s", blockInfo.blockState.toString(), blockInfo.blockPos.toString()));
+					LOGGER.info(String.format("Flags = %d, LightFace = %s", quad.geometryFlags(), quad.lightFace().toString()));
+					LOGGER.info(String.format("	Old Multiplier: %.2f, %.2f, %.2f, %.2f",
+							vanillaAo[0], vanillaAo[1], vanillaAo[2],vanillaAo[3]));
+					LOGGER.info(String.format("	New Multiplier: %.2f, %.2f, %.2f, %.2f", ao[0], ao[1], ao[2], ao[3]));
+					LOGGER.info(String.format("	Old Brightness: %s, %s, %s, %s",
+							Integer.toHexString(vanillaLight[0]), Integer.toHexString(vanillaLight[1]),
+							Integer.toHexString(vanillaLight[2]), Integer.toHexString(vanillaLight[3])));
+					LOGGER.info(String.format("	New Brightness: %s, %s, %s, %s", Integer.toHexString(light[0]),
+							Integer.toHexString(light[1]), Integer.toHexString(light[2]), Integer.toHexString(light[3])));
+					break;
+				}
+			}
+		}
+	}
+
+	private void calcVanilla(MutableQuadViewImpl quad) {
+		vanillaCalc.compute(blockInfo, quad, ao, light);
+	}
+
+	private void calcFastVanilla(MutableQuadViewImpl quad) {
+		int flags = quad.geometryFlags();
+
+		// force to block face if shape is full cube - matches vanilla logic
+		if ((flags & LIGHT_FACE_FLAG) == 0 && (flags & AXIS_ALIGNED_FLAG) == AXIS_ALIGNED_FLAG && Block.isShapeFullCube(blockInfo.blockState.getCollisionShape(blockInfo.blockView, blockInfo.blockPos))) {
+			flags |= LIGHT_FACE_FLAG;
+		}
+
+		if ((flags & CUBIC_FLAG) == 0) {
 			vanillaPartialFace(quad, (flags & LIGHT_FACE_FLAG) != 0);
 		} else {
 			vanillaFullFace(quad, (flags & LIGHT_FACE_FLAG) != 0);
 		}
-    }
-    
-    private void calcEnhanced(MutableQuadViewImpl quad) {
-        switch(quad.geometryFlags()) {
-            case AXIS_ALIGNED_FLAG | CUBIC_FLAG | LIGHT_FACE_FLAG:
-            case AXIS_ALIGNED_FLAG | LIGHT_FACE_FLAG:
-                vanillaPartialFace(quad, true);
-                break;
-                
-            case AXIS_ALIGNED_FLAG | CUBIC_FLAG:
-            case AXIS_ALIGNED_FLAG:
-                blendedPartialFace(quad);
-                break;
-                
-            default:
-                irregularFace(quad);
-                break;
-        }
-    }
-    
-    private void vanillaFullFace(QuadViewImpl quad, boolean isOnLightFace) {
-        final Direction lightFace = quad.lightFace();
-        computeFace(lightFace, isOnLightFace).toArray(ao, light, VERTEX_MAP[lightFace.getId()]);
-    }
-    
-    private void vanillaPartialFace(QuadViewImpl quad, boolean isOnLightFace) {
-        final Direction lightFace = quad.lightFace();
-        AoFaceData faceData = computeFace(lightFace, isOnLightFace);
-        final WeightFunction wFunc = AoFace.get(lightFace).weightFunc;
-        final float[] w = this.w;
-        for(int i = 0; i < 4; i++) {
-            wFunc.apply(quad, i, w);
-            light[i] = faceData.weightedCombinedLight(w);
-            ao[i] = faceData.weigtedAo(w);
-        }
-    }
+	}
 
-    /** used in {@link #blendedInsetFace(QuadViewImpl quad, int vertexIndex, Direction lightFace)} as return variable to avoid new allocation */
-    AoFaceData tmpFace = new AoFaceData();
-    
-    /** Returns linearly interpolated blend of outer and inner face based on depth of vertex in face */
-    private AoFaceData blendedInsetFace(QuadViewImpl quad, int vertexIndex, Direction lightFace) {
-        final float w1 = AoFace.get(lightFace).depthFunc.apply(quad, vertexIndex);
-        final float w0 = 1 - w1;
-        return AoFaceData.weightedMean(computeFace(lightFace, true), w0, computeFace(lightFace, false), w1, tmpFace);
-    }
-    
-    /** 
-     * Like {@link #blendedInsetFace(QuadViewImpl quad, int vertexIndex, Direction lightFace)} but optimizes if depth is 0 or 1.
-     * Used for irregular faces when depth varies by vertex to avoid unneeded interpolation.
-     */
-    private AoFaceData gatherInsetFace(QuadViewImpl quad, int vertexIndex, Direction lightFace) {
-        final float w1 = AoFace.get(lightFace).depthFunc.apply(quad, vertexIndex);
-        if(MathHelper.equalsApproximate(w1, 0)) {
-            return computeFace(lightFace, true);
-        } else if(MathHelper.equalsApproximate(w1, 1)) {
-            return computeFace(lightFace, false);
-        } else {
-            final float w0 = 1 - w1;
-            return AoFaceData.weightedMean(computeFace(lightFace, true), w0, computeFace(lightFace, false), w1, tmpFace);
-        }
-    }
-    
-    private void blendedPartialFace(QuadViewImpl quad) {
-        final Direction lightFace = quad.lightFace();
-        AoFaceData faceData = blendedInsetFace(quad, 0, lightFace);
-        final WeightFunction wFunc = AoFace.get(lightFace).weightFunc;
-        for(int i = 0; i < 4; i++) {
-            wFunc.apply(quad, i, w);
-            light[i] = faceData.weightedCombinedLight(w);
-            ao[i] = faceData.weigtedAo(w);
-        }
-    }
-    
-    /** used exclusively in irregular face to avoid new heap allocations each call. */
-    private final Vector3f vertexNormal = new Vector3f();
-    
-    private void irregularFace(MutableQuadViewImpl quad) {
-        final Vector3f faceNorm = quad.faceNormal();
-        Vector3f normal;
-        final float[] w = this.w;
-        final float aoResult[] = this.ao;
-        final int[] lightResult = this.light;
-        
-        for(int i = 0; i < 4; i++) {
-            normal = quad.hasNormal(i) ? quad.copyNormal(i, vertexNormal) : faceNorm;
-            float ao = 0, sky = 0, block = 0, maxAo = 0;
-            int maxSky = 0, maxBlock = 0;
-            
-            final float x = normal.getX();
-            if(!MathHelper.equalsApproximate(0f, x)) {
-                final Direction face = x > 0 ? Direction.EAST : Direction.WEST;
-                final AoFaceData fd = gatherInsetFace(quad, i, face);
-                AoFace.get(face).weightFunc.apply(quad, i, w);
-                final float n = x * x;
-                final float a = fd.weigtedAo(w);
-                final int s = fd.weigtedSkyLight(w);
-                final int b = fd.weigtedBlockLight(w);
-                ao += n * a;
-                sky += n * s;
-                block += n * b;
-                maxAo = a;
-                maxSky = s;
-                maxBlock = b;
-            }
-            
-            final float y = normal.getY();
-            if(!MathHelper.equalsApproximate(0f, y)) {
-                final Direction face = y > 0 ? Direction.UP: Direction.DOWN;
-                final AoFaceData fd = gatherInsetFace(quad, i, face);
-                AoFace.get(face).weightFunc.apply(quad, i, w);
-                final float n = y * y;
-                final float a = fd.weigtedAo(w);
-                final int s = fd.weigtedSkyLight(w);
-                final int b = fd.weigtedBlockLight(w);
-                ao += n * a;
-                sky += n * s;
-                block += n * b;
-                maxAo = Math.max(maxAo, a);
-                maxSky = Math.max(maxSky, s);
-                maxBlock = Math.max(maxBlock, b);
-            }
-            
-            final float z = normal.getZ();
-            if(!MathHelper.equalsApproximate(0f, z)) {
-                final Direction face = z > 0 ? Direction.SOUTH: Direction.NORTH;
-                final AoFaceData fd = gatherInsetFace(quad, i, face);
-                AoFace.get(face).weightFunc.apply(quad, i, w);
-                final float n = z * z;
-                final float a = fd.weigtedAo(w);
-                final int s = fd.weigtedSkyLight(w);
-                final int b = fd.weigtedBlockLight(w);
-                ao += n * a;
-                sky += n * s;
-                block += n * b;
-                maxAo = Math.max(maxAo, a);
-                maxSky = Math.max(maxSky, s);
-                maxBlock = Math.max(maxBlock, b);
-            }
-            
-            aoResult[i] = (ao + maxAo) * 0.5f;
-            lightResult[i] = (((int)((sky + maxSky) * 0.5f) & 0xF0) << 16) | ((int)((block + maxBlock) * 0.5f) & 0xF0);
-        }
-    }
-    
-    /**
-     * Computes smoothed brightness and Ao shading for four corners of a block face.
-     * Outer block face is what you normally see and what you get get when second
-     * parameter is true. Inner is light *within* the block and usually darker. 
-     * It is blended with the outer face for inset surfaces, but is also used directly
-     * in vanilla logic for some blocks that aren't full opaque cubes.
-     * Except for parameterization, the logic itself is practically identical to vanilla.
-     */
-    private AoFaceData computeFace(Direction lightFace, boolean isOnBlockFace) {
-        final int faceDataIndex = isOnBlockFace ? lightFace.getId() : lightFace.getId() + 6;
-        final int mask = 1 << faceDataIndex;
-        final AoFaceData result = faceData[faceDataIndex];
-        if((completionFlags & mask) == 0) {
-            completionFlags |= mask;
-            
-            final ExtendedBlockView world = blockInfo.blockView;
-            final BlockPos pos = blockInfo.blockPos;
-            final BlockPos.Mutable lightPos = this.lightPos;
-            final BlockPos.Mutable searchPos = this.searchPos;
-            
-            lightPos.set(isOnBlockFace ? pos.offset(lightFace) : pos);
-            AoFace aoFace = AoFace.get(lightFace);
-            
-            searchPos.set(lightPos).setOffset(aoFace.neighbors[0]);
-            final int light0 = brightnessFunc.applyAsInt(searchPos);
-            final float ao0 = aoFunc.apply(searchPos);
-            searchPos.set(lightPos).setOffset(aoFace.neighbors[1]);
-            final int light1 = brightnessFunc.applyAsInt(searchPos);
-            final float ao1 = aoFunc.apply(searchPos);
-            searchPos.set(lightPos).setOffset(aoFace.neighbors[2]);
-            final int light2 = brightnessFunc.applyAsInt(searchPos);
-            final float ao2 = aoFunc.apply(searchPos);
-            searchPos.set(lightPos).setOffset(aoFace.neighbors[3]);
-            final int light3 = brightnessFunc.applyAsInt(searchPos);
-            final float ao3 = aoFunc.apply(searchPos);
-            
-            // vanilla was further offsetting these in the direction of the light face
-            // but it was actually mis-sampling and causing visible artifacts in certain situation
-            searchPos.set(lightPos).setOffset(aoFace.neighbors[0]);//.setOffset(lightFace);
-            if(!Indigo.FIX_SMOOTH_LIGHTING_OFFSET) searchPos.setOffset(lightFace);
-            final boolean isClear0 = world.getBlockState(searchPos).getLightSubtracted(world, searchPos) == 0;
-            searchPos.set(lightPos).setOffset(aoFace.neighbors[1]);//.setOffset(lightFace);
-            if(!Indigo.FIX_SMOOTH_LIGHTING_OFFSET) searchPos.setOffset(lightFace);
-            final boolean isClear1 = world.getBlockState(searchPos).getLightSubtracted(world, searchPos) == 0;
-            searchPos.set(lightPos).setOffset(aoFace.neighbors[2]);//.setOffset(lightFace);
-            if(!Indigo.FIX_SMOOTH_LIGHTING_OFFSET) searchPos.setOffset(lightFace);
-            final boolean isClear2 = world.getBlockState(searchPos).getLightSubtracted(world, searchPos) == 0;
-            searchPos.set(lightPos).setOffset(aoFace.neighbors[3]);//.setOffset(lightFace);
-            if(!Indigo.FIX_SMOOTH_LIGHTING_OFFSET) searchPos.setOffset(lightFace);
-            final boolean isClear3 = world.getBlockState(searchPos).getLightSubtracted(world, searchPos) == 0;
+	private void calcEnhanced(MutableQuadViewImpl quad) {
+		switch (quad.geometryFlags()) {
+		case AXIS_ALIGNED_FLAG | CUBIC_FLAG | LIGHT_FACE_FLAG:
+		case AXIS_ALIGNED_FLAG | LIGHT_FACE_FLAG:
+			vanillaPartialFace(quad, true);
+			break;
 
-            // c = corner - values at corners of face
-            int cLight0, cLight1, cLight2, cLight3;
-            float cAo0, cAo1, cAo2, cAo3;
-    
-            // If neighbors on both side of the corner are opaque, then apparently we use the light/shade
-            // from one of the sides adjacent to the corner.  If either neighbor is clear (no light subtraction)
-            // then we use values from the outwardly diagonal corner. (outwardly = position is one more away from light face)
-            if (!isClear2 && !isClear0) {
-                cAo0 = ao0;
-                cLight0 = light0;
-            } else {
-                searchPos.set(lightPos).setOffset(aoFace.neighbors[0]).setOffset(aoFace.neighbors[2]);
-                cAo0 = aoFunc.apply(searchPos);
-                cLight0 = brightnessFunc.applyAsInt(searchPos);
-            }
-    
-            if (!isClear3 && !isClear0) {
-                cAo1 = ao0;
-                cLight1 = light0;
-            } else {
-                searchPos.set(lightPos).setOffset(aoFace.neighbors[0]).setOffset(aoFace.neighbors[3]);
-                cAo1 = aoFunc.apply(searchPos);
-                cLight1 = brightnessFunc.applyAsInt(searchPos);
-            }
-    
-            if (!isClear2 && !isClear1) {
-                cAo2 = ao1;
-                cLight2 = light1;
-            } else {
-                searchPos.set(lightPos).setOffset(aoFace.neighbors[1]).setOffset(aoFace.neighbors[2]);
-                cAo2 = aoFunc.apply(searchPos);
-                cLight2 = brightnessFunc.applyAsInt(searchPos);
-            }
-    
-            if (!isClear3 && !isClear1) {
-                cAo3 = ao1;
-                cLight3 = light1;
-            } else {
-                searchPos.set(lightPos).setOffset(aoFace.neighbors[1]).setOffset(aoFace.neighbors[3]);
-                cAo3 = aoFunc.apply(searchPos);
-                cLight3 = brightnessFunc.applyAsInt(searchPos);
-            }
-    
-            // If on block face or neighbor isn't occluding, "center" will be neighbor brightness
-            // Doesn't use light pos because logic not based solely on this block's geometry
-            int lightCenter;
-            searchPos.set((Vec3i)pos).setOffset(lightFace);
-            if (isOnBlockFace || !world.getBlockState(searchPos).isFullOpaque(world, searchPos)) {
-                lightCenter = brightnessFunc.applyAsInt(searchPos);
-            } else {
-                lightCenter = brightnessFunc.applyAsInt(pos);
-            }
-    
-            float aoCenter = aoFunc.apply(isOnBlockFace ? lightPos : pos);
-            
-            result.a0 = (ao3 + ao0 + cAo1 + aoCenter) * 0.25F;
-            result.a1 = (ao2 + ao0 + cAo0 + aoCenter) * 0.25F;
-            result.a2 = (ao2 + ao1 + cAo2 + aoCenter) * 0.25F;
-            result.a3 = (ao3 + ao1 + cAo3 + aoCenter) * 0.25F;
-            
-            result.l0(meanBrightness(light3, light0, cLight1, lightCenter));
-            result.l1(meanBrightness(light2, light0, cLight0, lightCenter));
-            result.l2(meanBrightness(light2, light1, cLight2, lightCenter));
-            result.l3(meanBrightness(light3, light1, cLight3, lightCenter));
-        }
-        return result;
-    }
-    
-    /** 
-     * Vanilla code excluded missing light values from mean but was not isotropic.
-     * Still need to substitute or edges are too dark but consistently use the min 
-     * value from all four samples.
-     */
-    private static int meanBrightness(int a, int b, int c, int d) {
-        if(Indigo.FIX_SMOOTH_LIGHTING_OFFSET) {
-            return a == 0 || b == 0 || c == 0 || d == 0 ? meanEdgeBrightness(a, b, c, d) : meanInnerBrightness(a, b, c, d);
-        } else {
-            return vanillaMeanBrightness(a, b, c, d);
-        }
-    }
-    
-    /** vanilla logic - excludes missing light values from mean and has anisotropy defect mentioned above */
-    private static int vanillaMeanBrightness(int a, int b, int c, int d) {
-        if (a == 0)
-            a = d;
-        if (b == 0)
-            b = d;
-        if (c == 0)
-            c = d;
-        // bitwise divide by 4, clamp to expected (positive) range
-        return a + b + c + d >> 2 & 16711935;
-    }
-    
-    private static int meanInnerBrightness(int a, int b, int c, int d) {
-        // bitwise divide by 4, clamp to expected (positive) range
-        return a + b + c + d >> 2 & 16711935;
-    }
+		case AXIS_ALIGNED_FLAG | CUBIC_FLAG:
+		case AXIS_ALIGNED_FLAG:
+			blendedPartialFace(quad);
+			break;
 
-    private static int nonZeroMin(int a, int b) {
-        if(a == 0) return b;
-        if(b == 0) return a;
-        return Math.min(a, b);
-    }
-    
-    private static int meanEdgeBrightness(int a, int b, int c, int d) {
-        final int min = nonZeroMin(nonZeroMin(a, b), nonZeroMin(c, d));
-        return meanInnerBrightness(max(a, min), max(b, min), max(c, min), max(d, min));
-    }
+		default:
+			irregularFace(quad);
+			break;
+		}
+	}
+
+	private void vanillaFullFace(QuadViewImpl quad, boolean isOnLightFace) {
+		final Direction lightFace = quad.lightFace();
+		computeFace(lightFace, isOnLightFace).toArray(ao, light, VERTEX_MAP[lightFace.getId()]);
+	}
+
+	private void vanillaPartialFace(QuadViewImpl quad, boolean isOnLightFace) {
+		final Direction lightFace = quad.lightFace();
+		AoFaceData faceData = computeFace(lightFace, isOnLightFace);
+		final WeightFunction wFunc = AoFace.get(lightFace).weightFunc;
+		final float[] w = this.w;
+
+		for (int i = 0; i < 4; i++) {
+			wFunc.apply(quad, i, w);
+			light[i] = faceData.weightedCombinedLight(w);
+			ao[i] = faceData.weigtedAo(w);
+		}
+	}
+
+	/** used in {@link #blendedInsetFace(QuadViewImpl quad, int vertexIndex, Direction lightFace)} as return variable to avoid new allocation. */
+	AoFaceData tmpFace = new AoFaceData();
+
+	/** Returns linearly interpolated blend of outer and inner face based on depth of vertex in face. */
+	private AoFaceData blendedInsetFace(QuadViewImpl quad, int vertexIndex, Direction lightFace) {
+		final float w1 = AoFace.get(lightFace).depthFunc.apply(quad, vertexIndex);
+		final float w0 = 1 - w1;
+		return AoFaceData.weightedMean(computeFace(lightFace, true), w0, computeFace(lightFace, false), w1, tmpFace);
+	}
+
+	/**
+	 * Like {@link #blendedInsetFace(QuadViewImpl quad, int vertexIndex, Direction lightFace)} but optimizes if depth is 0 or 1.
+	 * Used for irregular faces when depth varies by vertex to avoid unneeded interpolation.
+	 */
+	private AoFaceData gatherInsetFace(QuadViewImpl quad, int vertexIndex, Direction lightFace) {
+		final float w1 = AoFace.get(lightFace).depthFunc.apply(quad, vertexIndex);
+
+		if (MathHelper.equalsApproximate(w1, 0)) {
+			return computeFace(lightFace, true);
+		} else if (MathHelper.equalsApproximate(w1, 1)) {
+			return computeFace(lightFace, false);
+		} else {
+			final float w0 = 1 - w1;
+			return AoFaceData.weightedMean(computeFace(lightFace, true), w0, computeFace(lightFace, false), w1, tmpFace);
+		}
+	}
+
+	private void blendedPartialFace(QuadViewImpl quad) {
+		final Direction lightFace = quad.lightFace();
+		AoFaceData faceData = blendedInsetFace(quad, 0, lightFace);
+		final WeightFunction wFunc = AoFace.get(lightFace).weightFunc;
+
+		for (int i = 0; i < 4; i++) {
+			wFunc.apply(quad, i, w);
+			light[i] = faceData.weightedCombinedLight(w);
+			ao[i] = faceData.weigtedAo(w);
+		}
+	}
+
+	/** used exclusively in irregular face to avoid new heap allocations each call. */
+	private final Vector3f vertexNormal = new Vector3f();
+
+	private void irregularFace(MutableQuadViewImpl quad) {
+		final Vector3f faceNorm = quad.faceNormal();
+		Vector3f normal;
+		final float[] w = this.w;
+		final float[] aoResult = this.ao;
+		final int[] lightResult = this.light;
+
+		for (int i = 0; i < 4; i++) {
+			normal = quad.hasNormal(i) ? quad.copyNormal(i, vertexNormal) : faceNorm;
+			float ao = 0, sky = 0, block = 0, maxAo = 0;
+			int maxSky = 0, maxBlock = 0;
+
+			final float x = normal.getX();
+
+			if (!MathHelper.equalsApproximate(0f, x)) {
+				final Direction face = x > 0 ? Direction.EAST : Direction.WEST;
+				final AoFaceData fd = gatherInsetFace(quad, i, face);
+				AoFace.get(face).weightFunc.apply(quad, i, w);
+				final float n = x * x;
+				final float a = fd.weigtedAo(w);
+				final int s = fd.weigtedSkyLight(w);
+				final int b = fd.weigtedBlockLight(w);
+				ao += n * a;
+				sky += n * s;
+				block += n * b;
+				maxAo = a;
+				maxSky = s;
+				maxBlock = b;
+			}
+
+			final float y = normal.getY();
+
+			if (!MathHelper.equalsApproximate(0f, y)) {
+				final Direction face = y > 0 ? Direction.UP : Direction.DOWN;
+				final AoFaceData fd = gatherInsetFace(quad, i, face);
+				AoFace.get(face).weightFunc.apply(quad, i, w);
+				final float n = y * y;
+				final float a = fd.weigtedAo(w);
+				final int s = fd.weigtedSkyLight(w);
+				final int b = fd.weigtedBlockLight(w);
+				ao += n * a;
+				sky += n * s;
+				block += n * b;
+				maxAo = Math.max(maxAo, a);
+				maxSky = Math.max(maxSky, s);
+				maxBlock = Math.max(maxBlock, b);
+			}
+
+			final float z = normal.getZ();
+
+			if (!MathHelper.equalsApproximate(0f, z)) {
+				final Direction face = z > 0 ? Direction.SOUTH : Direction.NORTH;
+				final AoFaceData fd = gatherInsetFace(quad, i, face);
+				AoFace.get(face).weightFunc.apply(quad, i, w);
+				final float n = z * z;
+				final float a = fd.weigtedAo(w);
+				final int s = fd.weigtedSkyLight(w);
+				final int b = fd.weigtedBlockLight(w);
+				ao += n * a;
+				sky += n * s;
+				block += n * b;
+				maxAo = Math.max(maxAo, a);
+				maxSky = Math.max(maxSky, s);
+				maxBlock = Math.max(maxBlock, b);
+			}
+
+			aoResult[i] = (ao + maxAo) * 0.5f;
+			lightResult[i] = (((int) ((sky + maxSky) * 0.5f) & 0xF0) << 16) | ((int) ((block + maxBlock) * 0.5f) & 0xF0);
+		}
+	}
+
+	/**
+	 * Computes smoothed brightness and Ao shading for four corners of a block face.
+	 * Outer block face is what you normally see and what you get get when second
+	 * parameter is true. Inner is light *within* the block and usually darker.
+	 * It is blended with the outer face for inset surfaces, but is also used directly
+	 * in vanilla logic for some blocks that aren't full opaque cubes.
+	 * Except for parameterization, the logic itself is practically identical to vanilla.
+	 */
+	private AoFaceData computeFace(Direction lightFace, boolean isOnBlockFace) {
+		final int faceDataIndex = isOnBlockFace ? lightFace.getId() : lightFace.getId() + 6;
+		final int mask = 1 << faceDataIndex;
+		final AoFaceData result = faceData[faceDataIndex];
+
+		if ((completionFlags & mask) == 0) {
+			completionFlags |= mask;
+
+			final ExtendedBlockView world = blockInfo.blockView;
+			final BlockPos pos = blockInfo.blockPos;
+			final BlockPos.Mutable lightPos = this.lightPos;
+			final BlockPos.Mutable searchPos = this.searchPos;
+
+			lightPos.set(isOnBlockFace ? pos.offset(lightFace) : pos);
+			AoFace aoFace = AoFace.get(lightFace);
+
+			searchPos.set(lightPos).setOffset(aoFace.neighbors[0]);
+			final int light0 = brightnessFunc.applyAsInt(searchPos);
+			final float ao0 = aoFunc.apply(searchPos);
+			searchPos.set(lightPos).setOffset(aoFace.neighbors[1]);
+			final int light1 = brightnessFunc.applyAsInt(searchPos);
+			final float ao1 = aoFunc.apply(searchPos);
+			searchPos.set(lightPos).setOffset(aoFace.neighbors[2]);
+			final int light2 = brightnessFunc.applyAsInt(searchPos);
+			final float ao2 = aoFunc.apply(searchPos);
+			searchPos.set(lightPos).setOffset(aoFace.neighbors[3]);
+			final int light3 = brightnessFunc.applyAsInt(searchPos);
+			final float ao3 = aoFunc.apply(searchPos);
+
+			// vanilla was further offsetting these in the direction of the light face
+			// but it was actually mis-sampling and causing visible artifacts in certain situation
+			searchPos.set(lightPos).setOffset(aoFace.neighbors[0]);//.setOffset(lightFace);
+			if (!Indigo.FIX_SMOOTH_LIGHTING_OFFSET) searchPos.setOffset(lightFace);
+			final boolean isClear0 = world.getBlockState(searchPos).getLightSubtracted(world, searchPos) == 0;
+			searchPos.set(lightPos).setOffset(aoFace.neighbors[1]);//.setOffset(lightFace);
+			if (!Indigo.FIX_SMOOTH_LIGHTING_OFFSET) searchPos.setOffset(lightFace);
+			final boolean isClear1 = world.getBlockState(searchPos).getLightSubtracted(world, searchPos) == 0;
+			searchPos.set(lightPos).setOffset(aoFace.neighbors[2]);//.setOffset(lightFace);
+			if (!Indigo.FIX_SMOOTH_LIGHTING_OFFSET) searchPos.setOffset(lightFace);
+			final boolean isClear2 = world.getBlockState(searchPos).getLightSubtracted(world, searchPos) == 0;
+			searchPos.set(lightPos).setOffset(aoFace.neighbors[3]);//.setOffset(lightFace);
+			if (!Indigo.FIX_SMOOTH_LIGHTING_OFFSET) searchPos.setOffset(lightFace);
+			final boolean isClear3 = world.getBlockState(searchPos).getLightSubtracted(world, searchPos) == 0;
+
+			// c = corner - values at corners of face
+			int cLight0, cLight1, cLight2, cLight3;
+			float cAo0, cAo1, cAo2, cAo3;
+
+			// If neighbors on both side of the corner are opaque, then apparently we use the light/shade
+			// from one of the sides adjacent to the corner.  If either neighbor is clear (no light subtraction)
+			// then we use values from the outwardly diagonal corner. (outwardly = position is one more away from light face)
+			if (!isClear2 && !isClear0) {
+				cAo0 = ao0;
+				cLight0 = light0;
+			} else {
+				searchPos.set(lightPos).setOffset(aoFace.neighbors[0]).setOffset(aoFace.neighbors[2]);
+				cAo0 = aoFunc.apply(searchPos);
+				cLight0 = brightnessFunc.applyAsInt(searchPos);
+			}
+
+			if (!isClear3 && !isClear0) {
+				cAo1 = ao0;
+				cLight1 = light0;
+			} else {
+				searchPos.set(lightPos).setOffset(aoFace.neighbors[0]).setOffset(aoFace.neighbors[3]);
+				cAo1 = aoFunc.apply(searchPos);
+				cLight1 = brightnessFunc.applyAsInt(searchPos);
+			}
+
+			if (!isClear2 && !isClear1) {
+				cAo2 = ao1;
+				cLight2 = light1;
+			} else {
+				searchPos.set(lightPos).setOffset(aoFace.neighbors[1]).setOffset(aoFace.neighbors[2]);
+				cAo2 = aoFunc.apply(searchPos);
+				cLight2 = brightnessFunc.applyAsInt(searchPos);
+			}
+
+			if (!isClear3 && !isClear1) {
+				cAo3 = ao1;
+				cLight3 = light1;
+			} else {
+				searchPos.set(lightPos).setOffset(aoFace.neighbors[1]).setOffset(aoFace.neighbors[3]);
+				cAo3 = aoFunc.apply(searchPos);
+				cLight3 = brightnessFunc.applyAsInt(searchPos);
+			}
+
+			// If on block face or neighbor isn't occluding, "center" will be neighbor brightness
+			// Doesn't use light pos because logic not based solely on this block's geometry
+			int lightCenter;
+			searchPos.set(pos).setOffset(lightFace);
+
+			if (isOnBlockFace || !world.getBlockState(searchPos).isFullOpaque(world, searchPos)) {
+				lightCenter = brightnessFunc.applyAsInt(searchPos);
+			} else {
+				lightCenter = brightnessFunc.applyAsInt(pos);
+			}
+
+			float aoCenter = aoFunc.apply(isOnBlockFace ? lightPos : pos);
+
+			result.a0 = (ao3 + ao0 + cAo1 + aoCenter) * 0.25F;
+			result.a1 = (ao2 + ao0 + cAo0 + aoCenter) * 0.25F;
+			result.a2 = (ao2 + ao1 + cAo2 + aoCenter) * 0.25F;
+			result.a3 = (ao3 + ao1 + cAo3 + aoCenter) * 0.25F;
+
+			result.l0(meanBrightness(light3, light0, cLight1, lightCenter));
+			result.l1(meanBrightness(light2, light0, cLight0, lightCenter));
+			result.l2(meanBrightness(light2, light1, cLight2, lightCenter));
+			result.l3(meanBrightness(light3, light1, cLight3, lightCenter));
+		}
+
+		return result;
+	}
+
+	/**
+	 * Vanilla code excluded missing light values from mean but was not isotropic.
+	 * Still need to substitute or edges are too dark but consistently use the min
+	 * value from all four samples.
+	 */
+	private static int meanBrightness(int a, int b, int c, int d) {
+		if (Indigo.FIX_SMOOTH_LIGHTING_OFFSET) {
+			return a == 0 || b == 0 || c == 0 || d == 0 ? meanEdgeBrightness(a, b, c, d) : meanInnerBrightness(a, b, c, d);
+		} else {
+			return vanillaMeanBrightness(a, b, c, d);
+		}
+	}
+
+	/** vanilla logic - excludes missing light values from mean and has anisotropy defect mentioned above. */
+	private static int vanillaMeanBrightness(int a, int b, int c, int d) {
+		if (a == 0) a = d;
+		if (b == 0) b = d;
+		if (c == 0) c = d;
+		// bitwise divide by 4, clamp to expected (positive) range
+		return a + b + c + d >> 2 & 16711935;
+	}
+
+	private static int meanInnerBrightness(int a, int b, int c, int d) {
+		// bitwise divide by 4, clamp to expected (positive) range
+		return a + b + c + d >> 2 & 16711935;
+	}
+
+	private static int nonZeroMin(int a, int b) {
+		if (a == 0) return b;
+		if (b == 0) return a;
+		return Math.min(a, b);
+	}
+
+	private static int meanEdgeBrightness(int a, int b, int c, int d) {
+		final int min = nonZeroMin(nonZeroMin(a, b), nonZeroMin(c, d));
+		return meanInnerBrightness(max(a, min), max(b, min), max(c, min), max(d, min));
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/aocalc/AoCalculator.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/aocalc/AoCalculator.java
@@ -155,7 +155,7 @@ public class AoCalculator {
 					LOGGER.info(String.format("Mismatch for %s @ %s", blockInfo.blockState.toString(), blockInfo.blockPos.toString()));
 					LOGGER.info(String.format("Flags = %d, LightFace = %s", quad.geometryFlags(), quad.lightFace().toString()));
 					LOGGER.info(String.format("	Old Multiplier: %.2f, %.2f, %.2f, %.2f",
-							vanillaAo[0], vanillaAo[1], vanillaAo[2],vanillaAo[3]));
+							vanillaAo[0], vanillaAo[1], vanillaAo[2], vanillaAo[3]));
 					LOGGER.info(String.format("	New Multiplier: %.2f, %.2f, %.2f, %.2f", ao[0], ao[1], ao[2], ao[3]));
 					LOGGER.info(String.format("	Old Brightness: %s, %s, %s, %s",
 							Integer.toHexString(vanillaLight[0]), Integer.toHexString(vanillaLight[1]),
@@ -375,16 +375,16 @@ public class AoCalculator {
 
 			// vanilla was further offsetting these in the direction of the light face
 			// but it was actually mis-sampling and causing visible artifacts in certain situation
-			searchPos.set(lightPos).setOffset(aoFace.neighbors[0]);//.setOffset(lightFace);
+			searchPos.set(lightPos).setOffset(aoFace.neighbors[0]); //.setOffset(lightFace);
 			if (!Indigo.FIX_SMOOTH_LIGHTING_OFFSET) searchPos.setOffset(lightFace);
 			final boolean isClear0 = world.getBlockState(searchPos).getLightSubtracted(world, searchPos) == 0;
-			searchPos.set(lightPos).setOffset(aoFace.neighbors[1]);//.setOffset(lightFace);
+			searchPos.set(lightPos).setOffset(aoFace.neighbors[1]); //.setOffset(lightFace);
 			if (!Indigo.FIX_SMOOTH_LIGHTING_OFFSET) searchPos.setOffset(lightFace);
 			final boolean isClear1 = world.getBlockState(searchPos).getLightSubtracted(world, searchPos) == 0;
-			searchPos.set(lightPos).setOffset(aoFace.neighbors[2]);//.setOffset(lightFace);
+			searchPos.set(lightPos).setOffset(aoFace.neighbors[2]); //.setOffset(lightFace);
 			if (!Indigo.FIX_SMOOTH_LIGHTING_OFFSET) searchPos.setOffset(lightFace);
 			final boolean isClear2 = world.getBlockState(searchPos).getLightSubtracted(world, searchPos) == 0;
-			searchPos.set(lightPos).setOffset(aoFace.neighbors[3]);//.setOffset(lightFace);
+			searchPos.set(lightPos).setOffset(aoFace.neighbors[3]); //.setOffset(lightFace);
 			if (!Indigo.FIX_SMOOTH_LIGHTING_OFFSET) searchPos.setOffset(lightFace);
 			final boolean isClear3 = world.getBlockState(searchPos).getLightSubtracted(world, searchPos) == 0;
 

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/aocalc/AoConfig.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/aocalc/AoConfig.java
@@ -21,42 +21,42 @@ package net.fabricmc.indigo.renderer.aocalc;
  * This determine the appearance of smooth lighting.
  */
 public enum AoConfig {
-    /**
-     * Quads will be lit with a slightly modified copy of the vanilla ambient 
-     * occlusion calculator. Quads with triangles, non-square or slopes will 
-     * not look good in this model.  This model also requires a fixed vertex 
-     * winding order for all quads.
-     */
-    VANILLA,
-    
-    /**
-     * Quads are lit with enhanced lighting logic.  Enhanced lighting will be
-     * similar to vanilla lighting for face-aligned quads, and will be different
-     * (generally better) for triangles, non-square and sloped quads.  Axis-
-     * aligned quads not on the block face will have interpolated brightness based
-     * on depth instead of the all-or-nothing brightness of vanilla.<p>
-     * 
-     * Non-vanilla quads can have vertices in any (counter-clockwise) order.<p>
-     */
-    ENHANCED,
-    
-    /**
-     * Enhanced lighting is configured to mimic vanilla lighting. Results will be
-     * identical to vanilla except that non-square quads, triangles, etc. will 
-     * not be sensitive to vertex order.  However shading will not be interpolated
-     * as it is with enhanced. These quads do not occur in vanilla models.
-     * Not recommended for models with complex geometry, but may be faster than 
-     * the vanilla calculator when vanilla lighting is desired.
-     */
-    EMULATE,
-    
-    /**
-     * Quads from vanilla models are lit using {@link #EMULATE} mode and all
-     * other quads are lit using {@link #ENHANCED} mode.  This mode ensures
-     * all vanilla models retain their normal appearance while providing 
-     * better lighting for models with more complex geometry.  However,
-     * inconsistencies may be visible when vanilla and non-vanilla models are
-     * near each other.
-     */
-    HYBRID;
+	/**
+	 * Quads will be lit with a slightly modified copy of the vanilla ambient
+	 * occlusion calculator. Quads with triangles, non-square or slopes will
+	 * not look good in this model.  This model also requires a fixed vertex
+	 * winding order for all quads.
+	 */
+	VANILLA,
+
+	/**
+	 * Quads are lit with enhanced lighting logic.  Enhanced lighting will be
+	 * similar to vanilla lighting for face-aligned quads, and will be different
+	 * (generally better) for triangles, non-square and sloped quads.  Axis-
+	 * aligned quads not on the block face will have interpolated brightness based
+	 * on depth instead of the all-or-nothing brightness of vanilla.
+	 *
+	 * <p>Non-vanilla quads can have vertices in any (counter-clockwise) order.
+	 */
+	ENHANCED,
+
+	/**
+	 * Enhanced lighting is configured to mimic vanilla lighting. Results will be
+	 * identical to vanilla except that non-square quads, triangles, etc. will
+	 * not be sensitive to vertex order.  However shading will not be interpolated
+	 * as it is with enhanced. These quads do not occur in vanilla models.
+	 * Not recommended for models with complex geometry, but may be faster than
+	 * the vanilla calculator when vanilla lighting is desired.
+	 */
+	EMULATE,
+
+	/**
+	 * Quads from vanilla models are lit using {@link #EMULATE} mode and all
+	 * other quads are lit using {@link #ENHANCED} mode.  This mode ensures
+	 * all vanilla models retain their normal appearance while providing
+	 * better lighting for models with more complex geometry.  However,
+	 * inconsistencies may be visible when vanilla and non-vanilla models are
+	 * near each other.
+	 */
+	HYBRID;
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/aocalc/AoFace.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/aocalc/AoFace.java
@@ -16,113 +16,113 @@
 
 package net.fabricmc.indigo.renderer.aocalc;
 
-import static net.minecraft.util.math.Direction.*;
 import static net.fabricmc.indigo.renderer.aocalc.AoVertexClampFunction.CLAMP_FUNC;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
+import static net.minecraft.util.math.Direction.DOWN;
+import static net.minecraft.util.math.Direction.EAST;
+import static net.minecraft.util.math.Direction.NORTH;
+import static net.minecraft.util.math.Direction.SOUTH;
+import static net.minecraft.util.math.Direction.UP;
+import static net.minecraft.util.math.Direction.WEST;
+
 import net.minecraft.util.SystemUtil;
 import net.minecraft.util.math.Direction;
 
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.fabricmc.indigo.renderer.mesh.QuadViewImpl;
 
 /**
  * Adapted from vanilla BlockModelRenderer.AoCalculator.
  */
-@Environment(EnvType.CLIENT) 
+@Environment(EnvType.CLIENT)
 enum AoFace {
-    AOF_DOWN(new Direction[]{WEST, EAST, NORTH, SOUTH}, (q, i) -> CLAMP_FUNC.clamp(q.y(i)),
-            (q, i, w) -> {
-                final float u = CLAMP_FUNC.clamp(q.x(i));
-                final float v = CLAMP_FUNC.clamp(q.z(i));
-                w[0] = (1-u) * v; 
-                w[1] = (1-u) * (1-v);
-                w[2] = u * (1-v);
-                w[3] = u * v;
-            }),
-    AOF_UP(new Direction[]{EAST, WEST, NORTH, SOUTH}, (q, i) -> 1 - CLAMP_FUNC.clamp(q.y(i)),
-            (q, i, w) -> {
-                final float u = CLAMP_FUNC.clamp(q.x(i));
-                final float v = CLAMP_FUNC.clamp(q.z(i));
-                w[0] = u * v; 
-                w[1] = u * (1-v);
-                w[2] = (1-u) * (1-v);
-                w[3] = (1-u) * v;
-            }), 
-    AOF_NORTH(new Direction[]{UP, DOWN, EAST, WEST}, (q, i) -> CLAMP_FUNC.clamp(q.z(i)),
-            (q, i, w) -> {
-                final float u = CLAMP_FUNC.clamp(q.y(i));
-                final float v = CLAMP_FUNC.clamp(q.x(i));
-                w[0] = u * (1-v);
-                w[1] = u * v; 
-                w[2] = (1-u) * v; 
-                w[3] = (1-u) * (1-v);
-            }), 
-    AOF_SOUTH(new Direction[]{WEST, EAST, DOWN, UP}, (q, i) -> 1 - CLAMP_FUNC.clamp(q.z(i)),
-            (q, i, w) -> {
-                final float u = CLAMP_FUNC.clamp(q.y(i));
-                final float v = CLAMP_FUNC.clamp(q.x(i));
-                w[0] = u * (1-v);
-                w[1] = (1-u) * (1-v);
-                w[2] = (1-u) * v;
-                w[3] = u * v; 
-            }), 
-    AOF_WEST(new Direction[]{UP, DOWN, NORTH, SOUTH}, (q, i) -> CLAMP_FUNC.clamp(q.x(i)),
-            (q, i, w) -> {
-                final float u = CLAMP_FUNC.clamp(q.y(i));
-                final float v = CLAMP_FUNC.clamp(q.z(i));
-                w[0] = u * v; 
-                w[1] = u * (1-v);
-                w[2] = (1-u) * (1-v);
-                w[3] = (1-u) * v;
-            }), 
-    AOF_EAST(new Direction[]{DOWN, UP, NORTH, SOUTH}, (q, i) -> 1 - CLAMP_FUNC.clamp(q.x(i)),
-            (q, i, w) -> {
-                final float u = CLAMP_FUNC.clamp(q.y(i));
-                final float v = CLAMP_FUNC.clamp(q.z(i));
-                w[0] = (1-u) * v; 
-                w[1] = (1-u) * (1-v);
-                w[2] = u * (1-v);
-                w[3] = u * v;
-            });
+	AOF_DOWN(new Direction[] { WEST, EAST, NORTH, SOUTH }, (q, i) -> CLAMP_FUNC.clamp(q.y(i)), (q, i, w) -> {
+		final float u = CLAMP_FUNC.clamp(q.x(i));
+		final float v = CLAMP_FUNC.clamp(q.z(i));
+		w[0] = (1-u) * v;
+		w[1] = (1-u) * (1-v);
+		w[2] = u * (1-v);
+		w[3] = u * v;
+	}),
+	AOF_UP(new Direction[] { EAST, WEST, NORTH, SOUTH }, (q, i) -> 1 - CLAMP_FUNC.clamp(q.y(i)), (q, i, w) -> {
+		final float u = CLAMP_FUNC.clamp(q.x(i));
+		final float v = CLAMP_FUNC.clamp(q.z(i));
+		w[0] = u * v;
+		w[1] = u * (1-v);
+		w[2] = (1-u) * (1-v);
+		w[3] = (1-u) * v;
+	}),
+	AOF_NORTH(new Direction[] { UP, DOWN, EAST, WEST }, (q, i) -> CLAMP_FUNC.clamp(q.z(i)), (q, i, w) -> {
+		final float u = CLAMP_FUNC.clamp(q.y(i));
+		final float v = CLAMP_FUNC.clamp(q.x(i));
+		w[0] = u * (1-v);
+		w[1] = u * v;
+		w[2] = (1-u) * v;
+		w[3] = (1-u) * (1-v);
+	}),
+	AOF_SOUTH(new Direction[] { WEST, EAST, DOWN, UP }, (q, i) -> 1 - CLAMP_FUNC.clamp(q.z(i)), (q, i, w) -> {
+		final float u = CLAMP_FUNC.clamp(q.y(i));
+		final float v = CLAMP_FUNC.clamp(q.x(i));
+		w[0] = u * (1-v);
+		w[1] = (1-u) * (1-v);
+		w[2] = (1-u) * v;
+		w[3] = u * v;
+	}),
+	AOF_WEST(new Direction[] { UP, DOWN, NORTH, SOUTH }, (q, i) -> CLAMP_FUNC.clamp(q.x(i)), (q, i, w) -> {
+		final float u = CLAMP_FUNC.clamp(q.y(i));
+		final float v = CLAMP_FUNC.clamp(q.z(i));
+		w[0] = u * v;
+		w[1] = u * (1-v);
+		w[2] = (1-u) * (1-v);
+		w[3] = (1-u) * v;
+	}),
+	AOF_EAST(new Direction[] { DOWN, UP, NORTH, SOUTH }, (q, i) -> 1 - CLAMP_FUNC.clamp(q.x(i)), (q, i, w) -> {
+		final float u = CLAMP_FUNC.clamp(q.y(i));
+		final float v = CLAMP_FUNC.clamp(q.z(i));
+		w[0] = (1-u) * v;
+		w[1] = (1-u) * (1-v);
+		w[2] = u * (1-v);
+		w[3] = u * v;
+	});
 
-    final Direction[] neighbors;
-    final WeightFunction weightFunc;
-    final Vertex2Float depthFunc;
-    
-    private AoFace(Direction[] faces, Vertex2Float depthFunc, WeightFunction weightFunc) {
-        this.neighbors = faces;
-        this.depthFunc = depthFunc;
-        this.weightFunc = weightFunc;
-    }
-    
-    private static final AoFace[] values = (AoFace[])SystemUtil.consume(new AoFace[6], (neighborData) -> {
-        neighborData[DOWN.getId()] = AOF_DOWN;
-        neighborData[UP.getId()] = AOF_UP;
-        neighborData[NORTH.getId()] = AOF_NORTH;
-        neighborData[SOUTH.getId()] = AOF_SOUTH;
-        neighborData[WEST.getId()] = AOF_WEST;
-        neighborData[EAST.getId()] = AOF_EAST;
-    });
+	final Direction[] neighbors;
+	final WeightFunction weightFunc;
+	final Vertex2Float depthFunc;
 
-    public static AoFace get(Direction direction){
-        return values[direction.getId()];
-    }
-    
-    /**
-     * Implementations handle bilinear interpolation of a point on a light face
-     * by computing weights for each corner of the light face. Relies on the fact 
-     * that each face is a unit cube. Uses coordinates from axes orthogonal to face
-     * as distance from the edge of the cube, flipping as needed. Multiplying distance 
-     * coordinate pairs together gives sub-area that are the corner weights. 
-     * Weights sum to 1 because it is a unit cube. Values are stored in the provided array.
-     */
-    @FunctionalInterface
-    static interface WeightFunction {
-        void apply(QuadViewImpl q, int vertexIndex, float[] out);
-    }
+	AoFace(Direction[] faces, Vertex2Float depthFunc, WeightFunction weightFunc) {
+		this.neighbors = faces;
+		this.depthFunc = depthFunc;
+		this.weightFunc = weightFunc;
+	}
 
-    @FunctionalInterface
-    static interface Vertex2Float {
-        float apply(QuadViewImpl q, int vertexIndex);
-    }
+	private static final AoFace[] values = SystemUtil.consume(new AoFace[6], (neighborData) -> {
+		neighborData[DOWN.getId()] = AOF_DOWN;
+		neighborData[UP.getId()] = AOF_UP;
+		neighborData[NORTH.getId()] = AOF_NORTH;
+		neighborData[SOUTH.getId()] = AOF_SOUTH;
+		neighborData[WEST.getId()] = AOF_WEST;
+		neighborData[EAST.getId()] = AOF_EAST;
+	});
+
+	public static AoFace get(Direction direction) {
+		return values[direction.getId()];
+	}
+
+	/**
+	 * Implementations handle bilinear interpolation of a point on a light face
+	 * by computing weights for each corner of the light face. Relies on the fact
+	 * that each face is a unit cube. Uses coordinates from axes orthogonal to face
+	 * as distance from the edge of the cube, flipping as needed. Multiplying distance
+	 * coordinate pairs together gives sub-area that are the corner weights.
+	 * Weights sum to 1 because it is a unit cube. Values are stored in the provided array.
+	 */
+	@FunctionalInterface
+	interface WeightFunction {
+		void apply(QuadViewImpl q, int vertexIndex, float[] out);
+	}
+
+	@FunctionalInterface
+	interface Vertex2Float {
+		float apply(QuadViewImpl q, int vertexIndex);
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/aocalc/AoFaceData.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/aocalc/AoFaceData.java
@@ -21,82 +21,82 @@ package net.fabricmc.indigo.renderer.aocalc;
  * Handles caching and provides various utility methods to simplify code elsewhere.
  */
 class AoFaceData {
-    float a0;
-    float a1;
-    float a2;
-    float a3;
-    int b0;
-    int b1;
-    int b2;
-    int b3;
-    int s0;
-    int s1;
-    int s2;
-    int s3;
-    
-    void l0(int l0) {
-        this.b0 = l0 & 0xFFFF;
-        this.s0 = (l0 >>> 16) & 0xFFFF;
-    }
-    
-    void l1(int l1) {
-        this.b1 = l1 & 0xFFFF;
-        this.s1 = (l1 >>> 16) & 0xFFFF;
-    }
-    
-    void l2(int l2) {
-        this.b2 = l2 & 0xFFFF;
-        this.s2 = (l2 >>> 16) & 0xFFFF;
-    }
-    
-    void l3(int l3) {
-        this.b3 = l3 & 0xFFFF;
-        this.s3 = (l3 >>> 16) & 0xFFFF;
-    }
-    
-    int weigtedBlockLight(float[] w) {
-        return (int) (b0 * w[0] + b1 * w[1] + b2 * w[2] + b3 * w[3]) & 0xFF;
-    }
-    
-    int weigtedSkyLight(float[] w) {
-        return (int) (s0 * w[0] + s1 * w[1] + s2 * w[2] + s3 * w[3]) & 0xFF;
-    }
-    
-    int weightedCombinedLight(float[] w) {
-        return weigtedSkyLight(w) << 16 | weigtedBlockLight(w);
-    }
-    
-    float weigtedAo(float[] w) {
-        return a0 * w[0] + a1 * w[1] + a2 * w[2] + a3 * w[3];
-    }
-    
-    void toArray(float[] aOut, int[] bOut, int[] vertexMap) {
-        aOut[vertexMap[0]] = a0;
-        aOut[vertexMap[1]] = a1;
-        aOut[vertexMap[2]] = a2;
-        aOut[vertexMap[3]] = a3;
-        bOut[vertexMap[0]] = s0 << 16 | b0;
-        bOut[vertexMap[1]] = s1 << 16 | b1;
-        bOut[vertexMap[2]] = s2 << 16 | b2;
-        bOut[vertexMap[3]] = s3 << 16 | b3;
-    }
-    
-    static AoFaceData weightedMean(AoFaceData in0, float w0, AoFaceData in1, float w1, AoFaceData out) {
-        out.a0 = in0.a0 * w0 + in1.a0 * w1;
-        out.a1 = in0.a1 * w0 + in1.a1 * w1;
-        out.a2 = in0.a2 * w0 + in1.a2 * w1;
-        out.a3 = in0.a3 * w0 + in1.a3 * w1;
-        
-        out.b0 = (int) (in0.b0 * w0 + in1.b0 * w1);
-        out.b1 = (int) (in0.b1 * w0 + in1.b1 * w1);
-        out.b2 = (int) (in0.b2 * w0 + in1.b2 * w1);
-        out.b3 = (int) (in0.b3 * w0 + in1.b3 * w1);
-        
-        out.s0 = (int) (in0.s0 * w0 + in1.s0 * w1);
-        out.s1 = (int) (in0.s1 * w0 + in1.s1 * w1);
-        out.s2 = (int) (in0.s2 * w0 + in1.s2 * w1);
-        out.s3 = (int) (in0.s3 * w0 + in1.s3 * w1);
-        
-        return out;
-    }
+	float a0;
+	float a1;
+	float a2;
+	float a3;
+	int b0;
+	int b1;
+	int b2;
+	int b3;
+	int s0;
+	int s1;
+	int s2;
+	int s3;
+
+	void l0(int l0) {
+		this.b0 = l0 & 0xFFFF;
+		this.s0 = (l0 >>> 16) & 0xFFFF;
+	}
+
+	void l1(int l1) {
+		this.b1 = l1 & 0xFFFF;
+		this.s1 = (l1 >>> 16) & 0xFFFF;
+	}
+
+	void l2(int l2) {
+		this.b2 = l2 & 0xFFFF;
+		this.s2 = (l2 >>> 16) & 0xFFFF;
+	}
+
+	void l3(int l3) {
+		this.b3 = l3 & 0xFFFF;
+		this.s3 = (l3 >>> 16) & 0xFFFF;
+	}
+
+	int weigtedBlockLight(float[] w) {
+		return (int) (b0 * w[0] + b1 * w[1] + b2 * w[2] + b3 * w[3]) & 0xFF;
+	}
+
+	int weigtedSkyLight(float[] w) {
+		return (int) (s0 * w[0] + s1 * w[1] + s2 * w[2] + s3 * w[3]) & 0xFF;
+	}
+
+	int weightedCombinedLight(float[] w) {
+		return weigtedSkyLight(w) << 16 | weigtedBlockLight(w);
+	}
+
+	float weigtedAo(float[] w) {
+		return a0 * w[0] + a1 * w[1] + a2 * w[2] + a3 * w[3];
+	}
+
+	void toArray(float[] aOut, int[] bOut, int[] vertexMap) {
+		aOut[vertexMap[0]] = a0;
+		aOut[vertexMap[1]] = a1;
+		aOut[vertexMap[2]] = a2;
+		aOut[vertexMap[3]] = a3;
+		bOut[vertexMap[0]] = s0 << 16 | b0;
+		bOut[vertexMap[1]] = s1 << 16 | b1;
+		bOut[vertexMap[2]] = s2 << 16 | b2;
+		bOut[vertexMap[3]] = s3 << 16 | b3;
+	}
+
+	static AoFaceData weightedMean(AoFaceData in0, float w0, AoFaceData in1, float w1, AoFaceData out) {
+		out.a0 = in0.a0 * w0 + in1.a0 * w1;
+		out.a1 = in0.a1 * w0 + in1.a1 * w1;
+		out.a2 = in0.a2 * w0 + in1.a2 * w1;
+		out.a3 = in0.a3 * w0 + in1.a3 * w1;
+
+		out.b0 = (int) (in0.b0 * w0 + in1.b0 * w1);
+		out.b1 = (int) (in0.b1 * w0 + in1.b1 * w1);
+		out.b2 = (int) (in0.b2 * w0 + in1.b2 * w1);
+		out.b3 = (int) (in0.b3 * w0 + in1.b3 * w1);
+
+		out.s0 = (int) (in0.s0 * w0 + in1.s0 * w1);
+		out.s1 = (int) (in0.s1 * w0 + in1.s1 * w1);
+		out.s2 = (int) (in0.s2 * w0 + in1.s2 * w1);
+		out.s3 = (int) (in0.s3 * w0 + in1.s3 * w1);
+
+		return out;
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/aocalc/AoLuminanceFix.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/aocalc/AoLuminanceFix.java
@@ -16,10 +16,11 @@
 
 package net.fabricmc.indigo.renderer.aocalc;
 
-import net.fabricmc.indigo.Indigo;
 import net.minecraft.block.BlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockView;
+
+import net.fabricmc.indigo.Indigo;
 
 /**
  * Implements a fix to prevent luminous blocks from casting AO shade.
@@ -27,16 +28,16 @@ import net.minecraft.world.BlockView;
  */
 @FunctionalInterface
 public interface AoLuminanceFix {
-    float apply(BlockView view, BlockPos pos);
-    
-    AoLuminanceFix INSTANCE = Indigo.FIX_LUMINOUS_AO_SHADE ? AoLuminanceFix::fixed : AoLuminanceFix::vanilla;
-    
-    static float vanilla(BlockView view, BlockPos pos) {
-        return view.getBlockState(pos).getAmbientOcclusionLightLevel(view, pos);
-    }
-    
-    static float fixed(BlockView view, BlockPos pos) {
-        final BlockState state = view.getBlockState(pos);
-        return state.getLuminance() == 0 ? state.getAmbientOcclusionLightLevel(view, pos) : 1f;
-    }
+	float apply(BlockView view, BlockPos pos);
+
+	AoLuminanceFix INSTANCE = Indigo.FIX_LUMINOUS_AO_SHADE ? AoLuminanceFix::fixed : AoLuminanceFix::vanilla;
+
+	static float vanilla(BlockView view, BlockPos pos) {
+		return view.getBlockState(pos).getAmbientOcclusionLightLevel(view, pos);
+	}
+
+	static float fixed(BlockView view, BlockPos pos) {
+		final BlockState state = view.getBlockState(pos);
+		return state.getLuminance() == 0 ? state.getAmbientOcclusionLightLevel(view, pos) : 1f;
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/aocalc/AoVertexClampFunction.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/aocalc/AoVertexClampFunction.java
@@ -23,7 +23,7 @@ import net.fabricmc.indigo.Indigo;
 @Environment(EnvType.CLIENT)
 @FunctionalInterface
 interface AoVertexClampFunction {
-    float clamp(float x);
+	float clamp(float x);
 
-    AoVertexClampFunction CLAMP_FUNC = Indigo.FIX_EXTERIOR_VERTEX_LIGHTING ? x -> x < 0f ? 0f : (x > 1f ? 1f : x) : x -> x;
+	AoVertexClampFunction CLAMP_FUNC = Indigo.FIX_EXTERIOR_VERTEX_LIGHTING ? x -> x < 0f ? 0f : (x > 1f ? 1f : x) : x -> x;
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/aocalc/VanillaAoCalc.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/aocalc/VanillaAoCalc.java
@@ -210,8 +210,8 @@ public class VanillaAoCalc {
 	}
 
 	private int getBrightness(int int_1, int int_2, int int_3, int int_4, float float_1, float float_2, float float_3, float float_4) {
-		int int_5 = (int)((int_1 >> 16 & 255) * float_1 + (int_2 >> 16 & 255) * float_2 + (int_3 >> 16 & 255) * float_3 + (int_4 >> 16 & 255) * float_4) & 255;
-		int int_6 = (int)((int_1 & 255) * float_1 + (int_2 & 255) * float_2 + (int_3 & 255) * float_3 + (int_4 & 255) * float_4) & 255;
+		int int_5 = (int) ((int_1 >> 16 & 255) * float_1 + (int_2 >> 16 & 255) * float_2 + (int_3 >> 16 & 255) * float_3 + (int_4 >> 16 & 255) * float_4) & 255;
+		int int_6 = (int) ((int_1 & 255) * float_1 + (int_2 & 255) * float_2 + (int_3 & 255) * float_3 + (int_4 & 255) * float_4) & 255;
 		return int_5 << 16 | int_6;
 	}
 

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/aocalc/VanillaAoCalc.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/aocalc/VanillaAoCalc.java
@@ -19,353 +19,360 @@ package net.fabricmc.indigo.renderer.aocalc;
 import java.util.BitSet;
 import java.util.function.ToIntFunction;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
-import net.fabricmc.fabric.api.renderer.v1.mesh.QuadView;
-import net.fabricmc.indigo.renderer.aocalc.AoCalculator.AoFunc;
-import net.fabricmc.indigo.renderer.render.BlockRenderInfo;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.util.SystemUtil;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
-import net.minecraft.util.math.Vec3i;
 import net.minecraft.world.ExtendedBlockView;
 
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.renderer.v1.mesh.QuadView;
+import net.fabricmc.indigo.renderer.aocalc.AoCalculator.AoFunc;
+import net.fabricmc.indigo.renderer.render.BlockRenderInfo;
+
 /**
- * Copy of vanilla AoCalculator modified to output to use parameterized 
+ * Copy of vanilla AoCalculator modified to output to use parameterized
  * outputs and brightness function.
  */
 @Environment(EnvType.CLIENT)
 public class VanillaAoCalc {
-    private int[] vertexData = new int[28];
-    private float[] aoBounds = new float[12];
-    private final ToIntFunction<BlockPos> brightnessFunc;
-    private final AoFunc aoFunc;
-    
-    public VanillaAoCalc(ToIntFunction<BlockPos> brightnessFunc, AoFunc aoFunc) {
-        this.brightnessFunc = brightnessFunc;
-        this.aoFunc = aoFunc;
-    }
+	private int[] vertexData = new int[28];
+	private float[] aoBounds = new float[12];
+	private final ToIntFunction<BlockPos> brightnessFunc;
+	private final AoFunc aoFunc;
 
-    public void compute(BlockRenderInfo blockInfo, QuadView quad, float ao[], int[] brightness) {
-        BitSet bits = new BitSet(3);
-        quad.toVanilla(0, vertexData, 0, false);
-        updateShape(blockInfo.blockView, blockInfo.blockState, blockInfo.blockPos, vertexData, quad.lightFace(), aoBounds, bits);
-        apply(blockInfo.blockView, blockInfo.blockState, blockInfo.blockPos, quad.lightFace(), aoBounds, bits, ao, brightness);
-    }
+	public VanillaAoCalc(ToIntFunction<BlockPos> brightnessFunc, AoFunc aoFunc) {
+		this.brightnessFunc = brightnessFunc;
+		this.aoFunc = aoFunc;
+	}
 
-   private void apply(ExtendedBlockView blockView, BlockState blockState, BlockPos blockPos, Direction side, 
-           float[] aoBounds, BitSet bits, float[] ao, int brightness[]) {
-      BlockPos lightPos = bits.get(0) ? blockPos.offset(side) : blockPos;
-      NeighborData neighborData = NeighborData.getData(side);
-      BlockPos.Mutable mpos = new BlockPos.Mutable();
-      mpos.set((Vec3i)lightPos).setOffset(neighborData.faces[0]);
-      int int_1 = brightnessFunc.applyAsInt(mpos);
-      float float_1 = aoFunc.apply(mpos);
-      mpos.set((Vec3i)lightPos).setOffset(neighborData.faces[1]);
-      int int_2 = brightnessFunc.applyAsInt(mpos);
-      float float_2 = aoFunc.apply(mpos);
-      mpos.set((Vec3i)lightPos).setOffset(neighborData.faces[2]);
-      int int_3 = brightnessFunc.applyAsInt(mpos);
-      float float_3 = aoFunc.apply(mpos);
-      mpos.set((Vec3i)lightPos).setOffset(neighborData.faces[3]);
-      int int_4 = brightnessFunc.applyAsInt(mpos);
-      float float_4 = aoFunc.apply(mpos);
-      mpos.set((Vec3i)lightPos).setOffset(neighborData.faces[0]).setOffset(side);
-      boolean boolean_1 = blockView.getBlockState(mpos).getLightSubtracted(blockView, mpos) == 0;
-      mpos.set((Vec3i)lightPos).setOffset(neighborData.faces[1]).setOffset(side);
-      boolean boolean_2 = blockView.getBlockState(mpos).getLightSubtracted(blockView, mpos) == 0;
-      mpos.set((Vec3i)lightPos).setOffset(neighborData.faces[2]).setOffset(side);
-      boolean boolean_3 = blockView.getBlockState(mpos).getLightSubtracted(blockView, mpos) == 0;
-      mpos.set((Vec3i)lightPos).setOffset(neighborData.faces[3]).setOffset(side);
-      boolean boolean_4 = blockView.getBlockState(mpos).getLightSubtracted(blockView, mpos) == 0;
-      float float_6;
-      int int_6;
-      if (!boolean_3 && !boolean_1) {
-         float_6 = float_1;
-         int_6 = int_1;
-      } else {
-         mpos.set((Vec3i)lightPos).setOffset(neighborData.faces[0]).setOffset(neighborData.faces[2]);
-         float_6 = aoFunc.apply(mpos);
-         int_6 = brightnessFunc.applyAsInt(mpos);
-      }
+	public void compute(BlockRenderInfo blockInfo, QuadView quad, float[] ao, int[] brightness) {
+		BitSet bits = new BitSet(3);
+		quad.toVanilla(0, vertexData, 0, false);
+		updateShape(blockInfo.blockView, blockInfo.blockState, blockInfo.blockPos, vertexData, quad.lightFace(), aoBounds, bits);
+		apply(blockInfo.blockView, blockInfo.blockState, blockInfo.blockPos, quad.lightFace(), aoBounds, bits, ao, brightness);
+	}
 
-      float float_8;
-      int int_8;
-      if (!boolean_4 && !boolean_1) {
-         float_8 = float_1;
-         int_8 = int_1;
-      } else {
-         mpos.set((Vec3i)lightPos).setOffset(neighborData.faces[0]).setOffset(neighborData.faces[3]);
-         float_8 = aoFunc.apply(mpos);
-         int_8 = brightnessFunc.applyAsInt(mpos);
-      }
+	private void apply(ExtendedBlockView blockView, BlockState blockState, BlockPos blockPos, Direction side,
+			float[] aoBounds, BitSet bits, float[] ao, int[] brightness) {
+		BlockPos lightPos = bits.get(0) ? blockPos.offset(side) : blockPos;
+		NeighborData neighborData = NeighborData.getData(side);
+		BlockPos.Mutable mpos = new BlockPos.Mutable();
+		mpos.set(lightPos).setOffset(neighborData.faces[0]);
+		int int_1 = brightnessFunc.applyAsInt(mpos);
+		float float_1 = aoFunc.apply(mpos);
+		mpos.set(lightPos).setOffset(neighborData.faces[1]);
+		int int_2 = brightnessFunc.applyAsInt(mpos);
+		float float_2 = aoFunc.apply(mpos);
+		mpos.set(lightPos).setOffset(neighborData.faces[2]);
+		int int_3 = brightnessFunc.applyAsInt(mpos);
+		float float_3 = aoFunc.apply(mpos);
+		mpos.set(lightPos).setOffset(neighborData.faces[3]);
+		int int_4 = brightnessFunc.applyAsInt(mpos);
+		float float_4 = aoFunc.apply(mpos);
+		mpos.set(lightPos).setOffset(neighborData.faces[0]).setOffset(side);
+		boolean boolean_1 = blockView.getBlockState(mpos).getLightSubtracted(blockView, mpos) == 0;
+		mpos.set(lightPos).setOffset(neighborData.faces[1]).setOffset(side);
+		boolean boolean_2 = blockView.getBlockState(mpos).getLightSubtracted(blockView, mpos) == 0;
+		mpos.set(lightPos).setOffset(neighborData.faces[2]).setOffset(side);
+		boolean boolean_3 = blockView.getBlockState(mpos).getLightSubtracted(blockView, mpos) == 0;
+		mpos.set(lightPos).setOffset(neighborData.faces[3]).setOffset(side);
+		boolean boolean_4 = blockView.getBlockState(mpos).getLightSubtracted(blockView, mpos) == 0;
+		float float_6;
+		int int_6;
 
-      float float_10;
-      int int_10;
-      if (!boolean_3 && !boolean_2) {
-         float_10 = float_2;
-         int_10 = int_2;
-      } else {
-         mpos.set((Vec3i)lightPos).setOffset(neighborData.faces[1]).setOffset(neighborData.faces[2]);
-         float_10 = aoFunc.apply(mpos);
-         int_10 = brightnessFunc.applyAsInt(mpos);
-      }
+		if (!boolean_3 && !boolean_1) {
+			float_6 = float_1;
+			int_6 = int_1;
+		} else {
+			mpos.set(lightPos).setOffset(neighborData.faces[0]).setOffset(neighborData.faces[2]);
+			float_6 = aoFunc.apply(mpos);
+			int_6 = brightnessFunc.applyAsInt(mpos);
+		}
 
-      float float_12;
-      int int_12;
-      if (!boolean_4 && !boolean_2) {
-         float_12 = float_2;
-         int_12 = int_2;
-      } else {
-         mpos.set((Vec3i)lightPos).setOffset(neighborData.faces[1]).setOffset(neighborData.faces[3]);
-         float_12 = aoFunc.apply(mpos);
-         int_12 = brightnessFunc.applyAsInt(mpos);
-      }
+		float float_8;
+		int int_8;
 
-      int int_13 = brightnessFunc.applyAsInt(blockPos);
-      mpos.set((Vec3i)blockPos).setOffset(side);
-      if (bits.get(0) || !blockView.getBlockState(mpos).isFullOpaque(blockView, mpos)) {
-         int_13 = brightnessFunc.applyAsInt(mpos);
-      }
+		if (!boolean_4 && !boolean_1) {
+			float_8 = float_1;
+			int_8 = int_1;
+		} else {
+			mpos.set(lightPos).setOffset(neighborData.faces[0]).setOffset(neighborData.faces[3]);
+			float_8 = aoFunc.apply(mpos);
+			int_8 = brightnessFunc.applyAsInt(mpos);
+		}
 
-      float float_13 = bits.get(0) ? blockView.getBlockState(lightPos).getAmbientOcclusionLightLevel(blockView, lightPos) : blockView.getBlockState(blockPos).getAmbientOcclusionLightLevel(blockView, blockPos);
-      Translation blockModelRenderer$Translation_1 = Translation.getTranslations(side);
-      float float_14;
-      float float_15;
-      float float_16;
-      float float_17;
-      if (bits.get(1) && neighborData.nonCubicWeight) {
-         float_14 = (float_4 + float_1 + float_8 + float_13) * 0.25F;
-         float_15 = (float_3 + float_1 + float_6 + float_13) * 0.25F;
-         float_16 = (float_3 + float_2 + float_10 + float_13) * 0.25F;
-         float_17 = (float_4 + float_2 + float_12 + float_13) * 0.25F;
-         float float_22 = aoBounds[neighborData.field_4192[0].shape] * aoBounds[neighborData.field_4192[1].shape];
-         float float_23 = aoBounds[neighborData.field_4192[2].shape] * aoBounds[neighborData.field_4192[3].shape];
-         float float_24 = aoBounds[neighborData.field_4192[4].shape] * aoBounds[neighborData.field_4192[5].shape];
-         float float_25 = aoBounds[neighborData.field_4192[6].shape] * aoBounds[neighborData.field_4192[7].shape];
-         float float_26 = aoBounds[neighborData.field_4185[0].shape] * aoBounds[neighborData.field_4185[1].shape];
-         float float_27 = aoBounds[neighborData.field_4185[2].shape] * aoBounds[neighborData.field_4185[3].shape];
-         float float_28 = aoBounds[neighborData.field_4185[4].shape] * aoBounds[neighborData.field_4185[5].shape];
-         float float_29 = aoBounds[neighborData.field_4185[6].shape] * aoBounds[neighborData.field_4185[7].shape];
-         float float_30 = aoBounds[neighborData.field_4180[0].shape] * aoBounds[neighborData.field_4180[1].shape];
-         float float_31 = aoBounds[neighborData.field_4180[2].shape] * aoBounds[neighborData.field_4180[3].shape];
-         float float_32 = aoBounds[neighborData.field_4180[4].shape] * aoBounds[neighborData.field_4180[5].shape];
-         float float_33 = aoBounds[neighborData.field_4180[6].shape] * aoBounds[neighborData.field_4180[7].shape];
-         float float_34 = aoBounds[neighborData.field_4188[0].shape] * aoBounds[neighborData.field_4188[1].shape];
-         float float_35 = aoBounds[neighborData.field_4188[2].shape] * aoBounds[neighborData.field_4188[3].shape];
-         float float_36 = aoBounds[neighborData.field_4188[4].shape] * aoBounds[neighborData.field_4188[5].shape];
-         float float_37 = aoBounds[neighborData.field_4188[6].shape] * aoBounds[neighborData.field_4188[7].shape];
-         
-         ao[blockModelRenderer$Translation_1.firstCorner] = float_14 * float_22 + float_15 * float_23 + float_16 * float_24 + float_17 * float_25;
-         ao[blockModelRenderer$Translation_1.secondCorner] = float_14 * float_26 + float_15 * float_27 + float_16 * float_28 + float_17 * float_29;
-         ao[blockModelRenderer$Translation_1.thirdCorner] = float_14 * float_30 + float_15 * float_31 + float_16 * float_32 + float_17 * float_33;
-         ao[blockModelRenderer$Translation_1.fourthCorner] = float_14 * float_34 + float_15 * float_35 + float_16 * float_36 + float_17 * float_37;
-         int int_14 = this.getAmbientOcclusionBrightness(int_4, int_1, int_8, int_13);
-         int int_15 = this.getAmbientOcclusionBrightness(int_3, int_1, int_6, int_13);
-         int int_16 = this.getAmbientOcclusionBrightness(int_3, int_2, int_10, int_13);
-         int int_17 = this.getAmbientOcclusionBrightness(int_4, int_2, int_12, int_13);
-         brightness[blockModelRenderer$Translation_1.firstCorner] = this.getBrightness(int_14, int_15, int_16, int_17, float_22, float_23, float_24, float_25);
-         brightness[blockModelRenderer$Translation_1.secondCorner] = this.getBrightness(int_14, int_15, int_16, int_17, float_26, float_27, float_28, float_29);
-         brightness[blockModelRenderer$Translation_1.thirdCorner] = this.getBrightness(int_14, int_15, int_16, int_17, float_30, float_31, float_32, float_33);
-         brightness[blockModelRenderer$Translation_1.fourthCorner] = this.getBrightness(int_14, int_15, int_16, int_17, float_34, float_35, float_36, float_37);
-      } else {
-         float_14 = (float_4 + float_1 + float_8 + float_13) * 0.25F;
-         float_15 = (float_3 + float_1 + float_6 + float_13) * 0.25F;
-         float_16 = (float_3 + float_2 + float_10 + float_13) * 0.25F;
-         float_17 = (float_4 + float_2 + float_12 + float_13) * 0.25F;
-         brightness[blockModelRenderer$Translation_1.firstCorner] = this.getAmbientOcclusionBrightness(int_4, int_1, int_8, int_13);
-         brightness[blockModelRenderer$Translation_1.secondCorner] = this.getAmbientOcclusionBrightness(int_3, int_1, int_6, int_13);
-         brightness[blockModelRenderer$Translation_1.thirdCorner] = this.getAmbientOcclusionBrightness(int_3, int_2, int_10, int_13);
-         brightness[blockModelRenderer$Translation_1.fourthCorner] = this.getAmbientOcclusionBrightness(int_4, int_2, int_12, int_13);
-         
-         ao[blockModelRenderer$Translation_1.firstCorner] = float_14;
-         ao[blockModelRenderer$Translation_1.secondCorner] = float_15;
-         ao[blockModelRenderer$Translation_1.thirdCorner] = float_16;
-         ao[blockModelRenderer$Translation_1.fourthCorner] = float_17;
-      }
-   }
+		float float_10;
+		int int_10;
 
-   private int getAmbientOcclusionBrightness(int int_1, int int_2, int int_3, int int_4) {
-      if (int_1 == 0) {
-         int_1 = int_4;
-      }
+		if (!boolean_3 && !boolean_2) {
+			float_10 = float_2;
+			int_10 = int_2;
+		} else {
+			mpos.set(lightPos).setOffset(neighborData.faces[1]).setOffset(neighborData.faces[2]);
+			float_10 = aoFunc.apply(mpos);
+			int_10 = brightnessFunc.applyAsInt(mpos);
+		}
 
-      if (int_2 == 0) {
-         int_2 = int_4;
-      }
+		float float_12;
+		int int_12;
 
-      if (int_3 == 0) {
-         int_3 = int_4;
-      }
+		if (!boolean_4 && !boolean_2) {
+			float_12 = float_2;
+			int_12 = int_2;
+		} else {
+			mpos.set(lightPos).setOffset(neighborData.faces[1]).setOffset(neighborData.faces[3]);
+			float_12 = aoFunc.apply(mpos);
+			int_12 = brightnessFunc.applyAsInt(mpos);
+		}
 
-      return int_1 + int_2 + int_3 + int_4 >> 2 & 16711935;
-   }
+		int int_13 = brightnessFunc.applyAsInt(blockPos);
+		mpos.set(blockPos).setOffset(side);
 
-   private int getBrightness(int int_1, int int_2, int int_3, int int_4, float float_1, float float_2, float float_3, float float_4) {
-      int int_5 = (int)((float)(int_1 >> 16 & 255) * float_1 + (float)(int_2 >> 16 & 255) * float_2 + (float)(int_3 >> 16 & 255) * float_3 + (float)(int_4 >> 16 & 255) * float_4) & 255;
-      int int_6 = (int)((float)(int_1 & 255) * float_1 + (float)(int_2 & 255) * float_2 + (float)(int_3 & 255) * float_3 + (float)(int_4 & 255) * float_4) & 255;
-      return int_5 << 16 | int_6;
-   }
-    
-    @Environment(EnvType.CLIENT)
-    static enum Translation {
-       DOWN(0, 1, 2, 3),
-       UP(2, 3, 0, 1),
-       NORTH(3, 0, 1, 2),
-       SOUTH(0, 1, 2, 3),
-       WEST(3, 0, 1, 2),
-       EAST(1, 2, 3, 0);
-    
-       private final int firstCorner;
-       private final int secondCorner;
-       private final int thirdCorner;
-       private final int fourthCorner;
-       private static final Translation[] VALUES = (Translation[])SystemUtil.consume(new Translation[6], (blockModelRenderer$Translations_1) -> {
-          blockModelRenderer$Translations_1[Direction.DOWN.getId()] = DOWN;
-          blockModelRenderer$Translations_1[Direction.UP.getId()] = UP;
-          blockModelRenderer$Translations_1[Direction.NORTH.getId()] = NORTH;
-          blockModelRenderer$Translations_1[Direction.SOUTH.getId()] = SOUTH;
-          blockModelRenderer$Translations_1[Direction.WEST.getId()] = WEST;
-          blockModelRenderer$Translations_1[Direction.EAST.getId()] = EAST;
-       });
-    
-       private Translation(int int_1, int int_2, int int_3, int int_4) {
-          this.firstCorner = int_1;
-          this.secondCorner = int_2;
-          this.thirdCorner = int_3;
-          this.fourthCorner = int_4;
-       }
-    
-       public static Translation getTranslations(Direction direction_1) {
-          return VALUES[direction_1.getId()];
-       }
-    }
-    
-    @Environment(EnvType.CLIENT)
-    public static enum NeighborData {
-       DOWN(new Direction[]{Direction.WEST, Direction.EAST, Direction.NORTH, Direction.SOUTH}, 0.5F, true, new NeighborOrientation[]{NeighborOrientation.FLIP_WEST, NeighborOrientation.SOUTH, NeighborOrientation.FLIP_WEST, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.WEST, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.WEST, NeighborOrientation.SOUTH}, new NeighborOrientation[]{NeighborOrientation.FLIP_WEST, NeighborOrientation.NORTH, NeighborOrientation.FLIP_WEST, NeighborOrientation.FLIP_NORTH, NeighborOrientation.WEST, NeighborOrientation.FLIP_NORTH, NeighborOrientation.WEST, NeighborOrientation.NORTH}, new NeighborOrientation[]{NeighborOrientation.FLIP_EAST, NeighborOrientation.NORTH, NeighborOrientation.FLIP_EAST, NeighborOrientation.FLIP_NORTH, NeighborOrientation.EAST, NeighborOrientation.FLIP_NORTH, NeighborOrientation.EAST, NeighborOrientation.NORTH}, new NeighborOrientation[]{NeighborOrientation.FLIP_EAST, NeighborOrientation.SOUTH, NeighborOrientation.FLIP_EAST, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.EAST, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.EAST, NeighborOrientation.SOUTH}),
-       UP(new Direction[]{Direction.EAST, Direction.WEST, Direction.NORTH, Direction.SOUTH}, 1.0F, true, new NeighborOrientation[]{NeighborOrientation.EAST, NeighborOrientation.SOUTH, NeighborOrientation.EAST, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.FLIP_EAST, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.FLIP_EAST, NeighborOrientation.SOUTH}, new NeighborOrientation[]{NeighborOrientation.EAST, NeighborOrientation.NORTH, NeighborOrientation.EAST, NeighborOrientation.FLIP_NORTH, NeighborOrientation.FLIP_EAST, NeighborOrientation.FLIP_NORTH, NeighborOrientation.FLIP_EAST, NeighborOrientation.NORTH}, new NeighborOrientation[]{NeighborOrientation.WEST, NeighborOrientation.NORTH, NeighborOrientation.WEST, NeighborOrientation.FLIP_NORTH, NeighborOrientation.FLIP_WEST, NeighborOrientation.FLIP_NORTH, NeighborOrientation.FLIP_WEST, NeighborOrientation.NORTH}, new NeighborOrientation[]{NeighborOrientation.WEST, NeighborOrientation.SOUTH, NeighborOrientation.WEST, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.FLIP_WEST, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.FLIP_WEST, NeighborOrientation.SOUTH}),
-       NORTH(new Direction[]{Direction.UP, Direction.DOWN, Direction.EAST, Direction.WEST}, 0.8F, true, new NeighborOrientation[]{NeighborOrientation.UP, NeighborOrientation.FLIP_WEST, NeighborOrientation.UP, NeighborOrientation.WEST, NeighborOrientation.FLIP_UP, NeighborOrientation.WEST, NeighborOrientation.FLIP_UP, NeighborOrientation.FLIP_WEST}, new NeighborOrientation[]{NeighborOrientation.UP, NeighborOrientation.FLIP_EAST, NeighborOrientation.UP, NeighborOrientation.EAST, NeighborOrientation.FLIP_UP, NeighborOrientation.EAST, NeighborOrientation.FLIP_UP, NeighborOrientation.FLIP_EAST}, new NeighborOrientation[]{NeighborOrientation.DOWN, NeighborOrientation.FLIP_EAST, NeighborOrientation.DOWN, NeighborOrientation.EAST, NeighborOrientation.FLIP_DOWN, NeighborOrientation.EAST, NeighborOrientation.FLIP_DOWN, NeighborOrientation.FLIP_EAST}, new NeighborOrientation[]{NeighborOrientation.DOWN, NeighborOrientation.FLIP_WEST, NeighborOrientation.DOWN, NeighborOrientation.WEST, NeighborOrientation.FLIP_DOWN, NeighborOrientation.WEST, NeighborOrientation.FLIP_DOWN, NeighborOrientation.FLIP_WEST}),
-       SOUTH(new Direction[]{Direction.WEST, Direction.EAST, Direction.DOWN, Direction.UP}, 0.8F, true, new NeighborOrientation[]{NeighborOrientation.UP, NeighborOrientation.FLIP_WEST, NeighborOrientation.FLIP_UP, NeighborOrientation.FLIP_WEST, NeighborOrientation.FLIP_UP, NeighborOrientation.WEST, NeighborOrientation.UP, NeighborOrientation.WEST}, new NeighborOrientation[]{NeighborOrientation.DOWN, NeighborOrientation.FLIP_WEST, NeighborOrientation.FLIP_DOWN, NeighborOrientation.FLIP_WEST, NeighborOrientation.FLIP_DOWN, NeighborOrientation.WEST, NeighborOrientation.DOWN, NeighborOrientation.WEST}, new NeighborOrientation[]{NeighborOrientation.DOWN, NeighborOrientation.FLIP_EAST, NeighborOrientation.FLIP_DOWN, NeighborOrientation.FLIP_EAST, NeighborOrientation.FLIP_DOWN, NeighborOrientation.EAST, NeighborOrientation.DOWN, NeighborOrientation.EAST}, new NeighborOrientation[]{NeighborOrientation.UP, NeighborOrientation.FLIP_EAST, NeighborOrientation.FLIP_UP, NeighborOrientation.FLIP_EAST, NeighborOrientation.FLIP_UP, NeighborOrientation.EAST, NeighborOrientation.UP, NeighborOrientation.EAST}),
-       WEST(new Direction[]{Direction.UP, Direction.DOWN, Direction.NORTH, Direction.SOUTH}, 0.6F, true, new NeighborOrientation[]{NeighborOrientation.UP, NeighborOrientation.SOUTH, NeighborOrientation.UP, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.FLIP_UP, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.FLIP_UP, NeighborOrientation.SOUTH}, new NeighborOrientation[]{NeighborOrientation.UP, NeighborOrientation.NORTH, NeighborOrientation.UP, NeighborOrientation.FLIP_NORTH, NeighborOrientation.FLIP_UP, NeighborOrientation.FLIP_NORTH, NeighborOrientation.FLIP_UP, NeighborOrientation.NORTH}, new NeighborOrientation[]{NeighborOrientation.DOWN, NeighborOrientation.NORTH, NeighborOrientation.DOWN, NeighborOrientation.FLIP_NORTH, NeighborOrientation.FLIP_DOWN, NeighborOrientation.FLIP_NORTH, NeighborOrientation.FLIP_DOWN, NeighborOrientation.NORTH}, new NeighborOrientation[]{NeighborOrientation.DOWN, NeighborOrientation.SOUTH, NeighborOrientation.DOWN, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.FLIP_DOWN, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.FLIP_DOWN, NeighborOrientation.SOUTH}),
-       EAST(new Direction[]{Direction.DOWN, Direction.UP, Direction.NORTH, Direction.SOUTH}, 0.6F, true, new NeighborOrientation[]{NeighborOrientation.FLIP_DOWN, NeighborOrientation.SOUTH, NeighborOrientation.FLIP_DOWN, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.DOWN, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.DOWN, NeighborOrientation.SOUTH}, new NeighborOrientation[]{NeighborOrientation.FLIP_DOWN, NeighborOrientation.NORTH, NeighborOrientation.FLIP_DOWN, NeighborOrientation.FLIP_NORTH, NeighborOrientation.DOWN, NeighborOrientation.FLIP_NORTH, NeighborOrientation.DOWN, NeighborOrientation.NORTH}, new NeighborOrientation[]{NeighborOrientation.FLIP_UP, NeighborOrientation.NORTH, NeighborOrientation.FLIP_UP, NeighborOrientation.FLIP_NORTH, NeighborOrientation.UP, NeighborOrientation.FLIP_NORTH, NeighborOrientation.UP, NeighborOrientation.NORTH}, new NeighborOrientation[]{NeighborOrientation.FLIP_UP, NeighborOrientation.SOUTH, NeighborOrientation.FLIP_UP, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.UP, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.UP, NeighborOrientation.SOUTH});
+		if (bits.get(0) || !blockView.getBlockState(mpos).isFullOpaque(blockView, mpos)) {
+			int_13 = brightnessFunc.applyAsInt(mpos);
+		}
 
-       private final Direction[] faces;
-       private final boolean nonCubicWeight;
-       private final NeighborOrientation[] field_4192;
-       private final NeighborOrientation[] field_4185;
-       private final NeighborOrientation[] field_4180;
-       private final NeighborOrientation[] field_4188;
-       private static final NeighborData[] field_4190 = (NeighborData[])SystemUtil.consume(new NeighborData[6], (blockModelRenderer$NeighborDatas_1) -> {
-          blockModelRenderer$NeighborDatas_1[Direction.DOWN.getId()] = DOWN;
-          blockModelRenderer$NeighborDatas_1[Direction.UP.getId()] = UP;
-          blockModelRenderer$NeighborDatas_1[Direction.NORTH.getId()] = NORTH;
-          blockModelRenderer$NeighborDatas_1[Direction.SOUTH.getId()] = SOUTH;
-          blockModelRenderer$NeighborDatas_1[Direction.WEST.getId()] = WEST;
-          blockModelRenderer$NeighborDatas_1[Direction.EAST.getId()] = EAST;
-       });
+		float float_13 = bits.get(0) ? blockView.getBlockState(lightPos).getAmbientOcclusionLightLevel(blockView, lightPos) : blockView.getBlockState(blockPos).getAmbientOcclusionLightLevel(blockView, blockPos);
+		Translation blockModelRenderer$Translation_1 = Translation.getTranslations(side);
+		float float_14;
+		float float_15;
+		float float_16;
+		float float_17;
 
-       private NeighborData(Direction[] directions_1, float float_1, boolean boolean_1, NeighborOrientation[] blockModelRenderer$NeighborOrientations_1, NeighborOrientation[] blockModelRenderer$NeighborOrientations_2, NeighborOrientation[] blockModelRenderer$NeighborOrientations_3, NeighborOrientation[] blockModelRenderer$NeighborOrientations_4) {
-          this.faces = directions_1;
-          this.nonCubicWeight = boolean_1;
-          this.field_4192 = blockModelRenderer$NeighborOrientations_1;
-          this.field_4185 = blockModelRenderer$NeighborOrientations_2;
-          this.field_4180 = blockModelRenderer$NeighborOrientations_3;
-          this.field_4188 = blockModelRenderer$NeighborOrientations_4;
-       }
+		if (bits.get(1) && neighborData.nonCubicWeight) {
+			float_14 = (float_4 + float_1 + float_8 + float_13) * 0.25F;
+			float_15 = (float_3 + float_1 + float_6 + float_13) * 0.25F;
+			float_16 = (float_3 + float_2 + float_10 + float_13) * 0.25F;
+			float_17 = (float_4 + float_2 + float_12 + float_13) * 0.25F;
+			float float_22 = aoBounds[neighborData.field_4192[0].shape] * aoBounds[neighborData.field_4192[1].shape];
+			float float_23 = aoBounds[neighborData.field_4192[2].shape] * aoBounds[neighborData.field_4192[3].shape];
+			float float_24 = aoBounds[neighborData.field_4192[4].shape] * aoBounds[neighborData.field_4192[5].shape];
+			float float_25 = aoBounds[neighborData.field_4192[6].shape] * aoBounds[neighborData.field_4192[7].shape];
+			float float_26 = aoBounds[neighborData.field_4185[0].shape] * aoBounds[neighborData.field_4185[1].shape];
+			float float_27 = aoBounds[neighborData.field_4185[2].shape] * aoBounds[neighborData.field_4185[3].shape];
+			float float_28 = aoBounds[neighborData.field_4185[4].shape] * aoBounds[neighborData.field_4185[5].shape];
+			float float_29 = aoBounds[neighborData.field_4185[6].shape] * aoBounds[neighborData.field_4185[7].shape];
+			float float_30 = aoBounds[neighborData.field_4180[0].shape] * aoBounds[neighborData.field_4180[1].shape];
+			float float_31 = aoBounds[neighborData.field_4180[2].shape] * aoBounds[neighborData.field_4180[3].shape];
+			float float_32 = aoBounds[neighborData.field_4180[4].shape] * aoBounds[neighborData.field_4180[5].shape];
+			float float_33 = aoBounds[neighborData.field_4180[6].shape] * aoBounds[neighborData.field_4180[7].shape];
+			float float_34 = aoBounds[neighborData.field_4188[0].shape] * aoBounds[neighborData.field_4188[1].shape];
+			float float_35 = aoBounds[neighborData.field_4188[2].shape] * aoBounds[neighborData.field_4188[3].shape];
+			float float_36 = aoBounds[neighborData.field_4188[4].shape] * aoBounds[neighborData.field_4188[5].shape];
+			float float_37 = aoBounds[neighborData.field_4188[6].shape] * aoBounds[neighborData.field_4188[7].shape];
 
-       public static NeighborData getData(Direction direction_1) {
-          return field_4190[direction_1.getId()];
-       }
-    }
+			ao[blockModelRenderer$Translation_1.firstCorner] = float_14 * float_22 + float_15 * float_23 + float_16 * float_24 + float_17 * float_25;
+			ao[blockModelRenderer$Translation_1.secondCorner] = float_14 * float_26 + float_15 * float_27 + float_16 * float_28 + float_17 * float_29;
+			ao[blockModelRenderer$Translation_1.thirdCorner] = float_14 * float_30 + float_15 * float_31 + float_16 * float_32 + float_17 * float_33;
+			ao[blockModelRenderer$Translation_1.fourthCorner] = float_14 * float_34 + float_15 * float_35 + float_16 * float_36 + float_17 * float_37;
+			int int_14 = this.getAmbientOcclusionBrightness(int_4, int_1, int_8, int_13);
+			int int_15 = this.getAmbientOcclusionBrightness(int_3, int_1, int_6, int_13);
+			int int_16 = this.getAmbientOcclusionBrightness(int_3, int_2, int_10, int_13);
+			int int_17 = this.getAmbientOcclusionBrightness(int_4, int_2, int_12, int_13);
+			brightness[blockModelRenderer$Translation_1.firstCorner] = this.getBrightness(int_14, int_15, int_16, int_17, float_22, float_23, float_24, float_25);
+			brightness[blockModelRenderer$Translation_1.secondCorner] = this.getBrightness(int_14, int_15, int_16, int_17, float_26, float_27, float_28, float_29);
+			brightness[blockModelRenderer$Translation_1.thirdCorner] = this.getBrightness(int_14, int_15, int_16, int_17, float_30, float_31, float_32, float_33);
+			brightness[blockModelRenderer$Translation_1.fourthCorner] = this.getBrightness(int_14, int_15, int_16, int_17, float_34, float_35, float_36, float_37);
+		} else {
+			float_14 = (float_4 + float_1 + float_8 + float_13) * 0.25F;
+			float_15 = (float_3 + float_1 + float_6 + float_13) * 0.25F;
+			float_16 = (float_3 + float_2 + float_10 + float_13) * 0.25F;
+			float_17 = (float_4 + float_2 + float_12 + float_13) * 0.25F;
+			brightness[blockModelRenderer$Translation_1.firstCorner] = this.getAmbientOcclusionBrightness(int_4, int_1, int_8, int_13);
+			brightness[blockModelRenderer$Translation_1.secondCorner] = this.getAmbientOcclusionBrightness(int_3, int_1, int_6, int_13);
+			brightness[blockModelRenderer$Translation_1.thirdCorner] = this.getAmbientOcclusionBrightness(int_3, int_2, int_10, int_13);
+			brightness[blockModelRenderer$Translation_1.fourthCorner] = this.getAmbientOcclusionBrightness(int_4, int_2, int_12, int_13);
 
-    @Environment(EnvType.CLIENT)
-    public static enum NeighborOrientation {
-       DOWN(Direction.DOWN, false),
-       UP(Direction.UP, false),
-       NORTH(Direction.NORTH, false),
-       SOUTH(Direction.SOUTH, false),
-       WEST(Direction.WEST, false),
-       EAST(Direction.EAST, false),
-       FLIP_DOWN(Direction.DOWN, true),
-       FLIP_UP(Direction.UP, true),
-       FLIP_NORTH(Direction.NORTH, true),
-       FLIP_SOUTH(Direction.SOUTH, true),
-       FLIP_WEST(Direction.WEST, true),
-       FLIP_EAST(Direction.EAST, true);
+			ao[blockModelRenderer$Translation_1.firstCorner] = float_14;
+			ao[blockModelRenderer$Translation_1.secondCorner] = float_15;
+			ao[blockModelRenderer$Translation_1.thirdCorner] = float_16;
+			ao[blockModelRenderer$Translation_1.fourthCorner] = float_17;
+		}
+	}
 
-       private final int shape;
+	private int getAmbientOcclusionBrightness(int int_1, int int_2, int int_3, int int_4) {
+		if (int_1 == 0) {
+			int_1 = int_4;
+		}
 
-       private NeighborOrientation(Direction direction_1, boolean boolean_1) {
-          this.shape = direction_1.getId() + (boolean_1 ? Direction.values().length : 0);
-       }
-    }
-    
-    public static void updateShape(ExtendedBlockView extendedBlockView_1, BlockState blockState_1, BlockPos blockPos_1, int[] ints_1, Direction direction_1, float[] floats_1, BitSet bitSet_1) {
-        float float_1 = 32.0F;
-        float float_2 = 32.0F;
-        float float_3 = 32.0F;
-        float float_4 = -32.0F;
-        float float_5 = -32.0F;
-        float float_6 = -32.0F;
+		if (int_2 == 0) {
+			int_2 = int_4;
+		}
 
-        int int_2;
-        float float_11;
-        for(int_2 = 0; int_2 < 4; ++int_2) {
-           float_11 = Float.intBitsToFloat(ints_1[int_2 * 7]);
-           float float_8 = Float.intBitsToFloat(ints_1[int_2 * 7 + 1]);
-           float float_9 = Float.intBitsToFloat(ints_1[int_2 * 7 + 2]);
-           float_1 = Math.min(float_1, float_11);
-           float_2 = Math.min(float_2, float_8);
-           float_3 = Math.min(float_3, float_9);
-           float_4 = Math.max(float_4, float_11);
-           float_5 = Math.max(float_5, float_8);
-           float_6 = Math.max(float_6, float_9);
-        }
+		if (int_3 == 0) {
+			int_3 = int_4;
+		}
 
-        if (floats_1 != null) {
-           floats_1[Direction.WEST.getId()] = float_1;
-           floats_1[Direction.EAST.getId()] = float_4;
-           floats_1[Direction.DOWN.getId()] = float_2;
-           floats_1[Direction.UP.getId()] = float_5;
-           floats_1[Direction.NORTH.getId()] = float_3;
-           floats_1[Direction.SOUTH.getId()] = float_6;
-           int_2 = Direction.values().length;
-           floats_1[Direction.WEST.getId() + int_2] = 1.0F - float_1;
-           floats_1[Direction.EAST.getId() + int_2] = 1.0F - float_4;
-           floats_1[Direction.DOWN.getId() + int_2] = 1.0F - float_2;
-           floats_1[Direction.UP.getId() + int_2] = 1.0F - float_5;
-           floats_1[Direction.NORTH.getId() + int_2] = 1.0F - float_3;
-           floats_1[Direction.SOUTH.getId() + int_2] = 1.0F - float_6;
-        }
+		return int_1 + int_2 + int_3 + int_4 >> 2 & 16711935;
+	}
 
-        float_11 = 0.9999F;
-        switch(direction_1) {
-        case DOWN:
-           bitSet_1.set(1, float_1 >= 1.0E-4F || float_3 >= 1.0E-4F || float_4 <= 0.9999F || float_6 <= 0.9999F);
-           bitSet_1.set(0, (float_2 < 1.0E-4F || Block.isShapeFullCube(blockState_1.getCollisionShape(extendedBlockView_1, blockPos_1))) && float_2 == float_5);
-           break;
-        case UP:
-           bitSet_1.set(1, float_1 >= 1.0E-4F || float_3 >= 1.0E-4F || float_4 <= 0.9999F || float_6 <= 0.9999F);
-           bitSet_1.set(0, (float_5 > 0.9999F || Block.isShapeFullCube(blockState_1.getCollisionShape(extendedBlockView_1, blockPos_1))) && float_2 == float_5);
-           break;
-        case NORTH:
-           bitSet_1.set(1, float_1 >= 1.0E-4F || float_2 >= 1.0E-4F || float_4 <= 0.9999F || float_5 <= 0.9999F);
-           bitSet_1.set(0, (float_3 < 1.0E-4F || Block.isShapeFullCube(blockState_1.getCollisionShape(extendedBlockView_1, blockPos_1))) && float_3 == float_6);
-           break;
-        case SOUTH:
-           bitSet_1.set(1, float_1 >= 1.0E-4F || float_2 >= 1.0E-4F || float_4 <= 0.9999F || float_5 <= 0.9999F);
-           bitSet_1.set(0, (float_6 > 0.9999F || Block.isShapeFullCube(blockState_1.getCollisionShape(extendedBlockView_1, blockPos_1))) && float_3 == float_6);
-           break;
-        case WEST:
-           bitSet_1.set(1, float_2 >= 1.0E-4F || float_3 >= 1.0E-4F || float_5 <= 0.9999F || float_6 <= 0.9999F);
-           bitSet_1.set(0, (float_1 < 1.0E-4F || Block.isShapeFullCube(blockState_1.getCollisionShape(extendedBlockView_1, blockPos_1))) && float_1 == float_4);
-           break;
-        case EAST:
-           bitSet_1.set(1, float_2 >= 1.0E-4F || float_3 >= 1.0E-4F || float_5 <= 0.9999F || float_6 <= 0.9999F);
-           bitSet_1.set(0, (float_4 > 0.9999F || Block.isShapeFullCube(blockState_1.getCollisionShape(extendedBlockView_1, blockPos_1))) && float_1 == float_4);
-        }
-     }
+	private int getBrightness(int int_1, int int_2, int int_3, int int_4, float float_1, float float_2, float float_3, float float_4) {
+		int int_5 = (int)((int_1 >> 16 & 255) * float_1 + (int_2 >> 16 & 255) * float_2 + (int_3 >> 16 & 255) * float_3 + (int_4 >> 16 & 255) * float_4) & 255;
+		int int_6 = (int)((int_1 & 255) * float_1 + (int_2 & 255) * float_2 + (int_3 & 255) * float_3 + (int_4 & 255) * float_4) & 255;
+		return int_5 << 16 | int_6;
+	}
+
+	@Environment(EnvType.CLIENT)
+	enum Translation {
+		DOWN(0, 1, 2, 3),
+		UP(2, 3, 0, 1),
+		NORTH(3, 0, 1, 2),
+		SOUTH(0, 1, 2, 3),
+		WEST(3, 0, 1, 2),
+		EAST(1, 2, 3, 0);
+
+		private final int firstCorner;
+		private final int secondCorner;
+		private final int thirdCorner;
+		private final int fourthCorner;
+		private static final Translation[] VALUES = SystemUtil.consume(new Translation[6], (blockModelRenderer$Translations_1) -> {
+			blockModelRenderer$Translations_1[Direction.DOWN.getId()] = DOWN;
+			blockModelRenderer$Translations_1[Direction.UP.getId()] = UP;
+			blockModelRenderer$Translations_1[Direction.NORTH.getId()] = NORTH;
+			blockModelRenderer$Translations_1[Direction.SOUTH.getId()] = SOUTH;
+			blockModelRenderer$Translations_1[Direction.WEST.getId()] = WEST;
+			blockModelRenderer$Translations_1[Direction.EAST.getId()] = EAST;
+		});
+
+		Translation(int int_1, int int_2, int int_3, int int_4) {
+			this.firstCorner = int_1;
+			this.secondCorner = int_2;
+			this.thirdCorner = int_3;
+			this.fourthCorner = int_4;
+		}
+
+		public static Translation getTranslations(Direction direction_1) {
+			return VALUES[direction_1.getId()];
+		}
+	}
+
+	@Environment(EnvType.CLIENT)
+	public enum NeighborData {
+		DOWN(new Direction[]{Direction.WEST, Direction.EAST, Direction.NORTH, Direction.SOUTH}, 0.5F, true, new NeighborOrientation[]{NeighborOrientation.FLIP_WEST, NeighborOrientation.SOUTH, NeighborOrientation.FLIP_WEST, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.WEST, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.WEST, NeighborOrientation.SOUTH}, new NeighborOrientation[]{NeighborOrientation.FLIP_WEST, NeighborOrientation.NORTH, NeighborOrientation.FLIP_WEST, NeighborOrientation.FLIP_NORTH, NeighborOrientation.WEST, NeighborOrientation.FLIP_NORTH, NeighborOrientation.WEST, NeighborOrientation.NORTH}, new NeighborOrientation[]{NeighborOrientation.FLIP_EAST, NeighborOrientation.NORTH, NeighborOrientation.FLIP_EAST, NeighborOrientation.FLIP_NORTH, NeighborOrientation.EAST, NeighborOrientation.FLIP_NORTH, NeighborOrientation.EAST, NeighborOrientation.NORTH}, new NeighborOrientation[]{NeighborOrientation.FLIP_EAST, NeighborOrientation.SOUTH, NeighborOrientation.FLIP_EAST, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.EAST, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.EAST, NeighborOrientation.SOUTH}),
+		UP(new Direction[]{Direction.EAST, Direction.WEST, Direction.NORTH, Direction.SOUTH}, 1.0F, true, new NeighborOrientation[]{NeighborOrientation.EAST, NeighborOrientation.SOUTH, NeighborOrientation.EAST, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.FLIP_EAST, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.FLIP_EAST, NeighborOrientation.SOUTH}, new NeighborOrientation[]{NeighborOrientation.EAST, NeighborOrientation.NORTH, NeighborOrientation.EAST, NeighborOrientation.FLIP_NORTH, NeighborOrientation.FLIP_EAST, NeighborOrientation.FLIP_NORTH, NeighborOrientation.FLIP_EAST, NeighborOrientation.NORTH}, new NeighborOrientation[]{NeighborOrientation.WEST, NeighborOrientation.NORTH, NeighborOrientation.WEST, NeighborOrientation.FLIP_NORTH, NeighborOrientation.FLIP_WEST, NeighborOrientation.FLIP_NORTH, NeighborOrientation.FLIP_WEST, NeighborOrientation.NORTH}, new NeighborOrientation[]{NeighborOrientation.WEST, NeighborOrientation.SOUTH, NeighborOrientation.WEST, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.FLIP_WEST, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.FLIP_WEST, NeighborOrientation.SOUTH}),
+		NORTH(new Direction[]{Direction.UP, Direction.DOWN, Direction.EAST, Direction.WEST}, 0.8F, true, new NeighborOrientation[]{NeighborOrientation.UP, NeighborOrientation.FLIP_WEST, NeighborOrientation.UP, NeighborOrientation.WEST, NeighborOrientation.FLIP_UP, NeighborOrientation.WEST, NeighborOrientation.FLIP_UP, NeighborOrientation.FLIP_WEST}, new NeighborOrientation[]{NeighborOrientation.UP, NeighborOrientation.FLIP_EAST, NeighborOrientation.UP, NeighborOrientation.EAST, NeighborOrientation.FLIP_UP, NeighborOrientation.EAST, NeighborOrientation.FLIP_UP, NeighborOrientation.FLIP_EAST}, new NeighborOrientation[]{NeighborOrientation.DOWN, NeighborOrientation.FLIP_EAST, NeighborOrientation.DOWN, NeighborOrientation.EAST, NeighborOrientation.FLIP_DOWN, NeighborOrientation.EAST, NeighborOrientation.FLIP_DOWN, NeighborOrientation.FLIP_EAST}, new NeighborOrientation[]{NeighborOrientation.DOWN, NeighborOrientation.FLIP_WEST, NeighborOrientation.DOWN, NeighborOrientation.WEST, NeighborOrientation.FLIP_DOWN, NeighborOrientation.WEST, NeighborOrientation.FLIP_DOWN, NeighborOrientation.FLIP_WEST}),
+		SOUTH(new Direction[]{Direction.WEST, Direction.EAST, Direction.DOWN, Direction.UP}, 0.8F, true, new NeighborOrientation[]{NeighborOrientation.UP, NeighborOrientation.FLIP_WEST, NeighborOrientation.FLIP_UP, NeighborOrientation.FLIP_WEST, NeighborOrientation.FLIP_UP, NeighborOrientation.WEST, NeighborOrientation.UP, NeighborOrientation.WEST}, new NeighborOrientation[]{NeighborOrientation.DOWN, NeighborOrientation.FLIP_WEST, NeighborOrientation.FLIP_DOWN, NeighborOrientation.FLIP_WEST, NeighborOrientation.FLIP_DOWN, NeighborOrientation.WEST, NeighborOrientation.DOWN, NeighborOrientation.WEST}, new NeighborOrientation[]{NeighborOrientation.DOWN, NeighborOrientation.FLIP_EAST, NeighborOrientation.FLIP_DOWN, NeighborOrientation.FLIP_EAST, NeighborOrientation.FLIP_DOWN, NeighborOrientation.EAST, NeighborOrientation.DOWN, NeighborOrientation.EAST}, new NeighborOrientation[]{NeighborOrientation.UP, NeighborOrientation.FLIP_EAST, NeighborOrientation.FLIP_UP, NeighborOrientation.FLIP_EAST, NeighborOrientation.FLIP_UP, NeighborOrientation.EAST, NeighborOrientation.UP, NeighborOrientation.EAST}),
+		WEST(new Direction[]{Direction.UP, Direction.DOWN, Direction.NORTH, Direction.SOUTH}, 0.6F, true, new NeighborOrientation[]{NeighborOrientation.UP, NeighborOrientation.SOUTH, NeighborOrientation.UP, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.FLIP_UP, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.FLIP_UP, NeighborOrientation.SOUTH}, new NeighborOrientation[]{NeighborOrientation.UP, NeighborOrientation.NORTH, NeighborOrientation.UP, NeighborOrientation.FLIP_NORTH, NeighborOrientation.FLIP_UP, NeighborOrientation.FLIP_NORTH, NeighborOrientation.FLIP_UP, NeighborOrientation.NORTH}, new NeighborOrientation[]{NeighborOrientation.DOWN, NeighborOrientation.NORTH, NeighborOrientation.DOWN, NeighborOrientation.FLIP_NORTH, NeighborOrientation.FLIP_DOWN, NeighborOrientation.FLIP_NORTH, NeighborOrientation.FLIP_DOWN, NeighborOrientation.NORTH}, new NeighborOrientation[]{NeighborOrientation.DOWN, NeighborOrientation.SOUTH, NeighborOrientation.DOWN, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.FLIP_DOWN, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.FLIP_DOWN, NeighborOrientation.SOUTH}),
+		EAST(new Direction[]{Direction.DOWN, Direction.UP, Direction.NORTH, Direction.SOUTH}, 0.6F, true, new NeighborOrientation[]{NeighborOrientation.FLIP_DOWN, NeighborOrientation.SOUTH, NeighborOrientation.FLIP_DOWN, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.DOWN, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.DOWN, NeighborOrientation.SOUTH}, new NeighborOrientation[]{NeighborOrientation.FLIP_DOWN, NeighborOrientation.NORTH, NeighborOrientation.FLIP_DOWN, NeighborOrientation.FLIP_NORTH, NeighborOrientation.DOWN, NeighborOrientation.FLIP_NORTH, NeighborOrientation.DOWN, NeighborOrientation.NORTH}, new NeighborOrientation[]{NeighborOrientation.FLIP_UP, NeighborOrientation.NORTH, NeighborOrientation.FLIP_UP, NeighborOrientation.FLIP_NORTH, NeighborOrientation.UP, NeighborOrientation.FLIP_NORTH, NeighborOrientation.UP, NeighborOrientation.NORTH}, new NeighborOrientation[]{NeighborOrientation.FLIP_UP, NeighborOrientation.SOUTH, NeighborOrientation.FLIP_UP, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.UP, NeighborOrientation.FLIP_SOUTH, NeighborOrientation.UP, NeighborOrientation.SOUTH});
+
+		private final Direction[] faces;
+		private final boolean nonCubicWeight;
+		private final NeighborOrientation[] field_4192;
+		private final NeighborOrientation[] field_4185;
+		private final NeighborOrientation[] field_4180;
+		private final NeighborOrientation[] field_4188;
+		private static final NeighborData[] field_4190 = SystemUtil.consume(new NeighborData[6], (blockModelRenderer$NeighborDatas_1) -> {
+			blockModelRenderer$NeighborDatas_1[Direction.DOWN.getId()] = DOWN;
+			blockModelRenderer$NeighborDatas_1[Direction.UP.getId()] = UP;
+			blockModelRenderer$NeighborDatas_1[Direction.NORTH.getId()] = NORTH;
+			blockModelRenderer$NeighborDatas_1[Direction.SOUTH.getId()] = SOUTH;
+			blockModelRenderer$NeighborDatas_1[Direction.WEST.getId()] = WEST;
+			blockModelRenderer$NeighborDatas_1[Direction.EAST.getId()] = EAST;
+		});
+
+		NeighborData(Direction[] directions_1, float float_1, boolean boolean_1, NeighborOrientation[] blockModelRenderer$NeighborOrientations_1, NeighborOrientation[] blockModelRenderer$NeighborOrientations_2, NeighborOrientation[] blockModelRenderer$NeighborOrientations_3, NeighborOrientation[] blockModelRenderer$NeighborOrientations_4) {
+			this.faces = directions_1;
+			this.nonCubicWeight = boolean_1;
+			this.field_4192 = blockModelRenderer$NeighborOrientations_1;
+			this.field_4185 = blockModelRenderer$NeighborOrientations_2;
+			this.field_4180 = blockModelRenderer$NeighborOrientations_3;
+			this.field_4188 = blockModelRenderer$NeighborOrientations_4;
+		}
+
+		public static NeighborData getData(Direction direction_1) {
+			return field_4190[direction_1.getId()];
+		}
+	}
+
+	@Environment(EnvType.CLIENT)
+	public enum NeighborOrientation {
+		DOWN(Direction.DOWN, false),
+		UP(Direction.UP, false),
+		NORTH(Direction.NORTH, false),
+		SOUTH(Direction.SOUTH, false),
+		WEST(Direction.WEST, false),
+		EAST(Direction.EAST, false),
+		FLIP_DOWN(Direction.DOWN, true),
+		FLIP_UP(Direction.UP, true),
+		FLIP_NORTH(Direction.NORTH, true),
+		FLIP_SOUTH(Direction.SOUTH, true),
+		FLIP_WEST(Direction.WEST, true),
+		FLIP_EAST(Direction.EAST, true);
+
+		private final int shape;
+
+		NeighborOrientation(Direction direction_1, boolean boolean_1) {
+			this.shape = direction_1.getId() + (boolean_1 ? Direction.values().length : 0);
+		}
+	}
+
+	public static void updateShape(ExtendedBlockView extendedBlockView_1, BlockState blockState_1, BlockPos blockPos_1, int[] ints_1, Direction direction_1, float[] floats_1, BitSet bitSet_1) {
+		float float_1 = 32.0F;
+		float float_2 = 32.0F;
+		float float_3 = 32.0F;
+		float float_4 = -32.0F;
+		float float_5 = -32.0F;
+		float float_6 = -32.0F;
+
+		int int_2;
+		float float_11;
+
+		for (int_2 = 0; int_2 < 4; ++int_2) {
+			float_11 = Float.intBitsToFloat(ints_1[int_2 * 7]);
+			float float_8 = Float.intBitsToFloat(ints_1[int_2 * 7 + 1]);
+			float float_9 = Float.intBitsToFloat(ints_1[int_2 * 7 + 2]);
+			float_1 = Math.min(float_1, float_11);
+			float_2 = Math.min(float_2, float_8);
+			float_3 = Math.min(float_3, float_9);
+			float_4 = Math.max(float_4, float_11);
+			float_5 = Math.max(float_5, float_8);
+			float_6 = Math.max(float_6, float_9);
+		}
+
+		if (floats_1 != null) {
+			floats_1[Direction.WEST.getId()] = float_1;
+			floats_1[Direction.EAST.getId()] = float_4;
+			floats_1[Direction.DOWN.getId()] = float_2;
+			floats_1[Direction.UP.getId()] = float_5;
+			floats_1[Direction.NORTH.getId()] = float_3;
+			floats_1[Direction.SOUTH.getId()] = float_6;
+			int_2 = Direction.values().length;
+			floats_1[Direction.WEST.getId() + int_2] = 1.0F - float_1;
+			floats_1[Direction.EAST.getId() + int_2] = 1.0F - float_4;
+			floats_1[Direction.DOWN.getId() + int_2] = 1.0F - float_2;
+			floats_1[Direction.UP.getId() + int_2] = 1.0F - float_5;
+			floats_1[Direction.NORTH.getId() + int_2] = 1.0F - float_3;
+			floats_1[Direction.SOUTH.getId() + int_2] = 1.0F - float_6;
+		}
+
+		float_11 = 0.9999F;
+		switch (direction_1) {
+		case DOWN:
+			bitSet_1.set(1, float_1 >= 1.0E-4F || float_3 >= 1.0E-4F || float_4 <= 0.9999F || float_6 <= 0.9999F);
+			bitSet_1.set(0, (float_2 < 1.0E-4F || Block.isShapeFullCube(blockState_1.getCollisionShape(extendedBlockView_1, blockPos_1))) && float_2 == float_5);
+			break;
+		case UP:
+			bitSet_1.set(1, float_1 >= 1.0E-4F || float_3 >= 1.0E-4F || float_4 <= 0.9999F || float_6 <= 0.9999F);
+			bitSet_1.set(0, (float_5 > 0.9999F || Block.isShapeFullCube(blockState_1.getCollisionShape(extendedBlockView_1, blockPos_1))) && float_2 == float_5);
+			break;
+		case NORTH:
+			bitSet_1.set(1, float_1 >= 1.0E-4F || float_2 >= 1.0E-4F || float_4 <= 0.9999F || float_5 <= 0.9999F);
+			bitSet_1.set(0, (float_3 < 1.0E-4F || Block.isShapeFullCube(blockState_1.getCollisionShape(extendedBlockView_1, blockPos_1))) && float_3 == float_6);
+			break;
+		case SOUTH:
+			bitSet_1.set(1, float_1 >= 1.0E-4F || float_2 >= 1.0E-4F || float_4 <= 0.9999F || float_5 <= 0.9999F);
+			bitSet_1.set(0, (float_6 > 0.9999F || Block.isShapeFullCube(blockState_1.getCollisionShape(extendedBlockView_1, blockPos_1))) && float_3 == float_6);
+			break;
+		case WEST:
+			bitSet_1.set(1, float_2 >= 1.0E-4F || float_3 >= 1.0E-4F || float_5 <= 0.9999F || float_6 <= 0.9999F);
+			bitSet_1.set(0, (float_1 < 1.0E-4F || Block.isShapeFullCube(blockState_1.getCollisionShape(extendedBlockView_1, blockPos_1))) && float_1 == float_4);
+			break;
+		case EAST:
+			bitSet_1.set(1, float_2 >= 1.0E-4F || float_3 >= 1.0E-4F || float_5 <= 0.9999F || float_6 <= 0.9999F);
+			bitSet_1.set(0, (float_4 > 0.9999F || Block.isShapeFullCube(blockState_1.getCollisionShape(extendedBlockView_1, blockPos_1))) && float_1 == float_4);
+		}
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/helper/ColorHelper.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/helper/ColorHelper.java
@@ -19,10 +19,12 @@ package net.fabricmc.indigo.renderer.helper;
 import java.nio.ByteOrder;
 
 import it.unimi.dsi.fastutil.ints.Int2IntFunction;
-import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
+
 import net.minecraft.client.render.model.BakedQuadFactory;
 import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.util.math.Direction;
+
+import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
 
 /**
  * Static routines of general utility for renderer implementations.
@@ -30,152 +32,155 @@ import net.minecraft.util.math.Direction;
  * designed to be usable without the default renderer.
  */
 public abstract class ColorHelper {
-    /**
-     * Implement on quads to use methods that require it.
-     * Allows for much cleaner method signatures.
-     */
-    public static interface ShadeableQuad extends MutableQuadView {
-        boolean isFaceAligned();
-        boolean needsDiffuseShading(int textureIndex);
-    }
-    
-    private ColorHelper() {}
+	/**
+	 * Implement on quads to use methods that require it.
+	 * Allows for much cleaner method signatures.
+	 */
+	public interface ShadeableQuad extends MutableQuadView {
+		boolean isFaceAligned();
+		boolean needsDiffuseShading(int textureIndex);
+	}
 
-    /** Same as vanilla values */
-    private static final float[] FACE_SHADE_FACTORS = { 0.5F, 1.0F, 0.8F, 0.8F, 0.6F, 0.6F};
-    
-    private static final Int2IntFunction colorSwapper = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN
-            ? color -> ((color & 0xFF00FF00) | ((color & 0x00FF0000) >> 16) | ((color & 0xFF) << 16))
-            : color -> color;
-            
-    /**
-     * Swaps red blue order if needed to match GPU expectations for color component order.
-     */
-    public static int swapRedBlueIfNeeded(int color) {
-        return colorSwapper.applyAsInt(color);
-    }
+	private ColorHelper() { }
 
-    /** Component-wise multiply. Components need to be in same order in both inputs! */
-    public static int multiplyColor(int color1, int color2) {
-        if(color1 == -1) {
-            return color2;
-        } else if (color2 == -1) {
-            return color1;
-        }
-        
-        int alpha = ((color1 >> 24) & 0xFF) * ((color2 >> 24) & 0xFF) / 0xFF;
-        int red = ((color1 >> 16) & 0xFF) * ((color2 >> 16) & 0xFF) / 0xFF;
-        int green = ((color1 >> 8) & 0xFF) * ((color2 >> 8) & 0xFF) / 0xFF;
-        int blue = (color1 & 0xFF) * (color2 & 0xFF) / 0xFF;
+	/** Same as vanilla values. */
+	private static final float[] FACE_SHADE_FACTORS = { 0.5F, 1.0F, 0.8F, 0.8F, 0.6F, 0.6F};
 
-        return (alpha << 24) | (red << 16) | (green << 8) | blue;
-    }
+	private static final Int2IntFunction colorSwapper = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN
+			? color -> ((color & 0xFF00FF00) | ((color & 0x00FF0000) >> 16) | ((color & 0xFF) << 16))
+			: color -> color;
 
-    /** Multiplies three lowest components by shade. High byte (usually alpha) unchanged. */
-    public static int multiplyRGB(int color, float shade) {
-        int alpha = ((color >> 24) & 0xFF);
-        int red = (int) (((color >> 16) & 0xFF) * shade);
-        int green = (int) (((color >> 8) & 0xFF) * shade);
-        int blue = (int) ((color & 0xFF) * shade);
+	/**
+	 * Swaps red blue order if needed to match GPU expectations for color component order.
+	 */
+	public static int swapRedBlueIfNeeded(int color) {
+		return colorSwapper.applyAsInt(color);
+	}
 
-        return (alpha << 24) | (red << 16) | (green << 8) | blue;
-    }
+	/** Component-wise multiply. Components need to be in same order in both inputs! */
+	public static int multiplyColor(int color1, int color2) {
+		if (color1 == -1) {
+			return color2;
+		} else if (color2 == -1) {
+			return color1;
+		}
 
-    /**
-     * Same results as {@link BakedQuadFactory#method_3456(Direction)}
-     */
-    public static float diffuseShade(Direction direction) {
-        return FACE_SHADE_FACTORS[direction.getId()];
-    }
+		int alpha = ((color1 >> 24) & 0xFF) * ((color2 >> 24) & 0xFF) / 0xFF;
+		int red = ((color1 >> 16) & 0xFF) * ((color2 >> 16) & 0xFF) / 0xFF;
+		int green = ((color1 >> 8) & 0xFF) * ((color2 >> 8) & 0xFF) / 0xFF;
+		int blue = (color1 & 0xFF) * (color2 & 0xFF) / 0xFF;
 
-    /**
-     * Formula mimics vanilla lighting for plane-aligned quads and
-     * is vaguely consistent with Phong lighting ambient + diffuse for others.
-     */
-    public static float normalShade(float normalX, float normalY, float normalZ) {
-        return Math.min(0.5f + Math.abs(normalX) * 0.1f + (normalY > 0 ? 0.5f * normalY : 0) + Math.abs(normalZ) * 0.3f, 1f);
-    }
-    
-    public static float normalShade(Vector3f normal) {
-        return normalShade(normal.getX(), normal.getY(), normal.getZ());
-    }
+		return (alpha << 24) | (red << 16) | (green << 8) | blue;
+	}
 
-    /**
-     * See {@link diffuseShade}
-     */
-    public static float vertexShade(ShadeableQuad q, int vertexIndex, float faceShade) {
-        return q.hasNormal(vertexIndex) 
-                ? normalShade(q.normalX(vertexIndex), q.normalY(vertexIndex), q.normalZ(vertexIndex)) : faceShade;
-    }
+	/** Multiplies three lowest components by shade. High byte (usually alpha) unchanged. */
+	public static int multiplyRGB(int color, float shade) {
+		int alpha = ((color >> 24) & 0xFF);
+		int red = (int) (((color >> 16) & 0xFF) * shade);
+		int green = (int) (((color >> 8) & 0xFF) * shade);
+		int blue = (int) ((color & 0xFF) * shade);
 
-    /**
-     * Returns {@link #diffuseShade(Direction)} if quad is aligned to light face,
-     * otherwise uses face normal and {@link #normalShade}
-     */
-    public static float faceShade(ShadeableQuad quad) {
-        return quad.isFaceAligned() ? diffuseShade(quad.lightFace()) : normalShade(quad.faceNormal());
-    }
-    
-    @FunctionalInterface
-    private static interface VertexLighter {
-        void shade(ShadeableQuad quad,  int vertexIndex, float shade);
-    }
-    
-    private static VertexLighter[] VERTEX_LIGHTERS = new VertexLighter[8];
-    
-    static {
-        VERTEX_LIGHTERS[0b000] = (q, i, s) -> {};
-        VERTEX_LIGHTERS[0b001] = (q, i, s) -> q.spriteColor(i, 0, multiplyRGB(q.spriteColor(i, 0), s));
-        VERTEX_LIGHTERS[0b010] = (q, i, s) -> q.spriteColor(i, 1, multiplyRGB(q.spriteColor(i, 1), s));
-        VERTEX_LIGHTERS[0b011] = (q, i, s) -> q.spriteColor(i, 0, multiplyRGB(q.spriteColor(i, 0), s))
-                                               .spriteColor(i, 1, multiplyRGB(q.spriteColor(i, 1), s));
-        VERTEX_LIGHTERS[0b100] = (q, i, s) -> q.spriteColor(i, 2, multiplyRGB(q.spriteColor(i, 2), s));
-        VERTEX_LIGHTERS[0b101] = (q, i, s) -> q.spriteColor(i, 0, multiplyRGB(q.spriteColor(i, 0), s))
-                                               .spriteColor(i, 2, multiplyRGB(q.spriteColor(i, 2), s));
-        VERTEX_LIGHTERS[0b110] = (q, i, s) -> q.spriteColor(i, 1, multiplyRGB(q.spriteColor(i, 1), s))
-                                               .spriteColor(i, 2, multiplyRGB(q.spriteColor(i, 2), s));
-        VERTEX_LIGHTERS[0b111] = (q, i, s) -> q.spriteColor(i, 0, multiplyRGB(q.spriteColor(i, 0), s))
-                                               .spriteColor(i, 1, multiplyRGB(q.spriteColor(i, 1), s))
-                                               .spriteColor(i, 2, multiplyRGB(q.spriteColor(i, 2), s));
-    }
-    
-    /**
-     * Honors vertex normals and uses non-cubic face normals for non-cubic quads.
-     * 
-     * @param quad Quad to be shaded/unshaded.<p>
-     * 
-     * @param undo If true, will reverse prior application.  Does not check that
-     * prior application actually happened.  Use to "unbake" a quad.
-     * Some drift of colors may occur due to floating-point precision error.
-     */
-    public static void applyDiffuseShading(ShadeableQuad quad, boolean undo) {
-        final float faceShade = faceShade(quad);
-        int i = quad.needsDiffuseShading(0) ? 1 : 0;
-        if(quad.needsDiffuseShading(1)) {
-            i |= 2;
-        }
-        if(quad.needsDiffuseShading(2)) {
-            i |= 4;
-        }
-        if(i == 0) {
-            return;
-        }
-        
-        final VertexLighter shader = VERTEX_LIGHTERS[i];
-        for(int j = 0; j < 4; j++) {
-            final float vertexShade = vertexShade(quad, j, faceShade);
-            shader.shade(quad, j, undo ? 1f / vertexShade : vertexShade);
-        }
-    }
+		return (alpha << 24) | (red << 16) | (green << 8) | blue;
+	}
 
-    /**
-     * Component-wise max
-     */
-    public static int maxBrightness(int b0, int b1) {
-        if(b0 == 0)
-            return b1;
-        else if (b1 == 0)
-            return b0;
-        return Math.max(b0 & 0xFFFF, b1 & 0xFFFF) | Math.max(b0 & 0xFFFF0000, b1 & 0xFFFF0000);
-    }
+	/**
+	 * Same results as {@link BakedQuadFactory#method_3456(Direction)}.
+	 */
+	public static float diffuseShade(Direction direction) {
+		return FACE_SHADE_FACTORS[direction.getId()];
+	}
+
+	/**
+	 * Formula mimics vanilla lighting for plane-aligned quads and
+	 * is vaguely consistent with Phong lighting ambient + diffuse for others.
+	 */
+	public static float normalShade(float normalX, float normalY, float normalZ) {
+		return Math.min(0.5f + Math.abs(normalX) * 0.1f + (normalY > 0 ? 0.5f * normalY : 0) + Math.abs(normalZ) * 0.3f, 1f);
+	}
+
+	public static float normalShade(Vector3f normal) {
+		return normalShade(normal.getX(), normal.getY(), normal.getZ());
+	}
+
+	/**
+	 * See {@link diffuseShade}.
+	 */
+	public static float vertexShade(ShadeableQuad q, int vertexIndex, float faceShade) {
+		return q.hasNormal(vertexIndex)
+				? normalShade(q.normalX(vertexIndex), q.normalY(vertexIndex), q.normalZ(vertexIndex)) : faceShade;
+	}
+
+	/**
+	 * Returns {@link #diffuseShade(Direction)} if quad is aligned to light face,
+	 * otherwise uses face normal and {@link #normalShade}.
+	 */
+	public static float faceShade(ShadeableQuad quad) {
+		return quad.isFaceAligned() ? diffuseShade(quad.lightFace()) : normalShade(quad.faceNormal());
+	}
+
+	@FunctionalInterface
+	private interface VertexLighter {
+		void shade(ShadeableQuad quad, int vertexIndex, float shade);
+	}
+
+	private static VertexLighter[] VERTEX_LIGHTERS = new VertexLighter[8];
+
+	static {
+		VERTEX_LIGHTERS[0b000] = (q, i, s) -> { };
+		VERTEX_LIGHTERS[0b001] = (q, i, s) -> q.spriteColor(i, 0, multiplyRGB(q.spriteColor(i, 0), s));
+		VERTEX_LIGHTERS[0b010] = (q, i, s) -> q.spriteColor(i, 1, multiplyRGB(q.spriteColor(i, 1), s));
+		VERTEX_LIGHTERS[0b011] = (q, i, s) -> q.spriteColor(i, 0, multiplyRGB(q.spriteColor(i, 0), s))
+				.spriteColor(i, 1, multiplyRGB(q.spriteColor(i, 1), s));
+		VERTEX_LIGHTERS[0b100] = (q, i, s) -> q.spriteColor(i, 2, multiplyRGB(q.spriteColor(i, 2), s));
+		VERTEX_LIGHTERS[0b101] = (q, i, s) -> q.spriteColor(i, 0, multiplyRGB(q.spriteColor(i, 0), s))
+				.spriteColor(i, 2, multiplyRGB(q.spriteColor(i, 2), s));
+		VERTEX_LIGHTERS[0b110] = (q, i, s) -> q.spriteColor(i, 1, multiplyRGB(q.spriteColor(i, 1), s))
+				.spriteColor(i, 2, multiplyRGB(q.spriteColor(i, 2), s));
+		VERTEX_LIGHTERS[0b111] = (q, i, s) -> q.spriteColor(i, 0, multiplyRGB(q.spriteColor(i, 0), s))
+				.spriteColor(i, 1, multiplyRGB(q.spriteColor(i, 1), s))
+				.spriteColor(i, 2, multiplyRGB(q.spriteColor(i, 2), s));
+	}
+
+	/**
+	 * Honors vertex normals and uses non-cubic face normals for non-cubic quads.
+	 *
+	 * @param quad Quad to be shaded/unshaded.
+	 *
+	 * @param undo If true, will reverse prior application.  Does not check that
+	 * prior application actually happened.  Use to "unbake" a quad.
+	 * Some drift of colors may occur due to floating-point precision error.
+	 */
+	public static void applyDiffuseShading(ShadeableQuad quad, boolean undo) {
+		final float faceShade = faceShade(quad);
+		int i = quad.needsDiffuseShading(0) ? 1 : 0;
+
+		if (quad.needsDiffuseShading(1)) {
+			i |= 2;
+		}
+
+		if (quad.needsDiffuseShading(2)) {
+			i |= 4;
+		}
+
+		if (i == 0) {
+			return;
+		}
+
+		final VertexLighter shader = VERTEX_LIGHTERS[i];
+
+		for (int j = 0; j < 4; j++) {
+			final float vertexShade = vertexShade(quad, j, faceShade);
+			shader.shade(quad, j, undo ? 1f / vertexShade : vertexShade);
+		}
+	}
+
+	/**
+	 * Component-wise max.
+	 */
+	public static int maxBrightness(int b0, int b1) {
+		if (b0 == 0) return b1;
+		if (b1 == 0) return b0;
+
+		return Math.max(b0 & 0xFFFF, b1 & 0xFFFF) | Math.max(b0 & 0xFFFF0000, b1 & 0xFFFF0000);
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/helper/GeometryHelper.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/helper/GeometryHelper.java
@@ -18,12 +18,13 @@ package net.fabricmc.indigo.renderer.helper;
 
 import static net.minecraft.util.math.MathHelper.equalsApproximate;
 
-import net.fabricmc.fabric.api.renderer.v1.mesh.QuadView;
 import net.minecraft.client.render.model.BakedQuad;
 import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Direction.Axis;
 import net.minecraft.util.math.Direction.AxisDirection;
+
+import net.fabricmc.fabric.api.renderer.v1.mesh.QuadView;
 
 /**
  * Static routines of general utility for renderer implementations.
@@ -31,215 +32,220 @@ import net.minecraft.util.math.Direction.AxisDirection;
  * designed to be usable without the default renderer.
  */
 public abstract class GeometryHelper {
-    /** set when a quad touches all four corners of a unit cube */
-    public static final int CUBIC_FLAG = 1;
-    
-    /** set when a quad is parallel to (but not necessarily on) a its light face */
-    public static final int AXIS_ALIGNED_FLAG = CUBIC_FLAG << 1;
-    
-    /** set when a quad is coplanar with its light face. Implies {@link #AXIS_ALIGNED_FLAG} */
-    public static final int LIGHT_FACE_FLAG = AXIS_ALIGNED_FLAG << 1;
+	/** set when a quad touches all four corners of a unit cube. */
+	public static final int CUBIC_FLAG = 1;
+
+	/** set when a quad is parallel to (but not necessarily on) a its light face. */
+	public static final int AXIS_ALIGNED_FLAG = CUBIC_FLAG << 1;
+
+	/** set when a quad is coplanar with its light face. Implies {@link #AXIS_ALIGNED_FLAG} */
+	public static final int LIGHT_FACE_FLAG = AXIS_ALIGNED_FLAG << 1;
 
 	private static final float EPS_MIN = 0.0001f;
 	private static final float EPS_MAX = 1.0f - EPS_MIN;
 
-    private GeometryHelper() {}
+	private GeometryHelper() { }
 
-    /**
-     * Analyzes the quad and returns a value with some combination 
-     * of {@link #AXIS_ALIGNED_FLAG}, {@link #LIGHT_FACE_FLAG} and {@link #CUBIC_FLAG}.
-     * Intended use is to optimize lighting when the geometry is regular.
-     * Expects convex quads with all points co-planar.
-     */
-    public static int computeShapeFlags(QuadView quad) {
-        Direction lightFace = quad.lightFace();
-        int bits = 0;
-        if(isQuadParallelToFace(lightFace, quad)) {
-            bits |= AXIS_ALIGNED_FLAG;
-            if(isParallelQuadOnFace(lightFace, quad)) {
-                bits |= LIGHT_FACE_FLAG;
-            }
-        }
-		if(isQuadCubic(lightFace, quad)) {
+	/**
+	 * Analyzes the quad and returns a value with some combination
+	 * of {@link #AXIS_ALIGNED_FLAG}, {@link #LIGHT_FACE_FLAG} and {@link #CUBIC_FLAG}.
+	 * Intended use is to optimize lighting when the geometry is regular.
+	 * Expects convex quads with all points co-planar.
+	 */
+	public static int computeShapeFlags(QuadView quad) {
+		Direction lightFace = quad.lightFace();
+		int bits = 0;
+
+		if (isQuadParallelToFace(lightFace, quad)) {
+			bits |= AXIS_ALIGNED_FLAG;
+
+			if (isParallelQuadOnFace(lightFace, quad)) {
+				bits |= LIGHT_FACE_FLAG;
+			}
+		}
+
+		if (isQuadCubic(lightFace, quad)) {
 			bits |= CUBIC_FLAG;
 		}
-        return bits;
-    }
-    
-    /**
-     * Returns true if quad is parallel to the given face.
-     * Does not validate quad winding order.
-     * Expects convex quads with all points co-planar.
-     */
-    public static boolean isQuadParallelToFace(Direction face, QuadView quad) {
-        if(face == null) {
-            return false;
-        }
-        int i = face.getAxis().ordinal();
-        final float val = quad.posByIndex(0, i);
-        return equalsApproximate(val, quad.posByIndex(1, i))
-                && equalsApproximate(val, quad.posByIndex(2, i))
-                && equalsApproximate(val, quad.posByIndex(3, i));
-    }
-    
-    /**
-     * True if quad - already known to be parallel to a face - is actually coplanar with it.
-	 * For compatibility with vanilla resource packs, also true if quad is outside the face.<p>
-     * 
-     * Test will be unreliable if not already parallel, use {@link #isQuadParallelToFace(Direction, QuadView)}
-     * for that purpose. Expects convex quads with all points co-planar.<p>
-     */
-    public static boolean isParallelQuadOnFace(Direction lightFace, QuadView quad) {
-        if(lightFace == null)
-            return false;
-        final float x = quad.posByIndex(0, lightFace.getAxis().ordinal());
-        return lightFace.getDirection() == AxisDirection.POSITIVE ? x >= EPS_MAX : x <= EPS_MIN;
-    }
-    
-    /**
-     * Returns true if quad is truly a quad (not a triangle) and fills a full block cross-section.
-     * If known to be true, allows use of a simpler/faster AO lighting algorithm.<p>
-     * 
-     * Does not check if quad is actually coplanar with the light face, nor does it check that all
-     * quad vertices are coplanar with each other. <p>
-     * 
-     * Expects convex quads with all points co-planar.<p>
-     *
-     * @param lightFace MUST be non-null.
-     */
-    public static boolean isQuadCubic(Direction lightFace, QuadView quad) {
-        if(lightFace == null) {
-            return false;
-        }
-        
-        int a, b;
 
-        switch(lightFace) {
-        case EAST: 
-        case WEST:
-            a = 1;
-            b = 2;
-            break;
-        case UP:
-        case DOWN:
-            a = 0;
-            b = 2;
-            break;
-        case SOUTH:
-        case NORTH:
-            a = 1;
-            b = 0;
-            break;
-        default:
-            // handle WTF case
-            return false;
-        }
-       
-        return confirmSquareCorners(a, b, quad);
-    }
+		return bits;
+	}
 
-    /**
-     * Used by {@link #isQuadCubic(Direction, QuadView)}.
-     * True if quad touches all four corners of unit square.<p>
+	/**
+	 * Returns true if quad is parallel to the given face.
+	 * Does not validate quad winding order.
+	 * Expects convex quads with all points co-planar.
+	 */
+	public static boolean isQuadParallelToFace(Direction face, QuadView quad) {
+		if (face == null) {
+			return false;
+		}
+
+		int i = face.getAxis().ordinal();
+		final float val = quad.posByIndex(0, i);
+		return equalsApproximate(val, quad.posByIndex(1, i))
+				&& equalsApproximate(val, quad.posByIndex(2, i))
+				&& equalsApproximate(val, quad.posByIndex(3, i));
+	}
+
+	/**
+	 * True if quad - already known to be parallel to a face - is actually coplanar with it.
+	 * For compatibility with vanilla resource packs, also true if quad is outside the face.
 	 *
-	 * For compatibility with resource packs that contain models with quads exceeding
+	 * <p>Test will be unreliable if not already parallel, use {@link #isQuadParallelToFace(Direction, QuadView)}
+	 * for that purpose. Expects convex quads with all points co-planar.
+	 */
+	public static boolean isParallelQuadOnFace(Direction lightFace, QuadView quad) {
+		if (lightFace == null) return false;
+
+		final float x = quad.posByIndex(0, lightFace.getAxis().ordinal());
+		return lightFace.getDirection() == AxisDirection.POSITIVE ? x >= EPS_MAX : x <= EPS_MIN;
+	}
+
+	/**
+	 * Returns true if quad is truly a quad (not a triangle) and fills a full block cross-section.
+	 * If known to be true, allows use of a simpler/faster AO lighting algorithm.
+	 *
+	 * <p>Does not check if quad is actually coplanar with the light face, nor does it check that all
+	 * quad vertices are coplanar with each other.
+	 *
+	 * <p>Expects convex quads with all points co-planar.
+	 *
+	 * @param lightFace MUST be non-null.
+	 */
+	public static boolean isQuadCubic(Direction lightFace, QuadView quad) {
+		if (lightFace == null) {
+			return false;
+		}
+
+		int a, b;
+
+		switch (lightFace) {
+		case EAST:
+		case WEST:
+			a = 1;
+			b = 2;
+			break;
+		case UP:
+		case DOWN:
+			a = 0;
+			b = 2;
+			break;
+		case SOUTH:
+		case NORTH:
+			a = 1;
+			b = 0;
+			break;
+		default:
+			// handle WTF case
+			return false;
+		}
+
+		return confirmSquareCorners(a, b, quad);
+	}
+
+	/**
+	 * Used by {@link #isQuadCubic(Direction, QuadView)}.
+	 * True if quad touches all four corners of unit square.
+	 *
+	 * <p>For compatibility with resource packs that contain models with quads exceeding
 	 * block boundaries, considers corners outside the block to be at the corners.
-     */
-    private static boolean confirmSquareCorners(int aCoordinate, int bCoordinate, QuadView quad) {
-        int flags = 0;
-        
-        for(int i = 0; i < 4; i++) {
-            final float a = quad.posByIndex(i, aCoordinate);
-            final float b = quad.posByIndex(i, bCoordinate);
-            
-            if(a <= EPS_MIN) {
-                if(b <= EPS_MIN) {
-                    flags |= 1;
-                } else if(b >= EPS_MAX) {
-                    flags |= 2;
-                } else {
-                    return false;
-                }
-            } else if(a >= EPS_MAX) {
-                if(b <= EPS_MIN) {
-                    flags |= 4;
-                } else if(b >= EPS_MAX) {
-                    flags |= 8;
-                } else {
-                    return false;
-                }
-            } else {
-                return false;
-            }
-        }
-        return flags == 15;
-    }
-    
-    /**
-     * Identifies the face to which the quad is most closely aligned.
-     * This mimics the value that {@link BakedQuad#getFace()} returns, and is
-     * used in the vanilla renderer for all diffuse lighting.<p>
-     * 
-     * Derived from the quad face normal and expects convex quads with all points co-planar.
-     */
-    public static Direction lightFace(QuadView quad) {
-        final Vector3f normal = quad.faceNormal();
-        switch(GeometryHelper.longestAxis(normal)) {
-            case X:
-                return normal.getX() > 0 ? Direction.EAST : Direction.WEST;
-                
-            case Y:
-                return normal.getY() > 0 ? Direction.UP : Direction.DOWN;
-                
-            case Z:
-                return normal.getZ() > 0 ? Direction.SOUTH : Direction.NORTH;
-            
-            default:
-                // handle WTF case
-                return Direction.UP;
-        }
-    }
+	 */
+	private static boolean confirmSquareCorners(int aCoordinate, int bCoordinate, QuadView quad) {
+		int flags = 0;
 
-    /**
-     * Simple 4-way compare, doesn't handle NaN values.
-     */
-    public static float min(float a, float b, float c, float d) {
-        final float x = a < b ? a : b;
-        final float y = c < d ? c : d;
-        return x < y ? x : y;
-    }
+		for (int i = 0; i < 4; i++) {
+			final float a = quad.posByIndex(i, aCoordinate);
+			final float b = quad.posByIndex(i, bCoordinate);
 
-    /**
-     * Simple 4-way compare, doesn't handle NaN values.
-     */
-    public static float max(float a, float b, float c, float d) {
-        final float x = a > b ? a : b;
-        final float y = c > d ? c : d;
-        return x > y ? x : y;
-    }
-    
-    /**
-     * See {@link #longestAxis(float, float, float)}
-     */
-    public static Axis longestAxis(Vector3f vec) {
-        return longestAxis(vec.getX(), vec.getY(), vec.getZ());
-    }
-    
-    /**
-     * Identifies the largest (max absolute magnitude) component (X, Y, Z) in the given vector.
-     */
-    public static Axis longestAxis(float normalX, float normalY, float normalZ) {
-        Axis result = Axis.Y;
-        float longest = Math.abs(normalY);
-    
-        float a = Math.abs(normalX);
-        if(a > longest)
-        {
-            result = Axis.X;
-            longest = a;
-        }
-    
-        return Math.abs(normalZ) > longest
-                ? Axis.Z : result;
-    }
+			if (a <= EPS_MIN) {
+				if (b <= EPS_MIN) {
+					flags |= 1;
+				} else if (b >= EPS_MAX) {
+					flags |= 2;
+				} else {
+					return false;
+				}
+			} else if (a >= EPS_MAX) {
+				if (b <= EPS_MIN) {
+					flags |= 4;
+				} else if (b >= EPS_MAX) {
+					flags |= 8;
+				} else {
+					return false;
+				}
+			} else {
+				return false;
+			}
+		}
+
+		return flags == 15;
+	}
+
+	/**
+	 * Identifies the face to which the quad is most closely aligned.
+	 * This mimics the value that {@link BakedQuad#getFace()} returns, and is
+	 * used in the vanilla renderer for all diffuse lighting.
+	 *
+	 * <p>Derived from the quad face normal and expects convex quads with all points co-planar.
+	 */
+	public static Direction lightFace(QuadView quad) {
+		final Vector3f normal = quad.faceNormal();
+		switch (GeometryHelper.longestAxis(normal)) {
+		case X:
+			return normal.getX() > 0 ? Direction.EAST : Direction.WEST;
+
+		case Y:
+			return normal.getY() > 0 ? Direction.UP : Direction.DOWN;
+
+		case Z:
+			return normal.getZ() > 0 ? Direction.SOUTH : Direction.NORTH;
+
+		default:
+			// handle WTF case
+			return Direction.UP;
+		}
+	}
+
+	/**
+	 * Simple 4-way compare, doesn't handle NaN values.
+	 */
+	public static float min(float a, float b, float c, float d) {
+		final float x = a < b ? a : b;
+		final float y = c < d ? c : d;
+		return x < y ? x : y;
+	}
+
+	/**
+	 * Simple 4-way compare, doesn't handle NaN values.
+	 */
+	public static float max(float a, float b, float c, float d) {
+		final float x = a > b ? a : b;
+		final float y = c > d ? c : d;
+		return x > y ? x : y;
+	}
+
+	/**
+	 * @see #longestAxis(float, float, float)
+	 */
+	public static Axis longestAxis(Vector3f vec) {
+		return longestAxis(vec.getX(), vec.getY(), vec.getZ());
+	}
+
+	/**
+	 * Identifies the largest (max absolute magnitude) component (X, Y, Z) in the given vector.
+	 */
+	public static Axis longestAxis(float normalX, float normalY, float normalZ) {
+		Axis result = Axis.Y;
+		float longest = Math.abs(normalY);
+		float a = Math.abs(normalX);
+
+		if (a > longest) {
+			result = Axis.X;
+			longest = a;
+		}
+
+		return Math.abs(normalZ) > longest
+				? Axis.Z : result;
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/helper/NormalHelper.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/helper/NormalHelper.java
@@ -16,11 +16,12 @@
 
 package net.fabricmc.indigo.renderer.helper;
 
-import net.fabricmc.fabric.api.renderer.v1.mesh.QuadView;
 import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3i;
+
+import net.fabricmc.fabric.api.renderer.v1.mesh.QuadView;
 
 /**
  * Static routines of general utility for renderer implementations.
@@ -28,87 +29,90 @@ import net.minecraft.util.math.Vec3i;
  * designed to be usable without the default renderer.
  */
 public abstract class NormalHelper {
-    private NormalHelper() {}
+	private NormalHelper() { }
 
-    /**
-     * Stores a normal plus an extra value as a quartet of signed bytes.
-     * This is the same normal format that vanilla item rendering expects.
-     * The extra value is for use by shaders.
-     */
-    public static int packNormal(float x, float y, float z, float w) {
-        x = MathHelper.clamp(x, -1, 1);
-        y = MathHelper.clamp(y, -1, 1);
-        z = MathHelper.clamp(z, -1, 1);
-        w = MathHelper.clamp(w, -1, 1);
-        
-        return ((int)(x * 127) & 255)
-        | (((int)(y * 127) & 255) << 8)
-        | (((int)(z * 127) & 255) << 16)
-        | (((int)(w * 127) & 255) << 24);
-    }
-    
-    /**
-     * Version of {@link #packNormal(float, float, float, float)} that accepts a vector type.
-     */
-    public static int packNormal(Vector3f normal, float w) {
-        return packNormal(normal.getX(), normal.getY(), normal.getZ(), w);
-    }
+	/**
+	 * Stores a normal plus an extra value as a quartet of signed bytes.
+	 * This is the same normal format that vanilla item rendering expects.
+	 * The extra value is for use by shaders.
+	 */
+	public static int packNormal(float x, float y, float z, float w) {
+		x = MathHelper.clamp(x, -1, 1);
+		y = MathHelper.clamp(y, -1, 1);
+		z = MathHelper.clamp(z, -1, 1);
+		w = MathHelper.clamp(w, -1, 1);
 
-    /**
-     * Retrieves values packed by {@link #packNormal(float, float, float, float)}
-     * Components are x, y, z, w - zero based
-     */
-    public static float getPackedNormalComponent(int packedNormal, int component) {
-        return ((float)(byte)(packedNormal >> (8 * component))) / 127f;
-    }
+		return ((int)(x * 127) & 255)
+				| (((int)(y * 127) & 255) << 8)
+				| (((int)(z * 127) & 255) << 16)
+				| (((int)(w * 127) & 255) << 24);
+	}
 
-    /**
-     * Computes the face normal of the given quad and saves it in the provided non-null vector.
-     * If {@link QuadView#nominalFace()} is set will optimize by confirming quad is parallel to that
-     * face and, if so, use the standard normal for that face direction.<p>
-     * 
-     * Will work with triangles also. Assumes counter-clockwise winding order, which is the norm.
-     * Expects convex quads with all points co-planar.
-     */
-    public static void computeFaceNormal(Vector3f saveTo, QuadView q) {
-        final Direction nominalFace = q.nominalFace();
-        if(GeometryHelper.isQuadParallelToFace(nominalFace, q)) {
-            Vec3i vec = nominalFace.getVector();
-            saveTo.set(vec.getX(), vec.getY(), vec.getZ());
-            return;
-        }
-        
-        final float x0 = q.x(0);
-        final float y0 = q.y(0);
-        final float z0 = q.z(0);
-        final float x1 = q.x(1);
-        final float y1 = q.y(1);
-        final float z1 = q.z(1);
-        final float x2 = q.x(2);
-        final float y2 = q.y(2);
-        final float z2 = q.z(2);
-        final float x3 = q.x(3);
-        final float y3 = q.y(3);
-        final float z3 = q.z(3);
-    
-        final float dx0 = x2 - x0;
-        final float dy0 = y2 - y0;
-        final float dz0 = z2 - z0;
-        final float dx1 = x3 - x1;
-        final float dy1 = y3 - y1;
-        final float dz1 = z3 - z1;
-        
-        float normX = dy0 * dz1 - dz0 * dy1;
-        float normY = dz0 * dx1 - dx0 * dz1;
-        float normZ = dx0 * dy1 - dy0 * dx1;
-    
-        float l = (float) Math.sqrt(normX * normX + normY * normY + normZ * normZ);
-        if(l != 0) {
-            normX /= l;
-            normY /= l;
-            normZ /= l;
-        }
-    
-        saveTo.set(normX, normY, normZ);
-    }
+	/**
+	 * Version of {@link #packNormal(float, float, float, float)} that accepts a vector type.
+	 */
+	public static int packNormal(Vector3f normal, float w) {
+		return packNormal(normal.getX(), normal.getY(), normal.getZ(), w);
+	}
+
+	/**
+	 * Retrieves values packed by {@link #packNormal(float, float, float, float)}.
+	 *
+	 * <p>Components are x, y, z, w - zero based.
+	 */
+	public static float getPackedNormalComponent(int packedNormal, int component) {
+		return ((byte) (packedNormal >> (8 * component))) / 127f;
+	}
+
+	/**
+	 * Computes the face normal of the given quad and saves it in the provided non-null vector.
+	 * If {@link QuadView#nominalFace()} is set will optimize by confirming quad is parallel to that
+	 * face and, if so, use the standard normal for that face direction.
+	 *
+	 * <p>Will work with triangles also. Assumes counter-clockwise winding order, which is the norm.
+	 * Expects convex quads with all points co-planar.
+	 */
+	public static void computeFaceNormal(Vector3f saveTo, QuadView q) {
+		final Direction nominalFace = q.nominalFace();
+
+		if (GeometryHelper.isQuadParallelToFace(nominalFace, q)) {
+			Vec3i vec = nominalFace.getVector();
+			saveTo.set(vec.getX(), vec.getY(), vec.getZ());
+			return;
+		}
+
+		final float x0 = q.x(0);
+		final float y0 = q.y(0);
+		final float z0 = q.z(0);
+		final float x1 = q.x(1);
+		final float y1 = q.y(1);
+		final float z1 = q.z(1);
+		final float x2 = q.x(2);
+		final float y2 = q.y(2);
+		final float z2 = q.z(2);
+		final float x3 = q.x(3);
+		final float y3 = q.y(3);
+		final float z3 = q.z(3);
+
+		final float dx0 = x2 - x0;
+		final float dy0 = y2 - y0;
+		final float dz0 = z2 - z0;
+		final float dx1 = x3 - x1;
+		final float dy1 = y3 - y1;
+		final float dz1 = z3 - z1;
+
+		float normX = dy0 * dz1 - dz0 * dy1;
+		float normY = dz0 * dx1 - dx0 * dz1;
+		float normZ = dx0 * dy1 - dy0 * dx1;
+
+		float l = (float) Math.sqrt(normX * normX + normY * normY + normZ * normZ);
+
+		if (l != 0) {
+			normX /= l;
+			normY /= l;
+			normZ /= l;
+		}
+
+		saveTo.set(normX, normY, normZ);
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/helper/NormalHelper.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/helper/NormalHelper.java
@@ -42,10 +42,10 @@ public abstract class NormalHelper {
 		z = MathHelper.clamp(z, -1, 1);
 		w = MathHelper.clamp(w, -1, 1);
 
-		return ((int)(x * 127) & 255)
-				| (((int)(y * 127) & 255) << 8)
-				| (((int)(z * 127) & 255) << 16)
-				| (((int)(w * 127) & 255) << 24);
+		return ((int) (x * 127) & 255)
+				| (((int) (y * 127) & 255) << 8)
+				| (((int) (z * 127) & 255) << 16)
+				| (((int) (w * 127) & 255) << 24);
 	}
 
 	/**

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/helper/TextureHelper.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/helper/TextureHelper.java
@@ -16,9 +16,10 @@
 
 package net.fabricmc.indigo.renderer.helper;
 
-import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.util.math.Direction;
+
+import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
 
 /**
  * Handles most texture-baking use cases for model loaders and model libraries
@@ -26,81 +27,83 @@ import net.minecraft.util.math.Direction;
  * itself to implement automatic block-breaking models for enhanced models.
  */
 public class TextureHelper {
-    private static final float NORMALIZER = 1f / 16f;
-    
-    /**
-     * Bakes textures in the provided vertex data, handling UV locking,
-     * rotation, interpolation, etc. Textures must not be already baked. 
-     */
-    public static void bakeSprite(MutableQuadView quad, int spriteIndex, Sprite sprite, int bakeFlags) {
-        if(quad.nominalFace() != null && (MutableQuadView.BAKE_LOCK_UV & bakeFlags) != 0) {
-            // Assigns normalized UV coordinates based on vertex positions
-            applyModifier(quad, spriteIndex, UVLOCKERS[quad.nominalFace().getId()]);
-        } else if ((MutableQuadView.BAKE_NORMALIZED & bakeFlags) == 0) {
-            // Scales from 0-16 to 0-1
-            applyModifier(quad, spriteIndex, (q, i, t) -> q.sprite(i, t, q.spriteU(i, t) * NORMALIZER, q.spriteV(i, t) * NORMALIZER));
-        }
-        
-        final int rotation = bakeFlags & 3;
-        if(rotation != 0) {
-             // Rotates texture around the center of sprite.
-             // Assumes normalized coordinates.
-            applyModifier(quad, spriteIndex, ROTATIONS[rotation]);
-        }
-        
-        if((MutableQuadView.BAKE_FLIP_U & bakeFlags) != 0) {
-            // Inverts U coordinates.  Assumes normalized (0-1) values.
-            applyModifier(quad, spriteIndex, (q, i, t) -> q.sprite(i, t, 1 - q.spriteU(i, t), q.spriteV(i, t)));
-        }
-        
-        if((MutableQuadView.BAKE_FLIP_V & bakeFlags) != 0) {
-            // Inverts V coordinates.  Assumes normalized (0-1) values.
-            applyModifier(quad, spriteIndex, (q, i, t) -> q.sprite(i, t, q.spriteU(i, t), 1 - q.spriteV(i, t)));
-        }
-        
-        interpolate(quad, spriteIndex, sprite);
-    }
+	private static final float NORMALIZER = 1f / 16f;
 
-    /**
-     * Faster than sprite method. Sprite computes span and normalizes inputs each call, 
-     * so we'd have to denormalize before we called, only to have the sprite renormalize immediately.
-     */
-    private static void interpolate(MutableQuadView q, int spriteIndex, Sprite sprite) {
-        final float uMin = sprite.getMinU();
-        final float uSpan = sprite.getMaxU() - uMin;
-        final float vMin = sprite.getMinV();
-        final float vSpan = sprite.getMaxV() - vMin;
-        for(int i = 0; i < 4; i++) {
-            q.sprite(i, spriteIndex, uMin + q.spriteU(i, spriteIndex) * uSpan, vMin + q.spriteV(i, spriteIndex) * vSpan);
-        }
-    }
-    
-    @FunctionalInterface
-    private static interface VertexModifier {
-        void apply(MutableQuadView quad, int vertexIndex, int spriteIndex);
-    }
-    
-    private static void applyModifier(MutableQuadView quad, int spriteIndex, VertexModifier modifier) {
-        for(int i = 0; i < 4; i++) {
-            modifier.apply(quad, i, spriteIndex);
-        }
-    }
-    
-    private static final VertexModifier [] ROTATIONS = new VertexModifier[] {
-        null,
-        (q, i, t) -> q.sprite(i, t, q.spriteV(i, t), q.spriteU(i, t)), //90
-        (q, i, t) -> q.sprite(i, t, 1 - q.spriteU(i, t), 1 - q.spriteV(i, t)), //180
-        (q, i, t) -> q.sprite(i, t, 1 - q.spriteV(i, t), q.spriteU(i, t)) // 270
-    };
-    
-    private static final VertexModifier [] UVLOCKERS = new VertexModifier[6];
+	/**
+	 * Bakes textures in the provided vertex data, handling UV locking,
+	 * rotation, interpolation, etc. Textures must not be already baked.
+	 */
+	public static void bakeSprite(MutableQuadView quad, int spriteIndex, Sprite sprite, int bakeFlags) {
+		if (quad.nominalFace() != null && (MutableQuadView.BAKE_LOCK_UV & bakeFlags) != 0) {
+			// Assigns normalized UV coordinates based on vertex positions
+			applyModifier(quad, spriteIndex, UVLOCKERS[quad.nominalFace().getId()]);
+		} else if ((MutableQuadView.BAKE_NORMALIZED & bakeFlags) == 0) {
+			// Scales from 0-16 to 0-1
+			applyModifier(quad, spriteIndex, (q, i, t) -> q.sprite(i, t, q.spriteU(i, t) * NORMALIZER, q.spriteV(i, t) * NORMALIZER));
+		}
 
-    static {
-        UVLOCKERS[Direction.EAST.getId()] = (q, i, t) -> q.sprite(i, t, 1 - q.z(i), 1 - q.y(i));
-        UVLOCKERS[Direction.WEST.getId()] = (q, i, t) -> q.sprite(i, t, q.z(i), 1 - q.y(i));
-        UVLOCKERS[Direction.NORTH.getId()] = (q, i, t) -> q.sprite(i, t, 1 - q.x(i), 1 - q.y(i));
-        UVLOCKERS[Direction.SOUTH.getId()] = (q, i, t) -> q.sprite(i, t, q.x(i), 1 - q.y(i));
-        UVLOCKERS[Direction.DOWN.getId()] = (q, i, t) -> q.sprite(i, t, q.x(i), 1 - q.z(i));
-        UVLOCKERS[Direction.UP.getId()] = (q, i, t) -> q.sprite(i, t, q.x(i), 1 - q.z(i));
-    }
+		final int rotation = bakeFlags & 3;
+
+		if (rotation != 0) {
+			// Rotates texture around the center of sprite.
+			// Assumes normalized coordinates.
+			applyModifier(quad, spriteIndex, ROTATIONS[rotation]);
+		}
+
+		if ((MutableQuadView.BAKE_FLIP_U & bakeFlags) != 0) {
+			// Inverts U coordinates.  Assumes normalized (0-1) values.
+			applyModifier(quad, spriteIndex, (q, i, t) -> q.sprite(i, t, 1 - q.spriteU(i, t), q.spriteV(i, t)));
+		}
+
+		if ((MutableQuadView.BAKE_FLIP_V & bakeFlags) != 0) {
+			// Inverts V coordinates.  Assumes normalized (0-1) values.
+			applyModifier(quad, spriteIndex, (q, i, t) -> q.sprite(i, t, q.spriteU(i, t), 1 - q.spriteV(i, t)));
+		}
+
+		interpolate(quad, spriteIndex, sprite);
+	}
+
+	/**
+	 * Faster than sprite method. Sprite computes span and normalizes inputs each call,
+	 * so we'd have to denormalize before we called, only to have the sprite renormalize immediately.
+	 */
+	private static void interpolate(MutableQuadView q, int spriteIndex, Sprite sprite) {
+		final float uMin = sprite.getMinU();
+		final float uSpan = sprite.getMaxU() - uMin;
+		final float vMin = sprite.getMinV();
+		final float vSpan = sprite.getMaxV() - vMin;
+
+		for (int i = 0; i < 4; i++) {
+			q.sprite(i, spriteIndex, uMin + q.spriteU(i, spriteIndex) * uSpan, vMin + q.spriteV(i, spriteIndex) * vSpan);
+		}
+	}
+
+	@FunctionalInterface
+	private interface VertexModifier {
+		void apply(MutableQuadView quad, int vertexIndex, int spriteIndex);
+	}
+
+	private static void applyModifier(MutableQuadView quad, int spriteIndex, VertexModifier modifier) {
+		for (int i = 0; i < 4; i++) {
+			modifier.apply(quad, i, spriteIndex);
+		}
+	}
+
+	private static final VertexModifier [] ROTATIONS = new VertexModifier[] {
+		null,
+		(q, i, t) -> q.sprite(i, t, q.spriteV(i, t), q.spriteU(i, t)), //90
+		(q, i, t) -> q.sprite(i, t, 1 - q.spriteU(i, t), 1 - q.spriteV(i, t)), //180
+		(q, i, t) -> q.sprite(i, t, 1 - q.spriteV(i, t), q.spriteU(i, t)) // 270
+	};
+
+	private static final VertexModifier[] UVLOCKERS = new VertexModifier[6];
+
+	static {
+		UVLOCKERS[Direction.EAST.getId()] = (q, i, t) -> q.sprite(i, t, 1 - q.z(i), 1 - q.y(i));
+		UVLOCKERS[Direction.WEST.getId()] = (q, i, t) -> q.sprite(i, t, q.z(i), 1 - q.y(i));
+		UVLOCKERS[Direction.NORTH.getId()] = (q, i, t) -> q.sprite(i, t, 1 - q.x(i), 1 - q.y(i));
+		UVLOCKERS[Direction.SOUTH.getId()] = (q, i, t) -> q.sprite(i, t, q.x(i), 1 - q.y(i));
+		UVLOCKERS[Direction.DOWN.getId()] = (q, i, t) -> q.sprite(i, t, q.x(i), 1 - q.z(i));
+		UVLOCKERS[Direction.UP.getId()] = (q, i, t) -> q.sprite(i, t, q.x(i), 1 - q.z(i));
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/helper/TextureHelper.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/helper/TextureHelper.java
@@ -89,7 +89,7 @@ public class TextureHelper {
 		}
 	}
 
-	private static final VertexModifier [] ROTATIONS = new VertexModifier[] {
+	private static final VertexModifier[] ROTATIONS = new VertexModifier[] {
 		null,
 		(q, i, t) -> q.sprite(i, t, q.spriteV(i, t), q.spriteU(i, t)), //90
 		(q, i, t) -> q.sprite(i, t, 1 - q.spriteU(i, t), 1 - q.spriteV(i, t)), //180

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mesh/EncodingFormat.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mesh/EncodingFormat.java
@@ -16,9 +16,10 @@
 
 package net.fabricmc.indigo.renderer.mesh;
 
+import net.minecraft.util.math.Direction;
+
 import net.fabricmc.fabric.api.renderer.v1.model.ModelHelper;
 import net.fabricmc.indigo.renderer.RenderMaterialImpl;
-import net.minecraft.util.math.Direction;
 
 /**
  * Holds all the array offsets and bit-wise encoders/decoders for
@@ -26,77 +27,77 @@ import net.minecraft.util.math.Direction;
  * All of this is implementation-specific - that's why it isn't a "helper" class.
  */
 public abstract class EncodingFormat {
-    private EncodingFormat() {}
-    
-    static final int HEADER_MATERIAL = 0;
-    static final int HEADER_COLOR_INDEX = 1;
-    static final int HEADER_BITS = 2;
-    static final int HEADER_TAG = 3;
-    public static final int HEADER_STRIDE = 4;
-    
-    // our internal format always include packed normals
-    public static final int VERTEX_START_OFFSET = HEADER_STRIDE;
-    static final int VANILLA_STRIDE = 28;
-    public static final int NORMALS_OFFSET = VERTEX_START_OFFSET + VANILLA_STRIDE;
-    static final int NORMALS_STRIDE = 4;
+	private EncodingFormat() { }
+
+	static final int HEADER_MATERIAL = 0;
+	static final int HEADER_COLOR_INDEX = 1;
+	static final int HEADER_BITS = 2;
+	static final int HEADER_TAG = 3;
+	public static final int HEADER_STRIDE = 4;
+
+	// our internal format always include packed normals
+	public static final int VERTEX_START_OFFSET = HEADER_STRIDE;
+	static final int VANILLA_STRIDE = 28;
+	public static final int NORMALS_OFFSET = VERTEX_START_OFFSET + VANILLA_STRIDE;
+	static final int NORMALS_STRIDE = 4;
 	public static final int NORMALS_OFFSET_VANILLA = VANILLA_STRIDE;
-    // normals are followed by 0-2 sets of color/uv coordinates
-    static final int TEXTURE_STRIDE = 12;
-    /** is one tex stride less than the actual base, because when used tex index is &gt;= 1 */
-    static final int TEXTURE_OFFSET_MINUS = NORMALS_OFFSET + NORMALS_STRIDE - TEXTURE_STRIDE;
-    static final int SECOND_TEXTURE_OFFSET = NORMALS_OFFSET + NORMALS_STRIDE;
-    static final int THIRD_TEXTURE_OFFSET = SECOND_TEXTURE_OFFSET + TEXTURE_STRIDE;
-    public static final int MAX_STRIDE = HEADER_STRIDE + VANILLA_STRIDE + NORMALS_STRIDE 
-            + TEXTURE_STRIDE * (RenderMaterialImpl.MAX_SPRITE_DEPTH - 1);
-    
-    /** used for quick clearing of quad buffers */
-    static final int[] EMPTY = new int[MAX_STRIDE];
-    
-    private static final int DIRECTION_MASK = 7;
-    private static final int CULL_SHIFT = 0;
-    private static final int CULL_INVERSE_MASK = ~(DIRECTION_MASK << CULL_SHIFT);
-    private static final int LIGHT_SHIFT = CULL_SHIFT + Integer.bitCount(DIRECTION_MASK);
-    private static final int LIGHT_INVERSE_MASK = ~(DIRECTION_MASK << LIGHT_SHIFT);
-    private static final int NORMALS_SHIFT = LIGHT_SHIFT + Integer.bitCount(DIRECTION_MASK);
-    private static final int NORMALS_MASK = 0b1111;
-    private static final int NORMALS_INVERSE_MASK = ~(NORMALS_MASK << NORMALS_SHIFT);
-    private static final int GEOMETRY_SHIFT = NORMALS_SHIFT + Integer.bitCount(NORMALS_MASK);
-    private static final int GEOMETRY_MASK = 0b111;
-    private static final int GEOMETRY_INVERSE_MASK = ~(GEOMETRY_MASK << GEOMETRY_SHIFT);
-    
-    static Direction cullFace(int bits) {
-        return ModelHelper.faceFromIndex((bits >> CULL_SHIFT) & DIRECTION_MASK);
-    }
-    
-    static int cullFace(int bits, Direction face) {
-        return (bits & CULL_INVERSE_MASK) | (ModelHelper.toFaceIndex(face) << CULL_SHIFT);
-    }
-    
-    static Direction lightFace(int bits) {
-        return ModelHelper.faceFromIndex((bits >> LIGHT_SHIFT) & DIRECTION_MASK);
-    }
-    
-    static int lightFace(int bits, Direction face) {
-        return (bits & LIGHT_INVERSE_MASK) | (ModelHelper.toFaceIndex(face) << LIGHT_SHIFT);
-    }
-    
-    static int normalFlags(int bits) {
-        return (bits >> NORMALS_SHIFT) & NORMALS_MASK;
-    }
-    
-    static int normalFlags(int bits, int normalFlags) {
-        return (bits & NORMALS_INVERSE_MASK) | ((normalFlags & NORMALS_MASK) << NORMALS_SHIFT);
-    }
-    
-    public static int stride(int textureDepth) {
-        return SECOND_TEXTURE_OFFSET - TEXTURE_STRIDE + textureDepth * TEXTURE_STRIDE;
-    }
-    
-    static int geometryFlags(int bits) {
-        return bits >> GEOMETRY_SHIFT;
-    }
-    
-    static int geometryFlags(int bits, int geometryFlags) {
-        return (bits & GEOMETRY_INVERSE_MASK) | ((geometryFlags & GEOMETRY_MASK) << GEOMETRY_SHIFT);
-    }
+	// normals are followed by 0-2 sets of color/uv coordinates
+	static final int TEXTURE_STRIDE = 12;
+	/** is one tex stride less than the actual base, because when used tex index is &gt;= 1. */
+	static final int TEXTURE_OFFSET_MINUS = NORMALS_OFFSET + NORMALS_STRIDE - TEXTURE_STRIDE;
+	static final int SECOND_TEXTURE_OFFSET = NORMALS_OFFSET + NORMALS_STRIDE;
+	static final int THIRD_TEXTURE_OFFSET = SECOND_TEXTURE_OFFSET + TEXTURE_STRIDE;
+	public static final int MAX_STRIDE = HEADER_STRIDE + VANILLA_STRIDE + NORMALS_STRIDE
+			+ TEXTURE_STRIDE * (RenderMaterialImpl.MAX_SPRITE_DEPTH - 1);
+
+	/** used for quick clearing of quad buffers. */
+	static final int[] EMPTY = new int[MAX_STRIDE];
+
+	private static final int DIRECTION_MASK = 7;
+	private static final int CULL_SHIFT = 0;
+	private static final int CULL_INVERSE_MASK = ~(DIRECTION_MASK << CULL_SHIFT);
+	private static final int LIGHT_SHIFT = CULL_SHIFT + Integer.bitCount(DIRECTION_MASK);
+	private static final int LIGHT_INVERSE_MASK = ~(DIRECTION_MASK << LIGHT_SHIFT);
+	private static final int NORMALS_SHIFT = LIGHT_SHIFT + Integer.bitCount(DIRECTION_MASK);
+	private static final int NORMALS_MASK = 0b1111;
+	private static final int NORMALS_INVERSE_MASK = ~(NORMALS_MASK << NORMALS_SHIFT);
+	private static final int GEOMETRY_SHIFT = NORMALS_SHIFT + Integer.bitCount(NORMALS_MASK);
+	private static final int GEOMETRY_MASK = 0b111;
+	private static final int GEOMETRY_INVERSE_MASK = ~(GEOMETRY_MASK << GEOMETRY_SHIFT);
+
+	static Direction cullFace(int bits) {
+		return ModelHelper.faceFromIndex((bits >> CULL_SHIFT) & DIRECTION_MASK);
+	}
+
+	static int cullFace(int bits, Direction face) {
+		return (bits & CULL_INVERSE_MASK) | (ModelHelper.toFaceIndex(face) << CULL_SHIFT);
+	}
+
+	static Direction lightFace(int bits) {
+		return ModelHelper.faceFromIndex((bits >> LIGHT_SHIFT) & DIRECTION_MASK);
+	}
+
+	static int lightFace(int bits, Direction face) {
+		return (bits & LIGHT_INVERSE_MASK) | (ModelHelper.toFaceIndex(face) << LIGHT_SHIFT);
+	}
+
+	static int normalFlags(int bits) {
+		return (bits >> NORMALS_SHIFT) & NORMALS_MASK;
+	}
+
+	static int normalFlags(int bits, int normalFlags) {
+		return (bits & NORMALS_INVERSE_MASK) | ((normalFlags & NORMALS_MASK) << NORMALS_SHIFT);
+	}
+
+	public static int stride(int textureDepth) {
+		return SECOND_TEXTURE_OFFSET - TEXTURE_STRIDE + textureDepth * TEXTURE_STRIDE;
+	}
+
+	static int geometryFlags(int bits) {
+		return bits >> GEOMETRY_SHIFT;
+	}
+
+	static int geometryFlags(int bits, int geometryFlags) {
+		return (bits & GEOMETRY_INVERSE_MASK) | ((geometryFlags & GEOMETRY_MASK) << GEOMETRY_SHIFT);
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mesh/MeshBuilderImpl.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mesh/MeshBuilderImpl.java
@@ -27,58 +27,58 @@ import net.fabricmc.indigo.renderer.helper.GeometryHelper;
  * Not much to it - mainly it just needs to grow the int[] array as quads are appended
  * and maintain/provide a properly-configured {@link net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView} instance.
  * All the encoding and other work is handled in the quad base classes.
- * The one interesting bit is in {@link Maker#emit()}. 
+ * The one interesting bit is in {@link Maker#emit()}.
  */
 public class MeshBuilderImpl implements MeshBuilder {
-    int[] data = new int[256];
-    private final Maker maker = new Maker();
-    int index = 0;
-    int limit = data.length;
-    
-    protected void ensureCapacity(int stride) {
-        if(stride > limit - index) {
-            limit *= 2;
-            int[] bigger = new int[limit];
-            System.arraycopy(data, 0, bigger, 0, index);
-            data = bigger;
-            maker.data = bigger;
-        }
-    }
+	int[] data = new int[256];
+	private final Maker maker = new Maker();
+	int index = 0;
+	int limit = data.length;
 
-    @Override
-    public Mesh build() {
-        int[] packed = new int[index];
-        System.arraycopy(data, 0, packed, 0, index);
-        index = 0;
-        maker.begin(data, index);
-        return new MeshImpl(packed);
-    }
+	protected void ensureCapacity(int stride) {
+		if (stride > limit - index) {
+			limit *= 2;
+			int[] bigger = new int[limit];
+			System.arraycopy(data, 0, bigger, 0, index);
+			data = bigger;
+			maker.data = bigger;
+		}
+	}
 
-    @Override
-    public QuadEmitter getEmitter() {
-        ensureCapacity(EncodingFormat.MAX_STRIDE);
-        maker.begin(data, index);
-        return maker;
-    }
+	@Override
+	public Mesh build() {
+		int[] packed = new int[index];
+		System.arraycopy(data, 0, packed, 0, index);
+		index = 0;
+		maker.begin(data, index);
+		return new MeshImpl(packed);
+	}
 
-    /**
-     * Our base classes are used differently so we define final
-     * encoding steps in subtypes. This will be a static mesh used
-     * at render time so we want to capture all geometry now and
-     * apply non-location-dependent lighting. 
-     */
-    private class Maker extends MutableQuadViewImpl implements QuadEmitter {
-        @Override
-        public Maker emit() {
-            lightFace = GeometryHelper.lightFace(this);
-            geometryFlags = GeometryHelper.computeShapeFlags(this);
-            ColorHelper.applyDiffuseShading(this, false);
-            encodeHeader();
-            index += maker.stride();   
-            ensureCapacity(EncodingFormat.MAX_STRIDE);
-            baseIndex = index;
-            clear();
-            return this;
-        }
-    }
+	@Override
+	public QuadEmitter getEmitter() {
+		ensureCapacity(EncodingFormat.MAX_STRIDE);
+		maker.begin(data, index);
+		return maker;
+	}
+
+	/**
+	 * Our base classes are used differently so we define final
+	 * encoding steps in subtypes. This will be a static mesh used
+	 * at render time so we want to capture all geometry now and
+	 * apply non-location-dependent lighting.
+	 */
+	private class Maker extends MutableQuadViewImpl implements QuadEmitter {
+		@Override
+		public Maker emit() {
+			lightFace = GeometryHelper.lightFace(this);
+			geometryFlags = GeometryHelper.computeShapeFlags(this);
+			ColorHelper.applyDiffuseShading(this, false);
+			encodeHeader();
+			index += maker.stride();
+			ensureCapacity(EncodingFormat.MAX_STRIDE);
+			baseIndex = index;
+			clear();
+			return this;
+		}
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mesh/MeshImpl.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mesh/MeshImpl.java
@@ -21,42 +21,42 @@ import java.util.function.Consumer;
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadView;
 
-
 /**
  * Implementation of {@link Mesh}.
  * The way we encode meshes makes it very simple.
  */
 public class MeshImpl implements Mesh {
-    /** Used to satisfy external calls to {@link #forEach(Consumer)}. */
-    ThreadLocal<QuadViewImpl> POOL = ThreadLocal.withInitial(QuadViewImpl::new);
-    
-    final int[] data;
+	/** Used to satisfy external calls to {@link #forEach(Consumer)}. */
+	ThreadLocal<QuadViewImpl> POOL = ThreadLocal.withInitial(QuadViewImpl::new);
 
-    MeshImpl(int data[]) {
-        this.data = data;
-    }
-    
-    public int[] data() {
-        return data;
-    }
-    
-    @Override
-    public void forEach(Consumer<QuadView> consumer) {
-        forEach(consumer, POOL.get());
-    }
+	final int[] data;
 
-    /**
-     * The renderer will call this with it's own cursor
-     * to avoid the performance hit of a thread-local lookup.
-     * Also means renderer can hold final references to quad buffers.
-     */
-    void forEach(Consumer<QuadView> consumer, QuadViewImpl cursor) {
-        final int limit = data.length;
-        int index = 0;
-        while(index < limit) {
-            cursor.load(data, index);
-            consumer.accept(cursor);
-            index += cursor.stride();
-        }
-    }
+	MeshImpl(int[] data) {
+		this.data = data;
+	}
+
+	public int[] data() {
+		return data;
+	}
+
+	@Override
+	public void forEach(Consumer<QuadView> consumer) {
+		forEach(consumer, POOL.get());
+	}
+
+	/**
+	 * The renderer will call this with it's own cursor
+	 * to avoid the performance hit of a thread-local lookup.
+	 * Also means renderer can hold final references to quad buffers.
+	 */
+	void forEach(Consumer<QuadView> consumer, QuadViewImpl cursor) {
+		final int limit = data.length;
+		int index = 0;
+
+		while (index < limit) {
+			cursor.load(data, index);
+			consumer.accept(cursor);
+			index += cursor.stride();
+		}
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mesh/MutableQuadViewImpl.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mesh/MutableQuadViewImpl.java
@@ -21,150 +21,154 @@ import static net.fabricmc.indigo.renderer.mesh.EncodingFormat.NORMALS_OFFSET;
 import static net.fabricmc.indigo.renderer.mesh.EncodingFormat.VANILLA_STRIDE;
 import static net.fabricmc.indigo.renderer.mesh.EncodingFormat.VERTEX_START_OFFSET;
 
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.util.math.Direction;
+
 import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
-import net.fabricmc.indigo.renderer.RenderMaterialImpl.Value;
 import net.fabricmc.indigo.renderer.IndigoRenderer;
+import net.fabricmc.indigo.renderer.RenderMaterialImpl.Value;
 import net.fabricmc.indigo.renderer.helper.ColorHelper.ShadeableQuad;
 import net.fabricmc.indigo.renderer.helper.GeometryHelper;
 import net.fabricmc.indigo.renderer.helper.NormalHelper;
 import net.fabricmc.indigo.renderer.helper.TextureHelper;
-import net.minecraft.client.texture.Sprite;
-import net.minecraft.util.math.Direction;
 
 /**
  * Almost-concrete implementation of a mutable quad. The only missing part is {@link #emit()},
  * because that depends on where/how it is used. (Mesh encoding vs. render-time transformation).
  */
 public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEmitter, ShadeableQuad {
-    public final void begin(int[] data, int baseIndex) {
-        this.data = data;
-        this.baseIndex = baseIndex;
-        clear();
-    }
+	public final void begin(int[] data, int baseIndex) {
+		this.data = data;
+		this.baseIndex = baseIndex;
+		clear();
+	}
 
-    public void clear() {
-        System.arraycopy(EMPTY, 0, data, baseIndex, EncodingFormat.MAX_STRIDE);
-        isFaceNormalInvalid = true;
-        isGeometryInvalid = true;
-        normalFlags = 0;
-        tag = 0;
-        colorIndex = -1;
-        cullFace = null;
-        lightFace = null;
-        nominalFace = null;
-        material = IndigoRenderer.MATERIAL_STANDARD;
-    }
-    
-    @Override
-    public final MutableQuadViewImpl material(RenderMaterial material) {
-        if(material == null || material.spriteDepth() > this.material.spriteDepth()) {
-            throw new UnsupportedOperationException("Material texture depth must be the same or less than original material.");
-        }
-        this.material = (Value)material;
-        return this;
-    }
+	public void clear() {
+		System.arraycopy(EMPTY, 0, data, baseIndex, EncodingFormat.MAX_STRIDE);
+		isFaceNormalInvalid = true;
+		isGeometryInvalid = true;
+		normalFlags = 0;
+		tag = 0;
+		colorIndex = -1;
+		cullFace = null;
+		lightFace = null;
+		nominalFace = null;
+		material = IndigoRenderer.MATERIAL_STANDARD;
+	}
 
-    @Override
-    public final MutableQuadViewImpl cullFace(Direction face) {
-        cullFace = face;
-        nominalFace = face;
-        return this;
-    }
-    
-    public final MutableQuadViewImpl lightFace(Direction face) {
-        lightFace = face;
-        return this;
-    }
+	@Override
+	public final MutableQuadViewImpl material(RenderMaterial material) {
+		if (material == null || material.spriteDepth() > this.material.spriteDepth()) {
+			throw new UnsupportedOperationException("Material texture depth must be the same or less than original material.");
+		}
 
-    @Override
-    public final MutableQuadViewImpl nominalFace(Direction face) {
-        nominalFace = face;
-        return this;
-    }
-    
-    @Override
-    public final MutableQuadViewImpl colorIndex(int colorIndex) {
-        this.colorIndex = colorIndex;
-        return this;
-    }
+		this.material = (Value)material;
+		return this;
+	}
 
-    @Override
-    public final MutableQuadViewImpl tag(int tag) {
-        this.tag = tag;
-        return this;
-    }
-    
-    @Override
-    public final MutableQuadViewImpl fromVanilla(int[] quadData, int startIndex, boolean isItem) {
-        final int vertexStart = vertexStart();
-        if(isItem) {
-            System.arraycopy(quadData, startIndex, data, vertexStart, 6);
-            System.arraycopy(quadData, startIndex + 7, data, vertexStart + 7, 6);
-            System.arraycopy(quadData, startIndex + 14, data, vertexStart + 14, 6);
-            System.arraycopy(quadData, startIndex + 21, data, vertexStart + 21, 6);
-            final int normalsIndex = baseIndex + NORMALS_OFFSET;
-            data[normalsIndex] = quadData[startIndex + 6];
-            data[normalsIndex + 1] = quadData[startIndex + 13];
-            data[normalsIndex + 2] = quadData[startIndex + 20];
-            data[normalsIndex + 3] = quadData[startIndex + 27];
-        } else {
-            System.arraycopy(quadData, startIndex, data, vertexStart, 28);
-        }
-        this.invalidateShape();
-        return this;
-    }
-    
-    @Override
-    public boolean isFaceAligned() {
-        return (geometryFlags() & GeometryHelper.AXIS_ALIGNED_FLAG) != 0;
-    }
-    
-    @Override
-    public boolean needsDiffuseShading(int textureIndex) {
-        return textureIndex < material.spriteDepth() && !material.disableDiffuse(textureIndex);
-    }
-    
-    @Override
-    public MutableQuadViewImpl pos(int vertexIndex, float x, float y, float z) {
-        final int index = vertexStart() + vertexIndex * 7;
-        data[index] = Float.floatToRawIntBits(x);
-        data[index + 1] = Float.floatToRawIntBits(y);
-        data[index + 2] = Float.floatToRawIntBits(z);
-        isFaceNormalInvalid = true;
-        return this;
-    }
+	@Override
+	public final MutableQuadViewImpl cullFace(Direction face) {
+		cullFace = face;
+		nominalFace = face;
+		return this;
+	}
 
-    @Override
-    public MutableQuadViewImpl normal(int vertexIndex, float x, float y, float z) {
-        normalFlags |= (1 << vertexIndex);
-        data[baseIndex + VERTEX_START_OFFSET + VANILLA_STRIDE + vertexIndex] = NormalHelper.packNormal(x, y, z, 0);
-        return this;
-    }
+	public final MutableQuadViewImpl lightFace(Direction face) {
+		lightFace = face;
+		return this;
+	}
 
-    @Override
-    public MutableQuadViewImpl lightmap(int vertexIndex, int lightmap) {
-        data[baseIndex + vertexIndex * 7 + 6 + VERTEX_START_OFFSET] = lightmap;
-        return this;
-    }
+	@Override
+	public final MutableQuadViewImpl nominalFace(Direction face) {
+		nominalFace = face;
+		return this;
+	}
 
-    @Override
-    public MutableQuadViewImpl spriteColor(int vertexIndex, int textureIndex, int color) {
-        data[baseIndex + colorIndex(vertexIndex, textureIndex)] = color;
-        return this;
-    }
+	@Override
+	public final MutableQuadViewImpl colorIndex(int colorIndex) {
+		this.colorIndex = colorIndex;
+		return this;
+	}
 
-    @Override
-    public MutableQuadViewImpl sprite(int vertexIndex, int textureIndex, float u, float v) {
-        final int i = baseIndex + colorIndex(vertexIndex, textureIndex) + 1;
-        data[i] = Float.floatToRawIntBits(u);
-        data[i + 1] = Float.floatToRawIntBits(v);
-        return this;
-    }
-    
-    @Override
-    public MutableQuadViewImpl spriteBake(int spriteIndex, Sprite sprite, int bakeFlags) {
-        TextureHelper.bakeSprite(this, spriteIndex, sprite, bakeFlags);
-        return this;
-    }
+	@Override
+	public final MutableQuadViewImpl tag(int tag) {
+		this.tag = tag;
+		return this;
+	}
+
+	@Override
+	public final MutableQuadViewImpl fromVanilla(int[] quadData, int startIndex, boolean isItem) {
+		final int vertexStart = vertexStart();
+
+		if (isItem) {
+			System.arraycopy(quadData, startIndex, data, vertexStart, 6);
+			System.arraycopy(quadData, startIndex + 7, data, vertexStart + 7, 6);
+			System.arraycopy(quadData, startIndex + 14, data, vertexStart + 14, 6);
+			System.arraycopy(quadData, startIndex + 21, data, vertexStart + 21, 6);
+			final int normalsIndex = baseIndex + NORMALS_OFFSET;
+			data[normalsIndex] = quadData[startIndex + 6];
+			data[normalsIndex + 1] = quadData[startIndex + 13];
+			data[normalsIndex + 2] = quadData[startIndex + 20];
+			data[normalsIndex + 3] = quadData[startIndex + 27];
+		} else {
+			System.arraycopy(quadData, startIndex, data, vertexStart, 28);
+		}
+
+		this.invalidateShape();
+		return this;
+	}
+
+	@Override
+	public boolean isFaceAligned() {
+		return (geometryFlags() & GeometryHelper.AXIS_ALIGNED_FLAG) != 0;
+	}
+
+	@Override
+	public boolean needsDiffuseShading(int textureIndex) {
+		return textureIndex < material.spriteDepth() && !material.disableDiffuse(textureIndex);
+	}
+
+	@Override
+	public MutableQuadViewImpl pos(int vertexIndex, float x, float y, float z) {
+		final int index = vertexStart() + vertexIndex * 7;
+		data[index] = Float.floatToRawIntBits(x);
+		data[index + 1] = Float.floatToRawIntBits(y);
+		data[index + 2] = Float.floatToRawIntBits(z);
+		isFaceNormalInvalid = true;
+		return this;
+	}
+
+	@Override
+	public MutableQuadViewImpl normal(int vertexIndex, float x, float y, float z) {
+		normalFlags |= (1 << vertexIndex);
+		data[baseIndex + VERTEX_START_OFFSET + VANILLA_STRIDE + vertexIndex] = NormalHelper.packNormal(x, y, z, 0);
+		return this;
+	}
+
+	@Override
+	public MutableQuadViewImpl lightmap(int vertexIndex, int lightmap) {
+		data[baseIndex + vertexIndex * 7 + 6 + VERTEX_START_OFFSET] = lightmap;
+		return this;
+	}
+
+	@Override
+	public MutableQuadViewImpl spriteColor(int vertexIndex, int textureIndex, int color) {
+		data[baseIndex + colorIndex(vertexIndex, textureIndex)] = color;
+		return this;
+	}
+
+	@Override
+	public MutableQuadViewImpl sprite(int vertexIndex, int textureIndex, float u, float v) {
+		final int i = baseIndex + colorIndex(vertexIndex, textureIndex) + 1;
+		data[i] = Float.floatToRawIntBits(u);
+		data[i + 1] = Float.floatToRawIntBits(v);
+		return this;
+	}
+
+	@Override
+	public MutableQuadViewImpl spriteBake(int spriteIndex, Sprite sprite, int bakeFlags) {
+		TextureHelper.bakeSprite(this, spriteIndex, sprite, bakeFlags);
+		return this;
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mesh/MutableQuadViewImpl.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mesh/MutableQuadViewImpl.java
@@ -63,7 +63,7 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 			throw new UnsupportedOperationException("Material texture depth must be the same or less than original material.");
 		}
 
-		this.material = (Value)material;
+		this.material = (Value) material;
 		return this;
 	}
 

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mesh/QuadViewImpl.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mesh/QuadViewImpl.java
@@ -246,7 +246,7 @@ public class QuadViewImpl implements QuadView {
 
 	@Override
 	public void copyTo(MutableQuadView target) {
-		MutableQuadViewImpl quad = (MutableQuadViewImpl)target;
+		MutableQuadViewImpl quad = (MutableQuadViewImpl) target;
 
 		int len = Math.min(this.stride(), quad.stride());
 

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mesh/QuadViewImpl.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mesh/QuadViewImpl.java
@@ -28,333 +28,343 @@ import static net.fabricmc.indigo.renderer.mesh.EncodingFormat.THIRD_TEXTURE_OFF
 import static net.fabricmc.indigo.renderer.mesh.EncodingFormat.VANILLA_STRIDE;
 import static net.fabricmc.indigo.renderer.mesh.EncodingFormat.VERTEX_START_OFFSET;
 
+import net.minecraft.client.util.math.Vector3f;
+import net.minecraft.util.math.Direction;
+
 import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadView;
 import net.fabricmc.indigo.renderer.RenderMaterialImpl;
 import net.fabricmc.indigo.renderer.helper.GeometryHelper;
 import net.fabricmc.indigo.renderer.helper.NormalHelper;
-import net.minecraft.client.util.math.Vector3f;
-import net.minecraft.util.math.Direction;
 
 /**
  * Base class for all quads / quad makers. Handles the ugly bits
  * of maintaining and encoding the quad state.
  */
 public class QuadViewImpl implements QuadView {
-    protected RenderMaterialImpl.Value material;
-    protected Direction cullFace;
-    protected Direction nominalFace;
-    protected Direction lightFace;
-    protected int colorIndex = -1;
-    protected int tag = 0;
-    /** indicate if vertex normal has been set - bits correspond to vertex ordinals */
-    protected int normalFlags;
-    protected int geometryFlags;
-    protected boolean isGeometryInvalid = true;
-    protected final Vector3f faceNormal = new Vector3f();
-    protected boolean isFaceNormalInvalid = true;
-    
-    /** Size and where it comes from will vary in subtypes. But in all cases quad is fully encoded to array. */
-    protected int[] data;
-    
-    /** Beginning of the quad. Also the header index. */
-    protected int baseIndex = 0;
-    
-    /**
-     * Use when subtype is "attached" to a pre-existing array.
-     * Sets data reference and index and decodes state from array.
-     */
-    final void load(int[] data, int baseIndex) {
-        this.data = data;
-        this.baseIndex = baseIndex;
-        load();
-    }
-    
-    /**
-     * Used on vanilla quads or other quads that don't have encoded shape info
-     * to signal that such should be computed when requested.
-     */
-    public final void invalidateShape() {
-        isFaceNormalInvalid = true;
-        isGeometryInvalid = true;
-    }
-    
-    /**
-     * Like {@link #load(int[], int)} but assumes array and index already set.
-     * Only does the decoding part.
-     */
-    public final void load() {
-        // face normal isn't encoded but geometry flags are
-        isFaceNormalInvalid = true;
-        isGeometryInvalid = false;
-        decodeHeader();
-    }
-    
-    /** Reference to underlying array. Use with caution. Meant for fast renderer access */
-    public int[] data() {
-        return data;
-    }
-    
-    /** True if any vertex normal has been set. */
-    public boolean hasVertexNormals() {
-        return normalFlags != 0;
-    }
-    
-    /** Index after header where vertex data starts (first 28 will be vanilla format. */
-    public int vertexStart() {
-        return baseIndex + VERTEX_START_OFFSET;
-    }
-    
-    /** Length of encoded quad in array, including header. */
-    final int stride() {
-        return EncodingFormat.stride(material.spriteDepth());
-    }
-    
-    /** reads state from header - vertex attributes are saved directly */
-    protected void decodeHeader() {
-        material = RenderMaterialImpl.byIndex(data[baseIndex + HEADER_MATERIAL]);
-        final int bits = data[baseIndex + HEADER_BITS];
-        colorIndex = data[baseIndex + HEADER_COLOR_INDEX];
-        tag = data[baseIndex + HEADER_TAG];
-        geometryFlags = EncodingFormat.geometryFlags(bits);
-        cullFace = EncodingFormat.cullFace(bits);
-        lightFace = EncodingFormat.lightFace(bits);
-        nominalFace = lightFace;
-        normalFlags = EncodingFormat.normalFlags(bits);
-    }
-    
-    /** writes state to header - vertex attributes are saved directly */
-    protected void encodeHeader() {
-        data[baseIndex + HEADER_MATERIAL] = material.index();
-        data[baseIndex + HEADER_COLOR_INDEX] = colorIndex;
-        data[baseIndex + HEADER_TAG] = tag;
-        int bits = EncodingFormat.geometryFlags(0, geometryFlags);
-        bits = EncodingFormat.normalFlags(bits, normalFlags);
-        bits = EncodingFormat.cullFace(bits, cullFace);
-        bits = EncodingFormat.lightFace(bits, lightFace);
-        data[baseIndex + HEADER_BITS] = bits;
-    }
-    
-    /** gets flags used for lighting - lazily computed via {@link GeometryHelper#computeShapeFlags(QuadView)} */
-    public int geometryFlags() {
-        if(isGeometryInvalid) {
-            isGeometryInvalid = false;
-            geometryFlags = GeometryHelper.computeShapeFlags(this);
-        }
-        return geometryFlags;
-    }
-    
-    /**
-     * Used to override geometric analysis for compatibility edge case 
-     */
-    public void geometryFlags(int flags) {
-        isGeometryInvalid = false;
-        geometryFlags = flags;
-    }
-    
-    @Override
-    public final void toVanilla(int textureIndex, int[] target, int targetIndex, boolean isItem) {
-        System.arraycopy(data, vertexStart(), target, targetIndex, 28);
+	protected RenderMaterialImpl.Value material;
+	protected Direction cullFace;
+	protected Direction nominalFace;
+	protected Direction lightFace;
+	protected int colorIndex = -1;
+	protected int tag = 0;
+	/** indicate if vertex normal has been set - bits correspond to vertex ordinals. */
+	protected int normalFlags;
+	protected int geometryFlags;
+	protected boolean isGeometryInvalid = true;
+	protected final Vector3f faceNormal = new Vector3f();
+	protected boolean isFaceNormalInvalid = true;
 
-        if(textureIndex > 0) {
-            copyColorUV(textureIndex, target, targetIndex);
-        }
-            
-        if(isItem) {
-            copyNormals(target, targetIndex);
-        }
-    }
+	/** Size and where it comes from will vary in subtypes. But in all cases quad is fully encoded to array. */
+	protected int[] data;
 
-    /**
-     * Internal helper method. Copies color and UV for the given texture to target, assuming vanilla format.
-     */
-    public final void copyColorUV(int textureIndex, int[] target, int targetIndex) {
-        int indexTo = targetIndex + 3;
-        int indexFrom;
-        int strideFrom;
-        if(textureIndex == 0) {
-            indexFrom = baseIndex + VERTEX_START_OFFSET + 3;
-            strideFrom = 7;
-        } else {
-            indexFrom = baseIndex + (textureIndex == 1 ? SECOND_TEXTURE_OFFSET : THIRD_TEXTURE_OFFSET);
-            strideFrom = 3;
-        }
-        for(int i = 0; i < 4; i++) {
-            System.arraycopy(data, indexFrom, target, indexTo, 3);
-            indexTo += 7;
-            indexFrom += strideFrom;
-        }
-    }
-    
-    /**
-     * Internal helper method. Copies packed normals to target, assuming vanilla format.
-     */
-    public final void copyNormals(int[] target, int targetIndex) {
-        final int normalFlags = this.normalFlags;
-        final int packedFaceNormal = normalFlags == 0b1111 ? 0 : NormalHelper.packNormal(faceNormal(), 0);
-        final int normalsIndex = baseIndex + NORMALS_OFFSET;
-        for(int v = 0; v < 4; v++) {
-            final int packed = (normalFlags & (1 << v)) == 0 ? packedFaceNormal : data[normalsIndex + v];
-            target[targetIndex + v * 7 + 6] =  packed;
-        }
-    }
-    
-    @Override
-    public final RenderMaterialImpl.Value material() {
-        return material;
-    }
+	/** Beginning of the quad. Also the header index. */
+	protected int baseIndex = 0;
 
-    @Override
-    public final int colorIndex() {
-        return colorIndex;
-    }
+	/**
+	 * Use when subtype is "attached" to a pre-existing array.
+	 * Sets data reference and index and decodes state from array.
+	 */
+	final void load(int[] data, int baseIndex) {
+		this.data = data;
+		this.baseIndex = baseIndex;
+		load();
+	}
 
-    @Override
-    public final int tag() {
-        return tag;
-    }
-    
-    @Override
-    public final Direction lightFace() {
-        return lightFace;
-    }
+	/**
+	 * Used on vanilla quads or other quads that don't have encoded shape info
+	 * to signal that such should be computed when requested.
+	 */
+	public final void invalidateShape() {
+		isFaceNormalInvalid = true;
+		isGeometryInvalid = true;
+	}
 
-    @Override
-    public final Direction cullFace() {
-        return cullFace;
-    }
-    
-    @Override
-    public final Direction nominalFace() {
-        return nominalFace;
-    }
-    
-    @Override
-    public final Vector3f faceNormal() {
-        if(isFaceNormalInvalid) {
-            NormalHelper.computeFaceNormal(faceNormal, this);
-            isFaceNormalInvalid = false;
-        }
-        return faceNormal;
-    }
+	/**
+	 * Like {@link #load(int[], int)} but assumes array and index already set.
+	 * Only does the decoding part.
+	 */
+	public final void load() {
+		// face normal isn't encoded but geometry flags are
+		isFaceNormalInvalid = true;
+		isGeometryInvalid = false;
+		decodeHeader();
+	}
 
-    @Override
-    public void copyTo(MutableQuadView target) {
-        MutableQuadViewImpl quad = (MutableQuadViewImpl)target;
-        
-        int len = Math.min(this.stride(), quad.stride());
-        
-        // copy everything except the header/material
-        System.arraycopy(data, baseIndex + 1, quad.data, quad.baseIndex + 1, len - 1);
-        quad.isFaceNormalInvalid = this.isFaceNormalInvalid;
-        if(!this.isFaceNormalInvalid) {
-            quad.faceNormal.set(this.faceNormal.getX(), this.faceNormal.getY(), this.faceNormal.getZ());
-        }
-        quad.lightFace = this.lightFace;
-        quad.colorIndex = this.colorIndex;
-        quad.tag = this.tag;
-        quad.cullFace = this.cullFace;
-        quad.nominalFace = this.nominalFace;
-        quad.normalFlags = this.normalFlags;
-    }
-    
-    @Override
-    public Vector3f copyPos(int vertexIndex, Vector3f target) {
-        if(target == null) {
-            target = new Vector3f();
-        }
-        final int index = vertexStart() + vertexIndex * 7;
-        target.set(
-                Float.intBitsToFloat(data[index]), 
-                Float.intBitsToFloat(data[index + 1]), 
-                Float.intBitsToFloat(data[index + 2]));
-        return target;
-    }
+	/** Reference to underlying array. Use with caution. Meant for fast renderer access */
+	public int[] data() {
+		return data;
+	}
 
-    @Override
-    public float posByIndex(int vertexIndex, int coordinateIndex) {
-        return Float.intBitsToFloat(data[vertexStart() + vertexIndex * 7 + coordinateIndex]);
-    }
-    
-    @Override
-    public float x(int vertexIndex) {
-        return Float.intBitsToFloat(data[vertexStart() + vertexIndex * 7]);
-    }
+	/** True if any vertex normal has been set. */
+	public boolean hasVertexNormals() {
+		return normalFlags != 0;
+	}
 
-    @Override
-    public float y(int vertexIndex) {
-        return Float.intBitsToFloat(data[vertexStart() + vertexIndex * 7 + 1]);
-    }
+	/** Index after header where vertex data starts (first 28 will be vanilla format. */
+	public int vertexStart() {
+		return baseIndex + VERTEX_START_OFFSET;
+	}
 
-    @Override
-    public float z(int vertexIndex) {
-        return Float.intBitsToFloat(data[vertexStart() + vertexIndex * 7 + 2]);
-    }
+	/** Length of encoded quad in array, including header. */
+	final int stride() {
+		return EncodingFormat.stride(material.spriteDepth());
+	}
 
-    @Override
-    public boolean hasNormal(int vertexIndex) {
-        return (normalFlags & (1 << vertexIndex)) != 0;
-    }
+	/** reads state from header - vertex attributes are saved directly. */
+	protected void decodeHeader() {
+		material = RenderMaterialImpl.byIndex(data[baseIndex + HEADER_MATERIAL]);
+		final int bits = data[baseIndex + HEADER_BITS];
+		colorIndex = data[baseIndex + HEADER_COLOR_INDEX];
+		tag = data[baseIndex + HEADER_TAG];
+		geometryFlags = EncodingFormat.geometryFlags(bits);
+		cullFace = EncodingFormat.cullFace(bits);
+		lightFace = EncodingFormat.lightFace(bits);
+		nominalFace = lightFace;
+		normalFlags = EncodingFormat.normalFlags(bits);
+	}
 
-    @Override
-    public Vector3f copyNormal(int vertexIndex, Vector3f target) {
-        if(hasNormal(vertexIndex)) {
-            if(target == null) {
-                target = new Vector3f();
-            }
-            final int normal = data[vertexStart() + VANILLA_STRIDE + vertexIndex];
-            target.set(
-                    NormalHelper.getPackedNormalComponent(normal, 0),
-                    NormalHelper.getPackedNormalComponent(normal, 1),
-                    NormalHelper.getPackedNormalComponent(normal, 2));
-            return target;
-        } else {
-            return null;
-        }
-    }
+	/** writes state to header - vertex attributes are saved directly. */
+	protected void encodeHeader() {
+		data[baseIndex + HEADER_MATERIAL] = material.index();
+		data[baseIndex + HEADER_COLOR_INDEX] = colorIndex;
+		data[baseIndex + HEADER_TAG] = tag;
+		int bits = EncodingFormat.geometryFlags(0, geometryFlags);
+		bits = EncodingFormat.normalFlags(bits, normalFlags);
+		bits = EncodingFormat.cullFace(bits, cullFace);
+		bits = EncodingFormat.lightFace(bits, lightFace);
+		data[baseIndex + HEADER_BITS] = bits;
+	}
 
-    @Override
-    public float normalX(int vertexIndex) {
-        return hasNormal(vertexIndex)
-                ? NormalHelper.getPackedNormalComponent(data[baseIndex + VERTEX_START_OFFSET + VANILLA_STRIDE + vertexIndex], 0)
-                : Float.NaN;
-    }
+	/** gets flags used for lighting - lazily computed via {@link GeometryHelper#computeShapeFlags(QuadView)}. */
+	public int geometryFlags() {
+		if (isGeometryInvalid) {
+			isGeometryInvalid = false;
+			geometryFlags = GeometryHelper.computeShapeFlags(this);
+		}
 
-    @Override
-    public float normalY(int vertexIndex) {
-        return hasNormal(vertexIndex)
-                ? NormalHelper.getPackedNormalComponent(data[baseIndex + VERTEX_START_OFFSET + VANILLA_STRIDE + vertexIndex], 1)
-                : Float.NaN;
-    }
+		return geometryFlags;
+	}
 
-    @Override
-    public float normalZ(int vertexIndex) {
-        return hasNormal(vertexIndex)
-                ? NormalHelper.getPackedNormalComponent(data[baseIndex + VERTEX_START_OFFSET + VANILLA_STRIDE + vertexIndex], 2)
-                : Float.NaN;
-    }
+	/**
+	 * Used to override geometric analysis for compatibility edge case.
+	 */
+	public void geometryFlags(int flags) {
+		isGeometryInvalid = false;
+		geometryFlags = flags;
+	}
 
-    @Override
-    public int lightmap(int vertexIndex) {
-        return data[baseIndex + vertexIndex * 7 + 6 + VERTEX_START_OFFSET];
-    }
+	@Override
+	public final void toVanilla(int textureIndex, int[] target, int targetIndex, boolean isItem) {
+		System.arraycopy(data, vertexStart(), target, targetIndex, 28);
 
-    protected int colorIndex(int vertexIndex, int textureIndex) {
-        return textureIndex == 0 ? vertexIndex * 7 + 3 + VERTEX_START_OFFSET : TEXTURE_OFFSET_MINUS + textureIndex * TEXTURE_STRIDE + vertexIndex * 3;
-    }
-    
-    @Override
-    public int spriteColor(int vertexIndex, int textureIndex) {
-        return data[baseIndex + colorIndex(vertexIndex, textureIndex)];
-    }
+		if (textureIndex > 0) {
+			copyColorUV(textureIndex, target, targetIndex);
+		}
 
-    @Override
-    public float spriteU(int vertexIndex, int textureIndex) {
-        return Float.intBitsToFloat(data[baseIndex + colorIndex(vertexIndex, textureIndex) + 1]);
-    }
+		if (isItem) {
+			copyNormals(target, targetIndex);
+		}
+	}
 
-    @Override
-    public float spriteV(int vertexIndex, int textureIndex) {
-        return Float.intBitsToFloat(data[baseIndex + colorIndex(vertexIndex, textureIndex) + 2]);
-    }
+	/**
+	 * Internal helper method. Copies color and UV for the given texture to target, assuming vanilla format.
+	 */
+	public final void copyColorUV(int textureIndex, int[] target, int targetIndex) {
+		int indexTo = targetIndex + 3;
+		int indexFrom;
+		int strideFrom;
+
+		if (textureIndex == 0) {
+			indexFrom = baseIndex + VERTEX_START_OFFSET + 3;
+			strideFrom = 7;
+		} else {
+			indexFrom = baseIndex + (textureIndex == 1 ? SECOND_TEXTURE_OFFSET : THIRD_TEXTURE_OFFSET);
+			strideFrom = 3;
+		}
+
+		for (int i = 0; i < 4; i++) {
+			System.arraycopy(data, indexFrom, target, indexTo, 3);
+			indexTo += 7;
+			indexFrom += strideFrom;
+		}
+	}
+
+	/**
+	 * Internal helper method. Copies packed normals to target, assuming vanilla format.
+	 */
+	public final void copyNormals(int[] target, int targetIndex) {
+		final int normalFlags = this.normalFlags;
+		final int packedFaceNormal = normalFlags == 0b1111 ? 0 : NormalHelper.packNormal(faceNormal(), 0);
+		final int normalsIndex = baseIndex + NORMALS_OFFSET;
+
+		for (int v = 0; v < 4; v++) {
+			final int packed = (normalFlags & (1 << v)) == 0 ? packedFaceNormal : data[normalsIndex + v];
+			target[targetIndex + v * 7 + 6] = packed;
+		}
+	}
+
+	@Override
+	public final RenderMaterialImpl.Value material() {
+		return material;
+	}
+
+	@Override
+	public final int colorIndex() {
+		return colorIndex;
+	}
+
+	@Override
+	public final int tag() {
+		return tag;
+	}
+
+	@Override
+	public final Direction lightFace() {
+		return lightFace;
+	}
+
+	@Override
+	public final Direction cullFace() {
+		return cullFace;
+	}
+
+	@Override
+	public final Direction nominalFace() {
+		return nominalFace;
+	}
+
+	@Override
+	public final Vector3f faceNormal() {
+		if (isFaceNormalInvalid) {
+			NormalHelper.computeFaceNormal(faceNormal, this);
+			isFaceNormalInvalid = false;
+		}
+
+		return faceNormal;
+	}
+
+	@Override
+	public void copyTo(MutableQuadView target) {
+		MutableQuadViewImpl quad = (MutableQuadViewImpl)target;
+
+		int len = Math.min(this.stride(), quad.stride());
+
+		// copy everything except the header/material
+		System.arraycopy(data, baseIndex + 1, quad.data, quad.baseIndex + 1, len - 1);
+		quad.isFaceNormalInvalid = this.isFaceNormalInvalid;
+
+		if (!this.isFaceNormalInvalid) {
+			quad.faceNormal.set(this.faceNormal.getX(), this.faceNormal.getY(), this.faceNormal.getZ());
+		}
+
+		quad.lightFace = this.lightFace;
+		quad.colorIndex = this.colorIndex;
+		quad.tag = this.tag;
+		quad.cullFace = this.cullFace;
+		quad.nominalFace = this.nominalFace;
+		quad.normalFlags = this.normalFlags;
+	}
+
+	@Override
+	public Vector3f copyPos(int vertexIndex, Vector3f target) {
+		if (target == null) {
+			target = new Vector3f();
+		}
+
+		final int index = vertexStart() + vertexIndex * 7;
+		target.set(
+				Float.intBitsToFloat(data[index]),
+				Float.intBitsToFloat(data[index + 1]),
+				Float.intBitsToFloat(data[index + 2]));
+		return target;
+	}
+
+	@Override
+	public float posByIndex(int vertexIndex, int coordinateIndex) {
+		return Float.intBitsToFloat(data[vertexStart() + vertexIndex * 7 + coordinateIndex]);
+	}
+
+	@Override
+	public float x(int vertexIndex) {
+		return Float.intBitsToFloat(data[vertexStart() + vertexIndex * 7]);
+	}
+
+	@Override
+	public float y(int vertexIndex) {
+		return Float.intBitsToFloat(data[vertexStart() + vertexIndex * 7 + 1]);
+	}
+
+	@Override
+	public float z(int vertexIndex) {
+		return Float.intBitsToFloat(data[vertexStart() + vertexIndex * 7 + 2]);
+	}
+
+	@Override
+	public boolean hasNormal(int vertexIndex) {
+		return (normalFlags & (1 << vertexIndex)) != 0;
+	}
+
+	@Override
+	public Vector3f copyNormal(int vertexIndex, Vector3f target) {
+		if (hasNormal(vertexIndex)) {
+			if (target == null) {
+				target = new Vector3f();
+			}
+
+			final int normal = data[vertexStart() + VANILLA_STRIDE + vertexIndex];
+			target.set(
+					NormalHelper.getPackedNormalComponent(normal, 0),
+					NormalHelper.getPackedNormalComponent(normal, 1),
+					NormalHelper.getPackedNormalComponent(normal, 2));
+			return target;
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public float normalX(int vertexIndex) {
+		return hasNormal(vertexIndex)
+				? NormalHelper.getPackedNormalComponent(data[baseIndex + VERTEX_START_OFFSET + VANILLA_STRIDE + vertexIndex], 0)
+				: Float.NaN;
+	}
+
+	@Override
+	public float normalY(int vertexIndex) {
+		return hasNormal(vertexIndex)
+				? NormalHelper.getPackedNormalComponent(data[baseIndex + VERTEX_START_OFFSET + VANILLA_STRIDE + vertexIndex], 1)
+				: Float.NaN;
+	}
+
+	@Override
+	public float normalZ(int vertexIndex) {
+		return hasNormal(vertexIndex)
+				? NormalHelper.getPackedNormalComponent(data[baseIndex + VERTEX_START_OFFSET + VANILLA_STRIDE + vertexIndex], 2)
+				: Float.NaN;
+	}
+
+	@Override
+	public int lightmap(int vertexIndex) {
+		return data[baseIndex + vertexIndex * 7 + 6 + VERTEX_START_OFFSET];
+	}
+
+	protected int colorIndex(int vertexIndex, int textureIndex) {
+		return textureIndex == 0 ? vertexIndex * 7 + 3 + VERTEX_START_OFFSET : TEXTURE_OFFSET_MINUS + textureIndex * TEXTURE_STRIDE + vertexIndex * 3;
+	}
+
+	@Override
+	public int spriteColor(int vertexIndex, int textureIndex) {
+		return data[baseIndex + colorIndex(vertexIndex, textureIndex)];
+	}
+
+	@Override
+	public float spriteU(int vertexIndex, int textureIndex) {
+		return Float.intBitsToFloat(data[baseIndex + colorIndex(vertexIndex, textureIndex) + 1]);
+	}
+
+	@Override
+	public float spriteV(int vertexIndex, int textureIndex) {
+		return Float.intBitsToFloat(data[baseIndex + colorIndex(vertexIndex, textureIndex) + 2]);
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/BufferBuilderOffsetAccessor.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/BufferBuilderOffsetAccessor.java
@@ -16,9 +16,10 @@
 
 package net.fabricmc.indigo.renderer.mixin;
 
-import net.minecraft.client.render.BufferBuilder;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.client.render.BufferBuilder;
 
 @Mixin(BufferBuilder.class)
 public interface BufferBuilderOffsetAccessor {

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinBlockModelRenderer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinBlockModelRenderer.java
@@ -47,7 +47,7 @@ public abstract class MixinBlockModelRenderer {
 			BlockRenderContext context = CONTEXTS.get();
 
 			if (!context.isCallingVanilla()) {
-				ci.setReturnValue(CONTEXTS.get().tesselate((BlockModelRenderer)(Object)this, blockView, model, state, pos, buffer, seed));
+				ci.setReturnValue(CONTEXTS.get().tesselate((BlockModelRenderer) (Object) this, blockView, model, state, pos, buffer, seed));
 			}
 		}
 	}

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinBlockModelRenderer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinBlockModelRenderer.java
@@ -24,8 +24,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
-import net.fabricmc.indigo.renderer.render.BlockRenderContext;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.color.block.BlockColors;
 import net.minecraft.client.render.BufferBuilder;
@@ -34,18 +32,23 @@ import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.ExtendedBlockView;
 
+import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
+import net.fabricmc.indigo.renderer.render.BlockRenderContext;
+
 @Mixin(BlockModelRenderer.class)
 public abstract class MixinBlockModelRenderer {
-    @Shadow protected BlockColors colorMap;
-    private final ThreadLocal<BlockRenderContext> CONTEXTS = ThreadLocal.withInitial(BlockRenderContext::new);
-    
-    @Inject(at = @At("HEAD"), method = "tesselate", cancellable = true)
-    private void hookTesselate(ExtendedBlockView blockView, BakedModel model, BlockState state, BlockPos pos, BufferBuilder buffer, boolean checkSides, Random rand, long seed, CallbackInfoReturnable<Boolean> ci) {
-        if(!((FabricBakedModel)model).isVanillaAdapter()) {
-            BlockRenderContext context = CONTEXTS.get();
-            if(!context.isCallingVanilla()) {
-                ci.setReturnValue(CONTEXTS.get().tesselate((BlockModelRenderer)(Object)this, blockView, model, state, pos, buffer, seed));
-            }
-        }
-    }
+	@Shadow
+	protected BlockColors colorMap;
+	private final ThreadLocal<BlockRenderContext> CONTEXTS = ThreadLocal.withInitial(BlockRenderContext::new);
+
+	@Inject(at = @At("HEAD"), method = "tesselate", cancellable = true)
+	private void hookTesselate(ExtendedBlockView blockView, BakedModel model, BlockState state, BlockPos pos, BufferBuilder buffer, boolean checkSides, Random rand, long seed, CallbackInfoReturnable<Boolean> ci) {
+		if (!((FabricBakedModel) model).isVanillaAdapter()) {
+			BlockRenderContext context = CONTEXTS.get();
+
+			if (!context.isCallingVanilla()) {
+				ci.setReturnValue(CONTEXTS.get().tesselate((BlockModelRenderer)(Object)this, blockView, model, state, pos, buffer, seed));
+			}
+		}
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinBufferBuilder.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinBufferBuilder.java
@@ -21,87 +21,90 @@ import java.nio.IntBuffer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
-import net.fabricmc.indigo.Indigo;
-import net.fabricmc.indigo.renderer.accessor.AccessBufferBuilder;
-import net.fabricmc.indigo.renderer.mesh.QuadViewImpl;
 import net.minecraft.client.render.BufferBuilder;
 import net.minecraft.client.render.VertexFormat;
 import net.minecraft.client.render.VertexFormatElement;
 
+import net.fabricmc.indigo.Indigo;
+import net.fabricmc.indigo.renderer.accessor.AccessBufferBuilder;
+import net.fabricmc.indigo.renderer.mesh.QuadViewImpl;
+
 @Mixin(BufferBuilder.class)
 public abstract class MixinBufferBuilder implements AccessBufferBuilder {
-    @Shadow private IntBuffer bufInt;
-    @Shadow private int vertexCount;
-    @Shadow abstract void grow(int size);
-    @Shadow abstract int getCurrentSize();
-    @Shadow public abstract VertexFormat getVertexFormat();
+	@Shadow private IntBuffer bufInt;
+	@Shadow private int vertexCount;
+	@Shadow abstract void grow(int size);
+	@Shadow abstract int getCurrentSize();
+	@Shadow public abstract VertexFormat getVertexFormat();
 
 	private static final int VERTEX_STRIDE_INTS = 7;
-    private static final int QUAD_STRIDE_INTS = VERTEX_STRIDE_INTS * 4;
-    private static final int QUAD_STRIDE_BYTES = QUAD_STRIDE_INTS * 4;
+	private static final int QUAD_STRIDE_INTS = VERTEX_STRIDE_INTS * 4;
+	private static final int QUAD_STRIDE_BYTES = QUAD_STRIDE_INTS * 4;
 
-    @Override
-    public void fabric_putQuad(QuadViewImpl quad) {
-        if(Indigo.ENSURE_VERTEX_FORMAT_COMPATIBILITY) {
-            bufferCompatibly(quad);
-        } else {
-            bufferFast(quad);
-        }
-    }
+	@Override
+	public void fabric_putQuad(QuadViewImpl quad) {
+		if (Indigo.ENSURE_VERTEX_FORMAT_COMPATIBILITY) {
+			bufferCompatibly(quad);
+		} else {
+			bufferFast(quad);
+		}
+	}
 
-    private void bufferFast(QuadViewImpl quad) {
-        grow(QUAD_STRIDE_BYTES);
-        bufInt.position(getCurrentSize());
-        bufInt.put(quad.data(), quad.vertexStart(), QUAD_STRIDE_INTS);
-        vertexCount += 4;
-    }
+	private void bufferFast(QuadViewImpl quad) {
+		grow(QUAD_STRIDE_BYTES);
+		bufInt.position(getCurrentSize());
+		bufInt.put(quad.data(), quad.vertexStart(), QUAD_STRIDE_INTS);
+		vertexCount += 4;
+	}
 
-    /**
-     * Uses buffer vertex format to drive buffer population.
-     * Relies on logic elsewhere to ensure coordinates don't include chunk offset
-     * (because buffer builder will handle that.)<p>
-     * 
-     * Calling putVertexData() would likely be a little faster but this approach
-     * gives us a chance to pass vertex normals to shaders, which isn't possible
-     * with the standard block format. It also doesn't require us to encode a specific
-     * custom format directly, which would be prone to breakage outside our control. 
-     */
-    private void bufferCompatibly(QuadViewImpl quad) {
-        final VertexFormat format = getVertexFormat();;
-        final int elementCount = format.getElementCount();
-        for(int i = 0; i < 4; i++) {
-            for(int j = 0; j < elementCount; j++) {
-                VertexFormatElement e = format.getElement(j);
-                switch(e.getType()) {
-                case COLOR:
-                    final int c = quad.spriteColor(i, 0);
-                    ((BufferBuilder)(Object)this).color(c & 0xFF, (c >>> 8) & 0xFF, (c >>> 16) & 0xFF, (c >>> 24) & 0xFF);
-                    break;
-                case NORMAL:
-                    ((BufferBuilder)(Object)this).normal(quad.normalX(i), quad.normalY(i), quad.normalZ(i));
-                    break;
-                case POSITION:
-                    ((BufferBuilder)(Object)this).vertex(quad.x(i), quad.y(i), quad.z(i));
-                    break;
-                case UV:
-                    if(e.getIndex() == 0) {
-                        ((BufferBuilder)(Object)this).texture(quad.spriteU(i, 0), quad.spriteV(i, 0));
-                    } else {
-                        final int b = quad.lightmap(i);
-                        ((BufferBuilder)(Object)this).texture((b >> 16) & 0xFFFF, b & 0xFFFF);
-                    }
-                    break;
+	/**
+	 * Uses buffer vertex format to drive buffer population.
+	 * Relies on logic elsewhere to ensure coordinates don't include chunk offset
+	 * (because buffer builder will handle that.)
+	 *
+	 * <p>Calling putVertexData() would likely be a little faster but this approach
+	 * gives us a chance to pass vertex normals to shaders, which isn't possible
+	 * with the standard block format. It also doesn't require us to encode a specific
+	 * custom format directly, which would be prone to breakage outside our control.
+	 */
+	private void bufferCompatibly(QuadViewImpl quad) {
+		final VertexFormat format = getVertexFormat();;
+		final int elementCount = format.getElementCount();
 
-                // these types should never occur and/or require no action
-                case MATRIX:
-                case BLEND_WEIGHT:
-                case PADDING:
-                default:
-                    break;
+		for (int i = 0; i < 4; i++) {
+			for (int j = 0; j < elementCount; j++) {
+				VertexFormatElement e = format.getElement(j);
+				switch (e.getType()) {
+				case COLOR:
+					final int c = quad.spriteColor(i, 0);
+					((BufferBuilder)(Object)this).color(c & 0xFF, (c >>> 8) & 0xFF, (c >>> 16) & 0xFF, (c >>> 24) & 0xFF);
+					break;
+				case NORMAL:
+					((BufferBuilder)(Object)this).normal(quad.normalX(i), quad.normalY(i), quad.normalZ(i));
+					break;
+				case POSITION:
+					((BufferBuilder)(Object)this).vertex(quad.x(i), quad.y(i), quad.z(i));
+					break;
+				case UV:
+					if (e.getIndex() == 0) {
+						((BufferBuilder)(Object)this).texture(quad.spriteU(i, 0), quad.spriteV(i, 0));
+					} else {
+						final int b = quad.lightmap(i);
+						((BufferBuilder)(Object)this).texture((b >> 16) & 0xFFFF, b & 0xFFFF);
+					}
 
-                }
-            }
-            ((BufferBuilder)(Object)this).next();
-        }
-    }
+					break;
+
+				// these types should never occur and/or require no action
+				case MATRIX:
+				case BLEND_WEIGHT:
+				case PADDING:
+				default:
+					break;
+				}
+			}
+
+			((BufferBuilder)(Object)this).next();
+		}
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinBufferBuilder.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinBufferBuilder.java
@@ -77,20 +77,20 @@ public abstract class MixinBufferBuilder implements AccessBufferBuilder {
 				switch (e.getType()) {
 				case COLOR:
 					final int c = quad.spriteColor(i, 0);
-					((BufferBuilder)(Object)this).color(c & 0xFF, (c >>> 8) & 0xFF, (c >>> 16) & 0xFF, (c >>> 24) & 0xFF);
+					((BufferBuilder) (Object) this).color(c & 0xFF, (c >>> 8) & 0xFF, (c >>> 16) & 0xFF, (c >>> 24) & 0xFF);
 					break;
 				case NORMAL:
-					((BufferBuilder)(Object)this).normal(quad.normalX(i), quad.normalY(i), quad.normalZ(i));
+					((BufferBuilder) (Object) this).normal(quad.normalX(i), quad.normalY(i), quad.normalZ(i));
 					break;
 				case POSITION:
-					((BufferBuilder)(Object)this).vertex(quad.x(i), quad.y(i), quad.z(i));
+					((BufferBuilder) (Object) this).vertex(quad.x(i), quad.y(i), quad.z(i));
 					break;
 				case UV:
 					if (e.getIndex() == 0) {
-						((BufferBuilder)(Object)this).texture(quad.spriteU(i, 0), quad.spriteV(i, 0));
+						((BufferBuilder) (Object) this).texture(quad.spriteU(i, 0), quad.spriteV(i, 0));
 					} else {
 						final int b = quad.lightmap(i);
-						((BufferBuilder)(Object)this).texture((b >> 16) & 0xFFFF, b & 0xFFFF);
+						((BufferBuilder) (Object) this).texture((b >> 16) & 0xFFFF, b & 0xFFFF);
 					}
 
 					break;
@@ -104,7 +104,7 @@ public abstract class MixinBufferBuilder implements AccessBufferBuilder {
 				}
 			}
 
-			((BufferBuilder)(Object)this).next();
+			((BufferBuilder) (Object) this).next();
 		}
 	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinChunkRenderTask.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinChunkRenderTask.java
@@ -46,7 +46,7 @@ public abstract class MixinChunkRenderTask {
 		if (blockView != null) {
 			final TerrainRenderContext renderer = TerrainRenderContext.POOL.get();
 			renderer.setBlockView(blockView);
-			((AccessChunkRendererRegion)blockView).fabric_setRenderer(renderer);
+			((AccessChunkRendererRegion) blockView).fabric_setRenderer(renderer);
 		}
 	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinChunkRenderTask.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinChunkRenderTask.java
@@ -22,29 +22,31 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import net.fabricmc.indigo.renderer.accessor.AccessChunkRendererRegion;
-import net.fabricmc.indigo.renderer.render.TerrainRenderContext;
 import net.minecraft.client.render.chunk.ChunkRenderTask;
 import net.minecraft.client.render.chunk.ChunkRendererRegion;
 
+import net.fabricmc.indigo.renderer.accessor.AccessChunkRendererRegion;
+import net.fabricmc.indigo.renderer.render.TerrainRenderContext;
+
 @Mixin(ChunkRenderTask.class)
 public abstract class MixinChunkRenderTask {
-    @Shadow private ChunkRendererRegion region;
-    
-    /**
-     * The block view reference is voided when {@link ChunkRenderTask#getAndInvalidateWorldView()} is called during
-     * chunk rebuild, but we need it and it is harder to make reliable, non-invasive changes there.
-     * So we capture the block view before the reference is voided and send it to the renderer. <p>
-     * 
-     * We also store a reference to the renderer in the view to avoid doing thread-local lookups for each block.
-     */
-    @Inject(at = @At("HEAD"), method = "takeRegion")
-    private void chunkDataHook(CallbackInfoReturnable<ChunkRendererRegion> info) {
-        final ChunkRendererRegion blockView = region;
-        if(blockView != null) {
-            final TerrainRenderContext renderer  = TerrainRenderContext.POOL.get();
-            renderer.setBlockView(blockView);
-            ((AccessChunkRendererRegion)blockView).fabric_setRenderer(renderer);
-        }
-    }
+	@Shadow private ChunkRendererRegion region;
+
+	/**
+	 * The block view reference is voided when {@link ChunkRenderTask#getAndInvalidateWorldView()} is called during
+	 * chunk rebuild, but we need it and it is harder to make reliable, non-invasive changes there.
+	 * So we capture the block view before the reference is voided and send it to the renderer.
+	 *
+	 * <p>We also store a reference to the renderer in the view to avoid doing thread-local lookups for each block.
+	 */
+	@Inject(at = @At("HEAD"), method = "takeRegion")
+	private void chunkDataHook(CallbackInfoReturnable<ChunkRendererRegion> info) {
+		final ChunkRendererRegion blockView = region;
+
+		if (blockView != null) {
+			final TerrainRenderContext renderer = TerrainRenderContext.POOL.get();
+			renderer.setBlockView(blockView);
+			((AccessChunkRendererRegion)blockView).fabric_setRenderer(renderer);
+		}
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinChunkRenderer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinChunkRenderer.java
@@ -97,7 +97,7 @@ public abstract class MixinChunkRenderer implements AccessChunkRenderer {
 	 */
 	@ModifyVariable(method = "rebuildChunk", at = @At(value = "STORE", ordinal = 0), allow = 1, require = 1)
 	private boolean[] hookResultFlagsAndPrepare(boolean[] flagsIn) {
-		TerrainRenderContext.POOL.get().prepare((ChunkRenderer)(Object)this, origin, flagsIn);
+		TerrainRenderContext.POOL.get().prepare((ChunkRenderer) (Object) this, origin, flagsIn);
 		return flagsIn;
 	}
 

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinChunkRenderer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinChunkRenderer.java
@@ -18,9 +18,6 @@ package net.fabricmc.indigo.renderer.mixin;
 
 import java.util.Random;
 
-import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
-import net.fabricmc.indigo.Indigo;
-import net.minecraft.client.render.model.BakedModel;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -29,9 +26,6 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import net.fabricmc.indigo.renderer.accessor.AccessChunkRenderer;
-import net.fabricmc.indigo.renderer.accessor.AccessChunkRendererRegion;
-import net.fabricmc.indigo.renderer.render.TerrainRenderContext;
 import net.minecraft.block.BlockRenderLayer;
 import net.minecraft.block.BlockRenderType;
 import net.minecraft.block.BlockState;
@@ -40,97 +34,108 @@ import net.minecraft.client.render.block.BlockRenderManager;
 import net.minecraft.client.render.chunk.ChunkRenderData;
 import net.minecraft.client.render.chunk.ChunkRenderTask;
 import net.minecraft.client.render.chunk.ChunkRenderer;
+import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.ExtendedBlockView;
+
+import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
+import net.fabricmc.indigo.Indigo;
+import net.fabricmc.indigo.renderer.accessor.AccessChunkRenderer;
+import net.fabricmc.indigo.renderer.accessor.AccessChunkRendererRegion;
+import net.fabricmc.indigo.renderer.render.TerrainRenderContext;
 
 /**
  * Implements the main hooks for terrain rendering. Attempts to tread
  * lightly. This means we are deliberately stepping over some minor
- * optimization opportunities.<p>
- * 
- * Non-Fabric renderer implementations that are looking to maximize 
- * performance will likely take a much more aggressive approach. 
+ * optimization opportunities.
+ *
+ * <p>Non-Fabric renderer implementations that are looking to maximize
+ * performance will likely take a much more aggressive approach.
  * For that reason, mod authors who want compatibility with advanced
- * renderers will do well to steer clear of chunk rebuild hooks unless 
- * they are creating a renderer.<p>
- * 
- * These hooks are intended only for the Fabric default renderer and
+ * renderers will do well to steer clear of chunk rebuild hooks unless
+ * they are creating a renderer.
+ *
+ * <p>These hooks are intended only for the Fabric default renderer and
  * aren't expected to be present when a different renderer is being used.
  * Renderer authors are responsible for creating the hooks they need.
  * (Though they can use these as a example if they wish.)
  */
 @Mixin(ChunkRenderer.class)
-public abstract class MixinChunkRenderer implements AccessChunkRenderer{
-    @Shadow private BlockPos.Mutable origin;
+public abstract class MixinChunkRenderer implements AccessChunkRenderer {
+	@Shadow
+	private BlockPos.Mutable origin;
 
-    @Shadow abstract void beginBufferBuilding(BufferBuilder bufferBuilder_1, BlockPos blockPos_1);
-    @Shadow abstract void endBufferBuilding(BlockRenderLayer blockRenderLayer_1, float float_1, float float_2, float float_3, BufferBuilder bufferBuilder_1, ChunkRenderData chunkRenderData_1);
+	@Shadow
+	abstract void beginBufferBuilding(BufferBuilder bufferBuilder_1, BlockPos blockPos_1);
+	@Shadow
+	abstract void endBufferBuilding(BlockRenderLayer blockRenderLayer_1, float float_1, float float_2, float float_3, BufferBuilder bufferBuilder_1, ChunkRenderData chunkRenderData_1);
 
-    /** 
-     * Access method for renderer.
-     */
-    @Override
-    public void fabric_beginBufferBuilding(BufferBuilder bufferBuilder_1, BlockPos blockPos_1) {
-        beginBufferBuilding(bufferBuilder_1, blockPos_1);
-    }
-    
-    /**
-     * Save task to renderer, this is the easiest place to capture it.
-     */
-    @Inject(at = @At("HEAD"), method = "rebuildChunk")
-    private void hookRebuildChunkHead(float float_1, float float_2, float float_3, ChunkRenderTask chunkRenderTask_1, CallbackInfo info) {
-        if(chunkRenderTask_1 != null) {
-            TerrainRenderContext renderer = TerrainRenderContext.POOL.get();
-            renderer.setChunkTask(chunkRenderTask_1);
-        }
-    }
-    
-    /**
-     * Capture the block layer result flags when they are first created so our renderer
-     * can update then when more than one layer is renderer for a single model.
-     * This is also where we signal the renderer to prepare for a new chunk using
-     * the data we've accumulated up to this point.
-     */
-    @ModifyVariable(method = "rebuildChunk", at = @At(value = "STORE", ordinal = 0), allow = 1, require = 1)
-    private boolean[] hookResultFlagsAndPrepare(boolean[] flagsIn) {
-        TerrainRenderContext.POOL.get().prepare((ChunkRenderer)(Object)this, origin, flagsIn);
-        return flagsIn;
-    }
-    
-    /**
-     * This is the hook that actually implements the rendering API for terrain rendering.<p>
-     * 
-     * It's unusual to have a @Redirect in a Fabric library, but in this case
-     * it is our explicit intention that {@link BlockRenderManager#tesselateBlock(BlockState, BlockPos, ExtendedBlockView, BufferBuilder, Random)}
-     * does not execute for models that will be rendered by our renderer.<p>
-     * 
-     * Any mod that wants to redirect this specific call is likely also a renderer, in which case this
-     * renderer should not be present, or the mod should probably instead be relying on the renderer API
-     * which was specifically created to provide for enhanced terrain rendering.<p>
-     * 
-     * Note also that {@link BlockRenderManager#tesselateBlock(BlockState, BlockPos, ExtendedBlockView, BufferBuilder, Random)}
-     * IS called if the block render type is something other than {@link BlockRenderType#MODEL}.
-     * Normally this does nothing but will allow mods to create rendering hooks that are
-     * driven off of render type. (Not recommended or encouraged, but also not prevented.)
-     */
-    @Redirect(method = "rebuildChunk", require = 1,
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/block/BlockRenderManager;tesselateBlock(Lnet/minecraft/block/BlockState;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/world/ExtendedBlockView;Lnet/minecraft/client/render/BufferBuilder;Ljava/util/Random;)Z"))
-    private boolean hookChunkBuildTesselate(BlockRenderManager renderManager, BlockState blockState, BlockPos blockPos, ExtendedBlockView blockView, BufferBuilder bufferBuilder, Random random) {
-        if(blockState.getRenderType() == BlockRenderType.MODEL) {
+	/**
+	 * Access method for renderer.
+	 */
+	@Override
+	public void fabric_beginBufferBuilding(BufferBuilder bufferBuilder_1, BlockPos blockPos_1) {
+		beginBufferBuilding(bufferBuilder_1, blockPos_1);
+	}
+
+	/**
+	 * Save task to renderer, this is the easiest place to capture it.
+	 */
+	@Inject(at = @At("HEAD"), method = "rebuildChunk")
+	private void hookRebuildChunkHead(float float_1, float float_2, float float_3, ChunkRenderTask chunkRenderTask_1, CallbackInfo info) {
+		if (chunkRenderTask_1 != null) {
+			TerrainRenderContext renderer = TerrainRenderContext.POOL.get();
+			renderer.setChunkTask(chunkRenderTask_1);
+		}
+	}
+
+	/**
+	 * Capture the block layer result flags when they are first created so our renderer
+	 * can update then when more than one layer is renderer for a single model.
+	 * This is also where we signal the renderer to prepare for a new chunk using
+	 * the data we've accumulated up to this point.
+	 */
+	@ModifyVariable(method = "rebuildChunk", at = @At(value = "STORE", ordinal = 0), allow = 1, require = 1)
+	private boolean[] hookResultFlagsAndPrepare(boolean[] flagsIn) {
+		TerrainRenderContext.POOL.get().prepare((ChunkRenderer)(Object)this, origin, flagsIn);
+		return flagsIn;
+	}
+
+	/**
+	 * This is the hook that actually implements the rendering API for terrain rendering.
+	 *
+	 * <p>It's unusual to have a @Redirect in a Fabric library, but in this case
+	 * it is our explicit intention that {@link BlockRenderManager#tesselateBlock(BlockState, BlockPos, ExtendedBlockView, BufferBuilder, Random)}
+	 * does not execute for models that will be rendered by our renderer.
+	 *
+	 * <p>Any mod that wants to redirect this specific call is likely also a renderer, in which case this
+	 * renderer should not be present, or the mod should probably instead be relying on the renderer API
+	 * which was specifically created to provide for enhanced terrain rendering.
+	 *
+	 * <p>Note also that {@link BlockRenderManager#tesselateBlock(BlockState, BlockPos, ExtendedBlockView, BufferBuilder, Random)}
+	 * IS called if the block render type is something other than {@link BlockRenderType#MODEL}.
+	 * Normally this does nothing but will allow mods to create rendering hooks that are
+	 * driven off of render type. (Not recommended or encouraged, but also not prevented.)
+	 */
+	@Redirect(method = "rebuildChunk", require = 1,
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/block/BlockRenderManager;tesselateBlock(Lnet/minecraft/block/BlockState;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/world/ExtendedBlockView;Lnet/minecraft/client/render/BufferBuilder;Ljava/util/Random;)Z"))
+	private boolean hookChunkBuildTesselate(BlockRenderManager renderManager, BlockState blockState, BlockPos blockPos, ExtendedBlockView blockView, BufferBuilder bufferBuilder, Random random) {
+		if (blockState.getRenderType() == BlockRenderType.MODEL) {
 			final BakedModel model = renderManager.getModel(blockState);
+
 			if (Indigo.ALWAYS_TESSELATE_INDIGO || !((FabricBakedModel) model).isVanillaAdapter()) {
 				return ((AccessChunkRendererRegion) blockView).fabric_getRenderer().tesselateBlock(blockState, blockPos, model);
 			}
-        }
+		}
 
 		return renderManager.tesselateBlock(blockState, blockPos, blockView, bufferBuilder, random);
-    }
-    
-    /**
-     * Release all references. Probably not necessary but would be $#%! to debug if it is.
-     */
-    @Inject(at = @At("RETURN"), method = "rebuildChunk")
-    private void hookRebuildChunkReturn(float float_1, float float_2, float float_3, ChunkRenderTask chunkRenderTask_1, CallbackInfo info) {
-        TerrainRenderContext.POOL.get().release();
-    }
+	}
+
+	/**
+	 * Release all references. Probably not necessary but would be $#%! to debug if it is.
+	 */
+	@Inject(at = @At("RETURN"), method = "rebuildChunk")
+	private void hookRebuildChunkReturn(float float_1, float float_2, float float_3, ChunkRenderTask chunkRenderTask_1, CallbackInfo info) {
+		TerrainRenderContext.POOL.get().release();
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinChunkRendererRegion.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinChunkRendererRegion.java
@@ -18,21 +18,22 @@ package net.fabricmc.indigo.renderer.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;
 
+import net.minecraft.client.render.chunk.ChunkRendererRegion;
+
 import net.fabricmc.indigo.renderer.accessor.AccessChunkRendererRegion;
 import net.fabricmc.indigo.renderer.render.TerrainRenderContext;
-import net.minecraft.client.render.chunk.ChunkRendererRegion;
 
 @Mixin(ChunkRendererRegion.class)
 public abstract class MixinChunkRendererRegion implements AccessChunkRendererRegion {
-    private TerrainRenderContext fabric_renderer;
-    
-    @Override
-    public TerrainRenderContext fabric_getRenderer() {
-        return fabric_renderer;
-    }
-    
-    @Override
-    public void fabric_setRenderer(TerrainRenderContext renderer) {
-        fabric_renderer = renderer;
-    }
+	private TerrainRenderContext fabric_renderer;
+
+	@Override
+	public TerrainRenderContext fabric_getRenderer() {
+		return fabric_renderer;
+	}
+
+	@Override
+	public void fabric_setRenderer(TerrainRenderContext renderer) {
+		fabric_renderer = renderer;
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinItemRenderer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinItemRenderer.java
@@ -48,14 +48,14 @@ public abstract class MixinItemRenderer {
 	 */
 	@Inject(at = @At("HEAD"), method = "renderItemAndGlow")
 	private void hookRenderItemAndGlow(ItemStack stack, BakedModel model, CallbackInfo ci) {
-		if (stack.hasEnchantmentGlint() && !((FabricBakedModel)model).isVanillaAdapter()) {
+		if (stack.hasEnchantmentGlint() && !((FabricBakedModel) model).isVanillaAdapter()) {
 			CONTEXTS.get().enchantmentStack = stack;
 		}
 	}
 
 	@Inject(at = @At("HEAD"), method = "renderModel", cancellable = true)
 	private void hookRenderModel(BakedModel model, int color, ItemStack stack, CallbackInfo ci) {
-		FabricBakedModel fabricModel = (FabricBakedModel)model;
+		FabricBakedModel fabricModel = (FabricBakedModel) model;
 
 		if (!fabricModel.isVanillaAdapter()) {
 			CONTEXTS.get().renderModel(fabricModel, color, stack, this::renderQuads);

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinItemRenderer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/mixin/MixinItemRenderer.java
@@ -24,8 +24,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
-import net.fabricmc.indigo.renderer.render.ItemRenderContext;
 import net.minecraft.client.color.item.ItemColors;
 import net.minecraft.client.render.BufferBuilder;
 import net.minecraft.client.render.item.ItemRenderer;
@@ -33,29 +31,35 @@ import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.client.render.model.BakedQuad;
 import net.minecraft.item.ItemStack;
 
+import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
+import net.fabricmc.indigo.renderer.render.ItemRenderContext;
+
 @Mixin(ItemRenderer.class)
 public abstract class MixinItemRenderer {
-    @Shadow protected abstract void renderQuads(BufferBuilder bufferBuilder, List<BakedQuad> quads, int color, ItemStack stack);
-    @Shadow protected ItemColors colorMap;
-    private final ThreadLocal<ItemRenderContext> CONTEXTS = ThreadLocal.withInitial(() -> new ItemRenderContext(colorMap));
-    
-    /**
-     * Save stack for enchantment glint renders - we won't otherwise have access to it 
-     * during the glint render because it receives an empty stack. 
-     */
-    @Inject(at = @At("HEAD"), method = "renderItemAndGlow")
-    private void hookRenderItemAndGlow(ItemStack stack, BakedModel model, CallbackInfo ci) {
-        if(stack.hasEnchantmentGlint() && !((FabricBakedModel)model).isVanillaAdapter()) {
-            CONTEXTS.get().enchantmentStack = stack;
-        }
-    }
-    
-    @Inject(at = @At("HEAD"), method = "renderModel", cancellable = true)
-    private void hookRenderModel(BakedModel model, int color, ItemStack stack, CallbackInfo ci) {
-        FabricBakedModel fabricModel = (FabricBakedModel)model;
-        if(!fabricModel.isVanillaAdapter()) {
-            CONTEXTS.get().renderModel(fabricModel, color, stack, this::renderQuads);
-            ci.cancel();
-        }
-    }
+	@Shadow
+	protected abstract void renderQuads(BufferBuilder bufferBuilder, List<BakedQuad> quads, int color, ItemStack stack);
+	@Shadow
+	protected ItemColors colorMap;
+	private final ThreadLocal<ItemRenderContext> CONTEXTS = ThreadLocal.withInitial(() -> new ItemRenderContext(colorMap));
+
+	/**
+	 * Save stack for enchantment glint renders - we won't otherwise have access to it
+	 * during the glint render because it receives an empty stack.
+	 */
+	@Inject(at = @At("HEAD"), method = "renderItemAndGlow")
+	private void hookRenderItemAndGlow(ItemStack stack, BakedModel model, CallbackInfo ci) {
+		if (stack.hasEnchantmentGlint() && !((FabricBakedModel)model).isVanillaAdapter()) {
+			CONTEXTS.get().enchantmentStack = stack;
+		}
+	}
+
+	@Inject(at = @At("HEAD"), method = "renderModel", cancellable = true)
+	private void hookRenderModel(BakedModel model, int color, ItemStack stack, CallbackInfo ci) {
+		FabricBakedModel fabricModel = (FabricBakedModel)model;
+
+		if (!fabricModel.isVanillaAdapter()) {
+			CONTEXTS.get().renderModel(fabricModel, color, stack, this::renderQuads);
+			ci.cancel();
+		}
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractMeshConsumer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractMeshConsumer.java
@@ -19,6 +19,9 @@ package net.fabricmc.indigo.renderer.render;
 import java.util.function.Consumer;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectFunction;
+
+import net.minecraft.client.MinecraftClient;
+
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext.QuadTransform;
@@ -32,124 +35,124 @@ import net.fabricmc.indigo.renderer.helper.GeometryHelper;
 import net.fabricmc.indigo.renderer.mesh.EncodingFormat;
 import net.fabricmc.indigo.renderer.mesh.MeshImpl;
 import net.fabricmc.indigo.renderer.mesh.MutableQuadViewImpl;
-import net.minecraft.client.MinecraftClient;
 
 /**
  * Consumer for pre-baked meshes.  Works by copying the mesh data to a
  * "editor" quad held in the instance, where all transformations are applied before buffering.
  */
 public abstract class AbstractMeshConsumer extends AbstractQuadRenderer implements Consumer<Mesh> {
-    protected AbstractMeshConsumer(BlockRenderInfo blockInfo, Int2ObjectFunction<AccessBufferBuilder> bufferFunc, AoCalculator aoCalc, QuadTransform transform) {
-        super(blockInfo, bufferFunc, aoCalc, transform);
-    }
-    
-    /** 
-     * Where we handle all pre-buffer coloring, lighting, transformation, etc. 
-     * Reused for all mesh quads. Fixed baking array sized to hold largest possible mesh quad.
-     */
-    private class Maker extends MutableQuadViewImpl implements QuadEmitter {
-        {
-            data = new int[EncodingFormat.MAX_STRIDE];
-            material = (Value) IndigoRenderer.INSTANCE.materialFinder().spriteDepth(RenderMaterialImpl.MAX_SPRITE_DEPTH).find();
-        }
-        
-        // only used via RenderContext.getEmitter() 
-        @Override
-        public Maker emit() {
-            lightFace = GeometryHelper.lightFace(this);
-            ColorHelper.applyDiffuseShading(this, false);
-            renderQuad(this);
-            clear();
-            return this;
-        }
-    };
-    
-    private final Maker editorQuad = new Maker();
-    
-    @Override
-    public void accept(Mesh mesh) {
-        MeshImpl m = (MeshImpl)mesh;
-        final int[] data = m.data();
-        final int limit = data.length;
-        int index = 0;
-        while(index < limit) {
-            RenderMaterialImpl.Value mat = RenderMaterialImpl.byIndex(data[index]);
-            final int stride = EncodingFormat.stride(mat.spriteDepth());
-            System.arraycopy(data, index, editorQuad.data(), 0, stride);
-            editorQuad.load();
-            index += stride;
-            renderQuad(editorQuad);
-        }
-    }
-    
-    public QuadEmitter getEmitter() {
-        editorQuad.clear();
-        return editorQuad;
-    }
-    
-    private void renderQuad(MutableQuadViewImpl q) {
-        if(!transform.transform(editorQuad)) {
-            return;
-        }
+	protected AbstractMeshConsumer(BlockRenderInfo blockInfo, Int2ObjectFunction<AccessBufferBuilder> bufferFunc, AoCalculator aoCalc, QuadTransform transform) {
+		super(blockInfo, bufferFunc, aoCalc, transform);
+	}
 
-	    if(!blockInfo.shouldDrawFace(q.cullFace())) {
-		    return;
-	    }
-        
-        final RenderMaterialImpl.Value mat = q.material();
-        final int textureCount = mat.spriteDepth();
+	/**
+	 * Where we handle all pre-buffer coloring, lighting, transformation, etc.
+	 * Reused for all mesh quads. Fixed baking array sized to hold largest possible mesh quad.
+	 */
+	private class Maker extends MutableQuadViewImpl implements QuadEmitter {
+		{
+			data = new int[EncodingFormat.MAX_STRIDE];
+			material = (Value) IndigoRenderer.INSTANCE.materialFinder().spriteDepth(RenderMaterialImpl.MAX_SPRITE_DEPTH).find();
+		}
 
-        
-        if(mat.hasAo && MinecraftClient.isAmbientOcclusionEnabled()) {
-            // needs to happen before offsets are applied
-            aoCalc.compute(q, false);
-        }
-        
-        applyOffsets(q);
-        
-        // if maybe mix of emissive / non-emissive layers then
-        // need to save lightmaps in case they are overwritten by emissive
-        if(mat.hasEmissive && textureCount > 1) {
-            captureLightmaps(q);
-        }
-        
-        tesselateQuad(q, mat, 0);
-        
-        for(int t = 1; t < textureCount; t++) {
-            if(!mat.emissive(t)) {
-                restoreLightmaps(q);
-            }
-            
-            for(int i = 0; i < 4; i++) {
-                q.spriteColor(i, 0, q.spriteColor(i, t));
-                q.sprite(i, 0, q.spriteU(i, t), q.spriteV(i, t));
-            }
-            tesselateQuad(q, mat, t);
-        }
-    }
+		// only used via RenderContext.getEmitter()
+		@Override
+		public Maker emit() {
+			lightFace = GeometryHelper.lightFace(this);
+			ColorHelper.applyDiffuseShading(this, false);
+			renderQuad(this);
+			clear();
+			return this;
+		}
+	}
 
-    protected abstract void applyOffsets(MutableQuadViewImpl quad);
-    
-    /** 
-     * Determines color index and render layer, then routes to appropriate 
-     * tesselate routine based on material properties.
-     */
-    private void tesselateQuad(MutableQuadViewImpl quad, RenderMaterialImpl.Value mat, int textureIndex) {
-        final int colorIndex = mat.disableColorIndex(textureIndex) ? -1 : quad.colorIndex();
-        final int renderLayer = blockInfo.layerIndexOrDefault(mat.blendMode(textureIndex));
-        
-        if(blockInfo.defaultAo && !mat.disableAo(textureIndex)) {
-            if(mat.emissive(textureIndex)) {
-                tesselateSmoothEmissive(quad, renderLayer, colorIndex);
-            } else {
-                tesselateSmooth(quad, renderLayer, colorIndex);
-            }
-        } else {
-            if(mat.emissive(textureIndex)) {
-                tesselateFlatEmissive(quad, renderLayer, colorIndex, lightmaps);
-            } else {
-                tesselateFlat(quad, renderLayer, colorIndex);
-            }
-        }
-    }
+	private final Maker editorQuad = new Maker();
+
+	@Override
+	public void accept(Mesh mesh) {
+		MeshImpl m = (MeshImpl)mesh;
+		final int[] data = m.data();
+		final int limit = data.length;
+		int index = 0;
+
+		while (index < limit) {
+			RenderMaterialImpl.Value mat = RenderMaterialImpl.byIndex(data[index]);
+			final int stride = EncodingFormat.stride(mat.spriteDepth());
+			System.arraycopy(data, index, editorQuad.data(), 0, stride);
+			editorQuad.load();
+			index += stride;
+			renderQuad(editorQuad);
+		}
+	}
+
+	public QuadEmitter getEmitter() {
+		editorQuad.clear();
+		return editorQuad;
+	}
+
+	private void renderQuad(MutableQuadViewImpl q) {
+		if (!transform.transform(editorQuad)) {
+			return;
+		}
+
+		if (!blockInfo.shouldDrawFace(q.cullFace())) {
+			return;
+		}
+
+		final RenderMaterialImpl.Value mat = q.material();
+		final int textureCount = mat.spriteDepth();
+
+		if (mat.hasAo && MinecraftClient.isAmbientOcclusionEnabled()) {
+			// needs to happen before offsets are applied
+			aoCalc.compute(q, false);
+		}
+
+		applyOffsets(q);
+
+		// if maybe mix of emissive / non-emissive layers then
+		// need to save lightmaps in case they are overwritten by emissive
+		if (mat.hasEmissive && textureCount > 1) {
+			captureLightmaps(q);
+		}
+
+		tesselateQuad(q, mat, 0);
+
+		for (int t = 1; t < textureCount; t++) {
+			if (!mat.emissive(t)) {
+				restoreLightmaps(q);
+			}
+
+			for (int i = 0; i < 4; i++) {
+				q.spriteColor(i, 0, q.spriteColor(i, t));
+				q.sprite(i, 0, q.spriteU(i, t), q.spriteV(i, t));
+			}
+
+			tesselateQuad(q, mat, t);
+		}
+	}
+
+	protected abstract void applyOffsets(MutableQuadViewImpl quad);
+
+	/**
+	 * Determines color index and render layer, then routes to appropriate
+	 * tesselate routine based on material properties.
+	 */
+	private void tesselateQuad(MutableQuadViewImpl quad, RenderMaterialImpl.Value mat, int textureIndex) {
+		final int colorIndex = mat.disableColorIndex(textureIndex) ? -1 : quad.colorIndex();
+		final int renderLayer = blockInfo.layerIndexOrDefault(mat.blendMode(textureIndex));
+
+		if (blockInfo.defaultAo && !mat.disableAo(textureIndex)) {
+			if (mat.emissive(textureIndex)) {
+				tesselateSmoothEmissive(quad, renderLayer, colorIndex);
+			} else {
+				tesselateSmooth(quad, renderLayer, colorIndex);
+			}
+		} else {
+			if (mat.emissive(textureIndex)) {
+				tesselateFlatEmissive(quad, renderLayer, colorIndex, lightmaps);
+			} else {
+				tesselateFlat(quad, renderLayer, colorIndex);
+			}
+		}
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractMeshConsumer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractMeshConsumer.java
@@ -70,7 +70,7 @@ public abstract class AbstractMeshConsumer extends AbstractQuadRenderer implemen
 
 	@Override
 	public void accept(Mesh mesh) {
-		MeshImpl m = (MeshImpl)mesh;
+		MeshImpl m = (MeshImpl) mesh;
 		final int[] data = m.data();
 		final int limit = data.length;
 		int index = 0;

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractQuadRenderer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractQuadRenderer.java
@@ -19,128 +19,152 @@ package net.fabricmc.indigo.renderer.render;
 import static net.fabricmc.indigo.renderer.helper.GeometryHelper.LIGHT_FACE_FLAG;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectFunction;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.util.math.BlockPos;
+
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext.QuadTransform;
 import net.fabricmc.indigo.renderer.accessor.AccessBufferBuilder;
 import net.fabricmc.indigo.renderer.aocalc.AoCalculator;
 import net.fabricmc.indigo.renderer.helper.ColorHelper;
 import net.fabricmc.indigo.renderer.mesh.EncodingFormat;
 import net.fabricmc.indigo.renderer.mesh.MutableQuadViewImpl;
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
-import net.minecraft.util.math.BlockPos;
 
 /**
  * Base quad-rendering class for fallback and mesh consumers.
  * Has most of the actual buffer-time lighting and coloring logic.
  */
 public abstract class AbstractQuadRenderer {
-    private static final int FULL_BRIGHTNESS = 15 << 20 | 15 << 4;
-    
-    protected final Int2ObjectFunction<AccessBufferBuilder> bufferFunc;
-    protected final BlockRenderInfo blockInfo;
-    protected final AoCalculator aoCalc;
-    protected final QuadTransform transform;
-    
-    AbstractQuadRenderer(BlockRenderInfo blockInfo, Int2ObjectFunction<AccessBufferBuilder> bufferFunc, AoCalculator aoCalc, QuadTransform transform) {
-        this.blockInfo = blockInfo;
-        this.bufferFunc = bufferFunc;
-        this.aoCalc = aoCalc;
-        this.transform = transform;
-    }
-    
-    
-    /** handles block color and red-blue swizzle, common to all renders */
-    private void colorizeQuad(MutableQuadViewImpl q, int blockColorIndex) {
-        if(blockColorIndex == -1) {
-            for(int i = 0; i < 4; i++) {
-                q.spriteColor(i, 0, ColorHelper.swapRedBlueIfNeeded(q.spriteColor(i, 0)));
-            }
-        } else {
-            final int blockColor = blockInfo.blockColor(blockColorIndex);
-            for(int i = 0; i < 4; i++) {
-                q.spriteColor(i, 0, ColorHelper.swapRedBlueIfNeeded(ColorHelper.multiplyColor(blockColor, q.spriteColor(i, 0))));
-            }
-        }
-    }
-    
-    /** final output step, common to all renders */
-    private void bufferQuad(MutableQuadViewImpl quad, int renderLayer) {
-        bufferFunc.get(renderLayer).fabric_putQuad(quad);
-    }
+	private static final int FULL_BRIGHTNESS = 15 << 20 | 15 << 4;
 
-    // routines below have a bit of copy-paste code reuse to avoid conditional execution inside a hot loop
-    
-    /** for non-emissive mesh quads and all fallback quads with smooth lighting*/
-    protected void tesselateSmooth(MutableQuadViewImpl q, int renderLayer, int blockColorIndex) {
-        colorizeQuad(q, blockColorIndex);
-        for(int i = 0; i < 4; i++) {
-            q.spriteColor(i, 0, ColorHelper.multiplyRGB(q.spriteColor(i, 0), aoCalc.ao[i]));
-            q.lightmap(i, ColorHelper.maxBrightness(q.lightmap(i), aoCalc.light[i]));
-        }
-        bufferQuad(q, renderLayer);
-    }
-    
-    /** for emissive mesh quads with smooth lighting*/
-    protected void tesselateSmoothEmissive(MutableQuadViewImpl q, int renderLayer, int blockColorIndex) {
-        colorizeQuad(q, blockColorIndex);
-        for(int i = 0; i < 4; i++) {
-            q.spriteColor(i, 0, ColorHelper.multiplyRGB(q.spriteColor(i, 0), aoCalc.ao[i]));
-            q.lightmap(i, FULL_BRIGHTNESS);
-        }
-        bufferQuad(q, renderLayer);
-    }
-    
-    /** for non-emissive mesh quads and all fallback quads with flat lighting*/
-    protected void tesselateFlat(MutableQuadViewImpl quad, int renderLayer, int blockColorIndex) {
-        colorizeQuad(quad, blockColorIndex);
-        final int brightness = flatBrightness(quad, blockInfo.blockState, blockInfo.blockPos);
-        for(int i = 0; i < 4; i++) {
-            quad.lightmap(i, ColorHelper.maxBrightness(quad.lightmap(i), brightness));
-        }
-        bufferQuad(quad, renderLayer);
-    }
-    
-    /** for emissive mesh quads with flat lighting*/
-    protected void tesselateFlatEmissive(MutableQuadViewImpl quad, int renderLayer, int blockColorIndex, int[] lightmaps) {
-        colorizeQuad(quad, blockColorIndex);
-        for(int i = 0; i < 4; i++) {
-            quad.lightmap(i, FULL_BRIGHTNESS);
-        }
-        bufferQuad(quad, renderLayer);
-    }
-    
-    protected int[] lightmaps = new int[4];
-    
-    protected void captureLightmaps(MutableQuadViewImpl q) {
-        final int[] data = q.data();
-        final int[] lightmaps = this.lightmaps;
-        lightmaps[0] = data[EncodingFormat.VERTEX_START_OFFSET + 6];
-        lightmaps[1] = data[EncodingFormat.VERTEX_START_OFFSET + 6 + 7];
-        lightmaps[2] = data[EncodingFormat.VERTEX_START_OFFSET + 6 + 14];
-        lightmaps[3] = data[EncodingFormat.VERTEX_START_OFFSET + 6 + 21];
-    }
-    
-    protected void restoreLightmaps(MutableQuadViewImpl q) {
-        final int[] data = q.data();
-        final int[] lightmaps = this.lightmaps;
-        data[EncodingFormat.VERTEX_START_OFFSET + 6] = lightmaps[0];
-        data[EncodingFormat.VERTEX_START_OFFSET + 6 + 7] = lightmaps[1];
-        data[EncodingFormat.VERTEX_START_OFFSET + 6 + 14] = lightmaps[2];
-        data[EncodingFormat.VERTEX_START_OFFSET + 6 + 21] = lightmaps[3];
-    }
-    
-    private final BlockPos.Mutable mpos = new BlockPos.Mutable();
-    
-    /** 
-     * Handles geometry-based check for using self brightness or neighbor brightness.
-     * That logic only applies in flat lighting.
-     */
-    int flatBrightness(MutableQuadViewImpl quad, BlockState blockState, BlockPos pos) {
-        mpos.set(pos);
-        if((quad.geometryFlags() & LIGHT_FACE_FLAG) != 0 || Block.isShapeFullCube(blockState.getCollisionShape(blockInfo.blockView, pos))) {
-            mpos.setOffset(quad.lightFace());
-        }
-        // Unfortunately cannot use brightness cache here unless we implement one specifically for flat lighting. See #329
-        return blockState.getBlockBrightness(blockInfo.blockView, mpos);
-    }
+	protected final Int2ObjectFunction<AccessBufferBuilder> bufferFunc;
+	protected final BlockRenderInfo blockInfo;
+	protected final AoCalculator aoCalc;
+	protected final QuadTransform transform;
+
+	AbstractQuadRenderer(BlockRenderInfo blockInfo, Int2ObjectFunction<AccessBufferBuilder> bufferFunc, AoCalculator aoCalc, QuadTransform transform) {
+		this.blockInfo = blockInfo;
+		this.bufferFunc = bufferFunc;
+		this.aoCalc = aoCalc;
+		this.transform = transform;
+	}
+
+	/**
+	 * handles block color and red-blue swizzle, common to all renders.
+	 */
+	private void colorizeQuad(MutableQuadViewImpl q, int blockColorIndex) {
+		if (blockColorIndex == -1) {
+			for (int i = 0; i < 4; i++) {
+				q.spriteColor(i, 0, ColorHelper.swapRedBlueIfNeeded(q.spriteColor(i, 0)));
+			}
+		} else {
+			final int blockColor = blockInfo.blockColor(blockColorIndex);
+
+			for (int i = 0; i < 4; i++) {
+				q.spriteColor(i, 0, ColorHelper.swapRedBlueIfNeeded(ColorHelper.multiplyColor(blockColor, q.spriteColor(i, 0))));
+			}
+		}
+	}
+
+	/**
+	 * final output step, common to all renders.
+	 */
+	private void bufferQuad(MutableQuadViewImpl quad, int renderLayer) {
+		bufferFunc.get(renderLayer).fabric_putQuad(quad);
+	}
+
+	// routines below have a bit of copy-paste code reuse to avoid conditional execution inside a hot loop
+
+	/**
+	 * for non-emissive mesh quads and all fallback quads with smooth lighting.
+	 */
+	protected void tesselateSmooth(MutableQuadViewImpl q, int renderLayer, int blockColorIndex) {
+		colorizeQuad(q, blockColorIndex);
+
+		for (int i = 0; i < 4; i++) {
+			q.spriteColor(i, 0, ColorHelper.multiplyRGB(q.spriteColor(i, 0), aoCalc.ao[i]));
+			q.lightmap(i, ColorHelper.maxBrightness(q.lightmap(i), aoCalc.light[i]));
+		}
+
+		bufferQuad(q, renderLayer);
+	}
+
+	/**
+	 * for emissive mesh quads with smooth lighting.
+	 */
+	protected void tesselateSmoothEmissive(MutableQuadViewImpl q, int renderLayer, int blockColorIndex) {
+		colorizeQuad(q, blockColorIndex);
+
+		for (int i = 0; i < 4; i++) {
+			q.spriteColor(i, 0, ColorHelper.multiplyRGB(q.spriteColor(i, 0), aoCalc.ao[i]));
+			q.lightmap(i, FULL_BRIGHTNESS);
+		}
+
+		bufferQuad(q, renderLayer);
+	}
+
+	/**
+	 * for non-emissive mesh quads and all fallback quads with flat lighting.
+	 */
+	protected void tesselateFlat(MutableQuadViewImpl quad, int renderLayer, int blockColorIndex) {
+		colorizeQuad(quad, blockColorIndex);
+		final int brightness = flatBrightness(quad, blockInfo.blockState, blockInfo.blockPos);
+
+		for (int i = 0; i < 4; i++) {
+			quad.lightmap(i, ColorHelper.maxBrightness(quad.lightmap(i), brightness));
+		}
+
+		bufferQuad(quad, renderLayer);
+	}
+
+	/**
+	 *  for emissive mesh quads with flat lighting.
+	 */
+	protected void tesselateFlatEmissive(MutableQuadViewImpl quad, int renderLayer, int blockColorIndex, int[] lightmaps) {
+		colorizeQuad(quad, blockColorIndex);
+
+		for (int i = 0; i < 4; i++) {
+			quad.lightmap(i, FULL_BRIGHTNESS);
+		}
+
+		bufferQuad(quad, renderLayer);
+	}
+
+	protected int[] lightmaps = new int[4];
+
+	protected void captureLightmaps(MutableQuadViewImpl q) {
+		final int[] data = q.data();
+		final int[] lightmaps = this.lightmaps;
+		lightmaps[0] = data[EncodingFormat.VERTEX_START_OFFSET + 6];
+		lightmaps[1] = data[EncodingFormat.VERTEX_START_OFFSET + 6 + 7];
+		lightmaps[2] = data[EncodingFormat.VERTEX_START_OFFSET + 6 + 14];
+		lightmaps[3] = data[EncodingFormat.VERTEX_START_OFFSET + 6 + 21];
+	}
+
+	protected void restoreLightmaps(MutableQuadViewImpl q) {
+		final int[] data = q.data();
+		final int[] lightmaps = this.lightmaps;
+		data[EncodingFormat.VERTEX_START_OFFSET + 6] = lightmaps[0];
+		data[EncodingFormat.VERTEX_START_OFFSET + 6 + 7] = lightmaps[1];
+		data[EncodingFormat.VERTEX_START_OFFSET + 6 + 14] = lightmaps[2];
+		data[EncodingFormat.VERTEX_START_OFFSET + 6 + 21] = lightmaps[3];
+	}
+
+	private final BlockPos.Mutable mpos = new BlockPos.Mutable();
+
+	/**
+	 * Handles geometry-based check for using self brightness or neighbor brightness.
+	 * That logic only applies in flat lighting.
+	 */
+	int flatBrightness(MutableQuadViewImpl quad, BlockState blockState, BlockPos pos) {
+		mpos.set(pos);
+
+		if ((quad.geometryFlags() & LIGHT_FACE_FLAG) != 0 || Block.isShapeFullCube(blockState.getCollisionShape(blockInfo.blockView, pos))) {
+			mpos.setOffset(quad.lightFace());
+		}
+
+		// Unfortunately cannot use brightness cache here unless we implement one specifically for flat lighting. See #329
+		return blockState.getBlockBrightness(blockInfo.blockView, mpos);
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractRenderContext.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/AbstractRenderContext.java
@@ -17,53 +17,59 @@
 package net.fabricmc.indigo.renderer.render;
 
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+
 import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
 
 abstract class AbstractRenderContext implements RenderContext {
-    private final ObjectArrayList<QuadTransform> transformStack = new ObjectArrayList<>();
-    private static final QuadTransform NO_TRANSFORM = (q) -> true;
-    
-    private final QuadTransform stackTransform = (q) -> {
-        int i= transformStack.size() - 1;
-        while(i >= 0) {
-            if(!transformStack.get(i--).transform(q)) {
-                return false;
-            }
-        }
-        return true;
-    };
-    
-    private QuadTransform activeTransform = NO_TRANSFORM;
-    
-    protected final boolean transform(MutableQuadView q) {
-        return activeTransform.transform(q);
-    }
-    
-    protected boolean hasTransform() {
-        return activeTransform != NO_TRANSFORM;
-    }
-    
-    @Override
-    public void pushTransform(QuadTransform transform) {
-        if(transform == null) {
-            throw new NullPointerException("Renderer received null QuadTransform.");
-        }
-        transformStack.push(transform);
-        if(transformStack.size() == 1) {
-            activeTransform = transform;
-        } else if(transformStack.size() == 2) {
-            activeTransform = stackTransform;
-        }
-    }
+	private final ObjectArrayList<QuadTransform> transformStack = new ObjectArrayList<>();
+	private static final QuadTransform NO_TRANSFORM = (q) -> true;
 
-    @Override
-    public void popTransform() {
-        transformStack.pop();
-        if(transformStack.size() == 0) {
-            activeTransform = NO_TRANSFORM;
-        } else if (transformStack.size() == 1) {
-            activeTransform = transformStack.get(0);
-        } 
-    }
+	private final QuadTransform stackTransform = (q) -> {
+		int i = transformStack.size() - 1;
+
+		while (i >= 0) {
+			if (!transformStack.get(i--).transform(q)) {
+				return false;
+			}
+		}
+
+		return true;
+	};
+
+	private QuadTransform activeTransform = NO_TRANSFORM;
+
+	protected final boolean transform(MutableQuadView q) {
+		return activeTransform.transform(q);
+	}
+
+	protected boolean hasTransform() {
+		return activeTransform != NO_TRANSFORM;
+	}
+
+	@Override
+	public void pushTransform(QuadTransform transform) {
+		if (transform == null) {
+			throw new NullPointerException("Renderer received null QuadTransform.");
+		}
+
+		transformStack.push(transform);
+
+		if (transformStack.size() == 1) {
+			activeTransform = transform;
+		} else if (transformStack.size() == 2) {
+			activeTransform = stackTransform;
+		}
+	}
+
+	@Override
+	public void popTransform() {
+		transformStack.pop();
+
+		if (transformStack.size() == 0) {
+			activeTransform = NO_TRANSFORM;
+		} else if (transformStack.size() == 1) {
+			activeTransform = transformStack.get(0);
+		}
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/BlockRenderContext.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/BlockRenderContext.java
@@ -88,7 +88,7 @@ public class BlockRenderContext extends AbstractRenderContext implements RenderC
 		blockInfo.prepareForBlock(state, pos, model.useAmbientOcclusion());
 		setupOffsets();
 
-		((FabricBakedModel)model).emitBlockQuads(blockView, state, pos, blockInfo.randomSupplier, this);
+		((FabricBakedModel) model).emitBlockQuads(blockView, state, pos, blockInfo.randomSupplier, this);
 
 		this.vanillaRenderer = null;
 		blockInfo.release();
@@ -122,7 +122,7 @@ public class BlockRenderContext extends AbstractRenderContext implements RenderC
 			final double z = offsetZ;
 
 			for (int i = 0; i < 4; i++) {
-				q.pos(i, (float)(q.x(i) + x), (float)(q.y(i) + y), (float)(q.z(i) + z));
+				q.pos(i, (float) (q.x(i) + x), (float) (q.y(i) + y), (float) (q.z(i) + z));
 			}
 		}
 	}

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/BlockRenderContext.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/BlockRenderContext.java
@@ -20,6 +20,14 @@ import java.util.Random;
 import java.util.function.Consumer;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectFunction;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.client.render.BufferBuilder;
+import net.minecraft.client.render.block.BlockModelRenderer;
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.ExtendedBlockView;
+
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
@@ -29,112 +37,108 @@ import net.fabricmc.indigo.renderer.aocalc.AoCalculator;
 import net.fabricmc.indigo.renderer.aocalc.AoLuminanceFix;
 import net.fabricmc.indigo.renderer.mesh.MutableQuadViewImpl;
 import net.fabricmc.indigo.renderer.mixin.BufferBuilderOffsetAccessor;
-import net.minecraft.block.BlockState;
-import net.minecraft.client.render.BufferBuilder;
-import net.minecraft.client.render.block.BlockModelRenderer;
-import net.minecraft.client.render.model.BakedModel;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.ExtendedBlockView;
 
 /**
  * Context for non-terrain block rendering.
  */
 public class BlockRenderContext extends AbstractRenderContext implements RenderContext {
-    private final BlockRenderInfo blockInfo = new BlockRenderInfo();
-    private final AoCalculator aoCalc = new AoCalculator(blockInfo, this::brightness, this::aoLevel);
-    private final MeshConsumer meshConsumer = new MeshConsumer(blockInfo, this::outputBuffer, aoCalc, this::transform);
-    private final Random random = new Random();
-    private BlockModelRenderer vanillaRenderer;
-    private AccessBufferBuilder fabricBuffer;
-    private long seed;
-    private boolean isCallingVanilla = false;
-    private boolean didOutput = false;
-    
-    private double offsetX;
-    private double offsetY;
-    private double offsetZ;
-    
-    public boolean isCallingVanilla() {
-        return isCallingVanilla;
-    }
-    
-    private int brightness(BlockPos pos) {
-        if(blockInfo.blockView == null) {
-            return 15 << 20 | 15 << 4;
-        }
-        return blockInfo.blockView.getBlockState(pos).getBlockBrightness(blockInfo.blockView, pos);
-    }
+	private final BlockRenderInfo blockInfo = new BlockRenderInfo();
+	private final AoCalculator aoCalc = new AoCalculator(blockInfo, this::brightness, this::aoLevel);
+	private final MeshConsumer meshConsumer = new MeshConsumer(blockInfo, this::outputBuffer, aoCalc, this::transform);
+	private final Random random = new Random();
+	private BlockModelRenderer vanillaRenderer;
+	private AccessBufferBuilder fabricBuffer;
+	private long seed;
+	private boolean isCallingVanilla = false;
+	private boolean didOutput = false;
 
-    private float aoLevel(BlockPos pos) {
-        final ExtendedBlockView blockView = blockInfo.blockView;
-        return blockView == null ? 1f : AoLuminanceFix.INSTANCE.apply(blockView, pos);
-    }
-    
-    private AccessBufferBuilder outputBuffer(int renderLayer) {
-        didOutput = true;
-        return fabricBuffer;
-    }
-    
-    public boolean tesselate(BlockModelRenderer vanillaRenderer, ExtendedBlockView blockView, BakedModel model, BlockState state, BlockPos pos, BufferBuilder buffer, long seed) {
-        this.vanillaRenderer = vanillaRenderer;
-        this.fabricBuffer = (AccessBufferBuilder) buffer;
-        this.seed = seed;
-        this.didOutput = false;
-        aoCalc.clear();
-        blockInfo.setBlockView(blockView);
-        blockInfo.prepareForBlock(state, pos, model.useAmbientOcclusion());
-        setupOffsets();
-        
-        ((FabricBakedModel)model).emitBlockQuads(blockView, state, pos, blockInfo.randomSupplier, this);
-        
-        this.vanillaRenderer = null;
-        blockInfo.release();
-        this.fabricBuffer = null;
-        return didOutput;
-    }
+	private double offsetX;
+	private double offsetY;
+	private double offsetZ;
 
-    protected void acceptVanillaModel(BakedModel model) {
-        isCallingVanilla = true;
-        didOutput = didOutput && vanillaRenderer.tesselate(blockInfo.blockView, model, blockInfo.blockState, blockInfo.blockPos, (BufferBuilder) fabricBuffer, false, random, seed);
-        isCallingVanilla = false;
-    }
-    
-    private void setupOffsets() {
-        final BufferBuilderOffsetAccessor buffer = (BufferBuilderOffsetAccessor) fabricBuffer;
-        final BlockPos pos = blockInfo.blockPos;
-        offsetX = buffer.getOffsetX() + pos.getX();
-        offsetY = buffer.getOffsetY() + pos.getY();
-        offsetZ = buffer.getOffsetZ() + pos.getZ();
-    }
-    
-    private class MeshConsumer extends AbstractMeshConsumer {
-        MeshConsumer(BlockRenderInfo blockInfo, Int2ObjectFunction<AccessBufferBuilder> bufferFunc, AoCalculator aoCalc, QuadTransform transform) {
-            super(blockInfo, bufferFunc, aoCalc, transform);
-        }
+	public boolean isCallingVanilla() {
+		return isCallingVanilla;
+	}
 
-        @Override
-        protected void applyOffsets(MutableQuadViewImpl q) {
-            final double x = offsetX;
-            final double y = offsetY;
-            final double z = offsetZ;
-            for(int i = 0; i < 4; i++) {
-                q.pos(i, (float)(q.x(i) + x), (float)(q.y(i) + y), (float)(q.z(i) + z));
-            }
-        }
-    }
+	private int brightness(BlockPos pos) {
+		if (blockInfo.blockView == null) {
+			return 15 << 20 | 15 << 4;
+		}
 
-    @Override
-    public Consumer<Mesh> meshConsumer() {
-        return meshConsumer;
-    }
+		return blockInfo.blockView.getBlockState(pos).getBlockBrightness(blockInfo.blockView, pos);
+	}
 
-    @Override
-    public Consumer<BakedModel> fallbackConsumer() {
-        return this::acceptVanillaModel;
-    }
+	private float aoLevel(BlockPos pos) {
+		final ExtendedBlockView blockView = blockInfo.blockView;
+		return blockView == null ? 1f : AoLuminanceFix.INSTANCE.apply(blockView, pos);
+	}
 
-    @Override
-    public QuadEmitter getEmitter() {
-        return meshConsumer.getEmitter();
-    }
+	private AccessBufferBuilder outputBuffer(int renderLayer) {
+		didOutput = true;
+		return fabricBuffer;
+	}
+
+	public boolean tesselate(BlockModelRenderer vanillaRenderer, ExtendedBlockView blockView, BakedModel model, BlockState state, BlockPos pos, BufferBuilder buffer, long seed) {
+		this.vanillaRenderer = vanillaRenderer;
+		this.fabricBuffer = (AccessBufferBuilder) buffer;
+		this.seed = seed;
+		this.didOutput = false;
+		aoCalc.clear();
+		blockInfo.setBlockView(blockView);
+		blockInfo.prepareForBlock(state, pos, model.useAmbientOcclusion());
+		setupOffsets();
+
+		((FabricBakedModel)model).emitBlockQuads(blockView, state, pos, blockInfo.randomSupplier, this);
+
+		this.vanillaRenderer = null;
+		blockInfo.release();
+		this.fabricBuffer = null;
+		return didOutput;
+	}
+
+	protected void acceptVanillaModel(BakedModel model) {
+		isCallingVanilla = true;
+		didOutput = didOutput && vanillaRenderer.tesselate(blockInfo.blockView, model, blockInfo.blockState, blockInfo.blockPos, (BufferBuilder) fabricBuffer, false, random, seed);
+		isCallingVanilla = false;
+	}
+
+	private void setupOffsets() {
+		final BufferBuilderOffsetAccessor buffer = (BufferBuilderOffsetAccessor) fabricBuffer;
+		final BlockPos pos = blockInfo.blockPos;
+		offsetX = buffer.getOffsetX() + pos.getX();
+		offsetY = buffer.getOffsetY() + pos.getY();
+		offsetZ = buffer.getOffsetZ() + pos.getZ();
+	}
+
+	private class MeshConsumer extends AbstractMeshConsumer {
+		MeshConsumer(BlockRenderInfo blockInfo, Int2ObjectFunction<AccessBufferBuilder> bufferFunc, AoCalculator aoCalc, QuadTransform transform) {
+			super(blockInfo, bufferFunc, aoCalc, transform);
+		}
+
+		@Override
+		protected void applyOffsets(MutableQuadViewImpl q) {
+			final double x = offsetX;
+			final double y = offsetY;
+			final double z = offsetZ;
+
+			for (int i = 0; i < 4; i++) {
+				q.pos(i, (float)(q.x(i) + x), (float)(q.y(i) + y), (float)(q.z(i) + z));
+			}
+		}
+	}
+
+	@Override
+	public Consumer<Mesh> meshConsumer() {
+		return meshConsumer;
+	}
+
+	@Override
+	public Consumer<BakedModel> fallbackConsumer() {
+		return this::acceptVanillaModel;
+	}
+
+	@Override
+	public QuadEmitter getEmitter() {
+		return meshConsumer.getEmitter();
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/BlockRenderInfo.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/BlockRenderInfo.java
@@ -29,59 +29,61 @@ import net.minecraft.world.ExtendedBlockView;
 
 /**
  * Holds, manages and provides access to the block/world related state
- * needed by fallback and mesh consumers.<p>
- * 
- * Exception: per-block position offsets are tracked in {@link ChunkRenderInfo}
+ * needed by fallback and mesh consumers.
+ *
+ * <p>Exception: per-block position offsets are tracked in {@link ChunkRenderInfo}
  * so they can be applied together with chunk offsets.
  */
 public class BlockRenderInfo {
-    private final BlockColors blockColorMap = MinecraftClient.getInstance().getBlockColorMap();
-    public final Random random = new Random();
-    public ExtendedBlockView blockView;
-    public BlockPos blockPos;
-    public BlockState blockState; 
-    public long seed;
-    boolean defaultAo;
-    int defaultLayerIndex;
-    
-    public final Supplier<Random> randomSupplier = () -> {
-        final Random result = random;
-        long seed = this.seed;
-        if(seed == -1L) {
-            seed = blockState.getRenderingSeed(blockPos);
-            this.seed = seed;
-        }
-        result.setSeed(seed);
-        return result;
-    };
-    
-    public void setBlockView(ExtendedBlockView blockView) {
-        this.blockView = blockView;
-    }
-    
-    public void prepareForBlock(BlockState blockState, BlockPos blockPos, boolean modelAO) {
-        this.blockPos = blockPos;
-        this.blockState = blockState;
-        // in the unlikely case seed actually matches this, we'll simply retrieve it more than one
-        seed = -1L; 
-        defaultAo = modelAO && MinecraftClient.isAmbientOcclusionEnabled() && blockState.getLuminance() == 0;
-        defaultLayerIndex = blockState.getBlock().getRenderLayer().ordinal();
-    }
-    
-    public void release() {
-        blockPos = null;
-        blockState = null; 
-    }
-    
-    int blockColor(int colorIndex) {
-        return 0xFF000000 | blockColorMap.getColorMultiplier(blockState, blockView, blockPos, colorIndex);
-    }
-    
-    boolean shouldDrawFace(Direction face) {
-        return true;
-    }
-    
-    int layerIndexOrDefault(BlockRenderLayer layer) {
-        return layer == null ? this.defaultLayerIndex : layer.ordinal();
-    }
+	private final BlockColors blockColorMap = MinecraftClient.getInstance().getBlockColorMap();
+	public final Random random = new Random();
+	public ExtendedBlockView blockView;
+	public BlockPos blockPos;
+	public BlockState blockState;
+	public long seed;
+	boolean defaultAo;
+	int defaultLayerIndex;
+
+	public final Supplier<Random> randomSupplier = () -> {
+		final Random result = random;
+		long seed = this.seed;
+
+		if (seed == -1L) {
+			seed = blockState.getRenderingSeed(blockPos);
+			this.seed = seed;
+		}
+
+		result.setSeed(seed);
+		return result;
+	};
+
+	public void setBlockView(ExtendedBlockView blockView) {
+		this.blockView = blockView;
+	}
+
+	public void prepareForBlock(BlockState blockState, BlockPos blockPos, boolean modelAO) {
+		this.blockPos = blockPos;
+		this.blockState = blockState;
+		// in the unlikely case seed actually matches this, we'll simply retrieve it more than one
+		seed = -1L;
+		defaultAo = modelAO && MinecraftClient.isAmbientOcclusionEnabled() && blockState.getLuminance() == 0;
+		defaultLayerIndex = blockState.getBlock().getRenderLayer().ordinal();
+	}
+
+	public void release() {
+		blockPos = null;
+		blockState = null;
+	}
+
+	int blockColor(int colorIndex) {
+		return 0xFF000000 | blockColorMap.getColorMultiplier(blockState, blockView, blockPos, colorIndex);
+	}
+
+	boolean shouldDrawFace(Direction face) {
+		return true;
+	}
+
+	int layerIndexOrDefault(BlockRenderLayer layer) {
+		return layer == null ? this.defaultLayerIndex : layer.ordinal();
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/ChunkRenderInfo.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/ChunkRenderInfo.java
@@ -18,11 +18,7 @@ package net.fabricmc.indigo.renderer.render;
 
 import it.unimi.dsi.fastutil.longs.Long2FloatOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
-import net.fabricmc.indigo.Indigo;
-import net.fabricmc.indigo.renderer.accessor.AccessBufferBuilder;
-import net.fabricmc.indigo.renderer.accessor.AccessChunkRenderer;
-import net.fabricmc.indigo.renderer.aocalc.AoLuminanceFix;
-import net.fabricmc.indigo.renderer.mesh.MutableQuadViewImpl;
+
 import net.minecraft.block.Block.OffsetType;
 import net.minecraft.block.BlockRenderLayer;
 import net.minecraft.block.BlockState;
@@ -35,175 +31,188 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.ExtendedBlockView;
 
+import net.fabricmc.indigo.Indigo;
+import net.fabricmc.indigo.renderer.accessor.AccessBufferBuilder;
+import net.fabricmc.indigo.renderer.accessor.AccessChunkRenderer;
+import net.fabricmc.indigo.renderer.aocalc.AoLuminanceFix;
+import net.fabricmc.indigo.renderer.mesh.MutableQuadViewImpl;
+
 /**
  * Holds, manages and provides access to the chunk-related state
- * needed by fallback and mesh consumers during terrain rendering.<p>
- * 
- * Exception: per-block position offsets are tracked here so they can
+ * needed by fallback and mesh consumers during terrain rendering.
+ *
+ * <p>Exception: per-block position offsets are tracked here so they can
  * be applied together with chunk offsets.
  */
 public class ChunkRenderInfo {
-    /**
-     * Serves same function as brightness cache in Mojang's AO calculator,
-     * with some differences as follows...<p>
-     * 
-     * 1) Mojang uses Object2Int.  This uses Long2Int for performance and to avoid
-     * creating new immutable BlockPos references.  But will break if someone
-     * wants to expand Y limit or world borders.  If we want to support that may
-     * need to switch or make configurable.<p>
-     * 
-     * 2) Mojang overrides the map methods to limit the cache to 50 values.
-     * However, a render chunk only has 18^3 blocks in it, and the cache is cleared every chunk.
-     * For performance and simplicity, we just let map grow to the size of the render chunk.
-     * 
-     * 3) Mojang only uses the cache for Ao.  Here it is used for all brightness
-     * lookups, including flat lighting.
-     * 
-     * 4) The Mojang cache is a separate threadlocal with a threadlocal boolean to 
-     * enable disable. Cache clearing happens with the disable. There's no use case for 
-     * us when the cache needs to be disabled (and no apparent case in Mojang's code either)
-     * so we simply clear the cache at the start of each new chunk. It is also
-     * not a threadlocal because it's held within a threadlocal BlockRenderer.
-     */
-    private final Long2IntOpenHashMap brightnessCache;
-    private final Long2FloatOpenHashMap aoLevelCache;
-    
-    private final BlockRenderInfo blockInfo;
-    private final BlockPos.Mutable chunkOrigin = new BlockPos.Mutable();
-    ChunkRenderTask chunkTask; 
-    ChunkRenderData chunkData;
-    ChunkRenderer chunkRenderer;
-    ExtendedBlockView blockView;
-    boolean [] resultFlags;
-    
-    private final AccessBufferBuilder[] buffers = new AccessBufferBuilder[4];
-    private final BlockRenderLayer[] LAYERS = BlockRenderLayer.values();
-    
-    private double chunkOffsetX;
-    private double chunkOffsetY;
-    private double chunkOffsetZ;
-    
-    // chunk offset + block pos offset + model offsets for plants, etc.
-    private float offsetX = 0;
-    private float offsetY = 0;
-    private float offsetZ = 0;
-    
-    ChunkRenderInfo(BlockRenderInfo blockInfo) {
-        this.blockInfo = blockInfo;
-        brightnessCache = new Long2IntOpenHashMap();
-        brightnessCache.defaultReturnValue(Integer.MAX_VALUE);
-        aoLevelCache = new Long2FloatOpenHashMap();
-        aoLevelCache.defaultReturnValue(Float.MAX_VALUE);
-    }
-    
-    void setBlockView(ChunkRendererRegion blockView) {
-        this.blockView = blockView;
-    }
-    
-    void setChunkTask(ChunkRenderTask chunkTask) {
-        this.chunkTask = chunkTask;
-    }
-    
-    void prepare(ChunkRenderer chunkRenderer, BlockPos.Mutable chunkOrigin, boolean [] resultFlags) {
-        this.chunkOrigin.set(chunkOrigin);
-        this.chunkData = chunkTask.getRenderData();
-        this.chunkRenderer = chunkRenderer;
-        this.resultFlags = resultFlags;
-        buffers[0] = null;
-        buffers[1] = null;
-        buffers[2] = null;
-        buffers[3] = null;
-        chunkOffsetX = -chunkOrigin.getX();
-        chunkOffsetY = -chunkOrigin.getY();
-        chunkOffsetZ = -chunkOrigin.getZ();
-        brightnessCache.clear();
-        aoLevelCache.clear();
-    }
-    
-    void release() {
-        chunkData = null;
-        chunkTask = null;
-        chunkRenderer = null;
-        buffers[0] = null;
-        buffers[1] = null;
-        buffers[2] = null;
-        buffers[3] = null;
-    }
-    
-    void beginBlock() {
-        final BlockState blockState = blockInfo.blockState;
-        final BlockPos blockPos = blockInfo.blockPos;
-        
-        // When we are using the BufferBuilder input methods, the builder will
-        // add the chunk offset for us, so we should only apply the block offset.
-        if(Indigo.ENSURE_VERTEX_FORMAT_COMPATIBILITY) {
-            offsetX = (float) (blockPos.getX());
-            offsetY = (float) (blockPos.getY());
-            offsetZ = (float) (blockPos.getZ());
-        } else {
-            offsetX = (float) (chunkOffsetX + blockPos.getX());
-            offsetY = (float) (chunkOffsetY + blockPos.getY());
-            offsetZ = (float) (chunkOffsetZ + blockPos.getZ());
-        }
-        
-        if(blockState.getBlock().getOffsetType() != OffsetType.NONE) {
-            Vec3d offset = blockState.getOffsetPos(blockInfo.blockView, blockPos);
-            offsetX += (float)offset.x;
-            offsetY += (float)offset.y;
-            offsetZ += (float)offset.z;
-        }
-    }
-    
-    /** Lazily retrieves output buffer for given layer, initializing as needed. */
-    public AccessBufferBuilder getInitializedBuffer(int layerIndex) {
-        // redundant for first layer, but probably not faster to check
-        resultFlags[layerIndex] = true;
-        
-        AccessBufferBuilder result = buffers[layerIndex];
-        if (result == null) {
-            BufferBuilder builder = chunkTask.getBufferBuilders().get(layerIndex);
-            buffers[layerIndex] = (AccessBufferBuilder) builder;
-            BlockRenderLayer layer = LAYERS[layerIndex];
-            if (!chunkData.isBufferInitialized(layer)) {
-                chunkData.markBufferInitialized(layer); // start buffer
-                ((AccessChunkRenderer) chunkRenderer).fabric_beginBufferBuilding(builder, chunkOrigin);
-            }
-            result = (AccessBufferBuilder) builder;
-        }
-        return result;
-    }
-    
-    /**
-     * Applies position offset for chunk and, if present, block random offset.
-     */
-    void applyOffsets(MutableQuadViewImpl q) {
-        for(int i = 0; i < 4; i++) {
-            q.pos(i, q.x(i) + offsetX, q.y(i) + offsetY, q.z(i) + offsetZ);
-        }
-    }
-    
-    /**
-     * Cached values for {@link BlockState#getBlockBrightness(ExtendedBlockView, BlockPos)}.
-     * See also the comments for {@link #brightnessCache}.
-     */
-    int cachedBrightness(BlockPos pos) {
-        long key = pos.asLong();
-        int result = brightnessCache.get(key);
-        if (result == Integer.MAX_VALUE) {
-            result = blockView.getBlockState(pos).getBlockBrightness(blockView, pos);
-            brightnessCache.put(key, result);
-        }
-        return result;
-    }
-    
-    float cachedAoLevel(BlockPos pos)
-    {
-        long key = pos.asLong();
-        float result = aoLevelCache.get(key);
-        if (result == Float.MAX_VALUE) {
-            result = AoLuminanceFix.INSTANCE.apply(blockView, pos);
-            aoLevelCache.put(key, result);
-        }
-        return result;
-    }
+	/**
+	 * Serves same function as brightness cache in Mojang's AO calculator,
+	 * with some differences as follows...
+	 *
+	 * <ul><li>Mojang uses Object2Int.  This uses Long2Int for performance and to avoid
+	 * creating new immutable BlockPos references.  But will break if someone
+	 * wants to expand Y limit or world borders.  If we want to support that may
+	 * need to switch or make configurable.
+	 *
+	 * <li>Mojang overrides the map methods to limit the cache to 50 values.
+	 * However, a render chunk only has 18^3 blocks in it, and the cache is cleared every chunk.
+	 * For performance and simplicity, we just let map grow to the size of the render chunk.
+	 *
+	 * <li>Mojang only uses the cache for Ao.  Here it is used for all brightness
+	 * lookups, including flat lighting.
+	 *
+	 * <li>The Mojang cache is a separate threadlocal with a threadlocal boolean to
+	 * enable disable. Cache clearing happens with the disable. There's no use case for
+	 * us when the cache needs to be disabled (and no apparent case in Mojang's code either)
+	 * so we simply clear the cache at the start of each new chunk. It is also
+	 * not a threadlocal because it's held within a threadlocal BlockRenderer.</ul>
+	 */
+	private final Long2IntOpenHashMap brightnessCache;
+	private final Long2FloatOpenHashMap aoLevelCache;
+
+	private final BlockRenderInfo blockInfo;
+	private final BlockPos.Mutable chunkOrigin = new BlockPos.Mutable();
+	ChunkRenderTask chunkTask;
+	ChunkRenderData chunkData;
+	ChunkRenderer chunkRenderer;
+	ExtendedBlockView blockView;
+	boolean [] resultFlags;
+
+	private final AccessBufferBuilder[] buffers = new AccessBufferBuilder[4];
+	private final BlockRenderLayer[] LAYERS = BlockRenderLayer.values();
+
+	private double chunkOffsetX;
+	private double chunkOffsetY;
+	private double chunkOffsetZ;
+
+	// chunk offset + block pos offset + model offsets for plants, etc.
+	private float offsetX = 0;
+	private float offsetY = 0;
+	private float offsetZ = 0;
+
+	ChunkRenderInfo(BlockRenderInfo blockInfo) {
+		this.blockInfo = blockInfo;
+		brightnessCache = new Long2IntOpenHashMap();
+		brightnessCache.defaultReturnValue(Integer.MAX_VALUE);
+		aoLevelCache = new Long2FloatOpenHashMap();
+		aoLevelCache.defaultReturnValue(Float.MAX_VALUE);
+	}
+
+	void setBlockView(ChunkRendererRegion blockView) {
+		this.blockView = blockView;
+	}
+
+	void setChunkTask(ChunkRenderTask chunkTask) {
+		this.chunkTask = chunkTask;
+	}
+
+	void prepare(ChunkRenderer chunkRenderer, BlockPos.Mutable chunkOrigin, boolean [] resultFlags) {
+		this.chunkOrigin.set(chunkOrigin);
+		this.chunkData = chunkTask.getRenderData();
+		this.chunkRenderer = chunkRenderer;
+		this.resultFlags = resultFlags;
+		buffers[0] = null;
+		buffers[1] = null;
+		buffers[2] = null;
+		buffers[3] = null;
+		chunkOffsetX = -chunkOrigin.getX();
+		chunkOffsetY = -chunkOrigin.getY();
+		chunkOffsetZ = -chunkOrigin.getZ();
+		brightnessCache.clear();
+		aoLevelCache.clear();
+	}
+
+	void release() {
+		chunkData = null;
+		chunkTask = null;
+		chunkRenderer = null;
+		buffers[0] = null;
+		buffers[1] = null;
+		buffers[2] = null;
+		buffers[3] = null;
+	}
+
+	void beginBlock() {
+		final BlockState blockState = blockInfo.blockState;
+		final BlockPos blockPos = blockInfo.blockPos;
+
+		// When we are using the BufferBuilder input methods, the builder will
+		// add the chunk offset for us, so we should only apply the block offset.
+		if (Indigo.ENSURE_VERTEX_FORMAT_COMPATIBILITY) {
+			offsetX = (blockPos.getX());
+			offsetY = (blockPos.getY());
+			offsetZ = (blockPos.getZ());
+		} else {
+			offsetX = (float) (chunkOffsetX + blockPos.getX());
+			offsetY = (float) (chunkOffsetY + blockPos.getY());
+			offsetZ = (float) (chunkOffsetZ + blockPos.getZ());
+		}
+
+		if (blockState.getBlock().getOffsetType() != OffsetType.NONE) {
+			Vec3d offset = blockState.getOffsetPos(blockInfo.blockView, blockPos);
+			offsetX += (float)offset.x;
+			offsetY += (float)offset.y;
+			offsetZ += (float)offset.z;
+		}
+	}
+
+	/** Lazily retrieves output buffer for given layer, initializing as needed. */
+	public AccessBufferBuilder getInitializedBuffer(int layerIndex) {
+		// redundant for first layer, but probably not faster to check
+		resultFlags[layerIndex] = true;
+
+		AccessBufferBuilder result = buffers[layerIndex];
+
+		if (result == null) {
+			BufferBuilder builder = chunkTask.getBufferBuilders().get(layerIndex);
+			buffers[layerIndex] = (AccessBufferBuilder) builder;
+			BlockRenderLayer layer = LAYERS[layerIndex];
+
+			if (!chunkData.isBufferInitialized(layer)) {
+				chunkData.markBufferInitialized(layer); // start buffer
+				((AccessChunkRenderer) chunkRenderer).fabric_beginBufferBuilding(builder, chunkOrigin);
+			}
+
+			result = (AccessBufferBuilder) builder;
+		}
+
+		return result;
+	}
+
+	/**
+	 * Applies position offset for chunk and, if present, block random offset.
+	 */
+	void applyOffsets(MutableQuadViewImpl q) {
+		for (int i = 0; i < 4; i++) {
+			q.pos(i, q.x(i) + offsetX, q.y(i) + offsetY, q.z(i) + offsetZ);
+		}
+	}
+
+	/**
+	 * Cached values for {@link BlockState#getBlockBrightness(ExtendedBlockView, BlockPos)}.
+	 * See also the comments for {@link #brightnessCache}.
+	 */
+	int cachedBrightness(BlockPos pos) {
+		long key = pos.asLong();
+		int result = brightnessCache.get(key);
+
+		if (result == Integer.MAX_VALUE) {
+			result = blockView.getBlockState(pos).getBlockBrightness(blockView, pos);
+			brightnessCache.put(key, result);
+		}
+
+		return result;
+	}
+
+	float cachedAoLevel(BlockPos pos) {
+		long key = pos.asLong();
+		float result = aoLevelCache.get(key);
+
+		if (result == Float.MAX_VALUE) {
+			result = AoLuminanceFix.INSTANCE.apply(blockView, pos);
+			aoLevelCache.put(key, result);
+		}
+
+		return result;
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/ChunkRenderInfo.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/ChunkRenderInfo.java
@@ -76,7 +76,7 @@ public class ChunkRenderInfo {
 	ChunkRenderData chunkData;
 	ChunkRenderer chunkRenderer;
 	ExtendedBlockView blockView;
-	boolean [] resultFlags;
+	boolean[] resultFlags;
 
 	private final AccessBufferBuilder[] buffers = new AccessBufferBuilder[4];
 	private final BlockRenderLayer[] LAYERS = BlockRenderLayer.values();
@@ -106,7 +106,7 @@ public class ChunkRenderInfo {
 		this.chunkTask = chunkTask;
 	}
 
-	void prepare(ChunkRenderer chunkRenderer, BlockPos.Mutable chunkOrigin, boolean [] resultFlags) {
+	void prepare(ChunkRenderer chunkRenderer, BlockPos.Mutable chunkOrigin, boolean[] resultFlags) {
 		this.chunkOrigin.set(chunkOrigin);
 		this.chunkData = chunkTask.getRenderData();
 		this.chunkRenderer = chunkRenderer;
@@ -150,9 +150,9 @@ public class ChunkRenderInfo {
 
 		if (blockState.getBlock().getOffsetType() != OffsetType.NONE) {
 			Vec3d offset = blockState.getOffsetPos(blockInfo.blockView, blockPos);
-			offsetX += (float)offset.x;
-			offsetY += (float)offset.y;
-			offsetZ += (float)offset.z;
+			offsetX += (float) offset.x;
+			offsetY += (float) offset.y;
+			offsetZ += (float) offset.z;
 		}
 	}
 

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/CompatibilityHelper.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/CompatibilityHelper.java
@@ -22,20 +22,22 @@ import net.fabricmc.indigo.Indigo;
  * Controls 1x warning for vanilla quad vertex format when running in compatibility mode.
  */
 public abstract class CompatibilityHelper {
-    private CompatibilityHelper() {}
+	private CompatibilityHelper() { }
 
-    private static boolean logCompatibilityWarning = true;
-    
-    private static boolean isCompatible(int[] vertexData) {
-        final boolean result = vertexData.length == 28;
-        if(!result && logCompatibilityWarning) {
-            logCompatibilityWarning = false;
-            Indigo.LOGGER.warn("[Indigo] Encountered baked quad with non-standard vertex format. Some blocks will not be rendered");
-        }
-        return result;
-    }
-    
-    public static boolean canRender(int[] vertexData) {
-        return !Indigo.ENSURE_VERTEX_FORMAT_COMPATIBILITY || isCompatible(vertexData);
-    }
+	private static boolean logCompatibilityWarning = true;
+
+	private static boolean isCompatible(int[] vertexData) {
+		final boolean result = vertexData.length == 28;
+
+		if (!result && logCompatibilityWarning) {
+			logCompatibilityWarning = false;
+			Indigo.LOGGER.warn("[Indigo] Encountered baked quad with non-standard vertex format. Some blocks will not be rendered");
+		}
+
+		return result;
+	}
+
+	public static boolean canRender(int[] vertexData) {
+		return !Indigo.ENSURE_VERTEX_FORMAT_COMPATIBILITY || isCompatible(vertexData);
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/ItemRenderContext.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/ItemRenderContext.java
@@ -21,9 +21,18 @@ import java.util.Random;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import com.mojang.blaze3d.platform.GlStateManager;
 import org.lwjgl.opengl.GL11;
 
-import com.mojang.blaze3d.platform.GlStateManager;
+import net.minecraft.block.BlockState;
+import net.minecraft.client.color.item.ItemColors;
+import net.minecraft.client.render.BufferBuilder;
+import net.minecraft.client.render.Tessellator;
+import net.minecraft.client.render.VertexFormats;
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.render.model.BakedQuad;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.Direction;
 
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
@@ -37,241 +46,240 @@ import net.fabricmc.indigo.renderer.helper.GeometryHelper;
 import net.fabricmc.indigo.renderer.mesh.EncodingFormat;
 import net.fabricmc.indigo.renderer.mesh.MeshImpl;
 import net.fabricmc.indigo.renderer.mesh.MutableQuadViewImpl;
-import net.minecraft.block.BlockState;
-import net.minecraft.client.color.item.ItemColors;
-import net.minecraft.client.render.BufferBuilder;
-import net.minecraft.client.render.Tessellator;
-import net.minecraft.client.render.VertexFormats;
-import net.minecraft.client.render.model.BakedModel;
-import net.minecraft.client.render.model.BakedQuad;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.math.Direction;
 
 /**
- * The render context used for item rendering. 
+ * The render context used for item rendering.
  * Does not implement emissive lighting for sake
- * of simplicity in the default renderer. 
+ * of simplicity in the default renderer.
  */
 public class ItemRenderContext extends AbstractRenderContext implements RenderContext {
-    /** used to accept a method reference from the ItemRenderer */
-    @FunctionalInterface
-    public static interface VanillaQuadHandler {
-        void accept(BufferBuilder bufferBuilder, List<BakedQuad> quads, int color, ItemStack stack);
-    }
+	/** used to accept a method reference from the ItemRenderer. */
+	@FunctionalInterface
+	public interface VanillaQuadHandler {
+		void accept(BufferBuilder bufferBuilder, List<BakedQuad> quads, int color, ItemStack stack);
+	}
 
-    private final ItemColors colorMap;
-    private final Random random = new Random();
-    private final Consumer<BakedModel> fallbackConsumer;
-    BufferBuilder bufferBuilder;
-    AccessBufferBuilder fabricBuffer;
-    private int color;
-    private ItemStack itemStack;
-    private VanillaQuadHandler vanillaHandler;
-    private boolean smoothShading = false;
-    private boolean enchantment = false;
-    
-    private final Supplier<Random> randomSupplier = () -> {
-        Random result = random;
-        result.setSeed(42L);
-        return random;
-    };
-    
-    /** 
-     * When rendering an enchanted item, input stack will be empty.
-     * This value is populated earlier in the call tree when this is the case
-     * so that we can render correct geometry and only a single texture.
-     */
-    public ItemStack enchantmentStack;
-    
-    private final int[] quadData = new int[EncodingFormat.MAX_STRIDE];;
-    
-    public ItemRenderContext(ItemColors colorMap) {
-        this.colorMap = colorMap;
-        this.fallbackConsumer = this::fallbackConsumer;
-    }
-    
-    public void renderModel(FabricBakedModel model, int color, ItemStack stack, VanillaQuadHandler vanillaHandler) {
-        this.color = color;
-        
-        if(stack.isEmpty() && enchantmentStack != null) {
-            enchantment = true;
-            this.itemStack = enchantmentStack;
-            enchantmentStack = null;
-        } else {
-            enchantment = false;
-            this.itemStack = stack;
-        }
-        
-        this.vanillaHandler = vanillaHandler;
-        Tessellator tessellator = Tessellator.getInstance();
-        bufferBuilder = tessellator.getBufferBuilder();
-        fabricBuffer = (AccessBufferBuilder)this.bufferBuilder;
-        
-        bufferBuilder.begin(7, VertexFormats.POSITION_COLOR_UV_NORMAL);
-        model.emitItemQuads(stack, randomSupplier, this);
-        tessellator.draw();
-        
-        if(smoothShading) {
-            GlStateManager.shadeModel(GL11.GL_FLAT);
-            smoothShading = false;
-        }
-        
-        bufferBuilder = null;
-        fabricBuffer = null;
-        tessellator = null;
-        this.itemStack = null;
-        this.vanillaHandler = null;
-    }
+	private final ItemColors colorMap;
+	private final Random random = new Random();
+	private final Consumer<BakedModel> fallbackConsumer;
+	BufferBuilder bufferBuilder;
+	AccessBufferBuilder fabricBuffer;
+	private int color;
+	private ItemStack itemStack;
+	private VanillaQuadHandler vanillaHandler;
+	private boolean smoothShading = false;
+	private boolean enchantment = false;
 
-    private class Maker extends MutableQuadViewImpl implements QuadEmitter {
-        {
-            data = quadData;
-            clear();
-        }
-        
-        @Override
-        public Maker emit() {
-            lightFace = GeometryHelper.lightFace(this);
-            ColorHelper.applyDiffuseShading(this, false);
-            renderQuad();
-            clear();
-            return this;
-        }
-    }
-    
-    private final Maker editorQuad = new Maker();
-    
-    private final Consumer<Mesh> meshConsumer = (mesh) -> {
-        MeshImpl m = (MeshImpl)mesh;
-        final int[] data = m.data();
-        final int limit = data.length;
-        int index = 0;
-        while(index < limit) {
-            RenderMaterialImpl.Value mat = RenderMaterialImpl.byIndex(data[index]);
-            final int stride = EncodingFormat.stride(mat.spriteDepth());
-            System.arraycopy(data, index, editorQuad.data(), 0, stride);
-            editorQuad.load();
-            index += stride;
-            renderQuad();
-        }
-    };
-    
-    /**
-     * Vanilla normally renders items with flat shading - meaning only
-     * the last vertex normal is applied for lighting purposes. We 
-     * support non-cube vertex normals so we need to change this to smooth
-     * for models that use them.  We don't change it unless needed because
-     * OpenGL state changes always impose a performance cost and this happens
-     * for every item, every frame.
-     */
-    private void handleShading() {
-        if(!smoothShading && editorQuad.hasVertexNormals()) {
-            smoothShading = true;
-            GlStateManager.shadeModel(GL11.GL_SMOOTH);
-        }
-    }
-    
-    private int quadColor() {
-        final int colorIndex = editorQuad.colorIndex();
-        int quadColor = color;
-        if (!enchantment && quadColor == -1 && colorIndex != -1) {
-            quadColor = colorMap.getColorMultiplier(itemStack, colorIndex);
-            quadColor |= -16777216;
-         }
-        return quadColor;
-    }
-    
-    private void colorizeAndOutput(int quadColor) {
-        final MutableQuadViewImpl q = editorQuad;
-        for(int i = 0; i < 4; i++) {
-            int c = q.spriteColor(i, 0);
-            c = ColorHelper.multiplyColor(quadColor, c);
-            q.spriteColor(i, 0, ColorHelper.swapRedBlueIfNeeded(c));
-        }
-        fabricBuffer.fabric_putQuad(q);
-    }
-    
-    private void renderQuad() {
-        final MutableQuadViewImpl quad = editorQuad;
-        if(!transform(editorQuad)) {
-            return;
-        }
-        
-        RenderMaterialImpl.Value mat = quad.material();
-        final int quadColor = quadColor();
-        final int textureCount = mat.spriteDepth();
-        
-        handleShading();
-        
-        // A bit of a hack - copy packed normals on top of lightmaps.
-        // Violates normal encoding format but the editor content will be discarded
-        // and this avoids the step of copying to a separate array.
-        quad.copyNormals(quadData, EncodingFormat.VERTEX_START_OFFSET);
-        
-        colorizeAndOutput(!enchantment && mat.disableColorIndex(0) ? -1 : quadColor);
-        
-        // no need to render additional textures for enchantment overlay
-        if(!enchantment && textureCount > 1) {
-            quad.copyColorUV(1, quadData, EncodingFormat.VERTEX_START_OFFSET);
-            colorizeAndOutput(mat.disableColorIndex(1) ? -1 : quadColor);
-            
-            if(textureCount == 3) {
-                quad.copyColorUV(2, quadData, EncodingFormat.VERTEX_START_OFFSET);
-                colorizeAndOutput(mat.disableColorIndex(2) ? -1 : quadColor);
-            }
-        }
-    }
-    
-    @Override
-    public Consumer<Mesh> meshConsumer() {
-        return meshConsumer;
-    }
+	private final Supplier<Random> randomSupplier = () -> {
+		Random result = random;
+		result.setSeed(42L);
+		return random;
+	};
 
-    private void fallbackConsumer(BakedModel model) {
-        if(hasTransform()) {
-            // if there's a transform in effect, convert to mesh-based quads so that we can apply it
-            for(int i = 0; i < 7; i++) {
-                random.setSeed(42L);
-                final Direction cullFace = ModelHelper.faceFromIndex(i);
-                renderFallbackWithTransform(bufferBuilder, model.getQuads((BlockState)null, cullFace, random), color, itemStack, cullFace);
-             }
-        } else {
-            for(int i = 0; i < 7; i++) {
-                random.setSeed(42L);
-                vanillaHandler.accept(bufferBuilder, model.getQuads((BlockState)null, ModelHelper.faceFromIndex(i), random), color, itemStack);
-             }
-        }
-    };
-    
-    private void renderFallbackWithTransform(BufferBuilder bufferBuilder, List<BakedQuad> quads, int color, ItemStack stack, Direction cullFace) {
-        if(quads.isEmpty()) {
-            return;
-        }
-        if(CompatibilityHelper.canRender(quads.get(0).getVertexData())) {
-            Maker editorQuad = this.editorQuad;
-            for(BakedQuad q : quads) {
-                editorQuad.clear();
-                editorQuad.fromVanilla(q.getVertexData(), 0, false);
-                editorQuad.cullFace(cullFace);
-                final Direction lightFace = q.getFace();
-                editorQuad.lightFace(lightFace);
-                editorQuad.nominalFace(lightFace);
-                editorQuad.colorIndex(q.getColorIndex());
-                renderQuad();
-            }
-        } else {
-            vanillaHandler.accept(bufferBuilder, quads, color, stack);
-        }
-    }
-    
-    @Override
-    public Consumer<BakedModel> fallbackConsumer() {
-        return fallbackConsumer;
-    }
+	/**
+	 * When rendering an enchanted item, input stack will be empty.
+	 * This value is populated earlier in the call tree when this is the case
+	 * so that we can render correct geometry and only a single texture.
+	 */
+	public ItemStack enchantmentStack;
 
-    @Override
-    public QuadEmitter getEmitter() {
-        editorQuad.clear();
-        return editorQuad;
-    }
+	private final int[] quadData = new int[EncodingFormat.MAX_STRIDE];;
+
+	public ItemRenderContext(ItemColors colorMap) {
+		this.colorMap = colorMap;
+		this.fallbackConsumer = this::fallbackConsumer;
+	}
+
+	public void renderModel(FabricBakedModel model, int color, ItemStack stack, VanillaQuadHandler vanillaHandler) {
+		this.color = color;
+
+		if (stack.isEmpty() && enchantmentStack != null) {
+			enchantment = true;
+			this.itemStack = enchantmentStack;
+			enchantmentStack = null;
+		} else {
+			enchantment = false;
+			this.itemStack = stack;
+		}
+
+		this.vanillaHandler = vanillaHandler;
+		Tessellator tessellator = Tessellator.getInstance();
+		bufferBuilder = tessellator.getBufferBuilder();
+		fabricBuffer = (AccessBufferBuilder)this.bufferBuilder;
+
+		bufferBuilder.begin(7, VertexFormats.POSITION_COLOR_UV_NORMAL);
+		model.emitItemQuads(stack, randomSupplier, this);
+		tessellator.draw();
+
+		if (smoothShading) {
+			GlStateManager.shadeModel(GL11.GL_FLAT);
+			smoothShading = false;
+		}
+
+		bufferBuilder = null;
+		fabricBuffer = null;
+		tessellator = null;
+		this.itemStack = null;
+		this.vanillaHandler = null;
+	}
+
+	private class Maker extends MutableQuadViewImpl implements QuadEmitter {
+		{
+			data = quadData;
+			clear();
+		}
+
+		@Override
+		public Maker emit() {
+			lightFace = GeometryHelper.lightFace(this);
+			ColorHelper.applyDiffuseShading(this, false);
+			renderQuad();
+			clear();
+			return this;
+		}
+	}
+
+	private final Maker editorQuad = new Maker();
+
+	private final Consumer<Mesh> meshConsumer = (mesh) -> {
+		MeshImpl m = (MeshImpl)mesh;
+		final int[] data = m.data();
+		final int limit = data.length;
+		int index = 0;
+
+		while (index < limit) {
+			RenderMaterialImpl.Value mat = RenderMaterialImpl.byIndex(data[index]);
+			final int stride = EncodingFormat.stride(mat.spriteDepth());
+			System.arraycopy(data, index, editorQuad.data(), 0, stride);
+			editorQuad.load();
+			index += stride;
+			renderQuad();
+		}
+	};
+
+	/**
+	 * Vanilla normally renders items with flat shading - meaning only
+	 * the last vertex normal is applied for lighting purposes. We
+	 * support non-cube vertex normals so we need to change this to smooth
+	 * for models that use them.  We don't change it unless needed because
+	 * OpenGL state changes always impose a performance cost and this happens
+	 * for every item, every frame.
+	 */
+	private void handleShading() {
+		if (!smoothShading && editorQuad.hasVertexNormals()) {
+			smoothShading = true;
+			GlStateManager.shadeModel(GL11.GL_SMOOTH);
+		}
+	}
+
+	private int quadColor() {
+		final int colorIndex = editorQuad.colorIndex();
+		int quadColor = color;
+
+		if (!enchantment && quadColor == -1 && colorIndex != -1) {
+			quadColor = colorMap.getColorMultiplier(itemStack, colorIndex);
+			quadColor |= -16777216;
+		}
+
+		return quadColor;
+	}
+
+	private void colorizeAndOutput(int quadColor) {
+		final MutableQuadViewImpl q = editorQuad;
+
+		for (int i = 0; i < 4; i++) {
+			int c = q.spriteColor(i, 0);
+			c = ColorHelper.multiplyColor(quadColor, c);
+			q.spriteColor(i, 0, ColorHelper.swapRedBlueIfNeeded(c));
+		}
+
+		fabricBuffer.fabric_putQuad(q);
+	}
+
+	private void renderQuad() {
+		final MutableQuadViewImpl quad = editorQuad;
+
+		if (!transform(editorQuad)) {
+			return;
+		}
+
+		RenderMaterialImpl.Value mat = quad.material();
+		final int quadColor = quadColor();
+		final int textureCount = mat.spriteDepth();
+
+		handleShading();
+
+		// A bit of a hack - copy packed normals on top of lightmaps.
+		// Violates normal encoding format but the editor content will be discarded
+		// and this avoids the step of copying to a separate array.
+		quad.copyNormals(quadData, EncodingFormat.VERTEX_START_OFFSET);
+
+		colorizeAndOutput(!enchantment && mat.disableColorIndex(0) ? -1 : quadColor);
+
+		// no need to render additional textures for enchantment overlay
+		if (!enchantment && textureCount > 1) {
+			quad.copyColorUV(1, quadData, EncodingFormat.VERTEX_START_OFFSET);
+			colorizeAndOutput(mat.disableColorIndex(1) ? -1 : quadColor);
+
+			if (textureCount == 3) {
+				quad.copyColorUV(2, quadData, EncodingFormat.VERTEX_START_OFFSET);
+				colorizeAndOutput(mat.disableColorIndex(2) ? -1 : quadColor);
+			}
+		}
+	}
+
+	@Override
+	public Consumer<Mesh> meshConsumer() {
+		return meshConsumer;
+	}
+
+	private void fallbackConsumer(BakedModel model) {
+		if (hasTransform()) {
+			// if there's a transform in effect, convert to mesh-based quads so that we can apply it
+			for (int i = 0; i < 7; i++) {
+				random.setSeed(42L);
+				final Direction cullFace = ModelHelper.faceFromIndex(i);
+				renderFallbackWithTransform(bufferBuilder, model.getQuads((BlockState)null, cullFace, random), color, itemStack, cullFace);
+			}
+		} else {
+			for (int i = 0; i < 7; i++) {
+				random.setSeed(42L);
+				vanillaHandler.accept(bufferBuilder, model.getQuads((BlockState)null, ModelHelper.faceFromIndex(i), random), color, itemStack);
+			}
+		}
+	};
+
+	private void renderFallbackWithTransform(BufferBuilder bufferBuilder, List<BakedQuad> quads, int color, ItemStack stack, Direction cullFace) {
+		if (quads.isEmpty()) {
+			return;
+		}
+
+		if (CompatibilityHelper.canRender(quads.get(0).getVertexData())) {
+			Maker editorQuad = this.editorQuad;
+
+			for (BakedQuad q : quads) {
+				editorQuad.clear();
+				editorQuad.fromVanilla(q.getVertexData(), 0, false);
+				editorQuad.cullFace(cullFace);
+				final Direction lightFace = q.getFace();
+				editorQuad.lightFace(lightFace);
+				editorQuad.nominalFace(lightFace);
+				editorQuad.colorIndex(q.getColorIndex());
+				renderQuad();
+			}
+		} else {
+			vanillaHandler.accept(bufferBuilder, quads, color, stack);
+		}
+	}
+
+	@Override
+	public Consumer<BakedModel> fallbackConsumer() {
+		return fallbackConsumer;
+	}
+
+	@Override
+	public QuadEmitter getEmitter() {
+		editorQuad.clear();
+		return editorQuad;
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/ItemRenderContext.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/ItemRenderContext.java
@@ -105,7 +105,7 @@ public class ItemRenderContext extends AbstractRenderContext implements RenderCo
 		this.vanillaHandler = vanillaHandler;
 		Tessellator tessellator = Tessellator.getInstance();
 		bufferBuilder = tessellator.getBufferBuilder();
-		fabricBuffer = (AccessBufferBuilder)this.bufferBuilder;
+		fabricBuffer = (AccessBufferBuilder) this.bufferBuilder;
 
 		bufferBuilder.begin(7, VertexFormats.POSITION_COLOR_UV_NORMAL);
 		model.emitItemQuads(stack, randomSupplier, this);
@@ -142,7 +142,7 @@ public class ItemRenderContext extends AbstractRenderContext implements RenderCo
 	private final Maker editorQuad = new Maker();
 
 	private final Consumer<Mesh> meshConsumer = (mesh) -> {
-		MeshImpl m = (MeshImpl)mesh;
+		MeshImpl m = (MeshImpl) mesh;
 		final int[] data = m.data();
 		final int limit = data.length;
 		int index = 0;
@@ -239,12 +239,12 @@ public class ItemRenderContext extends AbstractRenderContext implements RenderCo
 			for (int i = 0; i < 7; i++) {
 				random.setSeed(42L);
 				final Direction cullFace = ModelHelper.faceFromIndex(i);
-				renderFallbackWithTransform(bufferBuilder, model.getQuads((BlockState)null, cullFace, random), color, itemStack, cullFace);
+				renderFallbackWithTransform(bufferBuilder, model.getQuads((BlockState) null, cullFace, random), color, itemStack, cullFace);
 			}
 		} else {
 			for (int i = 0; i < 7; i++) {
 				random.setSeed(42L);
-				vanillaHandler.accept(bufferBuilder, model.getQuads((BlockState)null, ModelHelper.faceFromIndex(i), random), color, itemStack);
+				vanillaHandler.accept(bufferBuilder, model.getQuads((BlockState) null, ModelHelper.faceFromIndex(i), random), color, itemStack);
 			}
 		}
 	};

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainBlockRenderInfo.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainBlockRenderInfo.java
@@ -22,34 +22,35 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 
 public class TerrainBlockRenderInfo extends BlockRenderInfo {
-    private int cullCompletionFlags;
-    private int cullResultFlags;
-    
-    
-    @Override
-    public void prepareForBlock(BlockState blockState, BlockPos blockPos, boolean modelAO) {
-        super.prepareForBlock(blockState, blockPos, modelAO);
-        cullCompletionFlags = 0;
-        cullResultFlags = 0;
-    }
-    
-    @Override
-    boolean shouldDrawFace(Direction face) {
-        if(face == null) {
-            return true;
-        }
-        final int mask = 1 << face.getId();
-        
-        if((cullCompletionFlags & mask) == 0) {
-            cullCompletionFlags |= mask;
-            if(Block.shouldDrawSide(blockState, blockView, blockPos, face)) {
-                cullResultFlags |= mask;
-                return true;
-            } else {
-                return false;
-            }
-        } else {
-            return (cullResultFlags & mask) != 0;
-        }
-    }
+	private int cullCompletionFlags;
+	private int cullResultFlags;
+
+	@Override
+	public void prepareForBlock(BlockState blockState, BlockPos blockPos, boolean modelAO) {
+		super.prepareForBlock(blockState, blockPos, modelAO);
+		cullCompletionFlags = 0;
+		cullResultFlags = 0;
+	}
+
+	@Override
+	boolean shouldDrawFace(Direction face) {
+		if (face == null) {
+			return true;
+		}
+
+		final int mask = 1 << face.getId();
+
+		if ((cullCompletionFlags & mask) == 0) {
+			cullCompletionFlags |= mask;
+
+			if (Block.shouldDrawSide(blockState, blockView, blockPos, face)) {
+				cullResultFlags |= mask;
+				return true;
+			} else {
+				return false;
+			}
+		} else {
+			return (cullResultFlags & mask) != 0;
+		}
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainFallbackConsumer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainFallbackConsumer.java
@@ -21,6 +21,11 @@ import java.util.Random;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import net.minecraft.block.BlockState;
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.render.model.BakedQuad;
+import net.minecraft.util.math.Direction;
+
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.renderer.v1.model.ModelHelper;
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext.QuadTransform;
@@ -30,122 +35,123 @@ import net.fabricmc.indigo.renderer.aocalc.AoCalculator;
 import net.fabricmc.indigo.renderer.helper.GeometryHelper;
 import net.fabricmc.indigo.renderer.mesh.EncodingFormat;
 import net.fabricmc.indigo.renderer.mesh.MutableQuadViewImpl;
-import net.minecraft.block.BlockState;
-import net.minecraft.client.render.model.BakedModel;
-import net.minecraft.client.render.model.BakedQuad;
-import net.minecraft.util.math.Direction;
 
 /**
- * Consumer for vanilla baked models. Generally intended to give visual results matching a vanilla render, 
- * however there could be subtle (and desirable) lighting variations so is good to be able to render 
- * everything consistently.<p>
- * 
- * Also, the API allows multi-part models that hold multiple vanilla models to render them without 
- * combining quad lists, but the vanilla logic only handles one model per block. To route all of 
- * them through vanilla logic would require additional hooks.<p>
- * 
- *  Works by copying the quad data to an "editor" quad held in the instance, 
+ * Consumer for vanilla baked models. Generally intended to give visual results matching a vanilla render,
+ * however there could be subtle (and desirable) lighting variations so is good to be able to render
+ * everything consistently.
+ *
+ * <p>Also, the API allows multi-part models that hold multiple vanilla models to render them without
+ * combining quad lists, but the vanilla logic only handles one model per block. To route all of
+ * them through vanilla logic would require additional hooks.
+ *
+ *  <p>Works by copying the quad data to an "editor" quad held in the instance,
  *  where all transformations are applied before buffering. Transformations should be
- *  the same as they would be in a vanilla render - the editor is serving mainly 
+ *  the same as they would be in a vanilla render - the editor is serving mainly
  *  as a way to access vertex data without magical numbers. It also allows a consistent interface
- *  for downstream tesselation routines.<p>
- *  
- *  Another difference from vanilla render is that all transformation happens before the
+ *  for downstream tesselation routines.
+ *
+ *  <p>Another difference from vanilla render is that all transformation happens before the
  *  vertex data is sent to the byte buffer.  Generally POJO array access will be faster than
  *  manipulating the data via NIO.
  */
 public class TerrainFallbackConsumer extends AbstractQuadRenderer implements Consumer<BakedModel> {
-    private static Value MATERIAL_FLAT = (Value) IndigoRenderer.INSTANCE.materialFinder().disableAo(0, true).find();
-    private static Value MATERIAL_SHADED = (Value) IndigoRenderer.INSTANCE.materialFinder().find();
-    
-    private final int[] editorBuffer = new int[28];
-    private final ChunkRenderInfo chunkInfo;
-    
-    TerrainFallbackConsumer(BlockRenderInfo blockInfo, ChunkRenderInfo chunkInfo, AoCalculator aoCalc, QuadTransform transform) {
-        super(blockInfo, chunkInfo::getInitializedBuffer, aoCalc, transform);
-        this.chunkInfo = chunkInfo;
-    }
-    
-    private final MutableQuadViewImpl editorQuad = new MutableQuadViewImpl() {
-        {
-            data = editorBuffer;
-            material = MATERIAL_SHADED;
-            baseIndex = -EncodingFormat.HEADER_STRIDE;
-        }
+	private static Value MATERIAL_FLAT = (Value) IndigoRenderer.INSTANCE.materialFinder().disableAo(0, true).find();
+	private static Value MATERIAL_SHADED = (Value) IndigoRenderer.INSTANCE.materialFinder().find();
 
-        @Override
-        public QuadEmitter emit() {
-            // should not be called
-            throw new UnsupportedOperationException("Fallback consumer does not support .emit()");
-        }
-    };
-    
-    @Override
-    public void accept(BakedModel model) {
-        final Supplier<Random> random = blockInfo.randomSupplier;
-        final Value defaultMaterial = blockInfo.defaultAo && model.useAmbientOcclusion()
-                ? MATERIAL_SHADED : MATERIAL_FLAT;
-        final BlockState blockState = blockInfo.blockState;
-        for(int i = 0; i < 6; i++) {
-            Direction face = ModelHelper.faceFromIndex(i);
-            List<BakedQuad> quads = model.getQuads(blockState, face, random.get());
-            final int count = quads.size();
-            if(count != 0 && blockInfo.shouldDrawFace(face)) {
-                for(int j = 0; j < count; j++) {
-                    BakedQuad q = quads.get(j);
-                    renderQuad(q, face, defaultMaterial);
-                }
-            }
-        }
+	private final int[] editorBuffer = new int[28];
+	private final ChunkRenderInfo chunkInfo;
 
-        List<BakedQuad> quads = model.getQuads(blockState, null, random.get());
-        final int count = quads.size();
-        if(count != 0) {
-            for(int j = 0; j < count; j++) {
-                BakedQuad q = quads.get(j);
-                renderQuad(q, null, defaultMaterial);
-            }
-        }
-    }
-    
-    private void renderQuad(BakedQuad quad, Direction cullFace, Value defaultMaterial) {
-        final int[] vertexData = quad.getVertexData();
-        if(!CompatibilityHelper.canRender(vertexData)) {
-        	return;
-        }
-        
-        final MutableQuadViewImpl editorQuad = this.editorQuad;
-        System.arraycopy(vertexData, 0, editorBuffer, 0, 28);
-        editorQuad.cullFace(cullFace);
-        final Direction lightFace = quad.getFace();
-        editorQuad.lightFace(lightFace);
-        editorQuad.nominalFace(lightFace);
-        editorQuad.colorIndex(quad.getColorIndex());
-        editorQuad.material(defaultMaterial);
-        
-        if(!transform.transform(editorQuad)) {
-            return;
-        }
-        
-        if (editorQuad.material().hasAo) {
-            // needs to happen before offsets are applied
-            editorQuad.invalidateShape();
-            aoCalc.compute(editorQuad, true);
-            chunkInfo.applyOffsets(editorQuad);
-            tesselateSmooth(editorQuad, blockInfo.defaultLayerIndex, editorQuad.colorIndex());
-        } else {
-            // vanilla compatibility hack
+	TerrainFallbackConsumer(BlockRenderInfo blockInfo, ChunkRenderInfo chunkInfo, AoCalculator aoCalc, QuadTransform transform) {
+		super(blockInfo, chunkInfo::getInitializedBuffer, aoCalc, transform);
+		this.chunkInfo = chunkInfo;
+	}
+
+	private final MutableQuadViewImpl editorQuad = new MutableQuadViewImpl() {
+		{
+			data = editorBuffer;
+			material = MATERIAL_SHADED;
+			baseIndex = -EncodingFormat.HEADER_STRIDE;
+		}
+
+		@Override
+		public QuadEmitter emit() {
+			// should not be called
+			throw new UnsupportedOperationException("Fallback consumer does not support .emit()");
+		}
+	};
+
+	@Override
+	public void accept(BakedModel model) {
+		final Supplier<Random> random = blockInfo.randomSupplier;
+		final Value defaultMaterial = blockInfo.defaultAo && model.useAmbientOcclusion()
+				? MATERIAL_SHADED : MATERIAL_FLAT;
+		final BlockState blockState = blockInfo.blockState;
+
+		for (int i = 0; i < 6; i++) {
+			Direction face = ModelHelper.faceFromIndex(i);
+			List<BakedQuad> quads = model.getQuads(blockState, face, random.get());
+			final int count = quads.size();
+
+			if (count != 0 && blockInfo.shouldDrawFace(face)) {
+				for (int j = 0; j < count; j++) {
+					BakedQuad q = quads.get(j);
+					renderQuad(q, face, defaultMaterial);
+				}
+			}
+		}
+
+		List<BakedQuad> quads = model.getQuads(blockState, null, random.get());
+		final int count = quads.size();
+
+		if (count != 0) {
+			for (int j = 0; j < count; j++) {
+				BakedQuad q = quads.get(j);
+				renderQuad(q, null, defaultMaterial);
+			}
+		}
+	}
+
+	private void renderQuad(BakedQuad quad, Direction cullFace, Value defaultMaterial) {
+		final int[] vertexData = quad.getVertexData();
+
+		if (!CompatibilityHelper.canRender(vertexData)) {
+			return;
+		}
+
+		final MutableQuadViewImpl editorQuad = this.editorQuad;
+		System.arraycopy(vertexData, 0, editorBuffer, 0, 28);
+		editorQuad.cullFace(cullFace);
+		final Direction lightFace = quad.getFace();
+		editorQuad.lightFace(lightFace);
+		editorQuad.nominalFace(lightFace);
+		editorQuad.colorIndex(quad.getColorIndex());
+		editorQuad.material(defaultMaterial);
+
+		if (!transform.transform(editorQuad)) {
+			return;
+		}
+
+		if (editorQuad.material().hasAo) {
+			// needs to happen before offsets are applied
+			editorQuad.invalidateShape();
+			aoCalc.compute(editorQuad, true);
+			chunkInfo.applyOffsets(editorQuad);
+			tesselateSmooth(editorQuad, blockInfo.defaultLayerIndex, editorQuad.colorIndex());
+		} else {
+			// vanilla compatibility hack
 			// For flat lighting, cull face drives everything and light face is ignored.
-            if(cullFace == null) {
-                editorQuad.invalidateShape();
-                // Can't rely on lazy computation in tesselateFlat() because needs to happen before offsets are applied
-                editorQuad.geometryFlags();
-            } else {
-                editorQuad.geometryFlags(GeometryHelper.LIGHT_FACE_FLAG);
-                editorQuad.lightFace(cullFace);
-            }
-            chunkInfo.applyOffsets(editorQuad);
-            tesselateFlat(editorQuad, blockInfo.defaultLayerIndex, editorQuad.colorIndex());
-        }
-    }
+			if (cullFace == null) {
+				editorQuad.invalidateShape();
+				// Can't rely on lazy computation in tesselateFlat() because needs to happen before offsets are applied
+				editorQuad.geometryFlags();
+			} else {
+				editorQuad.geometryFlags(GeometryHelper.LIGHT_FACE_FLAG);
+				editorQuad.lightFace(cullFace);
+			}
+
+			chunkInfo.applyOffsets(editorQuad);
+			tesselateFlat(editorQuad, blockInfo.defaultLayerIndex, editorQuad.colorIndex());
+		}
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainMeshConsumer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainMeshConsumer.java
@@ -21,14 +21,14 @@ import net.fabricmc.indigo.renderer.aocalc.AoCalculator;
 import net.fabricmc.indigo.renderer.mesh.MutableQuadViewImpl;
 
 public class TerrainMeshConsumer extends AbstractMeshConsumer {
-    private final ChunkRenderInfo chunkInfo;
-    TerrainMeshConsumer(TerrainBlockRenderInfo blockInfo,  ChunkRenderInfo chunkInfo, AoCalculator aoCalc, QuadTransform transform) {
-        super(blockInfo, chunkInfo::getInitializedBuffer, aoCalc, transform);
-        this.chunkInfo = chunkInfo;
-    }
-    
-    @Override
-    protected void applyOffsets(MutableQuadViewImpl quad) {
-        chunkInfo.applyOffsets(quad);
-    }
+	private final ChunkRenderInfo chunkInfo;
+	TerrainMeshConsumer(TerrainBlockRenderInfo blockInfo, ChunkRenderInfo chunkInfo, AoCalculator aoCalc, QuadTransform transform) {
+		super(blockInfo, chunkInfo::getInitializedBuffer, aoCalc, transform);
+		this.chunkInfo = chunkInfo;
+	}
+
+	@Override
+	protected void applyOffsets(MutableQuadViewImpl quad) {
+		chunkInfo.applyOffsets(quad);
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainRenderContext.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainRenderContext.java
@@ -18,11 +18,6 @@ package net.fabricmc.indigo.renderer.render;
 
 import java.util.function.Consumer;
 
-import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
-import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
-import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
-import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
-import net.fabricmc.indigo.renderer.aocalc.AoCalculator;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.render.chunk.ChunkRenderTask;
 import net.minecraft.client.render.chunk.ChunkRenderer;
@@ -33,66 +28,73 @@ import net.minecraft.util.crash.CrashReport;
 import net.minecraft.util.crash.CrashReportSection;
 import net.minecraft.util.math.BlockPos;
 
+import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
+import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
+import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
+import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
+import net.fabricmc.indigo.renderer.aocalc.AoCalculator;
+
 /**
  * Implementation of {@link RenderContext} used during terrain rendering.
  * Dispatches calls from models during chunk rebuild to the appropriate consumer,
  * and holds/manages all of the state needed by them.
  */
 public class TerrainRenderContext extends AbstractRenderContext implements RenderContext {
-    public static final ThreadLocal<TerrainRenderContext> POOL = ThreadLocal.withInitial(TerrainRenderContext::new);
-    private final TerrainBlockRenderInfo blockInfo = new TerrainBlockRenderInfo();
-    private final ChunkRenderInfo chunkInfo = new ChunkRenderInfo(blockInfo);
-    private final AoCalculator aoCalc = new AoCalculator(blockInfo, chunkInfo::cachedBrightness, chunkInfo::cachedAoLevel);
-    private final TerrainMeshConsumer meshConsumer = new TerrainMeshConsumer(blockInfo, chunkInfo, aoCalc, this::transform);
-    private final TerrainFallbackConsumer fallbackConsumer = new TerrainFallbackConsumer(blockInfo, chunkInfo, aoCalc, this::transform);
-    
-    public void setBlockView(ChunkRendererRegion blockView) {
-        blockInfo.setBlockView(blockView);
-        chunkInfo.setBlockView(blockView);
-    }
-    
-    public void setChunkTask(ChunkRenderTask chunkTask) {
-        chunkInfo.setChunkTask(chunkTask);
-    }
-    
-    public TerrainRenderContext prepare(ChunkRenderer chunkRenderer, BlockPos.Mutable chunkOrigin, boolean [] resultFlags) {
-        chunkInfo.prepare(chunkRenderer, chunkOrigin, resultFlags);
-        return this;
-    }
-    
-    public void release() {
-        chunkInfo.release();
-        blockInfo.release();
-    }
-    
-    /** Called from chunk renderer hook. */
-    public boolean tesselateBlock(BlockState blockState, BlockPos blockPos, final BakedModel model) {
-        try {
-            aoCalc.clear();
-            blockInfo.prepareForBlock(blockState, blockPos, model.useAmbientOcclusion());
-            chunkInfo.beginBlock();
-            ((FabricBakedModel)model).emitBlockQuads(blockInfo.blockView, blockInfo.blockState, blockInfo.blockPos, blockInfo.randomSupplier, this);
-        } catch (Throwable var9) {
-           CrashReport crashReport_1 = CrashReport.create(var9, "Tesselating block in world - Indigo Renderer");
-           CrashReportSection crashReportElement_1 = crashReport_1.addElement("Block being tesselated");
-           CrashReportSection.addBlockInfo(crashReportElement_1, blockPos, blockState);
-           throw new CrashException(crashReport_1);
-        }
-        return chunkInfo.resultFlags[blockInfo.defaultLayerIndex];
-     }
+	public static final ThreadLocal<TerrainRenderContext> POOL = ThreadLocal.withInitial(TerrainRenderContext::new);
+	private final TerrainBlockRenderInfo blockInfo = new TerrainBlockRenderInfo();
+	private final ChunkRenderInfo chunkInfo = new ChunkRenderInfo(blockInfo);
+	private final AoCalculator aoCalc = new AoCalculator(blockInfo, chunkInfo::cachedBrightness, chunkInfo::cachedAoLevel);
+	private final TerrainMeshConsumer meshConsumer = new TerrainMeshConsumer(blockInfo, chunkInfo, aoCalc, this::transform);
+	private final TerrainFallbackConsumer fallbackConsumer = new TerrainFallbackConsumer(blockInfo, chunkInfo, aoCalc, this::transform);
 
-    @Override
-    public Consumer<Mesh> meshConsumer() {
-        return meshConsumer;
-    }
+	public void setBlockView(ChunkRendererRegion blockView) {
+		blockInfo.setBlockView(blockView);
+		chunkInfo.setBlockView(blockView);
+	}
 
-    @Override
-    public Consumer<BakedModel> fallbackConsumer() {
-        return fallbackConsumer;
-    }
+	public void setChunkTask(ChunkRenderTask chunkTask) {
+		chunkInfo.setChunkTask(chunkTask);
+	}
 
-    @Override
-    public QuadEmitter getEmitter() {
-        return meshConsumer.getEmitter();
-    }
+	public TerrainRenderContext prepare(ChunkRenderer chunkRenderer, BlockPos.Mutable chunkOrigin, boolean [] resultFlags) {
+		chunkInfo.prepare(chunkRenderer, chunkOrigin, resultFlags);
+		return this;
+	}
+
+	public void release() {
+		chunkInfo.release();
+		blockInfo.release();
+	}
+
+	/** Called from chunk renderer hook. */
+	public boolean tesselateBlock(BlockState blockState, BlockPos blockPos, final BakedModel model) {
+		try {
+			aoCalc.clear();
+			blockInfo.prepareForBlock(blockState, blockPos, model.useAmbientOcclusion());
+			chunkInfo.beginBlock();
+			((FabricBakedModel)model).emitBlockQuads(blockInfo.blockView, blockInfo.blockState, blockInfo.blockPos, blockInfo.randomSupplier, this);
+		} catch (Throwable var9) {
+			CrashReport crashReport_1 = CrashReport.create(var9, "Tesselating block in world - Indigo Renderer");
+			CrashReportSection crashReportElement_1 = crashReport_1.addElement("Block being tesselated");
+			CrashReportSection.addBlockInfo(crashReportElement_1, blockPos, blockState);
+			throw new CrashException(crashReport_1);
+		}
+
+		return chunkInfo.resultFlags[blockInfo.defaultLayerIndex];
+	}
+
+	@Override
+	public Consumer<Mesh> meshConsumer() {
+		return meshConsumer;
+	}
+
+	@Override
+	public Consumer<BakedModel> fallbackConsumer() {
+		return fallbackConsumer;
+	}
+
+	@Override
+	public QuadEmitter getEmitter() {
+		return meshConsumer.getEmitter();
+	}
 }

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainRenderContext.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/indigo/renderer/render/TerrainRenderContext.java
@@ -56,7 +56,7 @@ public class TerrainRenderContext extends AbstractRenderContext implements Rende
 		chunkInfo.setChunkTask(chunkTask);
 	}
 
-	public TerrainRenderContext prepare(ChunkRenderer chunkRenderer, BlockPos.Mutable chunkOrigin, boolean [] resultFlags) {
+	public TerrainRenderContext prepare(ChunkRenderer chunkRenderer, BlockPos.Mutable chunkOrigin, boolean[] resultFlags) {
 		chunkInfo.prepare(chunkRenderer, chunkOrigin, resultFlags);
 		return this;
 	}
@@ -72,7 +72,7 @@ public class TerrainRenderContext extends AbstractRenderContext implements Rende
 			aoCalc.clear();
 			blockInfo.prepareForBlock(blockState, blockPos, model.useAmbientOcclusion());
 			chunkInfo.beginBlock();
-			((FabricBakedModel)model).emitBlockQuads(blockInfo.blockView, blockInfo.blockState, blockInfo.blockPos, blockInfo.randomSupplier, this);
+			((FabricBakedModel) model).emitBlockQuads(blockInfo.blockView, blockInfo.blockState, blockInfo.blockPos, blockInfo.randomSupplier, this);
 		} catch (Throwable var9) {
 			CrashReport crashReport_1 = CrashReport.create(var9, "Tesselating block in world - Indigo Renderer");
 			CrashReportSection crashReportElement_1 = crashReport_1.addElement("Block being tesselated");

--- a/fabric-rendering-data-attachment-v1/src/main/java/net/fabricmc/fabric/api/rendering/data/v1/RenderAttachedBlockView.java
+++ b/fabric-rendering-data-attachment-v1/src/main/java/net/fabricmc/fabric/api/rendering/data/v1/RenderAttachedBlockView.java
@@ -22,44 +22,44 @@ import net.minecraft.world.ExtendedBlockView;
 
 /**
  * BlockView-extending interface to be used by {@link net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel} for dynamic model
- * customization. It ensures thread safety and exploits data cached in render 
- * chunks for performance and data consistency.<p>
- * 
- * There are differences from BlockView consumers must understand:<p>
- * 
- * BlockEntity implementations that provide data for model customization should implement 
+ * customization. It ensures thread safety and exploits data cached in render
+ * chunks for performance and data consistency.
+ *
+ * <p>There are differences from BlockView consumers must understand:
+ *
+ * <p>BlockEntity implementations that provide data for model customization should implement
  * {@link RenderAttachmentBlockEntity} which will be queried on the main thread when a render
  * chunk is enqueued for rebuild. The model should retrieve the results via {@link #getBlockEntityRenderAttachment(BlockPos)}.
  * While {@link #getBlockEntity(net.minecraft.util.math.BlockPos)} is not disabled, it
  * is not thread-safe for use on render threads.  Models that violate this guidance are
- * responsible for any necessary synchronization or collision detection.<p>
- * 
- * {@link #getBlockState(net.minecraft.util.math.BlockPos)} and {@link #getFluidState(net.minecraft.util.math.BlockPos)}
+ * responsible for any necessary synchronization or collision detection.
+ *
+ * <p>{@link #getBlockState(net.minecraft.util.math.BlockPos)} and {@link #getFluidState(net.minecraft.util.math.BlockPos)}
  * will always reflect the state cached with the render chunk.  Block and fluid states
  * can thus be different from main-thread world state due to lag between block update
  * application from network packets and render chunk rebuilds. Use of {link #getCachedRenderData()}
- * will ensure consistency of model state with the rest of the chunk being rendered.<p>
+ * will ensure consistency of model state with the rest of the chunk being rendered.
  *
- * Models should avoid using {@link ExtendedBlockView#getBlockEntity(BlockPos)}
+ * <p>Models should avoid using {@link ExtendedBlockView#getBlockEntity(BlockPos)}
  * to ensure thread safety because this view may be accessed outside the main client thread.
  * Models that require Block Entity data should implement {@link RenderAttachmentBlockEntity}
  * and then use {@link #getBlockEntityRenderAttachment(BlockPos)} to retrieve it.  When called from the
- * main thread, that method will simply retrieve the data directly.<p>
- * 
- * This interface is only guaranteed to be present in the client environment.
+ * main thread, that method will simply retrieve the data directly.
+ *
+ * <p>This interface is only guaranteed to be present in the client environment.
  */
 // XXX can not link net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel
 public interface RenderAttachedBlockView extends ExtendedBlockView {
-    /**
-     * For models associated with Block Entities that implement {@link RenderAttachmentBlockEntity}
-     * this will be the most recent value provided by that implementation for the given block position.<p>
-     *
-     * Null in all other cases, or if the result from the implementation was null.<p>
-     *
-     * @param pos Position of the block for the block model.
-     */
-    default Object getBlockEntityRenderAttachment(BlockPos pos) {
-        BlockEntity be = this.getBlockEntity(pos);
-        return be == null ? null : ((RenderAttachmentBlockEntity) be).getRenderAttachmentData();
-    }
+	/**
+	 * For models associated with Block Entities that implement {@link RenderAttachmentBlockEntity}
+	 * this will be the most recent value provided by that implementation for the given block position.
+	 *
+	 * <p>Null in all other cases, or if the result from the implementation was null.
+	 *
+	 * @param pos Position of the block for the block model.
+	 */
+	default Object getBlockEntityRenderAttachment(BlockPos pos) {
+		BlockEntity be = this.getBlockEntity(pos);
+		return be == null ? null : ((RenderAttachmentBlockEntity) be).getRenderAttachmentData();
+	}
 }

--- a/fabric-rendering-data-attachment-v1/src/main/java/net/fabricmc/fabric/api/rendering/data/v1/RenderAttachmentBlockEntity.java
+++ b/fabric-rendering-data-attachment-v1/src/main/java/net/fabricmc/fabric/api/rendering/data/v1/RenderAttachmentBlockEntity.java
@@ -19,21 +19,21 @@ package net.fabricmc.fabric.api.rendering.data.v1;
 import net.minecraft.block.entity.BlockEntity;
 
 /**
- * Interface for {@link BlockEntity}s which provide dynamic model state data.<p>
+ * Interface for {@link BlockEntity}s which provide dynamic model state data.
  *
- * Dynamic model state data is separate from BlockState, and will be
+ * <p>Dynamic model state data is separate from BlockState, and will be
  * cached during render chunk building on the main thread (safely) and accessible
- * during chunk rendering on non-main threads.<p>
+ * during chunk rendering on non-main threads.
  *
- * For this reason, please ensure that all accesses to the passed model data are
+ * <p>For this reason, please ensure that all accesses to the passed model data are
  * thread-safe. This can be achieved by, for example, passing a pre-generated
  * immutable object, or ensuring all gets performed on the passed object are atomic
- * and well-checked for unusual states.<p>
+ * and well-checked for unusual states.
  */
 @FunctionalInterface
 public interface RenderAttachmentBlockEntity {
-    /**
-     * @return The model state data provided by this block entity. Can be null.
-     */
-    Object getRenderAttachmentData();
+	/**
+	 * @return The model state data provided by this block entity. Can be null.
+	 */
+	Object getRenderAttachmentData();
 }

--- a/fabric-rendering-data-attachment-v1/src/main/java/net/fabricmc/fabric/mixin/rendering/data/MixinBlockEntity.java
+++ b/fabric-rendering-data-attachment-v1/src/main/java/net/fabricmc/fabric/mixin/rendering/data/MixinBlockEntity.java
@@ -16,14 +16,16 @@
 
 package net.fabricmc.fabric.mixin.rendering.data;
 
-import net.fabricmc.fabric.api.rendering.data.v1.RenderAttachmentBlockEntity;
-import net.minecraft.block.entity.BlockEntity;
 import org.spongepowered.asm.mixin.Mixin;
+
+import net.minecraft.block.entity.BlockEntity;
+
+import net.fabricmc.fabric.api.rendering.data.v1.RenderAttachmentBlockEntity;
 
 @Mixin(BlockEntity.class)
 public class MixinBlockEntity implements RenderAttachmentBlockEntity {
-    @Override
-    public Object getRenderAttachmentData() {
-        return null;
-    }
+	@Override
+	public Object getRenderAttachmentData() {
+		return null;
+	}
 }

--- a/fabric-rendering-data-attachment-v1/src/main/java/net/fabricmc/fabric/mixin/rendering/data/MixinViewableWorld.java
+++ b/fabric-rendering-data-attachment-v1/src/main/java/net/fabricmc/fabric/mixin/rendering/data/MixinViewableWorld.java
@@ -16,12 +16,12 @@
 
 package net.fabricmc.fabric.mixin.rendering.data;
 
-import net.fabricmc.fabric.api.rendering.data.v1.RenderAttachedBlockView;
-import net.minecraft.world.ViewableWorld;
 import org.spongepowered.asm.mixin.Mixin;
+
+import net.minecraft.world.ViewableWorld;
+
+import net.fabricmc.fabric.api.rendering.data.v1.RenderAttachedBlockView;
 
 /** Make {@link ViewableWorld} implement {@link RenderAttachedBlockView}. */
 @Mixin(ViewableWorld.class)
-public interface MixinViewableWorld extends RenderAttachedBlockView {
-
-}
+public interface MixinViewableWorld extends RenderAttachedBlockView { }

--- a/fabric-rendering-data-attachment-v1/src/main/java/net/fabricmc/fabric/mixin/rendering/data/client/MixinChunkRendererRegion.java
+++ b/fabric-rendering-data-attachment-v1/src/main/java/net/fabricmc/fabric/mixin/rendering/data/client/MixinChunkRendererRegion.java
@@ -20,6 +20,7 @@ import java.util.ConcurrentModificationException;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Mixin;
@@ -28,14 +29,14 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import net.fabricmc.fabric.api.rendering.data.v1.RenderAttachedBlockView;
-import net.fabricmc.fabric.api.rendering.data.v1.RenderAttachmentBlockEntity;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.client.render.chunk.ChunkRendererRegion;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.WorldChunk;
+
+import net.fabricmc.fabric.api.rendering.data.v1.RenderAttachedBlockView;
+import net.fabricmc.fabric.api.rendering.data.v1.RenderAttachmentBlockEntity;
 
 @Mixin(ChunkRendererRegion.class)
 public abstract class MixinChunkRendererRegion implements RenderAttachedBlockView {
@@ -58,10 +59,10 @@ public abstract class MixinChunkRendererRegion implements RenderAttachedBlockVie
 		for (WorldChunk[] chunkOuter : chunks) {
 			for (WorldChunk chunk : chunkOuter) {
 				// Hash maps in chunks should generally not be modified outside of client thread
-				// but does happen in practice, due to mods or inconsistent vanilla behaviors, causing 
+				// but does happen in practice, due to mods or inconsistent vanilla behaviors, causing
 				// CMEs when we iterate the map.  (Vanilla does not iterate these maps when it builds
 				// the chunk cache and does not suffer from this problem.)
-				// 
+				//
 				// We handle this simply by retrying until it works.  Ugly but effective.
 				for (;;) {
 					try {
@@ -96,19 +97,21 @@ public abstract class MixinChunkRendererRegion implements RenderAttachedBlockVie
 		for (Map.Entry<BlockPos, BlockEntity> entry : chunk.getBlockEntities().entrySet()) {
 			final BlockPos entPos = entry.getKey();
 
-			if (entPos.getX() >= xMin && entPos.getX() <= xMax 
+			if (entPos.getX() >= xMin && entPos.getX() <= xMax
 					&& entPos.getY() >= yMin && entPos.getY() <= yMax
 					&& entPos.getZ() >= zMin && entPos.getZ() <= zMax) {
-
 				final Object o = ((RenderAttachmentBlockEntity) entry.getValue()).getRenderAttachmentData();
+
 				if (o != null) {
 					if (map == null) {
 						map = new Int2ObjectOpenHashMap<>();
 					}
+
 					map.put(getIndex(entPos), o);
 				}
 			}
 		}
+
 		return map;
 	}
 

--- a/fabric-rendering-fluids-v1/src/main/java/net/fabricmc/fabric/api/client/render/fluid/v1/FluidRenderHandler.java
+++ b/fabric-rendering-fluids-v1/src/main/java/net/fabricmc/fabric/api/client/render/fluid/v1/FluidRenderHandler.java
@@ -25,25 +25,25 @@ import net.minecraft.world.ExtendedBlockView;
  * Interface for handling the rendering of a FluidState.
  */
 public interface FluidRenderHandler {
-    /**
-     * Get the sprites for a fluid being rendered at a given position.
-     * For optimal performance, the sprites should be loaded as part of a
-     * resource reload and *not* looked up every time the method is called!
-     *
-     * The "fabric-textures" module contains sprite rendering facilities, which may come in handy here.
-     *
-     * @param view The world view pertaining to the fluid. May be null!
-     * @param pos The position of the fluid in the world. May be null!
-     * @param state The current state of the fluid.
-     * @return An array of size two: the first entry contains the "still" sprite,
-     * while the second entry contains the "flowing" sprite.
-     */
-    Sprite[] getFluidSprites(/* Nullable */ ExtendedBlockView view, /* Nullable */ BlockPos pos, FluidState state);
+	/**
+	 * Get the sprites for a fluid being rendered at a given position.
+	 * For optimal performance, the sprites should be loaded as part of a
+	 * resource reload and *not* looked up every time the method is called!
+	 *
+	 * <p>The "fabric-textures" module contains sprite rendering facilities, which may come in handy here.
+	 *
+	 * @param view The world view pertaining to the fluid. May be null!
+	 * @param pos The position of the fluid in the world. May be null!
+	 * @param state The current state of the fluid.
+	 * @return An array of size two: the first entry contains the "still" sprite,
+	 * while the second entry contains the "flowing" sprite.
+	 */
+	Sprite[] getFluidSprites(/* Nullable */ ExtendedBlockView view, /* Nullable */ BlockPos pos, FluidState state);
 
 	/**
 	 * Get the tint color for a fluid being rendered at a given position.
 	 *
-	 * NOTE: As of right now, our hook cannot handle setting a custom alpha
+	 * @note As of right now, our hook cannot handle setting a custom alpha
 	 * tint here - as such, it must be contained in the texture itself!
 	 *
 	 * @param view The world view pertaining to the fluid. May be null!
@@ -51,7 +51,7 @@ public interface FluidRenderHandler {
 	 * @param state The current state of the fluid.
 	 * @return The tint color of the fluid.
 	 */
-    default int getFluidColor(ExtendedBlockView view, BlockPos pos, FluidState state) {
-        return -1;
-    }
+	default int getFluidColor(ExtendedBlockView view, BlockPos pos, FluidState state) {
+		return -1;
+	}
 }

--- a/fabric-rendering-fluids-v1/src/main/java/net/fabricmc/fabric/api/client/render/fluid/v1/FluidRenderHandlerRegistry.java
+++ b/fabric-rendering-fluids-v1/src/main/java/net/fabricmc/fabric/api/client/render/fluid/v1/FluidRenderHandlerRegistry.java
@@ -16,32 +16,33 @@
 
 package net.fabricmc.fabric.api.client.render.fluid.v1;
 
-import net.fabricmc.fabric.impl.client.render.fluid.FluidRenderHandlerRegistryImpl;
 import net.minecraft.fluid.Fluid;
+
+import net.fabricmc.fabric.impl.client.render.fluid.FluidRenderHandlerRegistryImpl;
 
 /**
  * Registry for {@link FluidRenderHandler} instances.
  *
- * Notably, this supports querying, overriding and wrapping vanilla fluid
+ * <p>Notably, this supports querying, overriding and wrapping vanilla fluid
  * rendering.
  */
 public interface FluidRenderHandlerRegistry {
-    FluidRenderHandlerRegistry INSTANCE = FluidRenderHandlerRegistryImpl.INSTANCE;
+	FluidRenderHandlerRegistry INSTANCE = FluidRenderHandlerRegistryImpl.INSTANCE;
 
-    /**
-     * Get a {@link FluidRenderHandler} for a given Fluid.
-     * Supports vanilla and Fabric fluids.
-     *
-     * @param fluid The Fluid.
-     * @return The FluidRenderHandler.
-     */
-    FluidRenderHandler get(Fluid fluid);
+	/**
+	 * Get a {@link FluidRenderHandler} for a given Fluid.
+	 * Supports vanilla and Fabric fluids.
+	 *
+	 * @param fluid The Fluid.
+	 * @return The FluidRenderHandler.
+	 */
+	FluidRenderHandler get(Fluid fluid);
 
-    /**
-     * Register a {@link FluidRenderHandler} for a given Fluid.
-     *
-     * @param fluid The Fluid.
-     * @param renderer The FluidRenderHandler.
-     */
-    void register(Fluid fluid, FluidRenderHandler renderer);
+	/**
+	 * Register a {@link FluidRenderHandler} for a given Fluid.
+	 *
+	 * @param fluid The Fluid.
+	 * @param renderer The FluidRenderHandler.
+	 */
+	void register(Fluid fluid, FluidRenderHandler renderer);
 }

--- a/fabric-rendering-fluids-v1/src/main/java/net/fabricmc/fabric/impl/client/render/fluid/FluidRenderHandlerRegistryImpl.java
+++ b/fabric-rendering-fluids-v1/src/main/java/net/fabricmc/fabric/impl/client/render/fluid/FluidRenderHandlerRegistryImpl.java
@@ -16,8 +16,9 @@
 
 package net.fabricmc.fabric.impl.client.render.fluid;
 
-import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandler;
-import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandlerRegistry;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
 import net.minecraft.client.color.world.BiomeColors;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.fluid.Fluid;
@@ -27,61 +28,61 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.ExtendedBlockView;
 import net.minecraft.world.biome.Biomes;
 
-import java.util.IdentityHashMap;
-import java.util.Map;
+import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandler;
+import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandlerRegistry;
 
 public class FluidRenderHandlerRegistryImpl implements FluidRenderHandlerRegistry {
-    public static final FluidRenderHandlerRegistryImpl INSTANCE = new FluidRenderHandlerRegistryImpl();
-    private final Map<Fluid, FluidRenderHandler> handlers = new IdentityHashMap<>();
-    private final Map<Fluid, FluidRenderHandler> modHandlers = new IdentityHashMap<>();
+	public static final FluidRenderHandlerRegistryImpl INSTANCE = new FluidRenderHandlerRegistryImpl();
+	private final Map<Fluid, FluidRenderHandler> handlers = new IdentityHashMap<>();
+	private final Map<Fluid, FluidRenderHandler> modHandlers = new IdentityHashMap<>();
 
-    private FluidRenderHandlerRegistryImpl() {
-    }
+	private FluidRenderHandlerRegistryImpl() {
+	}
 
-    @Override
-    public FluidRenderHandler get(Fluid fluid) {
-        return handlers.get(fluid);
-    }
+	@Override
+	public FluidRenderHandler get(Fluid fluid) {
+		return handlers.get(fluid);
+	}
 
-    public FluidRenderHandler getOverride(Fluid fluid) {
-        return modHandlers.get(fluid);
-    }
+	public FluidRenderHandler getOverride(Fluid fluid) {
+		return modHandlers.get(fluid);
+	}
 
-    @Override
-    public void register(Fluid fluid, FluidRenderHandler renderer) {
-        handlers.put(fluid, renderer);
-        modHandlers.put(fluid, renderer);
-    }
+	@Override
+	public void register(Fluid fluid, FluidRenderHandler renderer) {
+		handlers.put(fluid, renderer);
+		modHandlers.put(fluid, renderer);
+	}
 
-    public void onFluidRendererReload(Sprite[] waterSprites, Sprite[] lavaSprites) {
-        FluidRenderHandler waterHandler = new FluidRenderHandler() {
-            @Override
-            public Sprite[] getFluidSprites(ExtendedBlockView view, BlockPos pos, FluidState state) {
-                return waterSprites;
-            }
+	public void onFluidRendererReload(Sprite[] waterSprites, Sprite[] lavaSprites) {
+		FluidRenderHandler waterHandler = new FluidRenderHandler() {
+			@Override
+			public Sprite[] getFluidSprites(ExtendedBlockView view, BlockPos pos, FluidState state) {
+				return waterSprites;
+			}
 
-            @Override
-            public int getFluidColor(ExtendedBlockView view, BlockPos pos, FluidState state) {
-                if (view != null && pos != null) {
-                    return BiomeColors.getWaterColor(view, pos);
-                } else {
-                    return Biomes.DEFAULT.getWaterColor();
-                }
-            }
-        };
+			@Override
+			public int getFluidColor(ExtendedBlockView view, BlockPos pos, FluidState state) {
+				if (view != null && pos != null) {
+					return BiomeColors.getWaterColor(view, pos);
+				} else {
+					return Biomes.DEFAULT.getWaterColor();
+				}
+			}
+		};
 
-        //noinspection Convert2Lambda
-        FluidRenderHandler lavaHandler = new FluidRenderHandler() {
-            @Override
-            public Sprite[] getFluidSprites(ExtendedBlockView view, BlockPos pos, FluidState state) {
-                return lavaSprites;
-            }
-        };
+		//noinspection Convert2Lambda
+		FluidRenderHandler lavaHandler = new FluidRenderHandler() {
+			@Override
+			public Sprite[] getFluidSprites(ExtendedBlockView view, BlockPos pos, FluidState state) {
+				return lavaSprites;
+			}
+		};
 
-        register(Fluids.WATER, waterHandler);
-        register(Fluids.FLOWING_WATER, waterHandler);
-        register(Fluids.LAVA, lavaHandler);
-        register(Fluids.FLOWING_LAVA, lavaHandler);
-        handlers.putAll(modHandlers);
-    }
+		register(Fluids.WATER, waterHandler);
+		register(Fluids.FLOWING_WATER, waterHandler);
+		register(Fluids.LAVA, lavaHandler);
+		register(Fluids.FLOWING_LAVA, lavaHandler);
+		handlers.putAll(modHandlers);
+	}
 }

--- a/fabric-rendering-fluids-v1/src/main/java/net/fabricmc/fabric/impl/client/render/fluid/FluidRendererHookContainer.java
+++ b/fabric-rendering-fluids-v1/src/main/java/net/fabricmc/fabric/impl/client/render/fluid/FluidRendererHookContainer.java
@@ -16,21 +16,22 @@
 
 package net.fabricmc.fabric.impl.client.render.fluid;
 
-import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandler;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.ExtendedBlockView;
 
-public class FluidRendererHookContainer {
-    public ExtendedBlockView view;
-    public BlockPos pos;
-    public FluidState state;
-    public FluidRenderHandler handler;
+import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandler;
 
-    public void clear() {
-        view = null;
-        pos = null;
-        state = null;
-        handler = null;
-    }
+public class FluidRendererHookContainer {
+	public ExtendedBlockView view;
+	public BlockPos pos;
+	public FluidState state;
+	public FluidRenderHandler handler;
+
+	public void clear() {
+		view = null;
+		pos = null;
+		state = null;
+		handler = null;
+	}
 }

--- a/fabric-rendering-fluids-v1/src/main/java/net/fabricmc/fabric/mixin/client/render/fluid/MixinFluidRenderer.java
+++ b/fabric-rendering-fluids-v1/src/main/java/net/fabricmc/fabric/mixin/client/render/fluid/MixinFluidRenderer.java
@@ -16,16 +16,6 @@
 
 package net.fabricmc.fabric.mixin.client.render.fluid;
 
-import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandler;
-import net.fabricmc.fabric.impl.client.render.fluid.FluidRendererHookContainer;
-import net.fabricmc.fabric.impl.client.render.fluid.FluidRenderHandlerRegistryImpl;
-import net.minecraft.client.render.BufferBuilder;
-import net.minecraft.client.render.block.FluidRenderer;
-import net.minecraft.client.texture.Sprite;
-import net.minecraft.fluid.FluidState;
-import net.minecraft.tag.FluidTags;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.ExtendedBlockView;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -34,66 +24,79 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import net.minecraft.client.render.BufferBuilder;
+import net.minecraft.client.render.block.FluidRenderer;
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.tag.FluidTags;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.ExtendedBlockView;
+
+import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandler;
+import net.fabricmc.fabric.impl.client.render.fluid.FluidRenderHandlerRegistryImpl;
+import net.fabricmc.fabric.impl.client.render.fluid.FluidRendererHookContainer;
+
 @Mixin(FluidRenderer.class)
 public class MixinFluidRenderer {
-    @Shadow
-    private Sprite[] lavaSprites;
-    @Shadow
-    private Sprite[] waterSprites;
+	@Shadow
+	private Sprite[] lavaSprites;
+	@Shadow
+	private Sprite[] waterSprites;
 
-    private final ThreadLocal<FluidRendererHookContainer> fabric_renderHandler = ThreadLocal.withInitial(FluidRendererHookContainer::new);
+	private final ThreadLocal<FluidRendererHookContainer> fabric_renderHandler = ThreadLocal.withInitial(FluidRendererHookContainer::new);
 
-    @Inject(at = @At("RETURN"), method = "onResourceReload")
-    public void onResourceReloadReturn(CallbackInfo info) {
-        FluidRenderHandlerRegistryImpl.INSTANCE.onFluidRendererReload(waterSprites, lavaSprites);
-    }
+	@Inject(at = @At("RETURN"), method = "onResourceReload")
+	public void onResourceReloadReturn(CallbackInfo info) {
+		FluidRenderHandlerRegistryImpl.INSTANCE.onFluidRendererReload(waterSprites, lavaSprites);
+	}
 
-    @Inject(at = @At("HEAD"), method = "tesselate", cancellable = true)
-    public void tesselate(ExtendedBlockView view, BlockPos pos, BufferBuilder bufferBuilder, FluidState state, CallbackInfoReturnable<Boolean> info) {
-        FluidRendererHookContainer ctr = fabric_renderHandler.get();
-        FluidRenderHandler handler = FluidRenderHandlerRegistryImpl.INSTANCE.getOverride(state.getFluid());
+	@Inject(at = @At("HEAD"), method = "tesselate", cancellable = true)
+	public void tesselate(ExtendedBlockView view, BlockPos pos, BufferBuilder bufferBuilder, FluidState state, CallbackInfoReturnable<Boolean> info) {
+		FluidRendererHookContainer ctr = fabric_renderHandler.get();
+		FluidRenderHandler handler = FluidRenderHandlerRegistryImpl.INSTANCE.getOverride(state.getFluid());
 
-        ctr.view = view;
-        ctr.pos = pos;
-        ctr.state = state;
-        ctr.handler = handler;
+		ctr.view = view;
+		ctr.pos = pos;
+		ctr.state = state;
+		ctr.handler = handler;
 
-        /* if (handler == null) {
-            return;
-        }
+		/* if (handler == null) {
+			return;
+		}
 
-        ActionResult hResult = handler.tesselate(view, pos, bufferBuilder, state);
-        if (hResult != ActionResult.PASS) {
-            info.setReturnValue(hResult == ActionResult.SUCCESS);
-            return;
-        } */
-    }
+		ActionResult hResult = handler.tesselate(view, pos, bufferBuilder, state);
 
-    @Inject(at = @At("RETURN"), method = "tesselate")
-    public void tesselateReturn(ExtendedBlockView view, BlockPos pos, BufferBuilder bufferBuilder, FluidState state, CallbackInfoReturnable<Boolean> info) {
-        fabric_renderHandler.get().clear();
-    }
+		if (hResult != ActionResult.PASS) {
+			info.setReturnValue(hResult == ActionResult.SUCCESS);
+			return;
+		} */
+	}
 
-    @ModifyVariable(at = @At(value = "INVOKE", target = "net/minecraft/client/render/block/FluidRenderer.isSameFluid(Lnet/minecraft/world/BlockView;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/Direction;Lnet/minecraft/fluid/FluidState;)Z"), method = "tesselate", ordinal = 0)
-    public boolean modLavaCheck(boolean chk) {
-        // First boolean local is set by vanilla according to 'matches lava'
-        // but uses the negation consistent with 'matches water'
-        // for determining if special water sprite should be used behind glass.
-        
-        // Has other uses but those have already happened by the time the hook is called.
-        final FluidRendererHookContainer ctr = fabric_renderHandler.get();
-        return chk || !ctr.state.matches(FluidTags.WATER);
-    }
+	@Inject(at = @At("RETURN"), method = "tesselate")
+	public void tesselateReturn(ExtendedBlockView view, BlockPos pos, BufferBuilder bufferBuilder, FluidState state, CallbackInfoReturnable<Boolean> info) {
+		fabric_renderHandler.get().clear();
+	}
 
-    @ModifyVariable(at = @At(value = "INVOKE", target = "net/minecraft/client/render/block/FluidRenderer.isSameFluid(Lnet/minecraft/world/BlockView;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/Direction;Lnet/minecraft/fluid/FluidState;)Z"), method = "tesselate", ordinal = 0)
-    public Sprite[] modSpriteArray(Sprite[] chk) {
-        FluidRendererHookContainer ctr = fabric_renderHandler.get();
-        return ctr.handler != null ? ctr.handler.getFluidSprites(ctr.view, ctr.pos, ctr.state) : chk;
-    }
+	@ModifyVariable(at = @At(value = "INVOKE", target = "net/minecraft/client/render/block/FluidRenderer.isSameFluid(Lnet/minecraft/world/BlockView;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/Direction;Lnet/minecraft/fluid/FluidState;)Z"), method = "tesselate", ordinal = 0)
+	public boolean modLavaCheck(boolean chk) {
+		// First boolean local is set by vanilla according to 'matches lava'
+		// but uses the negation consistent with 'matches water'
+		// for determining if special water sprite should be used behind glass.
 
-    @ModifyVariable(at = @At(value = "CONSTANT", args = "intValue=16", ordinal = 0, shift = At.Shift.BEFORE), method = "tesselate", ordinal = 0)
-    public int modTintColor(int chk) {
-        FluidRendererHookContainer ctr = fabric_renderHandler.get();
-        return ctr.handler != null ? ctr.handler.getFluidColor(ctr.view, ctr.pos, ctr.state) : chk;
-    }
+		// Has other uses but those have already happened by the time the hook is called.
+		final FluidRendererHookContainer ctr = fabric_renderHandler.get();
+		return chk || !ctr.state.matches(FluidTags.WATER);
+	}
+
+	@ModifyVariable(at = @At(value = "INVOKE", target = "net/minecraft/client/render/block/FluidRenderer.isSameFluid(Lnet/minecraft/world/BlockView;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/Direction;Lnet/minecraft/fluid/FluidState;)Z"), method = "tesselate", ordinal = 0)
+	public Sprite[] modSpriteArray(Sprite[] chk) {
+		FluidRendererHookContainer ctr = fabric_renderHandler.get();
+		return ctr.handler != null ? ctr.handler.getFluidSprites(ctr.view, ctr.pos, ctr.state) : chk;
+	}
+
+	@ModifyVariable(at = @At(value = "CONSTANT", args = "intValue=16", ordinal = 0, shift = At.Shift.BEFORE), method = "tesselate", ordinal = 0)
+	public int modTintColor(int chk) {
+		FluidRendererHookContainer ctr = fabric_renderHandler.get();
+		return ctr.handler != null ? ctr.handler.getFluidColor(ctr.view, ctr.pos, ctr.state) : chk;
+	}
 }

--- a/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/api/client/render/BlockEntityRendererRegistry.java
+++ b/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/api/client/render/BlockEntityRendererRegistry.java
@@ -16,12 +16,12 @@
 
 package net.fabricmc.fabric.api.client.render;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher;
 import net.minecraft.client.render.block.entity.BlockEntityRenderer;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Helper class for registering BlockEntityRenderers.
@@ -31,9 +31,7 @@ public class BlockEntityRendererRegistry {
 	private Map<Class<? extends BlockEntity>, BlockEntityRenderer<? extends BlockEntity>> renderers = null;
 	private Map<Class<? extends BlockEntity>, BlockEntityRenderer<? extends BlockEntity>> renderersTmp = new HashMap<>();
 
-	private BlockEntityRendererRegistry() {
-
-	}
+	private BlockEntityRendererRegistry() { }
 
 	public void initialize(BlockEntityRenderDispatcher instance, Map<Class<? extends BlockEntity>, BlockEntityRenderer<? extends BlockEntity>> map) {
 		if (renderers != null && renderers != map) {
@@ -45,9 +43,11 @@ public class BlockEntityRendererRegistry {
 		}
 
 		renderers = map;
+
 		for (BlockEntityRenderer renderer : renderersTmp.values()) {
 			renderer.setRenderManager(instance);
 		}
+
 		renderers.putAll(renderersTmp);
 		renderersTmp = null;
 	}

--- a/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/api/client/render/ColorProviderRegistry.java
+++ b/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/api/client/render/ColorProviderRegistry.java
@@ -16,11 +16,12 @@
 
 package net.fabricmc.fabric.api.client.render;
 
-import net.fabricmc.fabric.impl.client.render.ColorProviderRegistryImpl;
 import net.minecraft.block.Block;
 import net.minecraft.client.color.block.BlockColorProvider;
 import net.minecraft.client.color.item.ItemColorProvider;
 import net.minecraft.item.ItemConvertible;
+
+import net.fabricmc.fabric.impl.client.render.ColorProviderRegistryImpl;
 
 public interface ColorProviderRegistry<T, Provider> {
 	ColorProviderRegistry<ItemConvertible, ItemColorProvider> ITEM = ColorProviderRegistryImpl.ITEM;
@@ -28,7 +29,7 @@ public interface ColorProviderRegistry<T, Provider> {
 	ColorProviderRegistry<Block, BlockColorProvider> BLOCK = ColorProviderRegistryImpl.BLOCK;
 
 	/**
-	 * Register a color provider for one or more objects
+	 * Register a color provider for one or more objects.
 	 *
 	 * @param provider The color provider to register.
 	 * @param objects  The objects which should be colored using this provider.
@@ -37,8 +38,8 @@ public interface ColorProviderRegistry<T, Provider> {
 
 	/**
 	 * Get a color provider for the given object.
-	 * <p>
-	 * Please note that the underlying registry may not be fully populated or stable until the game has started,
+	 *
+	 * <p>Please note that the underlying registry may not be fully populated or stable until the game has started,
 	 * as other mods may overwrite the registry.
 	 *
 	 * @param object The object to acquire the provide for.

--- a/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/api/client/render/EntityRendererRegistry.java
+++ b/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/api/client/render/EntityRendererRegistry.java
@@ -16,16 +16,16 @@
 
 package net.fabricmc.fabric.api.client.render;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.WeakHashMap;
+
 import net.minecraft.client.render.entity.EntityRenderDispatcher;
 import net.minecraft.client.render.entity.EntityRenderer;
 import net.minecraft.client.render.item.ItemRenderer;
 import net.minecraft.client.texture.TextureManager;
 import net.minecraft.entity.Entity;
 import net.minecraft.resource.ReloadableResourceManager;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.WeakHashMap;
 
 /**
  * Helper class for registering EntityRenderers.
@@ -66,9 +66,7 @@ public class EntityRendererRegistry {
 	private final Map<EntityRenderDispatcher, Context> renderManagerMap = new WeakHashMap<>();
 	private final Map<Class<? extends Entity>, EntityRendererRegistry.Factory> renderSupplierMap = new HashMap<>();
 
-	private EntityRendererRegistry() {
-
-	}
+	private EntityRendererRegistry() { }
 
 	public void initialize(EntityRenderDispatcher manager, TextureManager textureManager, ReloadableResourceManager resourceManager, ItemRenderer itemRenderer, Map<Class<? extends Entity>, EntityRenderer<? extends Entity>> map) {
 		synchronized (renderSupplierMap) {
@@ -78,6 +76,7 @@ public class EntityRendererRegistry {
 
 			Context context = new Context(textureManager, resourceManager, itemRenderer, map);
 			renderManagerMap.put(manager, context);
+
 			for (Class<? extends Entity> c : renderSupplierMap.keySet()) {
 				map.put(c, renderSupplierMap.get(c).create(manager, context));
 			}
@@ -88,6 +87,7 @@ public class EntityRendererRegistry {
 		synchronized (renderSupplierMap) {
 			// TODO: warn on duplicate
 			renderSupplierMap.put(entityClass, factory);
+
 			for (EntityRenderDispatcher manager : renderManagerMap.keySet()) {
 				renderManagerMap.get(manager).rendererMap.put(entityClass, factory.create(manager, renderManagerMap.get(manager)));
 			}

--- a/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/api/client/render/InvalidateRenderStateCallback.java
+++ b/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/api/client/render/InvalidateRenderStateCallback.java
@@ -22,20 +22,20 @@ import net.fabricmc.fabric.api.event.EventFactory;
 /**
  * Called when the world renderer reloads, usually as result of changing resource pack
  * or video configuration, or when the player types F3+A in the debug screen.
- * Afterwards all render chunks will be reset and reloaded.<p>
- *     
- * Render chunks and other render-related object instances will be made null
+ * Afterwards all render chunks will be reset and reloaded.
+ *
+ * <p>Render chunks and other render-related object instances will be made null
  * or invalid after this event so do not use it to capture dependent state.
  * Instead, use it to invalidate state and reinitialize lazily.
  */
 public interface InvalidateRenderStateCallback {
-    public static final Event<InvalidateRenderStateCallback> EVENT = EventFactory.createArrayBacked(InvalidateRenderStateCallback.class,
-        (listeners) -> () -> {
-            for (InvalidateRenderStateCallback event : listeners) {
-                event.onInvalidate();
-            }
-        }
-    );
-    
-    void onInvalidate();
+	Event<InvalidateRenderStateCallback> EVENT = EventFactory.createArrayBacked(InvalidateRenderStateCallback.class,
+			(listeners) -> () -> {
+				for (InvalidateRenderStateCallback event : listeners) {
+					event.onInvalidate();
+				}
+			}
+	);
+
+	void onInvalidate();
 }

--- a/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/impl/client/render/ColorProviderRegistryImpl.java
+++ b/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/impl/client/render/ColorProviderRegistryImpl.java
@@ -16,7 +16,9 @@
 
 package net.fabricmc.fabric.impl.client.render;
 
-import net.fabricmc.fabric.api.client.render.ColorProviderRegistry;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
 import net.minecraft.block.Block;
 import net.minecraft.client.color.block.BlockColorProvider;
 import net.minecraft.client.color.block.BlockColors;
@@ -24,8 +26,7 @@ import net.minecraft.client.color.item.ItemColorProvider;
 import net.minecraft.client.color.item.ItemColors;
 import net.minecraft.item.ItemConvertible;
 
-import java.util.IdentityHashMap;
-import java.util.Map;
+import net.fabricmc.fabric.api.client.render.ColorProviderRegistry;
 
 public abstract class ColorProviderRegistryImpl<T, Provider, Underlying> implements ColorProviderRegistry<T, Provider> {
 	public static final ColorProviderRegistryImpl<Block, BlockColorProvider, BlockColors> BLOCK = new ColorProviderRegistryImpl<Block, BlockColorProvider, BlockColors>() {
@@ -54,9 +55,11 @@ public abstract class ColorProviderRegistryImpl<T, Provider, Underlying> impleme
 		}
 
 		this.colorMap = colorMap;
+
 		for (Map.Entry<T, Provider> mappers : tempMappers.entrySet()) {
 			registerUnderlying(colorMap, mappers.getValue(), mappers.getKey());
 		}
+
 		tempMappers = null;
 	}
 

--- a/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/mixin/client/render/MixinBlockColorMap.java
+++ b/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/mixin/client/render/MixinBlockColorMap.java
@@ -16,18 +16,20 @@
 
 package net.fabricmc.fabric.mixin.client.render;
 
-import net.fabricmc.fabric.impl.client.render.ColorProviderRegistryImpl;
-import net.minecraft.block.Block;
-import net.minecraft.client.color.block.BlockColorProvider;
-import net.minecraft.client.color.block.BlockColors;
-import net.minecraft.util.IdList;
-import net.minecraft.util.registry.Registry;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.block.Block;
+import net.minecraft.client.color.block.BlockColorProvider;
+import net.minecraft.client.color.block.BlockColors;
+import net.minecraft.util.IdList;
+import net.minecraft.util.registry.Registry;
+
+import net.fabricmc.fabric.impl.client.render.ColorProviderRegistryImpl;
 
 @Mixin(BlockColors.class)
 public class MixinBlockColorMap implements ColorProviderRegistryImpl.ColorMapperHolder<Block, BlockColorProvider> {

--- a/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/mixin/client/render/MixinBlockEntityRenderManager.java
+++ b/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/mixin/client/render/MixinBlockEntityRenderManager.java
@@ -16,17 +16,19 @@
 
 package net.fabricmc.fabric.mixin.client.render;
 
-import net.fabricmc.fabric.api.client.render.BlockEntityRendererRegistry;
-import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher;
-import net.minecraft.client.render.block.entity.BlockEntityRenderer;
+import java.util.Map;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Map;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher;
+import net.minecraft.client.render.block.entity.BlockEntityRenderer;
+
+import net.fabricmc.fabric.api.client.render.BlockEntityRendererRegistry;
 
 @Mixin(BlockEntityRenderDispatcher.class)
 public class MixinBlockEntityRenderManager {

--- a/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/mixin/client/render/MixinEntityRenderManager.java
+++ b/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/mixin/client/render/MixinEntityRenderManager.java
@@ -16,20 +16,22 @@
 
 package net.fabricmc.fabric.mixin.client.render;
 
-import net.fabricmc.fabric.api.client.render.EntityRendererRegistry;
-import net.minecraft.client.render.entity.EntityRenderDispatcher;
-import net.minecraft.client.render.entity.EntityRenderer;
-import net.minecraft.client.render.item.ItemRenderer;
-import net.minecraft.client.texture.TextureManager;
-import net.minecraft.entity.Entity;
-import net.minecraft.resource.ReloadableResourceManager;
+import java.util.Map;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Map;
+import net.minecraft.client.render.entity.EntityRenderDispatcher;
+import net.minecraft.client.render.entity.EntityRenderer;
+import net.minecraft.client.render.item.ItemRenderer;
+import net.minecraft.client.texture.TextureManager;
+import net.minecraft.entity.Entity;
+import net.minecraft.resource.ReloadableResourceManager;
+
+import net.fabricmc.fabric.api.client.render.EntityRendererRegistry;
 
 @Mixin(EntityRenderDispatcher.class)
 public class MixinEntityRenderManager {

--- a/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/mixin/client/render/MixinItemColorMap.java
+++ b/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/mixin/client/render/MixinItemColorMap.java
@@ -16,19 +16,21 @@
 
 package net.fabricmc.fabric.mixin.client.render;
 
-import net.fabricmc.fabric.impl.client.render.ColorProviderRegistryImpl;
-import net.minecraft.client.color.block.BlockColors;
-import net.minecraft.client.color.item.ItemColorProvider;
-import net.minecraft.client.color.item.ItemColors;
-import net.minecraft.item.ItemConvertible;
-import net.minecraft.util.IdList;
-import net.minecraft.util.registry.Registry;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.client.color.block.BlockColors;
+import net.minecraft.client.color.item.ItemColorProvider;
+import net.minecraft.client.color.item.ItemColors;
+import net.minecraft.item.ItemConvertible;
+import net.minecraft.util.IdList;
+import net.minecraft.util.registry.Registry;
+
+import net.fabricmc.fabric.impl.client.render.ColorProviderRegistryImpl;
 
 @Mixin(ItemColors.class)
 public class MixinItemColorMap implements ColorProviderRegistryImpl.ColorMapperHolder<ItemConvertible, ItemColorProvider> {

--- a/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/mixin/client/render/MixinWorldRenderer.java
+++ b/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/mixin/client/render/MixinWorldRenderer.java
@@ -21,13 +21,14 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import net.fabricmc.fabric.api.client.render.InvalidateRenderStateCallback;
 import net.minecraft.client.render.WorldRenderer;
+
+import net.fabricmc.fabric.api.client.render.InvalidateRenderStateCallback;
 
 @Mixin(WorldRenderer.class)
 public abstract class MixinWorldRenderer {
-    @Inject(method = "reload", at = @At("HEAD"))
-    private void onReload(CallbackInfo ci) {
-        InvalidateRenderStateCallback.EVENT.invoker().onInvalidate();
-    }
+	@Inject(method = "reload", at = @At("HEAD"))
+	private void onReload(CallbackInfo ci) {
+		InvalidateRenderStateCallback.EVENT.invoker().onInvalidate();
+	}
 }

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/IdentifiableResourceReloadListener.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/IdentifiableResourceReloadListener.java
@@ -16,20 +16,20 @@
 
 package net.fabricmc.fabric.api.resource;
 
-import net.minecraft.resource.ResourceReloadListener;
-import net.minecraft.util.Identifier;
-
 import java.util.Collection;
 import java.util.Collections;
 
+import net.minecraft.resource.ResourceReloadListener;
+import net.minecraft.util.Identifier;
+
 /**
  * Interface for "identifiable" resource reload listeners.
- * <p>
- * "Identifiable" listeners have an unique identifier, which can be depended on,
+ *
+ * <p>"Identifiable" listeners have an unique identifier, which can be depended on,
  * and can provide dependencies that they would like to see executed before
  * themselves.
- * <p>
- * {@link ResourceReloadListenerKeys}
+ *
+ * @see ResourceReloadListenerKeys
  */
 public interface IdentifiableResourceReloadListener extends ResourceReloadListener {
 	/**

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/ModResourcePack.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/ModResourcePack.java
@@ -16,8 +16,9 @@
 
 package net.fabricmc.fabric.api.resource;
 
-import net.fabricmc.loader.api.metadata.ModMetadata;
 import net.minecraft.resource.ResourcePack;
+
+import net.fabricmc.loader.api.metadata.ModMetadata;
 
 /**
  * Interface implemented by mod-provided resource packs.

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/ResourceManagerHelper.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/ResourceManagerHelper.java
@@ -16,9 +16,10 @@
 
 package net.fabricmc.fabric.api.resource;
 
-import net.fabricmc.fabric.impl.resources.ResourceManagerHelperImpl;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.resource.ResourceType;
+
+import net.fabricmc.fabric.impl.resources.ResourceManagerHelperImpl;
 
 /**
  * Helper for working with {@link ResourceManager} instances.

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/ResourceReloadListenerKeys.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/ResourceReloadListenerKeys.java
@@ -20,8 +20,8 @@ import net.minecraft.util.Identifier;
 
 /**
  * This class contains default keys for various Minecraft resource reload listeners.
- * <p>
- * {@link IdentifiableResourceReloadListener}
+ *
+ * @see IdentifiableResourceReloadListener
  */
 public final class ResourceReloadListenerKeys {
 	// client
@@ -38,7 +38,5 @@ public final class ResourceReloadListenerKeys {
 	public static final Identifier FUNCTIONS = new Identifier("minecraft:functions");
 	public static final Identifier LOOT_TABLES = new Identifier("minecraft:loot_tables");
 
-	private ResourceReloadListenerKeys() {
-
-	}
+	private ResourceReloadListenerKeys() { }
 }

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/SimpleResourceReloadListener.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/SimpleResourceReloadListener.java
@@ -16,28 +16,28 @@
 
 package net.fabricmc.fabric.api.resource;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.resource.ResourceReloadListener;
 import net.minecraft.resource.SynchronousResourceReloadListener;
 import net.minecraft.util.profiler.Profiler;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
-
 /**
  * A simplified version of the "resource reload listener" interface, hiding the
  * peculiarities of the API.
- * <p>
- * In essence, there are two stages:
- * <p>
- * - load: create an instance of your data object containing all loaded and
+ *
+ * <p>In essence, there are two stages:
+ *
+ * <ul><li>load: create an instance of your data object containing all loaded and
  * processed information,
- * - apply: apply the information from the data object to the game instance.
- * <p>
- * The load stage should be self-contained as it can run on any thread! However,
+ * <li>apply: apply the information from the data object to the game instance.</ul>
+ *
+ * <p>The load stage should be self-contained as it can run on any thread! However,
  * the apply stage is guaranteed to run on the game thread.
- * <p>
- * For a fully synchronous alternative, consider using
+ *
+ * <p>For a fully synchronous alternative, consider using
  * {@link SynchronousResourceReloadListener} in conjunction with
  * {@link IdentifiableResourceReloadListener}.
  *

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resources/DeferredInputStream.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resources/DeferredInputStream.java
@@ -16,11 +16,11 @@
 
 package net.fabricmc.fabric.impl.resources;
 
-import net.minecraft.util.Unit;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.Callable;
+
+import net.minecraft.util.Unit;
 
 /**
  * InputStream deferring to a separate I/O thread to work around
@@ -39,6 +39,7 @@ class DeferredInputStream extends InputStream {
 
 	DeferredInputStream(Callable<InputStream> streamSupplier) throws IOException {
 		stream = DeferredNioExecutionHandler.submit(streamSupplier);
+
 		if (stream == null) {
 			throw new IOException("Something happened while trying to create an InputStream!");
 		}
@@ -46,6 +47,7 @@ class DeferredInputStream extends InputStream {
 
 	DeferredInputStream(InputStream stream) throws IOException {
 		this.stream = stream;
+
 		if (this.stream == null) {
 			throw new IOException("Something happened while trying to create an InputStream!");
 		}

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resources/DeferredNioExecutionHandler.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resources/DeferredNioExecutionHandler.java
@@ -16,10 +16,14 @@
 
 package net.fabricmc.fabric.impl.resources;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-
 import java.io.IOException;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 class DeferredNioExecutionHandler {
 	// private static final ThreadLocal<Boolean> DEFERRED_REQUIRED = new ThreadLocal<>();
@@ -29,10 +33,12 @@ class DeferredNioExecutionHandler {
 	public static boolean shouldDefer() {
 		return DEFER_REQUESTED;
 		/* Boolean deferRequired = DEFERRED_REQUIRED.get();
+
 		if (deferRequired == null) {
 			deferRequired = false;
 
 			StackTraceElement[] elements = Thread.currentThread().getStackTrace();
+
 			for (int i = 0; i < elements.length; i++) {
 				if (elements[i].getClassName().startsWith("paulscode.sound.")) {
 					deferRequired = true;
@@ -75,6 +81,7 @@ class DeferredNioExecutionHandler {
 				return future.get();
 			} catch (ExecutionException e) {
 				Throwable t = e.getCause();
+
 				if (t instanceof IOException) {
 					throw (IOException) t;
 				} else {
@@ -85,6 +92,5 @@ class DeferredNioExecutionHandler {
 			}
 		}
 	}
-
 }
 

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resources/ModNioResourcePack.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resources/ModNioResourcePack.java
@@ -185,6 +185,7 @@ public class ModNioResourcePack extends AbstractFileResourcePack implements ModR
 			}
 
 			Set<String> namespaces = new HashSet<>();
+
 			try (DirectoryStream<Path> stream = Files.newDirectoryStream(typePath, Files::isDirectory)) {
 				for (Path path : stream) {
 					String s = path.getFileName().toString();

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resources/ModResourcePackCreator.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resources/ModResourcePackCreator.java
@@ -16,15 +16,16 @@
 
 package net.fabricmc.fabric.impl.resources;
 
-import net.fabricmc.fabric.api.resource.ModResourcePack;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import net.minecraft.resource.ResourcePack;
 import net.minecraft.resource.ResourcePackContainer;
 import net.minecraft.resource.ResourcePackCreator;
 import net.minecraft.resource.ResourceType;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import net.fabricmc.fabric.api.resource.ModResourcePack;
 
 public class ModResourcePackCreator implements ResourcePackCreator {
 	private final ResourceType type;
@@ -38,13 +39,14 @@ public class ModResourcePackCreator implements ResourcePackCreator {
 		// TODO: "vanilla" does not emit a message; neither should a modded datapack
 		List<ResourcePack> packs = new ArrayList<>();
 		ModResourcePackUtil.appendModResourcePacks(packs, type);
+
 		for (ResourcePack pack : packs) {
 			if (!(pack instanceof ModResourcePack)) {
 				throw new RuntimeException("Not a ModResourcePack!");
 			}
 
 			T var3 = ResourcePackContainer.of("fabric/" + ((ModResourcePack) pack).getFabricModMetadata().getId(),
-				false, () -> pack, factory, ResourcePackContainer.InsertionPosition.TOP);
+					false, () -> pack, factory, ResourcePackContainer.InsertionPosition.TOP);
 
 			if (var3 != null) {
 				map.put(var3.getName(), var3);

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resources/ModResourcePackUtil.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resources/ModResourcePackUtil.java
@@ -16,17 +16,19 @@
 
 package net.fabricmc.fabric.impl.resources;
 
-import com.google.common.base.Charsets;
-import net.fabricmc.loader.api.FabricLoader;
-import net.fabricmc.loader.api.ModContainer;
-import net.fabricmc.loader.api.metadata.ModMetadata;
-import net.minecraft.resource.ResourcePack;
-import net.minecraft.resource.ResourceType;
-import org.apache.commons.io.IOUtils;
-
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.List;
+
+import com.google.common.base.Charsets;
+import org.apache.commons.io.IOUtils;
+
+import net.minecraft.resource.ResourcePack;
+import net.minecraft.resource.ResourceType;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.metadata.ModMetadata;
 
 /**
  * Internal utilities for managing resource packs.
@@ -34,17 +36,17 @@ import java.util.List;
 public final class ModResourcePackUtil {
 	public static final int PACK_FORMAT_VERSION = 4;
 
-	private ModResourcePackUtil() {
-
-	}
+	private ModResourcePackUtil() { }
 
 	public static void appendModResourcePacks(List<ResourcePack> packList, ResourceType type) {
 		for (ModContainer container : FabricLoader.getInstance().getAllMods()) {
-			if(container.getMetadata().getType().equals("builtin")){
+			if (container.getMetadata().getType().equals("builtin")) {
 				continue;
 			}
+
 			Path path = container.getRootPath();
 			ResourcePack pack = new ModNioResourcePack(container.getMetadata(), path, null);
+
 			if (!pack.getNamespaces(type).isEmpty()) {
 				packList.add(pack);
 			}
@@ -57,17 +59,19 @@ public final class ModResourcePackUtil {
 
 	public static InputStream openDefault(ModMetadata info, String filename) {
 		switch (filename) {
-			case "pack.mcmeta":
-				String description = info.getName();
-				if (description == null) {
-					description = "";
-				} else {
-					description = description.replaceAll("\"", "\\\"");
-				}
-				String pack = String.format("{\"pack\":{\"pack_format\":" + PACK_FORMAT_VERSION + ",\"description\":\"%s\"}}", description);
-				return IOUtils.toInputStream(pack, Charsets.UTF_8);
-			default:
-				return null;
+		case "pack.mcmeta":
+			String description = info.getName();
+
+			if (description == null) {
+				description = "";
+			} else {
+				description = description.replaceAll("\"", "\\\"");
+			}
+
+			String pack = String.format("{\"pack\":{\"pack_format\":" + PACK_FORMAT_VERSION + ",\"description\":\"%s\"}}", description);
+			return IOUtils.toInputStream(pack, Charsets.UTF_8);
+		default:
+			return null;
 		}
 	}
 

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resources/ResourceManagerHelperImpl.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resources/ResourceManagerHelperImpl.java
@@ -16,16 +16,24 @@
 
 package net.fabricmc.fabric.impl.resources;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import com.google.common.collect.Lists;
-import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
-import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
-import net.minecraft.resource.ResourceReloadListener;
-import net.minecraft.resource.ResourceType;
-import net.minecraft.util.Identifier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.*;
+import net.minecraft.resource.ResourceReloadListener;
+import net.minecraft.resource.ResourceType;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
+import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 
 public class ResourceManagerHelperImpl implements ResourceManagerHelper {
 	private static final Map<ResourceType, ResourceManagerHelperImpl> registryMap = new HashMap<>();
@@ -40,6 +48,7 @@ public class ResourceManagerHelperImpl implements ResourceManagerHelper {
 
 	public static void sort(ResourceType type, List<ResourceReloadListener> listeners) {
 		ResourceManagerHelperImpl instance = registryMap.get(type);
+
 		if (instance != null) {
 			instance.sort(listeners);
 		}
@@ -56,6 +65,7 @@ public class ResourceManagerHelperImpl implements ResourceManagerHelper {
 
 		List<IdentifiableResourceReloadListener> listenersToAdd = Lists.newArrayList(addedListeners);
 		Set<Identifier> resolvedIds = new HashSet<>();
+
 		for (ResourceReloadListener listener : listeners) {
 			if (listener instanceof IdentifiableResourceReloadListener) {
 				resolvedIds.add(((IdentifiableResourceReloadListener) listener).getFabricId());
@@ -63,12 +73,15 @@ public class ResourceManagerHelperImpl implements ResourceManagerHelper {
 		}
 
 		int lastSize = -1;
+
 		while (listeners.size() != lastSize) {
 			lastSize = listeners.size();
 
 			Iterator<IdentifiableResourceReloadListener> it = listenersToAdd.iterator();
+
 			while (it.hasNext()) {
 				IdentifiableResourceReloadListener listener = it.next();
+
 				if (resolvedIds.containsAll(listener.getFabricDependencies())) {
 					resolvedIds.add(listener.getFabricId());
 					listeners.add(listener);

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resources/MixinDefaultResourcePack.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resources/MixinDefaultResourcePack.java
@@ -16,27 +16,27 @@
 
 package net.fabricmc.fabric.mixin.resources;
 
-import net.minecraft.resource.DefaultResourcePack;
-import net.minecraft.resource.DirectoryResourcePack;
-import net.minecraft.resource.ResourceType;
-import net.minecraft.util.Identifier;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Enumeration;
 
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.resource.DefaultResourcePack;
+import net.minecraft.resource.DirectoryResourcePack;
+import net.minecraft.resource.ResourceType;
+import net.minecraft.util.Identifier;
+
 @Mixin(DefaultResourcePack.class)
 public class MixinDefaultResourcePack {
-
 	@Inject(method = "findInputStream", at = @At("HEAD"), cancellable = true)
 	protected void onFindInputStream(ResourceType resourceType, Identifier identifier, CallbackInfoReturnable<InputStream> callback) {
-		if(DefaultResourcePack.RESOURCE_PATH != null) {
+		if (DefaultResourcePack.RESOURCE_PATH != null) {
 			// Fall through to Vanilla logic, they have a special case here.
 			return;
 		}
@@ -48,11 +48,11 @@ public class MixinDefaultResourcePack {
 			Enumeration<URL> candidates = DefaultResourcePack.class.getClassLoader().getResources(path);
 
 			// Get the last element
-			while(candidates.hasMoreElements()) {
+			while (candidates.hasMoreElements()) {
 				found = candidates.nextElement();
 			}
 
-			if(found == null || !DirectoryResourcePack.isValidPath(new File(found.getFile()), "/" + path)) {
+			if (found == null || !DirectoryResourcePack.isValidPath(new File(found.getFile()), "/" + path)) {
 				// Mimics vanilla behavior
 
 				callback.setReturnValue(null);
@@ -63,7 +63,7 @@ public class MixinDefaultResourcePack {
 		}
 
 		try {
-			if(found != null) {
+			if (found != null) {
 				callback.setReturnValue(found.openStream());
 			}
 		} catch (Exception e) {

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resources/MixinKeyedResourceReloadListener.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resources/MixinKeyedResourceReloadListener.java
@@ -16,8 +16,12 @@
 
 package net.fabricmc.fabric.mixin.resources;
 
-import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
-import net.fabricmc.fabric.api.resource.ResourceReloadListenerKeys;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Locale;
+
+import org.spongepowered.asm.mixin.Mixin;
+
 import net.minecraft.client.font.FontManager;
 import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.client.render.block.BlockRenderManager;
@@ -32,20 +36,18 @@ import net.minecraft.server.function.CommandFunctionManager;
 import net.minecraft.tag.RegistryTagManager;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.loot.LootManager;
-import org.spongepowered.asm.mixin.Mixin;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Locale;
+import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
+import net.fabricmc.fabric.api.resource.ResourceReloadListenerKeys;
 
 public class MixinKeyedResourceReloadListener {
 	@Mixin({
-		/* public */
-		SoundLoader.class, FontManager.class, BakedModelManager.class, LanguageManager.class, TextureManager.class,
-		/* private */
-		WorldRenderer.class, BlockRenderManager.class, ItemRenderer.class
+			/* public */
+			SoundLoader.class, FontManager.class, BakedModelManager.class, LanguageManager.class, TextureManager.class,
+			/* private */
+			WorldRenderer.class, BlockRenderManager.class, ItemRenderer.class
 	})
-	public static abstract class Client implements IdentifiableResourceReloadListener {
+	public abstract static class Client implements IdentifiableResourceReloadListener {
 		private Collection<Identifier> fabric_idDeps;
 		private Identifier fabric_id;
 
@@ -53,7 +55,8 @@ public class MixinKeyedResourceReloadListener {
 		@SuppressWarnings({"ConstantConditions", "RedundantCast"})
 		public Collection<Identifier> getFabricDependencies() {
 			if (fabric_idDeps == null) {
-				Object self = (Object) this;
+				Object self = this;
+
 				if (self instanceof BakedModelManager || self instanceof WorldRenderer) {
 					fabric_idDeps = Collections.singletonList(ResourceReloadListenerKeys.TEXTURES);
 				} else if (self instanceof ItemRenderer || self instanceof BlockRenderManager) {
@@ -70,7 +73,7 @@ public class MixinKeyedResourceReloadListener {
 		@SuppressWarnings({"ConstantConditions", "RedundantCast"})
 		public Identifier getFabricId() {
 			if (fabric_id == null) {
-				Object self = (Object) this;
+				Object self = this;
 
 				if (self instanceof SoundLoader) {
 					fabric_id = ResourceReloadListenerKeys.SOUNDS;
@@ -92,11 +95,11 @@ public class MixinKeyedResourceReloadListener {
 	}
 
 	@Mixin({
-		/* public */
-		RecipeManager.class, ServerAdvancementLoader.class, CommandFunctionManager.class, LootManager.class, RegistryTagManager.class
-		/* private */
+			/* public */
+			RecipeManager.class, ServerAdvancementLoader.class, CommandFunctionManager.class, LootManager.class, RegistryTagManager.class
+			/* private */
 	})
-	public static abstract class Server implements IdentifiableResourceReloadListener {
+	public abstract static class Server implements IdentifiableResourceReloadListener {
 		private Collection<Identifier> fabric_idDeps;
 		private Identifier fabric_id;
 
@@ -104,7 +107,7 @@ public class MixinKeyedResourceReloadListener {
 		@SuppressWarnings({"ConstantConditions", "RedundantCast"})
 		public Collection<Identifier> getFabricDependencies() {
 			if (fabric_idDeps == null) {
-				Object self = (Object) this;
+				Object self = this;
 
 				if (self instanceof RegistryTagManager) {
 					fabric_idDeps = Collections.emptyList();
@@ -120,8 +123,8 @@ public class MixinKeyedResourceReloadListener {
 		@SuppressWarnings({"ConstantConditions", "RedundantCast"})
 		public Identifier getFabricId() {
 			if (fabric_id == null) {
-				Object self = (Object) this;
-				;
+				Object self = this;
+
 				if (self instanceof RecipeManager) {
 					fabric_id = ResourceReloadListenerKeys.RECIPES;
 				} else if (self instanceof ServerAdvancementLoader) {

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resources/MixinMinecraftGame.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resources/MixinMinecraftGame.java
@@ -16,13 +16,10 @@
 
 package net.fabricmc.fabric.mixin.resources;
 
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
 import com.google.common.collect.Lists;
-import net.fabricmc.fabric.impl.resources.ModResourcePackUtil;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.resource.DefaultClientResourcePack;
-import net.minecraft.resource.ReloadableResourceManager;
-import net.minecraft.resource.ResourcePack;
-import net.minecraft.resource.ResourceType;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -31,8 +28,13 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.resource.DefaultClientResourcePack;
+import net.minecraft.resource.ReloadableResourceManager;
+import net.minecraft.resource.ResourcePack;
+import net.minecraft.resource.ResourceType;
+
+import net.fabricmc.fabric.impl.resources.ModResourcePackUtil;
 
 @Mixin(MinecraftClient.class)
 public class MixinMinecraftGame {
@@ -44,6 +46,7 @@ public class MixinMinecraftGame {
 		list.clear();
 
 		boolean appended = false;
+
 		for (int i = 0; i < oldList.size(); i++) {
 			ResourcePack pack = oldList.get(i);
 			list.add(pack);
@@ -56,9 +59,11 @@ public class MixinMinecraftGame {
 
 		if (!appended) {
 			StringBuilder builder = new StringBuilder("Fabric could not find resource pack injection location!");
+
 			for (ResourcePack rp : oldList) {
 				builder.append("\n - ").append(rp.getName()).append(" (").append(rp.getClass().getName()).append(")");
 			}
+
 			throw new RuntimeException(builder.toString());
 		}
 	}

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resources/MixinMinecraftServer.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resources/MixinMinecraftServer.java
@@ -16,19 +16,21 @@
 
 package net.fabricmc.fabric.mixin.resources;
 
-import net.fabricmc.fabric.impl.resources.ModResourcePackCreator;
-import net.minecraft.resource.ResourcePackContainer;
-import net.minecraft.resource.ResourcePackContainerManager;
-import net.minecraft.resource.ResourceType;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.world.level.LevelProperties;
+import java.io.File;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.io.File;
+import net.minecraft.resource.ResourcePackContainer;
+import net.minecraft.resource.ResourcePackContainerManager;
+import net.minecraft.resource.ResourceType;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.level.LevelProperties;
+
+import net.fabricmc.fabric.impl.resources.ModResourcePackCreator;
 
 @Mixin(MinecraftServer.class)
 public class MixinMinecraftServer {

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resources/MixinReloadableResourceManagerImpl.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resources/MixinReloadableResourceManagerImpl.java
@@ -16,19 +16,21 @@
 
 package net.fabricmc.fabric.mixin.resources;
 
-import net.fabricmc.fabric.impl.resources.ResourceManagerHelperImpl;
-import net.minecraft.resource.ReloadableResourceManagerImpl;
-import net.minecraft.resource.ResourceReloadListener;
-import net.minecraft.resource.ResourceType;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
+import net.minecraft.resource.ReloadableResourceManagerImpl;
+import net.minecraft.resource.ResourceReloadListener;
+import net.minecraft.resource.ResourceType;
+
+import net.fabricmc.fabric.impl.resources.ResourceManagerHelperImpl;
 
 @Mixin(ReloadableResourceManagerImpl.class)
 public class MixinReloadableResourceManagerImpl {

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resources/MixinReloadableResourceManagerImplClient.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resources/MixinReloadableResourceManagerImplClient.java
@@ -16,20 +16,22 @@
 
 package net.fabricmc.fabric.mixin.resources;
 
-import net.fabricmc.fabric.impl.resources.ResourceManagerHelperImpl;
-import net.minecraft.resource.ReloadableResourceManagerImpl;
-import net.minecraft.resource.ResourceReloadListener;
-import net.minecraft.resource.ResourceReloadMonitor;
-import net.minecraft.resource.ResourceType;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
+import net.minecraft.resource.ReloadableResourceManagerImpl;
+import net.minecraft.resource.ResourceReloadListener;
+import net.minecraft.resource.ResourceReloadMonitor;
+import net.minecraft.resource.ResourceType;
+
+import net.fabricmc.fabric.impl.resources.ResourceManagerHelperImpl;
 
 @Mixin(ReloadableResourceManagerImpl.class)
 public class MixinReloadableResourceManagerImplClient {

--- a/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/api/tag/TagRegistry.java
+++ b/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/api/tag/TagRegistry.java
@@ -16,25 +16,29 @@
 
 package net.fabricmc.fabric.api.tag;
 
-import net.fabricmc.fabric.impl.tag.TagDelegate;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.function.Supplier;
+
 import net.minecraft.block.Block;
 import net.minecraft.entity.EntityType;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.item.Item;
-import net.minecraft.tag.*;
+import net.minecraft.tag.BlockTags;
+import net.minecraft.tag.EntityTypeTags;
+import net.minecraft.tag.FluidTags;
+import net.minecraft.tag.ItemTags;
+import net.minecraft.tag.Tag;
+import net.minecraft.tag.TagContainer;
 import net.minecraft.util.Identifier;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.util.function.Supplier;
+import net.fabricmc.fabric.impl.tag.TagDelegate;
 
 /**
  * Helper methods for registering Tags.
  */
 public final class TagRegistry {
-	private TagRegistry() {
-
-	}
+	private TagRegistry() { }
 
 	public static <T> Tag<T> create(Identifier id, Supplier<TagContainer<T>> containerSupplier) {
 		return new TagDelegate<T>(id, null) {
@@ -43,6 +47,7 @@ public final class TagRegistry {
 			@Override
 			protected void onAccess() {
 				TagContainer<T> currContainer = containerSupplier.get();
+
 				if (container != currContainer) {
 					container = currContainer;
 					delegate = container.getOrCreate(this.getId());

--- a/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/impl/tag/TagDelegate.java
+++ b/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/impl/tag/TagDelegate.java
@@ -16,10 +16,10 @@
 
 package net.fabricmc.fabric.impl.tag;
 
+import java.util.Collection;
+
 import net.minecraft.tag.Tag;
 import net.minecraft.util.Identifier;
-
-import java.util.Collection;
 
 public class TagDelegate<T> extends Tag<T> {
 	protected Tag<T> delegate;
@@ -29,9 +29,7 @@ public class TagDelegate<T> extends Tag<T> {
 		this.delegate = delegate;
 	}
 
-	protected void onAccess() {
-
-	}
+	protected void onAccess() { }
 
 	@Override
 	public boolean contains(T var1) {

--- a/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/mixin/tag/MixinTag.java
+++ b/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/mixin/tag/MixinTag.java
@@ -16,11 +16,13 @@
 
 package net.fabricmc.fabric.mixin.tag;
 
-import net.fabricmc.fabric.api.tag.FabricTag;
-import net.fabricmc.fabric.impl.tag.FabricTagHooks;
-import net.minecraft.tag.Tag;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
+
+import net.minecraft.tag.Tag;
+
+import net.fabricmc.fabric.api.tag.FabricTag;
+import net.fabricmc.fabric.impl.tag.FabricTagHooks;
 
 @Mixin(Tag.class)
 public class MixinTag<T> implements FabricTag<T>, FabricTagHooks {

--- a/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/mixin/tag/MixinTagBuilder.java
+++ b/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/mixin/tag/MixinTagBuilder.java
@@ -16,11 +16,10 @@
 
 package net.fabricmc.fabric.mixin.tag;
 
+import java.util.Set;
+import java.util.function.Function;
+
 import com.google.gson.JsonObject;
-import net.fabricmc.fabric.api.tag.FabricTagBuilder;
-import net.fabricmc.fabric.impl.tag.FabricTagHooks;
-import net.minecraft.tag.Tag;
-import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -28,8 +27,11 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.Set;
-import java.util.function.Function;
+import net.minecraft.tag.Tag;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.api.tag.FabricTagBuilder;
+import net.fabricmc.fabric.impl.tag.FabricTagHooks;
 
 @Mixin(Tag.Builder.class)
 public class MixinTagBuilder<T> implements FabricTagBuilder<T> {

--- a/fabric-textures-v0/src/main/java/net/fabricmc/fabric/api/client/texture/CustomSpriteLoader.java
+++ b/fabric-textures-v0/src/main/java/net/fabricmc/fabric/api/client/texture/CustomSpriteLoader.java
@@ -16,9 +16,9 @@
 
 package net.fabricmc.fabric.api.client.texture;
 
-import net.minecraft.resource.ResourceManager;
-
 import java.io.IOException;
+
+import net.minecraft.resource.ResourceManager;
 
 /**
  * Implement this interface on a Sprite to use a custom loading process instead

--- a/fabric-textures-v0/src/main/java/net/fabricmc/fabric/api/client/texture/DependentSprite.java
+++ b/fabric-textures-v0/src/main/java/net/fabricmc/fabric/api/client/texture/DependentSprite.java
@@ -16,15 +16,15 @@
 
 package net.fabricmc.fabric.api.client.texture;
 
-import net.minecraft.util.Identifier;
-
 import java.util.Set;
+
+import net.minecraft.util.Identifier;
 
 /**
  * Implement this interface on a Sprite to declare additional dependencies
  * that should be processed prior to this sprite.
- * <p>
- * Best used in conjunction with {@link CustomSpriteLoader}.
+ *
+ * <p>Best used in conjunction with {@link CustomSpriteLoader}.
  */
 public interface DependentSprite {
 	/**

--- a/fabric-textures-v0/src/main/java/net/fabricmc/fabric/api/event/client/ClientSpriteRegistryCallback.java
+++ b/fabric-textures-v0/src/main/java/net/fabricmc/fabric/api/event/client/ClientSpriteRegistryCallback.java
@@ -16,14 +16,15 @@
 
 package net.fabricmc.fabric.api.event.client;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.impl.client.texture.SpriteRegistryCallbackHolder;
+import java.util.Map;
+import java.util.function.Consumer;
+
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.texture.SpriteAtlasTexture;
 import net.minecraft.util.Identifier;
 
-import java.util.Map;
-import java.util.function.Consumer;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.impl.client.texture.SpriteRegistryCallbackHolder;
 
 public interface ClientSpriteRegistryCallback {
 	/**
@@ -31,7 +32,7 @@ public interface ClientSpriteRegistryCallback {
 	 * started making use of multiple sprite atlases, it is unwise to register sprites to *all* of them.
 	 */
 	@Deprecated
-	public static final Event<ClientSpriteRegistryCallback> EVENT = SpriteRegistryCallbackHolder.EVENT_GLOBAL;
+	Event<ClientSpriteRegistryCallback> EVENT = SpriteRegistryCallbackHolder.EVENT_GLOBAL;
 
 	void registerSprites(SpriteAtlasTexture atlasTexture, Registry registry);
 
@@ -55,7 +56,7 @@ public interface ClientSpriteRegistryCallback {
 		event(SpriteAtlasTexture.BLOCK_ATLAS_TEX).register(callback);
 	}
 
-	public static class Registry {
+	class Registry {
 		private final Map<Identifier, Sprite> spriteMap;
 		private final Consumer<Identifier> defaultSpriteRegister;
 

--- a/fabric-textures-v0/src/main/java/net/fabricmc/fabric/impl/client/texture/SpriteRegistryCallbackHolder.java
+++ b/fabric-textures-v0/src/main/java/net/fabricmc/fabric/impl/client/texture/SpriteRegistryCallbackHolder.java
@@ -16,16 +16,17 @@
 
 package net.fabricmc.fabric.impl.client.texture;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
-import net.fabricmc.fabric.api.event.client.ClientSpriteRegistryCallback;
-import net.minecraft.util.Identifier;
-
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.fabricmc.fabric.api.event.client.ClientSpriteRegistryCallback;
 
 public final class SpriteRegistryCallbackHolder {
 	public static final Event<ClientSpriteRegistryCallback> EVENT_GLOBAL = createEvent();
@@ -34,9 +35,7 @@ public final class SpriteRegistryCallbackHolder {
 	private static final Lock eventMapReadLock = eventMapLock.readLock();
 	private static final Lock eventMapWriteLock = eventMapLock.writeLock();
 
-	private SpriteRegistryCallbackHolder() {
-
-	}
+	private SpriteRegistryCallbackHolder() { }
 
 	public static Event<ClientSpriteRegistryCallback> eventLocal(Identifier key) {
 		return eventMap.computeIfAbsent(key, (a) -> createEvent());

--- a/fabric-textures-v0/src/main/java/net/fabricmc/fabric/mixin/client/texture/MixinTextureManager.java
+++ b/fabric-textures-v0/src/main/java/net/fabricmc/fabric/mixin/client/texture/MixinTextureManager.java
@@ -16,14 +16,16 @@
 
 package net.fabricmc.fabric.mixin.client.texture;
 
-import net.fabricmc.fabric.impl.client.texture.SpriteAtlasTextureHooks;
-import net.minecraft.client.texture.Texture;
-import net.minecraft.client.texture.TextureManager;
-import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.client.texture.Texture;
+import net.minecraft.client.texture.TextureManager;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.impl.client.texture.SpriteAtlasTextureHooks;
 
 @Mixin(TextureManager.class)
 public class MixinTextureManager {


### PR DESCRIPTION
This PR adds a checkstyle configuration similar to the existing code, adds it to gradle for automatic verification and modifies the existing code to be compliant.

Most notably the following stylistic choices were nailed down and had broader impact:
- don't indent labels (especially switch-case)
- indent continued lines twice (disambiguates)
- add blank lines before and after block statements if there is no indentation level change
- reorder imports with the following blank like separated groups according to their proximity/dep order: java, javax, (other), net.minecraft, net.fabricmc
- replace wildcard imports with concrete imports

Some modules were converted from spaces to tabs. A lot of JavaDoc had to be fixed.

The existing code has been adjusted manually to avoid changing formatting that wasn't covered. There should be no functional changes, only redundancy removal, whitespace replacing, import reordering and minor JavaDoc editing.

IDE plugins for checkstyle work great and are highly recommended!