### PR TITLE
Bump fabric-rendering-v1 to 1.1.0

### DIFF
--- a/fabric-rendering-v1/build.gradle
+++ b/fabric-rendering-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-rendering-v1"
-version = getSubprojectVersion(project, "1.0.0")
+version = getSubprojectVersion(project, "1.1.0")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')


### PR DESCRIPTION
On the 1.16, 1.0.0 was already reserved for the 1.16 update, which means that there are now two 1.0.0s for 1.16 with different features (the later one has my builtin item rendering PR).

This doesn't fix the problem that the 1.15 version is also 1.0.0 with a different commit hash (that one contains the PR).