### PR TITLE
Add 1.14-combat3 snapshot branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ def ENV = System.getenv()
 
 class Globals {
 	static def baseVersion = "0.4.1"
-	static def mcVersion = "1.14.4"
+	static def mcVersion = "1.14_combat-3"
 	static def yarnVersion = "+build.1"
 }
 
@@ -65,6 +65,10 @@ allprojects {
 
 	repositories {
 		mavenLocal()
+	}
+
+	minecraft {
+		customManifest = "https://gist.githubusercontent.com/modmuss50/65e4e44e6840e6b3c3db664e7e85249e/raw/6dabb2b0db1d44a25e8ce38c6d34bd895abc37d4/1.14_combat-3.json"
 	}
 
 	jar {

--- a/fabric-events-interaction-v0/build.gradle
+++ b/fabric-events-interaction-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-events-interaction-v0"
-version = getSubprojectVersion(project, "0.1.2")
+version = getSubprojectVersion(project, "0.1.3")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/MixinServerPlayNetworkHandler.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/MixinServerPlayNetworkHandler.java
@@ -43,7 +43,7 @@ public class MixinServerPlayNetworkHandler {
 		Entity entity = packet.getEntity(world);
 
 		if (entity != null) {
-			EntityHitResult hitResult = new EntityHitResult(entity, packet.getHitPosition().add(entity.x, entity.y, entity.z));
+			EntityHitResult hitResult = new EntityHitResult(entity, packet.getHitPosition().add(entity.x, entity.y, entity.z), 0);
 			ActionResult result = UseEntityCallback.EVENT.invoker().interact(player, world, packet.getHand(), entity, hitResult);
 
 			if (result != ActionResult.PASS) {


### PR DESCRIPTION
Got 1.14_combat-3 snapshot to work; it seems like the only issue was that `EntityHitResult` has a new int parameter. I don't know what the new parameter does-- it seems to be related to the distance between entity A and B, but it's stuck inside a lot of unmapped parameters, so I can't fully figure it out. Regardless, no mod would rely on this parameter (and it's not present in 1.15), so I am simply passing 0 for now.

Not sure where this would go; if you don't want it on the main repo, I can certainly host the branch somewhere else and build a jar for it.

In response to #432.