### PR TITLE
Publish a fat javadoc jar to maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,16 @@ javadoc {
 			source( it.sourceSets.main.allJava.srcDirs)
 		}
 	classpath = sourceSets.main.compileClasspath
+	include ("**/api/**")
+	failOnError false
 }
+
+task javadocJar(type: Jar) {
+	from javadoc
+	//Set as `fatjavadoc` to prevent an ide form trying to use this javadoc, over using the modules javadoc
+	classifier = 'fatjavadoc'
+}
+build.dependsOn javadocJar
 
 subprojects {
 	task remapMavenJar(type: Copy, dependsOn: remapJar) {
@@ -137,6 +146,9 @@ subprojects {
 				}
 				artifact(sourcesJar) {
 					builtBy remapSourcesJar
+				}
+				artifact(javadocJar) {
+					builtBy javadocJar
 				}
 			}
 		}

--- a/build.gradle
+++ b/build.gradle
@@ -147,9 +147,7 @@ subprojects {
 				artifact(sourcesJar) {
 					builtBy remapSourcesJar
 				}
-				artifact(javadocJar) {
-					builtBy javadocJar
-				}
+				artifact javadocJar
 			}
 		}
 


### PR DESCRIPTION
This jar can be extracted once on the maven to be easily browseable from a normal web browser.

Only includes API classes.

Example jar:
[fabric-api-0.4.30+local-1.16-fatjavadoc.jar](https://ss.modmuss50.me/fabric-api-0.4.30%2Blocal-1.16-fatjavadoc.jar)

Online Example:
[fabric-api-0.4.30+local-1.16-fatjavadoc](https://modmuss50.me/fabric-api-0.4.30+local-1.16-fatjavadoc/)