### PR TITLE
Registry sync packet compression

### DIFF
--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySerialization.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySerialization.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.registry.sync;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableSet;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.PacketByteBuf;
+import net.minecraft.util.registry.MutableRegistry;
+import net.minecraft.util.registry.Registry;
+
+public class RegistrySerialization {
+	private static final Set<Identifier> REGISTRY_BLACKLIST = ImmutableSet.of();
+	private static final Set<Identifier> REGISTRY_BLACKLIST_NETWORK = ImmutableSet.of();
+
+	private static List<Identifier> getSerializableRegistries(boolean isClientSync) {
+		return Registry.REGISTRIES.stream()
+			.filter(registry -> registry instanceof RemappableRegistry)
+			.map(Registry.REGISTRIES::getId)
+			.filter(registryId -> !REGISTRY_BLACKLIST.contains(registryId))
+			.filter(registryId -> !isClientSync || !REGISTRY_BLACKLIST_NETWORK.contains(registryId))
+			.collect(Collectors.toList());
+	}
+
+	private static <T> CompoundTag writeRegistryToTag(Registry<T> registry) {
+		CompoundTag registryTag = new CompoundTag();
+
+		for (T o : registry) {
+			Identifier id = registry.getId(o);
+			int rawId = registry.getRawId(o);
+
+			registryTag.putInt(id.toString(), rawId);
+		}
+
+		return registryTag;
+	}
+
+	public static CompoundTag toTag(boolean isClientSync) {
+		CompoundTag registriesTag = new CompoundTag();
+
+		for (Identifier registryId : getSerializableRegistries(isClientSync)) {
+			MutableRegistry<?> registry = Registry.REGISTRIES.get(registryId);
+			registriesTag.put(registryId.toString(), writeRegistryToTag(registry));
+		}
+
+		CompoundTag tag = new CompoundTag();
+		tag.putInt("version", 1);
+		tag.put("registries", registriesTag);
+
+		return tag;
+	}
+
+	public static Map<Identifier, Object2IntMap<Identifier>> fromTag(CompoundTag tag) {
+		Map<Identifier, Object2IntMap<Identifier>> result = new HashMap<>();
+		CompoundTag mainTag = tag.getCompound("registries");
+
+		for (String registryKey : mainTag.getKeys()) {
+			CompoundTag registryTag = mainTag.getCompound(registryKey);
+			Identifier registryId = new Identifier(registryKey);
+			MutableRegistry registry = Registry.REGISTRIES.get(registryId);
+
+			if (registry instanceof RemappableRegistry) {
+				Object2IntMap<Identifier> idMap = new Object2IntOpenHashMap<>();
+
+				for (String key : registryTag.getKeys()) {
+					idMap.put(new Identifier(key), registryTag.getInt(key));
+				}
+
+				result.put(registryId, idMap);
+			}
+		}
+
+		return result;
+	}
+
+	private static <T> void writeRegistryToBuf(PacketByteBuf buf, Registry<T> registry) {
+		// Registry entries tend to share namespaces. We therefore group the registry entries by namespace.
+		// This allows us to write the name of each namespace only once.
+		// We can generally assume that the raw IDs of objects within a namespace are dense.
+		Map<String, List<T>> namespaces = registry.stream()
+				.collect(Collectors.groupingBy(o -> registry.getId(o).getNamespace()));
+
+		buf.writeVarInt(namespaces.size());
+
+		for (Map.Entry<String, List<T>> namespaceEntry : namespaces.entrySet()) {
+			String namespace = namespaceEntry.getKey();
+			List<T> objects = namespaceEntry.getValue();
+			// We are going to use differential encoding of the raw IDS. Sort the objects
+			objects.sort(Comparator.comparingInt(registry::getRawId));
+
+			int prevRawId = 0;
+			buf.writeString(namespace);
+			buf.writeVarInt(objects.size());
+
+			for (T object : objects) {
+				Identifier id = registry.getId(object);
+				int rawId = registry.getRawId(object);
+
+				buf.writeString(id.getPath());
+				buf.writeVarInt(rawId - prevRawId);
+				prevRawId = rawId;
+			}
+		}
+	}
+
+	public static void toBuf(PacketByteBuf buf, boolean isClientSync) {
+		List<Identifier> registryIds = getSerializableRegistries(isClientSync);
+
+		buf.writeInt(registryIds.size());
+
+		for (Identifier registryId : registryIds) {
+			MutableRegistry<?> registry = Registry.REGISTRIES.get(registryId);
+			buf.writeIdentifier(registryId);
+			writeRegistryToBuf(buf, registry);
+		}
+	}
+
+	public static Map<Identifier, Object2IntMap<Identifier>> fromBuf(PacketByteBuf buf) {
+		Map<Identifier, Object2IntMap<Identifier>> result = new HashMap<>();
+		int numRegistries = buf.readVarInt();
+
+		for (int i = 0; i < numRegistries; i++) {
+			Identifier registryId = buf.readIdentifier();
+			int numNamespaces = buf.readVarInt();
+			Object2IntMap<Identifier> idMap = new Object2IntOpenHashMap<>();
+
+			for (int j = 0; j < numNamespaces; j++) {
+				String namespace = buf.readString(32767);
+				int numObjects = buf.readInt();
+				int rawId = 0;
+
+				for (int k = 0; k < numObjects; k++) {
+					String path = buf.readString(32767);
+					rawId += buf.readVarInt();
+					idMap.put(new Identifier(namespace, path), rawId);
+				}
+			}
+
+			result.put(registryId, idMap);
+		}
+
+		return result;
+	}
+}


### PR DESCRIPTION
As described in #410, we have a problem with the registry sync packet being too large. Specifically, the NBT compound that contains the whole state that is sent to the client can be too large to deserialize. The registries must be very bloated for this to be a problem, but we have seen that it can happen in certain setups.

This packet is compressible, and compressing it should be beneficial even if the registries aren't excessively large. This reduces the size of the "vanilla" registry sync message by an estimated 45%, and in a specific modded case reduces it by an estimated 40%. It should also avoid the exception described in the issue. However, we will not have backward compatibility until we can actually perform some sort of handshake.

Instead of using NBT, this uses the byte buffer directly, which avoids some overhead both in processing and in raw byte size, and allows some compression tricks to improve it even further.

This proposed solution uses some assumptions about the state of the registries, namely:

1. Registry objects are grouped into a few namespaces where each namespace generally has multiple objects. Generally, each mod places multiple objects into its own one namespace.
2. The raw IDs of objects within a namespace are somewhat densely packed. Generally, mods register objects in bulks under the same namespace, where objects in a bulk are assigned raw IDs in series.

For each registry, registry objects are grouped by namespace so that the namespace string does not have to be re-written for each object in the namespace. The objects within each namespace are written in ascending order of raw IDs. The raw IDs within a group are written with differential encoding using varints.

Note that vanilla will by default compress messages using a Deflater. I have been unable to measure the true compressed size, but I have manually deflated the packets and measured their length which should be equivalent.

| Packet | Raw size (bytes) | Deflated size (bytes) |
| - | ---: | ---: |
| Vanilla 19w44a (Old) | 105805 | 27219 |
| Vanilla 19w44a (New) | 57283 | 15030 |
| Vanilla 19w44a + Painting Mod (Old) | 322399 | 66795 |
| Vanilla 19w44a + Painting Mod (New) | 185099 | 39566 |

It is a bit tricky to measure this with mods when targeting 19w44a, as many mods have not been updated, but I tested with Painting Mod, which is notorious for filling the registries.

Note that the differential encoding doesn't affect the raw byte size that much, but without it, deflate is less effective.