### PR TITLE
Always only return the last part of a branch in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,8 @@ def getBranch(){
 	if (grgit == null) {
 		return "unknown"
 	}
-	return grgit.branch.current().name
+	def branch = grgit.branch.current().name
+	return branch.substring(branch.lastIndexOf("/") + 1)
 }
 
 allprojects {


### PR DESCRIPTION
Not applying this causes certain environments (such as a local instance) to build artifacts in subdirectories with shortened names when the branch name contains a `/` such as `foo/bar`.
A workaround was applied to the environment variable method by someone else--this PR copies that behavior for getting the branch name through grgit.