### PR TITLE
Fix particle API javadocs

### DIFF
--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/api/client/particle/v1/FabricSpriteProvider.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/api/client/particle/v1/FabricSpriteProvider.java
@@ -21,6 +21,7 @@ import java.util.List;
 import net.minecraft.client.particle.SpriteProvider;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.texture.SpriteAtlasTexture;
+import net.minecraft.particle.ParticleType;
 
 /**
  * FabricSpriteProvider. It does the same thing as vanilla's SpriteProvider,
@@ -31,7 +32,7 @@ import net.minecraft.client.texture.SpriteAtlasTexture;
  * interface containing the sprites set loaded for their particle from the
  * active resourcepacks.
  *
- * @see ParticleFactoryRegistry#register(type, constructor)
+ * @see ParticleFactoryRegistry#register(ParticleType, ParticleFactoryRegistry.PendingParticleFactory)
  * @see ParticleFactoryRegistry.PendingParticleFactory
  */
 public interface FabricSpriteProvider extends SpriteProvider {

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/api/particle/v1/FabricParticleTypes.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/api/particle/v1/FabricParticleTypes.java
@@ -41,8 +41,6 @@ public final class FabricParticleTypes {
 
 	/**
 	 * Creates a new, default particle type for the given id.
-	 *
-	 * @param id The particle id.
 	 */
 	public static DefaultParticleType simple() {
 		return simple(false);
@@ -51,7 +49,6 @@ public final class FabricParticleTypes {
 	/**
 	 * Creates a new, default particle type for the given id.
 	 *
-	 * @param id The particle id.
 	 * @param alwaysSpawn True to always spawn the particle regardless of distance.
 	 */
 	public static DefaultParticleType simple(boolean alwaysSpawn) {
@@ -61,7 +58,6 @@ public final class FabricParticleTypes {
 	/**
 	 * Creates a new particle type with a custom factory for packet/data serialization.
 	 *
-	 * @param id The particle id.
 	 * @param factory	 A factory for serializing packet data and string command parameters into a particle effect.
 	 */
 	public static <T extends ParticleEffect> ParticleType<T> complex(ParticleEffect.Factory<T> factory) {
@@ -71,7 +67,6 @@ public final class FabricParticleTypes {
 	/**
 	 * Creates a new particle type with a custom factory for packet/data serialization.
 	 *
-	 * @param id The particle id.
 	 * @param alwaysSpawn True to always spawn the particle regardless of distance.
 	 * @param factory	 A factory for serializing packet data and string command parameters into a particle effect.
 	 */


### PR DESCRIPTION
Relics of previous iterations of the particle API, changes were made to the API but not to the docs. This fixes that.