### PR TITLE
Entrypoint Annotation

### DIFF
--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/annotation/Entrypoint.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/annotation/Entrypoint.java
@@ -1,0 +1,21 @@
+package net.fabricmc.fabric.api.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+/**
+ * An informative annotation type used to indicate that a member
+ * declaration is intended to be an <i>entrypoint</i> as
+ * defined by the loader specification.
+ *
+ * The loader will treat any member meeting the definition of an
+ * entrypoint as an entrypoint regardless of whether or not an
+ * {@code Entrypoint} annotation is present on the member declaration.
+ *
+ * @since 0.1.3
+ */
+@Documented
+@Target({ ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR })
+public @interface Entrypoint {
+}


### PR DESCRIPTION
Introduces an `Entrypoint` annotation for marking entry points in source code. Useful for readability, and can also be used as an annotation to suppress "unused" warnings in IDEs. The documentation is loosely based on the JDK's `FunctionalInterface` annotation documentation and describes the annotation as having no impact on semantics.

I am unsure as to whether this annotation should instead be named `EntryPoint`, as technically "entrypoint" is not a real word. Unfortunately, there are mixed uses in Fabric's environment, with the mod metadata entry being named "entrypoint" too, as opposed to "entry_point".