### PR TITLE
Add nonOpaque to FabricBlockSettings

### DIFF
--- a/fabric-object-builders-v0/build.gradle
+++ b/fabric-object-builders-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-object-builders"
-version = getSubprojectVersion(project, "0.1.2")
+version = getSubprojectVersion(project, "0.1.3")
 
 dependencies {
     compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/block/FabricBlockSettings.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/block/FabricBlockSettings.java
@@ -165,6 +165,11 @@ public class FabricBlockSettings {
 		return this;
 	}
 
+	public FabricBlockSettings nonOpaque() {
+		delegate.nonOpaque();
+		return this;
+	}
+
 	public FabricBlockSettings sounds(BlockSoundGroup group) {
 		BlockSettingsExtensions.sounds(delegate, group);
 		return this;


### PR DESCRIPTION
`nonOpaque` is a new method in `Block.Settings` which is used for stuff like glass and ice. The method is public, but it should still be in `FabricBlockSettings` for consistency. 