### PR TITLE
Fix FabricMaterialBuilder#notSolid returning the wrong builder type

### DIFF
--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/block/FabricMaterialBuilder.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/block/FabricMaterialBuilder.java
@@ -73,7 +73,7 @@ public class FabricMaterialBuilder extends Material.Builder {
 	}
 
 	@Override
-	public Material.Builder notSolid() {
+	public FabricMaterialBuilder notSolid() {
 		super.notSolid();
 		return this;
 	}


### PR DESCRIPTION
Binary compatibility should be preserved despite the return type being changed. Callers expecting the old type will simply call the synthetic bridge override method.