### PR TITLE
Add a hook for BuiltinModelItemRenderer

### DIFF
--- a/fabric-rendering-v1/build.gradle
+++ b/fabric-rendering-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-rendering-v1"
-version = getSubprojectVersion(project, "0.2.0")
+version = getSubprojectVersion(project, "1.0.0")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-rendering-v1/build.gradle
+++ b/fabric-rendering-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-rendering-v1"
-version = getSubprojectVersion(project, "0.1.0")
+version = getSubprojectVersion(project, "0.2.0")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/BuiltinItemRenderer.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/BuiltinItemRenderer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.api.client.rendering.v1;
 
 import net.minecraft.client.render.VertexConsumerProvider;

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/BuiltinItemRenderer.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/BuiltinItemRenderer.java
@@ -1,0 +1,21 @@
+package net.fabricmc.fabric.api.client.rendering.v1;
+
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.item.ItemStack;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+/**
+ * Builtin item renderers render items with custom code.
+ * They allow using non-model rendering, such as BERs, for items.
+ *
+ * <p>An item with a builtin renderer must have a model extending {@code minecraft:builtin/entity}.
+ * The renderers are registered with {@link BuiltinItemRendererRegistry#register}.
+ */
+@Environment(EnvType.CLIENT)
+@FunctionalInterface
+public interface BuiltinItemRenderer {
+	void render(ItemStack stack, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay);
+}

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/BuiltinItemRenderer.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/BuiltinItemRenderer.java
@@ -17,5 +17,14 @@ import net.fabricmc.api.Environment;
 @Environment(EnvType.CLIENT)
 @FunctionalInterface
 public interface BuiltinItemRenderer {
+	/**
+	 * Renders an item stack.
+	 *
+	 * @param stack           the rendered item stack
+	 * @param matrices        the matrix stack
+	 * @param vertexConsumers the vertex consumer provider
+	 * @param light           the color light multiplier at the rendering position
+	 * @param overlay         the overlay UV passed to {@link net.minecraft.client.render.VertexConsumer#overlay(int)}
+	 */
 	void render(ItemStack stack, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay);
 }

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/BuiltinItemRendererRegistry.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/BuiltinItemRendererRegistry.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.api.client.rendering.v1;
 
 import net.minecraft.item.Item;

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/BuiltinItemRendererRegistry.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/BuiltinItemRendererRegistry.java
@@ -18,8 +18,9 @@ public interface BuiltinItemRendererRegistry {
 	 *
 	 * <p>Note that the item's JSON model must also extend {@code minecraft:builtin/entity}.
 	 *
-	 * @param item the item
+	 * @param item     the item
 	 * @param renderer the renderer
+	 * @throws IllegalArgumentException if the item already has a registered renderer
 	 */
 	void register(Item item, BuiltinItemRenderer renderer);
 }

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/BuiltinItemRendererRegistry.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/BuiltinItemRendererRegistry.java
@@ -1,0 +1,25 @@
+package net.fabricmc.fabric.api.client.rendering.v1;
+
+import net.minecraft.item.Item;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.impl.client.rendering.BuiltinItemRendererRegistryImpl;
+
+/**
+ * This registry holds {@linkplain BuiltinItemRenderer builtin item renderers} for items.
+ */
+@Environment(EnvType.CLIENT)
+public interface BuiltinItemRendererRegistry {
+	BuiltinItemRendererRegistry INSTANCE = BuiltinItemRendererRegistryImpl.INSTANCE;
+
+	/**
+	 * Registers the renderer for the item.
+	 *
+	 * <p>Note that the item's JSON model must also extend {@code minecraft:builtin/entity}.
+	 *
+	 * @param item the item
+	 * @param renderer the renderer
+	 */
+	void register(Item item, BuiltinItemRenderer renderer);
+}

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/BuiltinItemRendererRegistry.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/BuiltinItemRendererRegistry.java
@@ -11,6 +11,10 @@ import net.fabricmc.fabric.impl.client.rendering.BuiltinItemRendererRegistryImpl
  */
 @Environment(EnvType.CLIENT)
 public interface BuiltinItemRendererRegistry {
+	/**
+	 * The singleton instance of the renderer registry.
+	 * Use this instance to call the methods in this interface.
+	 */
 	BuiltinItemRendererRegistry INSTANCE = BuiltinItemRendererRegistryImpl.INSTANCE;
 
 	/**

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/BuiltinItemRendererRegistry.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/BuiltinItemRendererRegistry.java
@@ -41,6 +41,7 @@ public interface BuiltinItemRendererRegistry {
 	 * @param item     the item
 	 * @param renderer the renderer
 	 * @throws IllegalArgumentException if the item already has a registered renderer
+	 * @throws NullPointerException if either the item or the renderer is null
 	 */
 	void register(Item item, BuiltinItemRenderer renderer);
 }

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/impl/client/rendering/BuiltinItemRendererRegistryImpl.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/impl/client/rendering/BuiltinItemRendererRegistryImpl.java
@@ -42,9 +42,11 @@ public final class BuiltinItemRendererRegistryImpl implements BuiltinItemRendere
 		Objects.requireNonNull(item, "item is null");
 		Objects.requireNonNull(renderer, "renderer is null");
 
-		if (RENDERERS.put(item, renderer) != null) {
+		if (RENDERERS.containsKey(item)) {
 			throw new IllegalArgumentException("Item " + Registry.ITEM.getId(item) + " already has a builtin renderer!");
 		}
+
+		RENDERERS.put(item, renderer);
 	}
 
 	/* @Nullable */

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/impl/client/rendering/BuiltinItemRendererRegistryImpl.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/impl/client/rendering/BuiltinItemRendererRegistryImpl.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import net.minecraft.item.Item;
+import net.minecraft.util.registry.Registry;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -19,12 +20,13 @@ public enum BuiltinItemRendererRegistryImpl implements BuiltinItemRendererRegist
 	@Override
 	public void register(Item item, BuiltinItemRenderer renderer) {
 		if (RENDERERS.containsKey(item)) {
-			throw new IllegalArgumentException("Item " + item + " already has a builtin renderer!");
+			throw new IllegalArgumentException("Item " + Registry.ITEM.getId(item) + " already has a builtin renderer!");
 		}
 
 		RENDERERS.put(item, renderer);
 	}
 
+	/* @Nullable */
 	public static BuiltinItemRenderer getRenderer(Item item) {
 		return RENDERERS.get(item);
 	}

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/impl/client/rendering/BuiltinItemRendererRegistryImpl.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/impl/client/rendering/BuiltinItemRendererRegistryImpl.java
@@ -28,10 +28,13 @@ import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRenderer;
 import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRendererRegistry;
 
 @Environment(EnvType.CLIENT)
-public enum BuiltinItemRendererRegistryImpl implements BuiltinItemRendererRegistry {
-	INSTANCE;
+public final class BuiltinItemRendererRegistryImpl implements BuiltinItemRendererRegistry {
+	public static final BuiltinItemRendererRegistryImpl INSTANCE = new BuiltinItemRendererRegistryImpl();
 
 	private static final Map<Item, BuiltinItemRenderer> RENDERERS = new HashMap<>();
+
+	private BuiltinItemRendererRegistryImpl() {
+	}
 
 	@Override
 	public void register(Item item, BuiltinItemRenderer renderer) {

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/impl/client/rendering/BuiltinItemRendererRegistryImpl.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/impl/client/rendering/BuiltinItemRendererRegistryImpl.java
@@ -19,11 +19,9 @@ public enum BuiltinItemRendererRegistryImpl implements BuiltinItemRendererRegist
 
 	@Override
 	public void register(Item item, BuiltinItemRenderer renderer) {
-		if (RENDERERS.containsKey(item)) {
+		if (RENDERERS.put(item, renderer) != null) {
 			throw new IllegalArgumentException("Item " + Registry.ITEM.getId(item) + " already has a builtin renderer!");
 		}
-
-		RENDERERS.put(item, renderer);
 	}
 
 	/* @Nullable */

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/impl/client/rendering/BuiltinItemRendererRegistryImpl.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/impl/client/rendering/BuiltinItemRendererRegistryImpl.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.impl.client.rendering;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import net.minecraft.item.Item;
 import net.minecraft.util.registry.Registry;
@@ -38,6 +39,9 @@ public final class BuiltinItemRendererRegistryImpl implements BuiltinItemRendere
 
 	@Override
 	public void register(Item item, BuiltinItemRenderer renderer) {
+		Objects.requireNonNull(item, "item is null");
+		Objects.requireNonNull(renderer, "renderer is null");
+
 		if (RENDERERS.put(item, renderer) != null) {
 			throw new IllegalArgumentException("Item " + Registry.ITEM.getId(item) + " already has a builtin renderer!");
 		}

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/impl/client/rendering/BuiltinItemRendererRegistryImpl.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/impl/client/rendering/BuiltinItemRendererRegistryImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.impl.client.rendering;
 
 import java.util.HashMap;

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/impl/client/rendering/BuiltinItemRendererRegistryImpl.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/impl/client/rendering/BuiltinItemRendererRegistryImpl.java
@@ -1,0 +1,31 @@
+package net.fabricmc.fabric.impl.client.rendering;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraft.item.Item;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRenderer;
+import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRendererRegistry;
+
+@Environment(EnvType.CLIENT)
+public enum BuiltinItemRendererRegistryImpl implements BuiltinItemRendererRegistry {
+	INSTANCE;
+
+	private static final Map<Item, BuiltinItemRenderer> RENDERERS = new HashMap<>();
+
+	@Override
+	public void register(Item item, BuiltinItemRenderer renderer) {
+		if (RENDERERS.containsKey(item)) {
+			throw new IllegalArgumentException("Item " + item + " already has a builtin renderer!");
+		}
+
+		RENDERERS.put(item, renderer);
+	}
+
+	public static BuiltinItemRenderer getRenderer(Item item) {
+		return RENDERERS.get(item);
+	}
+}

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/mixin/client/rendering/MixinBuiltinModelItemRenderer.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/mixin/client/rendering/MixinBuiltinModelItemRenderer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.client.rendering;
 
 import org.spongepowered.asm.mixin.Mixin;

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/mixin/client/rendering/MixinBuiltinModelItemRenderer.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/mixin/client/rendering/MixinBuiltinModelItemRenderer.java
@@ -1,0 +1,26 @@
+package net.fabricmc.fabric.mixin.client.rendering;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.item.BuiltinModelItemRenderer;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.item.ItemStack;
+
+import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRenderer;
+import net.fabricmc.fabric.impl.client.rendering.BuiltinItemRendererRegistryImpl;
+
+@Mixin(BuiltinModelItemRenderer.class)
+class MixinBuiltinModelItemRenderer {
+	@Inject(method = "render", at = @At("RETURN"))
+	private void fabric_onRender(ItemStack stack, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay, CallbackInfo info) {
+		BuiltinItemRenderer renderer = BuiltinItemRendererRegistryImpl.getRenderer(stack.getItem());
+
+		if (renderer != null) {
+			renderer.render(stack, matrices, vertexConsumers, light, overlay);
+		}
+	}
+}

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/mixin/client/rendering/MixinBuiltinModelItemRenderer.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/mixin/client/rendering/MixinBuiltinModelItemRenderer.java
@@ -14,13 +14,14 @@ import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRenderer;
 import net.fabricmc.fabric.impl.client.rendering.BuiltinItemRendererRegistryImpl;
 
 @Mixin(BuiltinModelItemRenderer.class)
-class MixinBuiltinModelItemRenderer {
-	@Inject(method = "render", at = @At("RETURN"))
+abstract class MixinBuiltinModelItemRenderer {
+	@Inject(method = "render", at = @At("HEAD"), cancellable = true)
 	private void fabric_onRender(ItemStack stack, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay, CallbackInfo info) {
 		BuiltinItemRenderer renderer = BuiltinItemRendererRegistryImpl.getRenderer(stack.getItem());
 
 		if (renderer != null) {
 			renderer.render(stack, matrices, vertexConsumers, light, overlay);
+			info.cancel();
 		}
 	}
 }

--- a/fabric-rendering-v1/src/main/resources/fabric-rendering-v1.mixins.json
+++ b/fabric-rendering-v1/src/main/resources/fabric-rendering-v1.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_8",
   "client": [
     "MixinBlockColorMap",
+    "MixinBuiltinModelItemRenderer",
     "MixinInGameHud",
     "MixinItemColorMap",
     "MixinWorldRenderer"


### PR DESCRIPTION
Closes #488.

This hook allows modders to register "builtin renderers" for their items, which can be used to render their items with custom code such as BERs.