### PR TITLE
Look into fixing issues when updating worlds when using vanilla clients

### DIFF
--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
@@ -54,6 +54,12 @@ public final class RegistrySyncManager {
 	private static final boolean DEBUG_WRITE_REGISTRY_DATA = System.getProperty("fabric.registry.debug.writeContentsAsCsv", "false").equalsIgnoreCase("true");
 	private static final Set<Identifier> REGISTRY_BLACKLIST = ImmutableSet.of();
 	private static final Set<Identifier> REGISTRY_BLACKLIST_NETWORK = ImmutableSet.of();
+	//These registry's are not saved to disk using their int id, so dont need to be same across runs.
+	private static final Set<Identifier> REGISTRY_BLACKLIST_SAVE = ImmutableSet.of(
+			new Identifier("block"),
+			new Identifier("item"),
+			new Identifier("sound_event")
+	);
 
 	private RegistrySyncManager() { }
 
@@ -135,6 +141,8 @@ public final class RegistrySyncManager {
 				continue;
 			} else if (isClientSync && REGISTRY_BLACKLIST_NETWORK.contains(registryId)) {
 				continue;
+			} else if (!isClientSync && REGISTRY_BLACKLIST_SAVE.contains(registryId)) {
+				continue;
 			}
 
 			MutableRegistry registry = Registry.REGISTRIES.get(registryId);
@@ -185,6 +193,9 @@ public final class RegistrySyncManager {
 
 		for (Identifier registryId : Registry.REGISTRIES.getIds()) {
 			if (!containedRegistries.remove(registryId.toString())) {
+				continue;
+			}
+			if (REGISTRY_BLACKLIST_SAVE.contains(registryId)) {
 				continue;
 			}
 


### PR DESCRIPTION
This is a proof of conecpt fix for incorrect ids beind sent to a vanilla client.

To repoduce this:

- Create a fabric server with fabric api on an older version such as 1.14.4

- Move that world to a 1.15.2 fabric server with fabric api as well.

- Login with a vanilla client and notice the issues.

This is caused by the new server using the old id map, and being unable to sync those ids to the vanilla client.

![](https://i.imgur.com/b9QGVrx.png)

The current work around for this is to delete the fabricregistry.dat file. This has been reported many times on the discord and here #464 and #458 and #418 and #122 and possibly #14

This PR is more of a possible solution to this issue, and is not a full fix as it requires finding all the registrys that are not saved to disk using their ids. (Biomes are for example.)

There may be other solutions to this issue, but this seems the easyist. A lot of testing will need to be done before merging a fix like this in.