### PR TITLE
Adopt checker framework annotations and annotate all current exposed API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ allprojects {
 		minecraft "com.mojang:minecraft:$Globals.mcVersion"
 		mappings "net.fabricmc:yarn:${Globals.mcVersion}${Globals.yarnVersion}:v2"
 		modCompile "net.fabricmc:fabric-loader:0.7.2+build.174"
+		compileOnly "org.checkerframework:checker-qual:3.0.1"
 	}
 
 	configurations {

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
@@ -18,6 +18,8 @@ package net.fabricmc.fabric.api.event;
 
 import java.util.function.Function;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.fabricmc.fabric.impl.base.event.EventFactoryImpl;
 
 /**
@@ -71,7 +73,7 @@ public final class EventFactory {
 	 * @return The Event instance.
 	 */
 	// TODO: Deprecate this once we have working codegen
-	public static <T> Event<T> createArrayBacked(Class<T> type, T emptyInvoker, Function<T[], T> invokerFactory) {
+	public static <T> Event<T> createArrayBacked(Class<? super T> type, @Nullable T emptyInvoker, Function<T[], T> invokerFactory) {
 		return EventFactoryImpl.createArrayBacked(type, emptyInvoker, invokerFactory);
 	}
 

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/package-info.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Event firing utilities provided by the fabric base API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.event;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/util/package-info.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/util/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A few utilities provided by the fabric base API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.util;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/ArrayBackedEvent.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/ArrayBackedEvent.java
@@ -20,15 +20,18 @@ import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.function.Function;
 
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.fabricmc.fabric.api.event.Event;
 
 class ArrayBackedEvent<T> extends Event<T> {
 	private final Class<? super T> type;
 	private final Function<T[], T> invokerFactory;
-	private final T dummyInvoker;
-	private T[] handlers;
+	private final @Nullable T dummyInvoker;
+	private T @MonotonicNonNull[] handlers;
 
-	ArrayBackedEvent(Class<? super T> type, T dummyInvoker, Function<T[], T> invokerFactory) {
+	ArrayBackedEvent(Class<? super T> type, @Nullable T dummyInvoker, Function<T[], T> invokerFactory) {
 		this.type = type;
 		this.dummyInvoker = dummyInvoker;
 		this.invokerFactory = invokerFactory;

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/EventFactoryImpl.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/EventFactoryImpl.java
@@ -27,6 +27,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.fabricmc.fabric.api.event.Event;
 
 public final class EventFactoryImpl {
@@ -42,7 +44,7 @@ public final class EventFactoryImpl {
 		return createArrayBacked(type, null /* buildEmptyInvoker(type, invokerFactory) */, invokerFactory);
 	}
 
-	public static <T> Event<T> createArrayBacked(Class<? super T> type, T emptyInvoker, Function<T[], T> invokerFactory) {
+	public static <T> Event<T> createArrayBacked(Class<? super T> type, @Nullable T emptyInvoker, Function<T[], T> invokerFactory) {
 		ArrayBackedEvent<T> event = new ArrayBackedEvent<>(type, emptyInvoker, invokerFactory);
 		ARRAY_BACKED_EVENTS.add(event);
 		return event;

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/api/biomes/v1/package-info.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/api/biomes/v1/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric biome API v1.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.biomes.v1;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/impl/biome/InternalBiomeData.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/impl/biome/InternalBiomeData.java
@@ -26,6 +26,7 @@ import java.util.Set;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biome;
@@ -50,7 +51,7 @@ public final class InternalBiomeData {
 
 	private static final Set<Biome> SPAWN_BIOMES = new HashSet<>();
 
-	private static Method injectBiomeMethod = null;
+	private static @MonotonicNonNull Method injectBiomeMethod = null;
 
 	public static void addOverworldContinentalBiome(OverworldClimate climate, Biome biome, double weight) {
 		Preconditions.checkArgument(climate != null, "Climate is null");

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/impl/biome/InternalBiomeUtils.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/impl/biome/InternalBiomeUtils.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.IntConsumer;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biome;
@@ -106,7 +108,7 @@ public final class InternalBiomeUtils {
 	 * @param climate The climate in which the biome resides, or null to indicate an unknown climate
 	 * @return The potentially transformed biome
 	 */
-	public static int transformBiome(LayerRandomnessSource random, Biome existing, OverworldClimate climate) {
+	public static int transformBiome(LayerRandomnessSource random, Biome existing, @Nullable OverworldClimate climate) {
 		Map<Biome, VariantTransformer> overworldVariantTransformers = InternalBiomeData.getOverworldVariantTransformers();
 		VariantTransformer transformer = overworldVariantTransformers.get(existing);
 

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/impl/biome/VariantTransformer.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/impl/biome/VariantTransformer.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.layer.util.LayerRandomnessSource;
 
@@ -38,7 +40,7 @@ final class VariantTransformer {
 	 * @param chance the chance of replacement of the biome into the variant
 	 * @param climates the climates that the variant can replace the base biome in, empty/null indicates all climates
 	 */
-	void addBiome(Biome variant, double chance, OverworldClimate[] climates) {
+	void addBiome(Biome variant, double chance, OverworldClimate @Nullable[] climates) {
 		if (climates == null || climates.length == 0) {
 			defaultTransformer.addBiome(variant, chance);
 			climates = OverworldClimate.values();
@@ -56,7 +58,7 @@ final class VariantTransformer {
 	 * @param random the {@link LayerRandomnessSource} from the layer
 	 * @return the transformed biome
 	 */
-	Biome transformBiome(Biome replaced, LayerRandomnessSource random, OverworldClimate climate) {
+	Biome transformBiome(Biome replaced, LayerRandomnessSource random, @Nullable OverworldClimate climate) {
 		if (climate == null) {
 			return defaultTransformer.transformBiome(replaced, random);
 		}

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/mixin/biome/MixinAddHillsLayer.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/mixin/biome/MixinAddHillsLayer.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.mixin.biome;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -59,7 +60,7 @@ public class MixinAddHillsLayer {
 
 		if (rand.nextInt(3) == 0 || processedNoiseSample == 0) {
 			int biomeReturn = Registry.BIOME.getRawId(hillPicker.pickRandom(rand));
-			Biome parent;
+			@Nullable Biome parent;
 
 			if (processedNoiseSample == 0 && biomeReturn != biomeId) {
 				parent = Biome.getModifiedBiome(Registry.BIOME.get(biomeReturn));

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/mixin/biome/MixinAddRiversLayer.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/mixin/biome/MixinAddRiversLayer.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.mixin.biome;
 
 import java.util.Map;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -52,7 +53,7 @@ public class MixinAddRiversLayer {
 		Map<Biome, Biome> overworldRivers = InternalBiomeData.getOverworldRivers();
 
 		if (overworldRivers.containsKey(landBiome) && riverBiomeId == RIVER_ID) {
-			Biome riverBiome = overworldRivers.get(landBiome);
+			@Nullable Biome riverBiome = overworldRivers.get(landBiome);
 			info.setReturnValue(riverBiome == null ? landBiomeId : Registry.BIOME.getRawId(riverBiome));
 		}
 	}

--- a/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/mixin/biome/MixinSetBaseBiomesLayer.java
+++ b/fabric-biomes-v1/src/main/java/net/fabricmc/fabric/mixin/biome/MixinSetBaseBiomesLayer.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.mixin.biome;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
@@ -99,7 +100,7 @@ public class MixinSetBaseBiomesLayer {
 		Biome biome = Registry.BIOME.get(biomeId);
 
 		// Determine what special case this is...
-		OverworldClimate climate;
+		@Nullable OverworldClimate climate;
 
 		if (biomeId == BADLANDS_PLATEAU_ID || biomeId == WOODED_BADLANDS_PLATEAU_ID) {
 			climate = OverworldClimate.DRY;

--- a/fabric-blockrenderlayer-v1/src/main/java/net/fabricmc/fabric/api/blockrenderlayer/v1/package-info.java
+++ b/fabric-blockrenderlayer-v1/src/main/java/net/fabricmc/fabric/api/blockrenderlayer/v1/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric block render layer API v1.
+ *
+ * <p>It provides hooks for easy registration of render layers for blocks, items, and fluids.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.blockrenderlayer.v1;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-commands-v0/src/main/java/net/fabricmc/fabric/api/registry/package-info.java
+++ b/fabric-commands-v0/src/main/java/net/fabricmc/fabric/api/registry/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The registry for commands.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.registry;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-containers-v0/src/main/java/net/fabricmc/fabric/api/client/screen/package-info.java
+++ b/fabric-containers-v0/src/main/java/net/fabricmc/fabric/api/client/screen/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The API for opening container screens based on their states on the client.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.client.screen;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-containers-v0/src/main/java/net/fabricmc/fabric/api/container/package-info.java
+++ b/fabric-containers-v0/src/main/java/net/fabricmc/fabric/api/container/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The API for creating container, or screen states, on the server.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.container;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-containers-v0/src/main/java/net/fabricmc/fabric/impl/client/container/ScreenProviderRegistryImpl.java
+++ b/fabric-containers-v0/src/main/java/net/fabricmc/fabric/impl/client/container/ScreenProviderRegistryImpl.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.ingame.AbstractContainerScreen;
@@ -56,7 +57,7 @@ public class ScreenProviderRegistryImpl implements ScreenProviderRegistry {
 	@Override
 	public <C extends Container> void registerFactory(Identifier identifier, ContainerScreenFactory<C> containerScreenFactory) {
 		registerFactory(identifier, (syncId, identifier1, player, buf) -> {
-			C container = ContainerProviderImpl.INSTANCE.createContainer(syncId, identifier1, player, buf);
+			@Nullable C container = ContainerProviderImpl.INSTANCE.createContainer(syncId, identifier1, player, buf);
 
 			if (container == null) {
 				LOGGER.error("Could not open container for {} - a null object was created!", identifier1.toString());

--- a/fabric-containers-v0/src/main/java/net/fabricmc/fabric/impl/container/ContainerProviderImpl.java
+++ b/fabric-containers-v0/src/main/java/net/fabricmc/fabric/impl/container/ContainerProviderImpl.java
@@ -23,6 +23,7 @@ import java.util.function.Consumer;
 import io.netty.buffer.Unpooled;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.minecraft.client.network.packet.CustomPayloadS2CPacket;
 import net.minecraft.container.Container;
@@ -97,7 +98,7 @@ public class ContainerProviderImpl implements ContainerProviderRegistry {
 		clonedBuf.readIdentifier();
 		clonedBuf.readUnsignedByte();
 
-		Container container = createContainer(syncId, identifier, player, clonedBuf);
+		@Nullable Container container = createContainer(syncId, identifier, player, clonedBuf);
 
 		if (container == null) {
 			return;
@@ -107,7 +108,7 @@ public class ContainerProviderImpl implements ContainerProviderRegistry {
 		player.container.addListener(player);
 	}
 
-	public <C extends Container> C createContainer(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
+	public <C extends Container> @Nullable C createContainer(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
 		ContainerFactory<Container> factory = FACTORIES.get(identifier);
 
 		if (factory == null) {

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/package-info.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric content registries API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.registry;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/util/package-info.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/util/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric content registries API's utilities.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.util;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/FlammableBlockRegistryImpl.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/FlammableBlockRegistryImpl.java
@@ -21,6 +21,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.minecraft.block.Block;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.resource.ResourceType;
@@ -85,7 +87,7 @@ public class FlammableBlockRegistryImpl implements FlammableBlockRegistry, Simpl
 	// User-facing fire registry interface - queries vanilla fire block
 	@Override
 	public Entry get(Block block) {
-		Entry entry = computedEntries.get(block);
+		@Nullable Entry entry = computedEntries.get(block);
 
 		if (entry != null) {
 			return entry;
@@ -94,7 +96,7 @@ public class FlammableBlockRegistryImpl implements FlammableBlockRegistry, Simpl
 		}
 	}
 
-	public Entry getFabric(Block block) {
+	public @Nullable Entry getFabric(Block block) {
 		return computedEntries.get(block);
 	}
 

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/LootEntryTypeRegistryImpl.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/LootEntryTypeRegistryImpl.java
@@ -18,6 +18,8 @@ package net.fabricmc.fabric.impl.content.registry;
 
 import java.lang.reflect.Method;
 
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+
 import net.minecraft.loot.entry.LootEntries;
 import net.minecraft.loot.entry.LootEntry;
 
@@ -29,7 +31,7 @@ public final class LootEntryTypeRegistryImpl implements LootEntryTypeRegistry {
 	private static final Method REGISTER_METHOD;
 
 	static {
-		Method target = null;
+		@MonotonicNonNull Method target = null;
 
 		for (Method m : LootEntries.class.getDeclaredMethods()) {
 			if (m.getParameterCount() == 1 && m.getParameterTypes()[0] == LootEntry.Serializer.class) {

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/package-info.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric content registries API's implementation.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.impl.content.registry;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/mixin/content/registry/MixinFireBlock.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/mixin/content/registry/MixinFireBlock.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.mixin.content.registry;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -53,7 +54,7 @@ public class MixinFireBlock implements FireBlockHooks {
 
 	@Inject(at = @At("HEAD"), method = "getBurnChance", cancellable = true)
 	private void getFabricBurnChance(BlockState block, CallbackInfoReturnable info) {
-		FlammableBlockRegistry.Entry entry = fabric_registry.getFabric(block.getBlock());
+		FlammableBlockRegistry.@Nullable Entry entry = fabric_registry.getFabric(block.getBlock());
 
 		if (entry != null) {
 			// TODO: use a (BlockState -> int) with this as the default impl
@@ -67,7 +68,7 @@ public class MixinFireBlock implements FireBlockHooks {
 
 	@Inject(at = @At("HEAD"), method = "getSpreadChance", cancellable = true)
 	private void getFabricSpreadChance(BlockState block, CallbackInfoReturnable info) {
-		FlammableBlockRegistry.Entry entry = fabric_registry.getFabric(block.getBlock());
+		FlammableBlockRegistry.@Nullable Entry entry = fabric_registry.getFabric(block.getBlock());
 
 		if (entry != null) {
 			// TODO: use a (BlockState -> int) with this as the default impl

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/mixin/content/registry/package-info.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/mixin/content/registry/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The mixins of the fabric content registries API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.mixin.content.registry;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/v1/EntityPlacer.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/v1/EntityPlacer.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.dimension.v1;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.minecraft.block.pattern.BlockPattern;
 import net.minecraft.entity.Entity;
 import net.minecraft.server.world.ServerWorld;
@@ -43,6 +45,5 @@ public interface EntityPlacer {
 	 * @return a teleportation target, or {@code null} to fall back to further handling
 	 * @apiNote When this method is called, the entity's world is its source dimension.
 	 */
-	/* @Nullable */
-	BlockPattern.TeleportTarget placeEntity(Entity teleported, ServerWorld destination, Direction portalDir, double horizontalOffset, double verticalOffset);
+	BlockPattern.@Nullable TeleportTarget placeEntity(Entity teleported, ServerWorld destination, Direction portalDir, double horizontalOffset, double verticalOffset);
 }

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/v1/FabricDimensionType.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/v1/FabricDimensionType.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.api.dimension.v1;
 import java.util.function.BiFunction;
 
 import com.google.common.base.Preconditions;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.server.world.ServerWorld;
@@ -118,8 +119,8 @@ public final class FabricDimensionType extends DimensionType {
 	 * @see FabricDimensionType#builder()
 	 */
 	public static final class Builder {
-		private EntityPlacer defaultPlacer;
-		private BiFunction<World, DimensionType, ? extends Dimension> factory;
+		private @MonotonicNonNull EntityPlacer defaultPlacer;
+		private @MonotonicNonNull BiFunction<World, DimensionType, ? extends Dimension> factory;
 		private int desiredRawId = 0;
 		private boolean skyLight = true;
 		private BiomeAccessType biomeAccessStrategy = VoronoiBiomeAccessType.INSTANCE;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/v1/FabricDimensions.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/v1/FabricDimensions.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.api.dimension.v1;
 
 import com.google.common.base.Preconditions;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.world.dimension.DimensionType;
@@ -85,7 +86,7 @@ public final class FabricDimensions {
 	 * @throws IllegalStateException if this method is called on a client entity
 	 * @apiNote this method must be called from the main server thread
 	 */
-	public static <E extends Entity> E teleport(E teleported, DimensionType destination, /*Nullable*/ EntityPlacer customPlacer) {
+	public static <E extends Entity> E teleport(E teleported, DimensionType destination, @Nullable EntityPlacer customPlacer) {
 		Preconditions.checkState(!teleported.world.isClient, "Entities can only be teleported on the server side");
 
 		return FabricDimensionInternals.changeDimension(teleported, destination, customPlacer);

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/v1/package-info.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/v1/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric dimensions API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.dimension.v1;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionClientInit.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionClientInit.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.impl.dimension;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
@@ -36,7 +37,7 @@ public final class FabricDimensionClientInit {
 
 	public static void onClientInit() {
 		ClientSidePacketRegistry.INSTANCE.register(DimensionIdsFixer.ID, (ctx, buf) -> {
-			CompoundTag compound = buf.readCompoundTag();
+			@Nullable CompoundTag compound = buf.readCompoundTag();
 
 			ctx.getTaskQueue().execute(() -> {
 				if (compound == null) {

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionInternals.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionInternals.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.impl.dimension;
 import com.google.common.base.Preconditions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.minecraft.block.pattern.BlockPattern;
 import net.minecraft.entity.Entity;
@@ -46,7 +47,7 @@ public final class FabricDimensionInternals {
 	/**
 	 * The custom placement logic passed from {@link FabricDimensions#teleport(Entity, DimensionType, EntityPlacer)}.
 	 */
-	private static EntityPlacer customPlacement;
+	private static @Nullable EntityPlacer customPlacement;
 
 	/*
 	 * The dimension change hooks consist of two steps:
@@ -77,8 +78,7 @@ public final class FabricDimensionInternals {
 		}
 	}
 
-	/* Nullable */
-	public static BlockPattern.TeleportTarget tryFindPlacement(ServerWorld destination, Direction portalDir, double portalX, double portalY) {
+	public static BlockPattern.@Nullable TeleportTarget tryFindPlacement(ServerWorld destination, Direction portalDir, double portalX, double portalY) {
 		Preconditions.checkNotNull(destination);
 		Entity teleported = PORTAL_ENTITY.get();
 		PORTAL_ENTITY.set(null);
@@ -89,10 +89,10 @@ public final class FabricDimensionInternals {
 		}
 
 		// Custom placement logic, falls back to default dimension placement if no placement or target found
-		EntityPlacer customPlacement = FabricDimensionInternals.customPlacement;
+		@Nullable EntityPlacer customPlacement = FabricDimensionInternals.customPlacement;
 
 		if (customPlacement != null) {
-			BlockPattern.TeleportTarget customTarget = customPlacement.placeEntity(teleported, destination, portalDir, portalX, portalY);
+			BlockPattern.@Nullable TeleportTarget customTarget = customPlacement.placeEntity(teleported, destination, portalDir, portalX, portalY);
 
 			if (customTarget != null) {
 				return customTarget;
@@ -103,7 +103,7 @@ public final class FabricDimensionInternals {
 		DimensionType dimType = destination.getDimension().getType();
 
 		if (dimType instanceof FabricDimensionType) {
-			BlockPattern.TeleportTarget defaultTarget = ((FabricDimensionType) dimType).getDefaultPlacement().placeEntity(teleported, destination, portalDir, portalX, portalY);
+			BlockPattern.@Nullable TeleportTarget defaultTarget = ((FabricDimensionType) dimType).getDefaultPlacement().placeEntity(teleported, destination, portalDir, portalX, portalY);
 
 			if (defaultTarget == null) {
 				throw new IllegalStateException("Mod dimension " + DimensionType.getId(dimType) + " returned an invalid teleport target");

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/dimension/idremap/package-info.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/dimension/idremap/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The dimension id remapping mixins for the fabric dimensions API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.mixin.dimension.idremap;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/block/package-info.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/block/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric block interaction hooks.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.block;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/entity/package-info.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/entity/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric entity interaction hooks.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.entity;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/client/player/package-info.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/client/player/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric client player interaction events.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.event.client.player;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/AttackEntityCallback.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/AttackEntityCallback.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.event.player;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.ActionResult;
@@ -50,5 +52,5 @@ public interface AttackEntityCallback {
 			}
 	);
 
-	ActionResult interact(PlayerEntity player, World world, Hand hand, Entity entity, /* Nullable */ EntityHitResult hitResult);
+	ActionResult interact(PlayerEntity player, World world, Hand hand, Entity entity, @Nullable EntityHitResult hitResult);
 }

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/UseEntityCallback.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/UseEntityCallback.java
@@ -50,5 +50,5 @@ public interface UseEntityCallback {
 			}
 	);
 
-	ActionResult interact(PlayerEntity player, World world, Hand hand, Entity entity, /* Nullable */ EntityHitResult hitResult);
+	ActionResult interact(PlayerEntity player, World world, Hand hand, Entity entity, EntityHitResult hitResult);
 }

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/package-info.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric player interaction events.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.event.player;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/MixinServerPlayNetworkHandler.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/MixinServerPlayNetworkHandler.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.mixin.event.interaction;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -40,7 +41,7 @@ public class MixinServerPlayNetworkHandler {
 	@Inject(method = "onPlayerInteractEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;interactAt(Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/math/Vec3d;Lnet/minecraft/util/Hand;)Lnet/minecraft/util/ActionResult;"), cancellable = true)
 	public void onPlayerInteractEntity(PlayerInteractEntityC2SPacket packet, CallbackInfo info) {
 		World world = player.getEntityWorld();
-		Entity entity = packet.getEntity(world);
+		@Nullable Entity entity = packet.getEntity(world);
 
 		if (entity != null) {
 			EntityHitResult hitResult = new EntityHitResult(entity, packet.getHitPosition().add(entity.getX(), entity.getY(), entity.getZ()));

--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/client/package-info.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/client/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric client lifecycle events.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.event.client;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/server/package-info.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/server/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric server lifecycle events.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.event.server;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/world/package-info.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/world/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric world lifecycle events.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.event.world;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/api/client/itemgroup/FabricItemGroupBuilder.java
+++ b/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/api/client/itemgroup/FabricItemGroupBuilder.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.DefaultedList;
@@ -30,7 +32,7 @@ import net.fabricmc.fabric.impl.item.group.ItemGroupExtensions;
 public final class FabricItemGroupBuilder {
 	private Identifier identifier;
 	private Supplier<ItemStack> stackSupplier = () -> ItemStack.EMPTY;
-	private Consumer<List<ItemStack>> stacksForDisplay;
+	private @Nullable Consumer<List<ItemStack>> stacksForDisplay;
 
 	private FabricItemGroupBuilder(Identifier identifier) {
 		this.identifier = identifier;
@@ -75,7 +77,7 @@ public final class FabricItemGroupBuilder {
 	 * @param stacksForDisplay Add ItemStack's to this list to show in the ItemGroup
 	 * @return a reference to the FabricItemGroupBuilder
 	 */
-	public FabricItemGroupBuilder appendItems(Consumer<List<ItemStack>> stacksForDisplay) {
+	public FabricItemGroupBuilder appendItems(@Nullable Consumer<List<ItemStack>> stacksForDisplay) {
 		this.stacksForDisplay = stacksForDisplay;
 		return this;
 	}

--- a/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/api/client/itemgroup/package-info.java
+++ b/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/api/client/itemgroup/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric item groups API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.client.itemgroup;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/package-info.java
+++ b/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/api/client/keybinding/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric keybindings API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.client.keybinding;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
+++ b/fabric-keybindings-v0/src/main/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import net.minecraft.client.options.KeyBinding;
 
@@ -34,7 +35,7 @@ public class KeyBindingRegistryImpl implements KeyBindingRegistry {
 	public static final KeyBindingRegistryImpl INSTANCE = new KeyBindingRegistryImpl();
 	private static final Logger LOGGER = LogManager.getLogger();
 
-	private Map<String, Integer> cachedCategoryMap;
+	private @MonotonicNonNull Map<String, Integer> cachedCategoryMap;
 	private List<FabricKeyBinding> fabricKeyBindingList;
 
 	private KeyBindingRegistryImpl() {

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/event/package-info.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/event/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The events for the fabric loot tables API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.loot.v1.event;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/package-info.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric loot tables API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.loot.v1;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/impl/loot/table/LootEntryTypeRegistryImpl.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/impl/loot/table/LootEntryTypeRegistryImpl.java
@@ -18,6 +18,8 @@ package net.fabricmc.fabric.impl.loot.table;
 
 import java.lang.reflect.Method;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.minecraft.loot.entry.LootEntries;
 import net.minecraft.loot.entry.LootEntry;
 
@@ -26,7 +28,7 @@ public final class LootEntryTypeRegistryImpl implements net.fabricmc.fabric.api.
 	private static final Method REGISTER_METHOD;
 
 	static {
-		Method target = null;
+		@Nullable Method target = null;
 
 		for (Method m : LootEntries.class.getDeclaredMethods()) {
 			if (m.getParameterCount() == 1 && m.getParameterTypes()[0] == LootEntry.Serializer.class) {

--- a/fabric-mining-levels-v0/src/main/java/net/fabricmc/fabric/api/tools/package-info.java
+++ b/fabric-mining-levels-v0/src/main/java/net/fabricmc/fabric/api/tools/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The tool utilties for the fabric mining levels API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.tools;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/ModelResourceProvider.java
+++ b/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/ModelResourceProvider.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.client.model;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.minecraft.client.render.model.UnbakedModel;
 import net.minecraft.util.Identifier;
 
@@ -46,5 +48,5 @@ public interface ModelResourceProvider {
 	 * @return The loaded UnbakedModel, or null if this ModelResourceProvider doesn't handle a specific Identifier
 	 * (or if there was no error!).
 	 */
-	/* @Nullable */ UnbakedModel loadModelResource(Identifier resourceId, ModelProviderContext context) throws ModelProviderException;
+	@Nullable UnbakedModel loadModelResource(Identifier resourceId, ModelProviderContext context) throws ModelProviderException;
 }

--- a/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/ModelVariantProvider.java
+++ b/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/ModelVariantProvider.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.client.model;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.minecraft.client.render.model.UnbakedModel;
 import net.minecraft.client.util.ModelIdentifier;
 
@@ -43,5 +45,5 @@ public interface ModelVariantProvider {
 	 * @return The loaded UnbakedModel, or null if this ModelVariantProvider doesn't handle a specific Identifier
 	 * (or if there was no error!).
 	 */
-	/* @Nullable */ UnbakedModel loadModelVariant(ModelIdentifier modelId, ModelProviderContext context) throws ModelProviderException;
+	@Nullable UnbakedModel loadModelVariant(ModelIdentifier modelId, ModelProviderContext context) throws ModelProviderException;
 }

--- a/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/package-info.java
+++ b/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric models API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.client.model;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-models-v0/src/main/java/net/fabricmc/fabric/mixin/client/model/MixinModelLoader.java
+++ b/fabric-models-v0/src/main/java/net/fabricmc/fabric/mixin/client/model/MixinModelLoader.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.mixin.client.model;
 import java.util.Map;
 import java.util.Set;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -59,7 +60,7 @@ public class MixinModelLoader implements ModelLoaderHooks {
 
 	@Inject(at = @At("HEAD"), method = "loadModel", cancellable = true)
 	private void loadModelHook(Identifier id, CallbackInfo ci) {
-		UnbakedModel customModel = fabric_mlrLoaderInstance.loadModelFromVariant(id);
+		@Nullable UnbakedModel customModel = fabric_mlrLoaderInstance.loadModelFromVariant(id);
 
 		if (customModel != null) {
 			putModel(id, customModel);

--- a/fabric-networking-blockentity-v0/src/main/java/net/fabricmc/fabric/api/block/entity/package-info.java
+++ b/fabric-networking-blockentity-v0/src/main/java/net/fabricmc/fabric/api/block/entity/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric block entity networking API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.block.entity;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/event/network/package-info.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/event/network/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The events for the fabric networking API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.event.network;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/network/ClientSidePacketRegistry.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/network/ClientSidePacketRegistry.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.api.network;
 
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.minecraft.network.Packet;
 import net.minecraft.util.Identifier;
@@ -52,7 +53,7 @@ public interface ClientSidePacketRegistry extends PacketRegistry {
 	 * @param completionListener Completion listener. Can be used to check for
 	 *                           the success or failure of sending a given packet, among others.
 	 */
-	void sendToServer(Packet<?> packet, GenericFutureListener<? extends Future<? super Void>> completionListener);
+	void sendToServer(Packet<?> packet, @Nullable GenericFutureListener<? extends Future<? super Void>> completionListener);
 
 	/**
 	 * Send an identifier/buffer-based packet to the server.
@@ -62,7 +63,7 @@ public interface ClientSidePacketRegistry extends PacketRegistry {
 	 * @param completionListener Completion listener. Can be used to check for
 	 *                           the success or failure of sending a given packet, among others.
 	 */
-	default void sendToServer(Identifier id, PacketByteBuf buf, GenericFutureListener<? extends Future<? super Void>> completionListener) {
+	default void sendToServer(Identifier id, PacketByteBuf buf, @Nullable GenericFutureListener<? extends Future<? super Void>> completionListener) {
 		sendToServer(toPacket(id, buf), completionListener);
 	}
 

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/network/ServerSidePacketRegistry.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/network/ServerSidePacketRegistry.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.api.network;
 
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.Packet;
@@ -57,7 +58,7 @@ public interface ServerSidePacketRegistry extends PacketRegistry {
 	 * @param completionListener Completion listener. Can be used to check for
 	 *                           the success or failure of sending a given packet, among others.
 	 */
-	void sendToPlayer(PlayerEntity player, Packet<?> packet, GenericFutureListener<? extends Future<? super Void>> completionListener);
+	void sendToPlayer(PlayerEntity player, Packet<?> packet, @Nullable GenericFutureListener<? extends Future<? super Void>> completionListener);
 
 	/**
 	 * Send an identifier/buffer-based packet to a given client.
@@ -68,7 +69,7 @@ public interface ServerSidePacketRegistry extends PacketRegistry {
 	 * @param completionListener Completion listener. Can be used to check for
 	 *                           the success or failure of sending a given packet, among others.
 	 */
-	default void sendToPlayer(PlayerEntity player, Identifier id, PacketByteBuf buf, GenericFutureListener<? extends Future<? super Void>> completionListener) {
+	default void sendToPlayer(PlayerEntity player, Identifier id, PacketByteBuf buf, @Nullable GenericFutureListener<? extends Future<? super Void>> completionListener) {
 		sendToPlayer(player, toPacket(id, buf), completionListener);
 	}
 

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/network/package-info.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/network/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric networking API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.network;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/server/package-info.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/server/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The server-side utilities for the fabric networking API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.server;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/block/FabricBlockSettings.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/block/FabricBlockSettings.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.Material;
 import net.minecraft.block.MaterialColor;
@@ -53,7 +55,7 @@ public class FabricBlockSettings {
 
 	static final class ExtraData {
 		private final List<MiningLevel> miningLevels = new ArrayList<>();
-		/* @Nullable */ private Boolean breakByHand;
+		private @MonotonicNonNull Boolean breakByHand;
 
 		private ExtraData(Block.Settings settings) {
 		}

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/block/package-info.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/block/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric block component builders.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.block;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/entity/package-info.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/entity/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric entity component builders.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.entity;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/event/registry/package-info.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/event/registry/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric events for building objects.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.event.registry;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/api/client/particle/v1/package-info.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/api/client/particle/v1/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The client component of the fabric particles API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.client.particle.v1;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/api/particle/v1/package-info.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/api/particle/v1/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric particles API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.particle.v1;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/impl/client/particle/FabricParticleManager.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/impl/client/particle/FabricParticleManager.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import com.google.common.collect.ImmutableList;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.minecraft.client.particle.ParticleTextureData;
 import net.minecraft.client.texture.Sprite;
@@ -92,8 +93,7 @@ public final class FabricParticleManager {
 	private final class FabricSpriteProviderImpl implements FabricSpriteProvider {
 		private List<Identifier> spriteIds;
 
-		// @Nullable
-		private List<Sprite> sprites;
+		private @Nullable List<Sprite> sprites;
 
 		@Override
 		public Sprite getSprite(int min, int max) {

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/package-info.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The events for the fabric registry sync API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.event.registry;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/material/BlendMode.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/material/BlendMode.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.renderer.v1.material;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.minecraft.client.render.RenderLayer;
 
 /**
@@ -50,9 +52,9 @@ public enum BlendMode {
 	 */
 	TRANSLUCENT(RenderLayer.getTranslucent());
 
-	public final RenderLayer blockRenderLayer;
+	public final @Nullable RenderLayer blockRenderLayer;
 
-	BlendMode(RenderLayer blockRenderLayer) {
+	BlendMode(@Nullable RenderLayer blockRenderLayer) {
 		this.blockRenderLayer = blockRenderLayer;
 	}
 

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/material/package-info.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/material/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The material hooks for the fabric rendering API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.renderer.v1.material;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.renderer.v1.mesh;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.minecraft.client.render.model.BakedQuad;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.util.math.Vector3f;
@@ -115,7 +117,7 @@ public interface MutableQuadView extends QuadView {
 	 * is computed based on face geometry and must be non-null in vanilla quads.
 	 * That computed value is returned by {@link #lightFace()}.
 	 */
-	MutableQuadView cullFace(Direction face);
+	MutableQuadView cullFace(@Nullable Direction face);
 
 	/**
 	 * Provides a hint to renderer about the facing of this quad. Not required,
@@ -130,7 +132,7 @@ public interface MutableQuadView extends QuadView {
 	 * @note This value is not persisted independently when the quad is encoded.
 	 * When reading encoded quads, this value will always be the same as {@link #lightFace()}.
 	 */
-	MutableQuadView nominalFace(Direction face);
+	MutableQuadView nominalFace(@Nullable Direction face);
 
 	/**
 	 * Value functions identically to {@link BakedQuad#getColorIndex()} and is

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.renderer.v1.mesh;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.util.math.Direction;
@@ -40,10 +42,10 @@ public interface QuadEmitter extends MutableQuadView {
 	QuadEmitter material(RenderMaterial material);
 
 	@Override
-	QuadEmitter cullFace(Direction face);
+	QuadEmitter cullFace(@Nullable Direction face);
 
 	@Override
-	QuadEmitter nominalFace(Direction face);
+	QuadEmitter nominalFace(@Nullable Direction face);
 
 	@Override
 	QuadEmitter colorIndex(int colorIndex);

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadView.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadView.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.renderer.v1.mesh;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.minecraft.client.render.VertexFormats;
 import net.minecraft.client.render.model.BakedQuad;
 import net.minecraft.client.texture.Sprite;
@@ -85,12 +87,12 @@ public interface QuadView {
 	 *
 	 * @see MutableQuadView#cullFace(Direction)
 	 */
-	Direction cullFace();
+	@Nullable Direction cullFace();
 
 	/**
 	 * See {@link MutableQuadView#nominalFace(Direction)}.
 	 */
-	Direction nominalFace();
+	@Nullable Direction nominalFace();
 
 	/**
 	 * Normal of the quad as implied by geometry. Will be invalid

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/package-info.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The mesh hooks for the fabric rendering API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.renderer.v1.mesh;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/model/ForwardingBakedModel.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/model/ForwardingBakedModel.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Random;
 import java.util.function.Supplier;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.minecraft.block.BlockState;
 import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.client.render.model.BakedQuad;
@@ -58,7 +60,7 @@ public abstract class ForwardingBakedModel implements BakedModel, FabricBakedMod
 	}
 
 	@Override
-	public List<BakedQuad> getQuads(BlockState blockState, Direction face, Random rand) {
+	public List<BakedQuad> getQuads(@Nullable BlockState blockState, @Nullable Direction face, Random rand) {
 		return wrapped.getQuads(blockState, face, rand);
 	}
 

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/model/ModelHelper.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/model/ModelHelper.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.model.BakedQuad;
@@ -45,7 +46,7 @@ public abstract class ModelHelper {
 	 * Null is returned as {@link #NULL_FACE_ID}.
 	 * Use {@link #faceFromIndex(int)} to retrieve encoded face.
 	 */
-	public static int toFaceIndex(Direction face) {
+	public static int toFaceIndex(@Nullable Direction face) {
 		return face == null ? NULL_FACE_ID : face.getId();
 	}
 
@@ -56,12 +57,12 @@ public abstract class ModelHelper {
 	 * optionally including the null face. (Use &lt; or  &lt;= {@link #NULL_FACE_ID}
 	 * to exclude or include the null value, respectively.)
 	 */
-	public static Direction faceFromIndex(int faceIndex) {
+	public static @Nullable Direction faceFromIndex(int faceIndex) {
 		return FACES[faceIndex];
 	}
 
 	/** @see #faceFromIndex(int) */
-	private static final Direction[] FACES = Arrays.copyOf(Direction.values(), 7);
+	private static final @Nullable Direction[] FACES = Arrays.copyOf(Direction.values(), 7);
 
 	/**
 	 * Converts a mesh into an array of lists of vanilla baked quads.
@@ -86,7 +87,7 @@ public abstract class ModelHelper {
 				final int limit = q.material().spriteDepth();
 
 				for (int l = 0; l < limit; l++) {
-					Direction face = q.cullFace();
+					@Nullable Direction face = q.cullFace();
 					builders[face == null ? 6 : face.getId()].add(q.toBakedQuad(l, finder.find(q, l), false));
 				}
 			});

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/model/package-info.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/model/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The model hooks for the fabric rendering API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.renderer.v1.model;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/package-info.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The events for the fabric renderer API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.renderer.v1;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/render/package-info.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/render/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The render hooks for the fabric rendering API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.renderer.v1.render;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
@@ -30,6 +30,7 @@ import static net.fabricmc.fabric.impl.client.indigo.renderer.mesh.EncodingForma
 import static net.fabricmc.fabric.impl.client.indigo.renderer.mesh.EncodingFormat.VERTEX_X;
 
 import com.google.common.base.Preconditions;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.util.math.Direction;
@@ -77,7 +78,7 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 	}
 
 	@Override
-	public final MutableQuadViewImpl cullFace(Direction face) {
+	public final MutableQuadViewImpl cullFace(@Nullable Direction face) {
 		data[baseIndex + HEADER_BITS] = EncodingFormat.cullFace(data[baseIndex + HEADER_BITS], face);
 		nominalFace(face);
 		return this;
@@ -91,7 +92,7 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 	}
 
 	@Override
-	public final MutableQuadViewImpl nominalFace(Direction face) {
+	public final MutableQuadViewImpl nominalFace(@Nullable Direction face) {
 		nominalFace = face;
 		return this;
 	}

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/QuadViewImpl.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/QuadViewImpl.java
@@ -32,6 +32,7 @@ import static net.fabricmc.fabric.impl.client.indigo.renderer.mesh.EncodingForma
 import static net.fabricmc.fabric.impl.client.indigo.renderer.mesh.EncodingFormat.VERTEX_Z;
 
 import com.google.common.base.Preconditions;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.util.math.Direction;
@@ -47,7 +48,7 @@ import net.fabricmc.fabric.impl.client.indigo.renderer.helper.NormalHelper;
  * of maintaining and encoding the quad state.
  */
 public class QuadViewImpl implements QuadView {
-	protected Direction nominalFace;
+	protected @Nullable Direction nominalFace;
 	protected boolean isGeometryInvalid = true;
 	protected final Vector3f faceNormal = new Vector3f();
 	protected boolean isFaceNormalInvalid = true;

--- a/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/api/client/rendereregistry/v1/package-info.java
+++ b/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/api/client/rendereregistry/v1/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric renderer registries API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.client.rendereregistry.v1;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-rendering-data-attachment-v1/src/main/java/net/fabricmc/fabric/api/rendering/data/v1/RenderAttachedBlockView.java
+++ b/fabric-rendering-data-attachment-v1/src/main/java/net/fabricmc/fabric/api/rendering/data/v1/RenderAttachedBlockView.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.rendering.data.v1;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockRenderView;
@@ -58,8 +60,8 @@ public interface RenderAttachedBlockView extends BlockRenderView {
 	 *
 	 * @param pos Position of the block for the block model.
 	 */
-	default Object getBlockEntityRenderAttachment(BlockPos pos) {
-		BlockEntity be = ((BlockRenderView) this).getBlockEntity(pos);
+	default @Nullable Object getBlockEntityRenderAttachment(BlockPos pos) {
+		@Nullable BlockEntity be = ((BlockRenderView) this).getBlockEntity(pos);
 		return be == null ? null : ((RenderAttachmentBlockEntity) be).getRenderAttachmentData();
 	}
 }

--- a/fabric-rendering-data-attachment-v1/src/main/java/net/fabricmc/fabric/api/rendering/data/v1/RenderAttachmentBlockEntity.java
+++ b/fabric-rendering-data-attachment-v1/src/main/java/net/fabricmc/fabric/api/rendering/data/v1/RenderAttachmentBlockEntity.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.rendering.data.v1;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.minecraft.block.entity.BlockEntity;
 
 /**
@@ -35,5 +37,5 @@ public interface RenderAttachmentBlockEntity {
 	/**
 	 * @return The model state data provided by this block entity. Can be null.
 	 */
-	Object getRenderAttachmentData();
+	@Nullable Object getRenderAttachmentData();
 }

--- a/fabric-rendering-data-attachment-v1/src/main/java/net/fabricmc/fabric/api/rendering/data/v1/package-info.java
+++ b/fabric-rendering-data-attachment-v1/src/main/java/net/fabricmc/fabric/api/rendering/data/v1/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric rendering data attachment API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.rendering.data.v1;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-rendering-fluids-v1/src/main/java/net/fabricmc/fabric/api/client/render/fluid/v1/FluidRenderHandler.java
+++ b/fabric-rendering-fluids-v1/src/main/java/net/fabricmc/fabric/api/client/render/fluid/v1/FluidRenderHandler.java
@@ -16,6 +16,9 @@
 
 package net.fabricmc.fabric.api.client.render.fluid.v1;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.common.value.qual.ArrayLen;
+
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.util.math.BlockPos;
@@ -38,7 +41,7 @@ public interface FluidRenderHandler {
 	 * @return An array of size two: the first entry contains the "still" sprite,
 	 * while the second entry contains the "flowing" sprite.
 	 */
-	Sprite[] getFluidSprites(/* Nullable */ BlockRenderView view, /* Nullable */ BlockPos pos, FluidState state);
+	Sprite @ArrayLen(2)[] getFluidSprites(@Nullable BlockRenderView view, @Nullable BlockPos pos, FluidState state);
 
 	/**
 	 * Get the tint color for a fluid being rendered at a given position.
@@ -51,7 +54,7 @@ public interface FluidRenderHandler {
 	 * @param state The current state of the fluid.
 	 * @return The tint color of the fluid.
 	 */
-	default int getFluidColor(BlockRenderView view, BlockPos pos, FluidState state) {
+	default int getFluidColor(@Nullable BlockRenderView view, @Nullable BlockPos pos, FluidState state) {
 		return -1;
 	}
 }

--- a/fabric-rendering-fluids-v1/src/main/java/net/fabricmc/fabric/api/client/render/fluid/v1/package-info.java
+++ b/fabric-rendering-fluids-v1/src/main/java/net/fabricmc/fabric/api/client/render/fluid/v1/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric fluid rendering API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.client.render.fluid.v1;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/api/client/render/ColorProviderRegistry.java
+++ b/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/api/client/render/ColorProviderRegistry.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.client.render;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.minecraft.block.Block;
 import net.minecraft.client.color.block.BlockColorProvider;
 import net.minecraft.client.color.item.ItemColorProvider;
@@ -45,5 +47,5 @@ public interface ColorProviderRegistry<T, Provider> {
 	 * @param object The object to acquire the provide for.
 	 * @return The registered mapper for this provider, or {@code null} if none is registered or available.
 	 */
-	Provider get(T object);
+	@Nullable Provider get(T object);
 }

--- a/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/api/client/render/package-info.java
+++ b/fabric-rendering-v0/src/main/java/net/fabricmc/fabric/api/client/render/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric rendering API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.client.render;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/package-info.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric resouce API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.resource;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/api/tag/package-info.java
+++ b/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/api/tag/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric tag extensions.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.tag;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-textures-v0/src/main/java/net/fabricmc/fabric/api/client/texture/package-info.java
+++ b/fabric-textures-v0/src/main/java/net/fabricmc/fabric/api/client/texture/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The fabric textures API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.client.texture;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/fabric-textures-v0/src/main/java/net/fabricmc/fabric/api/event/client/package-info.java
+++ b/fabric-textures-v0/src/main/java/net/fabricmc/fabric/api/event/client/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The events for the fabric textures API.
+ */
+
+@DefaultQualifier(NonNull.class)
+package net.fabricmc.fabric.api.event.client;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;


### PR DESCRIPTION
In pull requests like #460, we observe a need for nullability annotations for the API.

This pull request adopts `org.checkerframework:checker-qual` annotation library, which has `@NonNull`, `@MonotonicNonNull` (reading is nullable, writing is non-null), and `@Nullable` annotations. This library also has abilities like defining array length, etc.

Since this is a java 8 library, it can annotate on type use, such as `Supplier<@Nullable Entity>` declarations, which makes it even more useful.