### PR TITLE
Add methods for setting render layer of multiple objects with one call

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 def ENV = System.getenv()
 
 class Globals {
-	static def baseVersion = "0.4.16"
+	static def baseVersion = "0.4.17"
 	static def mcVersion = "1.15-pre2"
 	static def yarnVersion = "+build.1"
 }

--- a/fabric-blockrenderlayer-v1/build.gradle
+++ b/fabric-blockrenderlayer-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-blockrenderlayer-v1"
-version = getSubprojectVersion(project, "1.1.3")
+version = getSubprojectVersion(project, "1.2.0")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-blockrenderlayer-v1/src/main/java/net/fabricmc/fabric/api/blockrenderlayer/v1/BlockRenderLayerMap.java
+++ b/fabric-blockrenderlayer-v1/src/main/java/net/fabricmc/fabric/api/blockrenderlayer/v1/BlockRenderLayerMap.java
@@ -48,6 +48,15 @@ public interface BlockRenderLayerMap {
 	void putBlock(Block block, RenderLayer renderLayer);
 
 	/**
+	 * Map (or re-map) multiple block states with a render layer.  Re-mapping is not recommended but if done, last one in wins.
+	 * Must be called from client thread prior to world load/rendering. Best practice will be to call from mod's client initializer.
+	 *
+	 * @param renderLayer Render layer.  Should be one of the layers used for terrain rendering.
+	 * @param blocks Identifies blocks to be mapped.
+	 */
+	void putBlocks(RenderLayer renderLayer, Block... blocks);
+
+	/**
 	 * Map (or re-map) a item with a render layer.  Re-mapping is not recommended but if done, last one in wins.
 	 * Must be called from client thread prior to world load/rendering. Best practice will be to call from mod's client initializer.
 	 *
@@ -57,6 +66,15 @@ public interface BlockRenderLayerMap {
 	void putItem(Item item, RenderLayer renderLayer);
 
 	/**
+	 * Map (or re-map) multiple items with a render layer.  Re-mapping is not recommended but if done, last one in wins.
+	 * Must be called from client thread prior to world load/rendering. Best practice will be to call from mod's client initializer.
+	 *
+	 * @param renderLayer Render layer.  Should be one of the layers used for entity rendering.
+	 * @param items Identifies items to be mapped.
+	 */
+	void putItems(RenderLayer renderLayer, Item... items);
+
+	/**
 	 * Map (or re-map) a fluid state with a render layer.  Re-mapping is not recommended but if done, last one in wins.
 	 * Must be called from client thread prior to world load/rendering. Best practice will be to call from mod's client initializer.
 	 *
@@ -64,4 +82,13 @@ public interface BlockRenderLayerMap {
 	 * @param renderLayer Render layer.  Should be one of the layers used for terrain rendering.
 	 */
 	void putFluid(Fluid fluid, RenderLayer renderLayer);
+
+	/**
+	 * Map (or re-map) multiple fluid states with a render layer.  Re-mapping is not recommended but if done, last one in wins.
+	 * Must be called from client thread prior to world load/rendering. Best practice will be to call from mod's client initializer.
+	 *
+	 * @param renderLayer Render layer.  Should be one of the layers used for terrain rendering.
+	 * @param fluids Identifies fluids to be mapped.
+	 */
+	void putFluids(RenderLayer renderLayer, Fluid... fluids);
 }

--- a/fabric-blockrenderlayer-v1/src/main/java/net/fabricmc/fabric/impl/blockrenderlayer/BlockRenderLayerMapImpl.java
+++ b/fabric-blockrenderlayer-v1/src/main/java/net/fabricmc/fabric/impl/blockrenderlayer/BlockRenderLayerMapImpl.java
@@ -39,6 +39,13 @@ public class BlockRenderLayerMapImpl implements BlockRenderLayerMap {
 	}
 
 	@Override
+	public void putBlocks(RenderLayer renderLayer, Block... blocks) {
+		for (Block block : blocks) {
+			putBlock(block, renderLayer);
+		}
+	}
+
+	@Override
 	public void putItem(Item item, RenderLayer renderLayer) {
 		if (item == null) throw new IllegalArgumentException("Request to map null item to BlockRenderLayer");
 		if (renderLayer == null) throw new IllegalArgumentException("Request to map item " + item.toString() + " to null BlockRenderLayer");
@@ -47,11 +54,25 @@ public class BlockRenderLayerMapImpl implements BlockRenderLayerMap {
 	}
 
 	@Override
+	public void putItems(RenderLayer renderLayer, Item... items) {
+		for (Item item : items) {
+			putItem(item, renderLayer);
+		}
+	}
+
+	@Override
 	public void putFluid(Fluid fluid, RenderLayer renderLayer) {
 		if (fluid == null) throw new IllegalArgumentException("Request to map null fluid to BlockRenderLayer");
 		if (renderLayer == null) throw new IllegalArgumentException("Request to map fluid " + fluid.toString() + " to null BlockRenderLayer");
 
 		fluidHandler.accept(fluid, renderLayer);
+	}
+
+	@Override
+	public void putFluids(RenderLayer renderLayer, Fluid... fluids) {
+		for (Fluid fluid : fluids) {
+			putFluid(fluid, renderLayer);
+		}
 	}
 
 	public static final BlockRenderLayerMap INSTANCE = new BlockRenderLayerMapImpl();


### PR DESCRIPTION
Closes #438.

Adds three utility methods to `BlockRenderLayerMap`: `putBlocks`, `putItems` and `putFluids`, which set the render layer of multiple entries with a single call.