### PR TITLE
Entity Damage Event

### DIFF
--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/impl/event/interaction/EntityHealthChangeCallback.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/impl/event/interaction/EntityHealthChangeCallback.java
@@ -1,0 +1,25 @@
+package net.fabricmc.fabric.impl.event.interaction;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.util.ActionResult;
+import net.minecraft.entity.LivingEntity;
+
+public interface EntityHealthChangeCallback {
+	/**
+	 * Callback for entity health change. Triggered whenever the game updates the entity's health. Returns the entity
+	 * and it's new health
+	 */
+	Event<EntityHealthChangeCallback> EVENT = EventFactory.createArrayBacked(EntityHealthChangeCallback.class,
+			(listeners) -> (entity, health) -> {
+				for (EntityHealthChangeCallback event : listeners) {
+					ActionResult result = event.health(entity, health);
+					if (result != ActionResult.PASS) {
+						return result;
+					}
+				}
+				return ActionResult.PASS;
+			});
+
+	ActionResult health(LivingEntity entity, float health);
+}

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/MixinLivingEntity.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/MixinLivingEntity.java
@@ -1,0 +1,23 @@
+package net.fabricmc.fabric.mixin.event.interaction;
+
+import net.fabricmc.fabric.impl.event.interaction.EntityHealthChangeCallback;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.util.ActionResult;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(LivingEntity.class)
+public abstract class MixinLivingEntity {
+	/**
+	 * Callback injector for monitoring entity health changes.
+	 */
+	@Inject(at = @At("INVOKE"), method = "setHealth(F)V", cancellable = true)
+	private void entityHealthChange(float health, CallbackInfo ci) {
+		ActionResult result = EntityHealthChangeCallback.EVENT.invoker().health(((LivingEntity) (Object) this), health);
+		if (result == ActionResult.FAIL) {
+			ci.cancel();
+		}
+	}
+}

--- a/fabric-events-interaction-v0/src/main/resources/fabric-events-interaction-v0.mixins.json
+++ b/fabric-events-interaction-v0/src/main/resources/fabric-events-interaction-v0.mixins.json
@@ -5,7 +5,8 @@
   "mixins": [
     "MixinServerPlayerEntity",
     "MixinServerPlayerInteractionManager",
-    "MixinServerPlayNetworkHandler"
+    "MixinServerPlayNetworkHandler",
+    "MixinLivingEntity"
   ],
   "client": [
     "MixinClientPlayerInteractionManager",


### PR DESCRIPTION
An event for monitoring any entity's health being updated. 
Returns the entity's (new) health, but leaves tracking the difference in health and damage source to the dev. 