### PR TITLE
Fix render offset not being applied.

### DIFF
--- a/fabric-renderer-indigo/build.gradle
+++ b/fabric-renderer-indigo/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-renderer-indigo"
-version = getSubprojectVersion(project, "0.2.20")
+version = getSubprojectVersion(project, "0.2.21")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/mixin/client/indigo/renderer/MixinChunkRebuildTask.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/mixin/client/indigo/renderer/MixinChunkRebuildTask.java
@@ -39,6 +39,7 @@ import net.minecraft.client.render.chunk.ChunkRendererRegion;
 import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.BlockRenderView;
 
 import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
@@ -103,6 +104,8 @@ public class MixinChunkRebuildTask {
 			final BakedModel model = renderManager.getModel(blockState);
 
 			if (Indigo.ALWAYS_TESSELATE_INDIGO || !((FabricBakedModel) model).isVanillaAdapter()) {
+				Vec3d vec3d = blockState.getOffsetPos(blockView, blockPos);
+				matrix.translate(vec3d.x, vec3d.y, vec3d.z);
 				return ((AccessChunkRendererRegion) blockView).fabric_getRenderer().tesselateBlock(blockState, blockPos, model, matrix);
 			}
 		}


### PR DESCRIPTION
Fixes flower and other blocks always rendering in the center of the block.

Example of the issue: 
![](https://cdn.discordapp.com/attachments/507982478276034570/660109963024400404/unknown.png)