### PR TITLE
Make resource-loader-v0's generated resource packs use the latest data version

### DIFF
--- a/fabric-resource-loader-v0/build.gradle
+++ b/fabric-resource-loader-v0/build.gradle
@@ -1,2 +1,2 @@
 archivesBaseName = "fabric-resource-loader-v0"
-version = getSubprojectVersion(project, "0.1.12")
+version = getSubprojectVersion(project, "0.1.13")

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModResourcePackUtil.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModResourcePackUtil.java
@@ -23,6 +23,7 @@ import java.util.List;
 import com.google.common.base.Charsets;
 import org.apache.commons.io.IOUtils;
 
+import net.minecraft.SharedConstants;
 import net.minecraft.resource.ResourcePack;
 import net.minecraft.resource.ResourceType;
 
@@ -34,7 +35,7 @@ import net.fabricmc.loader.api.metadata.ModMetadata;
  * Internal utilities for managing resource packs.
  */
 public final class ModResourcePackUtil {
-	public static final int PACK_FORMAT_VERSION = 4;
+	public static final int PACK_FORMAT_VERSION = SharedConstants.getGameVersion().getPackVersion();
 
 	private ModResourcePackUtil() { }
 


### PR DESCRIPTION
This prevents incompatibility warnings about mod resource and data packs in 1.16 (pack version was bumped to 5) and it'll always automatically be the newest version.