### PR TITLE
Update FabricEntityTypeBuilder

### DIFF
--- a/fabric-object-builders-v0/build.gradle
+++ b/fabric-object-builders-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-object-builders"
-version = getSubprojectVersion(project, "0.1.4")
+version = getSubprojectVersion(project, "0.2.0")
 
 dependencies {
     compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/entity/FabricEntityTypeBuilder.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/entity/FabricEntityTypeBuilder.java
@@ -73,11 +73,11 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 	}
 
 	/**
-	 * @deprecated Old name that will be removed in a later version. Use {@link FabricEntityTypeBuilder#makeFireImmune()}.
+	 * @deprecated Old name that will be removed in a later version. Use {@link FabricEntityTypeBuilder#fireImmune()}.
 	 */
 	@Deprecated
 	public FabricEntityTypeBuilder<T> setImmuneToFire() {
-		return makeFireImmune();
+		return fireImmune();
 	}
 
 	public FabricEntityTypeBuilder<T> fireImmune() {
@@ -91,11 +91,11 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 	}
 
 	/**
-	 * @deprecated Old name that will be removed in a later version. Use {@link FabricEntityTypeBuilder#setDimensions(EntityDimensions size)}.
+	 * @deprecated Old name that will be removed in a later version. Use {@link FabricEntityTypeBuilder#dimensions(EntityDimensions size)}.
 	 */
 	@Deprecated
 	public FabricEntityTypeBuilder<T> size(EntityDimensions size) {
-		return setDimensions(size);
+		return dimensions(size);
 	}
 
 	public FabricEntityTypeBuilder<T> dimensions(EntityDimensions size) {

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/entity/FabricEntityTypeBuilder.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/entity/FabricEntityTypeBuilder.java
@@ -72,6 +72,14 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 		return this;
 	}
 
+	/**
+	 * @deprecated Old name that will be removed in a later version. Use {@link FabricEntityTypeBuilder#makeFireImmune()}.
+	 */
+	@Deprecated
+	public FabricEntityTypeBuilder<T> setImmuneToFire() {
+		return makeFireImmune();
+	}
+
 	public FabricEntityTypeBuilder<T> makeFireImmune() {
 		this.fireImmune = true;
 		return this;
@@ -80,6 +88,14 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 	public FabricEntityTypeBuilder<T> spawnableFarFromPlayer() {
 		this.spawnableFarFromPlayer = true;
 		return this;
+	}
+
+	/**
+	 * @deprecated Old name that will be removed in a later version. Use {@link FabricEntityTypeBuilder#setDimensions(EntityDimensions size)}.
+	 */
+	@Deprecated
+	public FabricEntityTypeBuilder<T> size(EntityDimensions size) {
+		return setDimensions(size);
 	}
 
 	public FabricEntityTypeBuilder<T> setDimensions(EntityDimensions size) {
@@ -110,21 +126,5 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 		}
 
 		return new FabricEntityType<>(this.function, this.category, this.saveable, this.summonable, this.fireImmune, spawnableFarFromPlayer, maxDespawnDistance, minDespawnDistance, size, trackingDistance, updateIntervalTicks, alwaysUpdateVelocity);
-	}
-
-	/**
-	 * @deprecated Old name that will be removed in a later version. Use {@link FabricEntityTypeBuilder#setDimensions(EntityDimensions size)}.
-	 */
-	@Deprecated
-	public FabricEntityTypeBuilder<T> size(EntityDimensions size) {
-		return setDimensions(size);
-	}
-
-	/**
-	 * @deprecated Old name that will be removed in a later version. Use {@link FabricEntityTypeBuilder#makeFireImmune()}.
-	 */
-	@Deprecated
-	public FabricEntityTypeBuilder<T> setImmuneToFire() {
-		return makeFireImmune();
 	}
 }

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/entity/FabricEntityTypeBuilder.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/entity/FabricEntityTypeBuilder.java
@@ -80,7 +80,7 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 		return makeFireImmune();
 	}
 
-	public FabricEntityTypeBuilder<T> makeFireImmune() {
+	public FabricEntityTypeBuilder<T> fireImmune() {
 		this.fireImmune = true;
 		return this;
 	}
@@ -98,12 +98,12 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 		return setDimensions(size);
 	}
 
-	public FabricEntityTypeBuilder<T> setDimensions(EntityDimensions size) {
+	public FabricEntityTypeBuilder<T> dimensions(EntityDimensions size) {
 		this.size = size;
 		return this;
 	}
 
-	public FabricEntityTypeBuilder<T> setMaxDespawnDistance(int maxDespawnDistance) {
+	public FabricEntityTypeBuilder<T> maxDespawnDistance(int maxDespawnDistance) {
 		this.maxDespawnDistance = maxDespawnDistance;
 		return this;
 	}

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/impl/object/builder/FabricEntityType.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/impl/object/builder/FabricEntityType.java
@@ -25,8 +25,8 @@ public class FabricEntityType<T extends Entity> extends EntityType<T> {
 	private final int maxTrackDistance, trackTickInterval;
 	private final Boolean alwaysUpdateVelocity;
 
-	public FabricEntityType(EntityType.EntityFactory<T> factory, EntityCategory category, boolean bl, boolean summonable, boolean fireImmune, boolean spawnableFarFromPlayer, int maxSpawnDistance, int minSpawnDistance, EntityDimensions entityDimensions, int maxTrackDistance, int trackTickInterval, Boolean alwaysUpdateVelocity) {
-		super(factory, category, bl, summonable, fireImmune, spawnableFarFromPlayer, maxSpawnDistance, minSpawnDistance, entityDimensions);
+	public FabricEntityType(EntityType.EntityFactory<T> factory, EntityCategory category, boolean bl, boolean summonable, boolean fireImmune, boolean spawnableFarFromPlayer, int maxDespawnDistance, int minDespawnDistance, EntityDimensions entityDimensions, int maxTrackDistance, int trackTickInterval, Boolean alwaysUpdateVelocity) {
+		super(factory, category, bl, summonable, fireImmune, spawnableFarFromPlayer, maxDespawnDistance, minDespawnDistance, entityDimensions);
 		this.maxTrackDistance = maxTrackDistance;
 		this.trackTickInterval = trackTickInterval;
 		this.alwaysUpdateVelocity = alwaysUpdateVelocity;

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/impl/object/builder/FabricEntityType.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/impl/object/builder/FabricEntityType.java
@@ -25,8 +25,8 @@ public class FabricEntityType<T extends Entity> extends EntityType<T> {
 	private final int maxTrackDistance, trackTickInterval;
 	private final Boolean alwaysUpdateVelocity;
 
-	public FabricEntityType(EntityType.EntityFactory<T> factory, EntityCategory category, boolean bl, boolean summonable, boolean fireImmune, boolean spawnableFarFromPlayer, int i, int j, EntityDimensions entityDimensions, int maxTrackDistance, int trackTickInterval, Boolean alwaysUpdateVelocity) {
-		super(factory, category, bl, summonable, fireImmune, spawnableFarFromPlayer, i, j, entityDimensions);
+	public FabricEntityType(EntityType.EntityFactory<T> factory, EntityCategory category, boolean bl, boolean summonable, boolean fireImmune, boolean spawnableFarFromPlayer, int maxSpawnDistance, int minSpawnDistance, EntityDimensions entityDimensions, int maxTrackDistance, int trackTickInterval, Boolean alwaysUpdateVelocity) {
+		super(factory, category, bl, summonable, fireImmune, spawnableFarFromPlayer, maxSpawnDistance, minSpawnDistance, entityDimensions);
 		this.maxTrackDistance = maxTrackDistance;
 		this.trackTickInterval = trackTickInterval;
 		this.alwaysUpdateVelocity = alwaysUpdateVelocity;


### PR DESCRIPTION
This PR completes the deprecation cycle on old methods, along with renaming
others to match their current Yarn names and adding methods that are present in EntityType.Builder but not FabricEntityTypeBuilder. The old names have been kept, but
marked as deprecated for removal.

`setMaxDespawnDistance` does not have a Yarn name in EntityType.Builder and is
still unmapped. Its name was inferred from b7d52fa581a5166e6d80f5ea60ca0ff9ea5edebf.

Please note:
`create(EntityCategory category, Function<? super World, ? extends T> function)`
and `size(float width, float height)` had been deprecated for 13 months.

EDIT: The idea of updating method names with deprecation comes from #415