### PR TITLE
Indigo: Check cullface after transforming vanilla model

### DIFF
--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainFallbackConsumer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainFallbackConsumer.java
@@ -92,7 +92,7 @@ public abstract class TerrainFallbackConsumer extends AbstractQuadRenderer imple
 			List<BakedQuad> quads = model.getQuads(blockState, face, random.get());
 			final int count = quads.size();
 
-			if (count != 0 && blockInfo.shouldDrawFace(face)) {
+			if (count != 0) {
 				for (int j = 0; j < count; j++) {
 					BakedQuad q = quads.get(j);
 					renderQuad(q, face, defaultMaterial);
@@ -128,6 +128,12 @@ public abstract class TerrainFallbackConsumer extends AbstractQuadRenderer imple
 		editorQuad.material(defaultMaterial);
 
 		if (!transform.transform(editorQuad)) {
+			return;
+		}
+
+		cullFace = editorQuad.cullFace();
+
+		if (cullFace != null && !blockInfo.shouldDrawFace(cullFace)) {
 			return;
 		}
 


### PR DESCRIPTION
Currently the renderer discards quads immediately if the baked model says they have a certain cull face, without giving potential transformers to change that information. This makes it impossible to rotate a model correctly since the old cull faces will still be used. This PR delays the cull face check until after the transformer pipeline has run.