### PR TITLE
Make checkstyle always use English

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -3,6 +3,8 @@
 <module name="Checker">
 	<property name="charset" value="UTF-8"/>
 	<property name="fileExtensions" value="java"/>
+	<property name="localeLanguage" value="en"/>
+	<property name="localeCountry" value="US"/>
 
 	<module name="NewlineAtEndOfFile"/>
 


### PR DESCRIPTION
As much as I love broken Finnish machine translations, it'd be nice to know what's wrong with the style.