### PR TITLE
Fix duplicate input class from object builder mixins

### DIFF
--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/mixin/object/builder/OldMixinBlock.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/mixin/object/builder/OldMixinBlock.java
@@ -21,15 +21,15 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import net.minecraft.item.Item;
+import net.minecraft.block.Block;
 
-import net.fabricmc.fabric.api.event.registry.ItemConstructedCallback;
+import net.fabricmc.fabric.api.event.registry.BlockConstructedCallback;
 
-@Mixin(Item.class)
+@Mixin(Block.class)
 @Deprecated
-public class MixinItem {
-	@Inject(method = "<init>(Lnet/minecraft/item/Item$Settings;)V", at = @At("RETURN"))
-	public void init(Item.Settings builder, CallbackInfo info) {
-		ItemConstructedCallback.EVENT.invoker().building(builder, (Item) (Object) this);
+public class OldMixinBlock {
+	@Inject(method = "<init>(Lnet/minecraft/block/Block$Settings;)V", at = @At("RETURN"))
+	public void init(Block.Settings builder, CallbackInfo info) {
+		BlockConstructedCallback.EVENT.invoker().building(builder, (Block) (Object) this);
 	}
 }

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/mixin/object/builder/OldMixinItem.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/mixin/object/builder/OldMixinItem.java
@@ -21,15 +21,15 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import net.minecraft.block.Block;
+import net.minecraft.item.Item;
 
-import net.fabricmc.fabric.api.event.registry.BlockConstructedCallback;
+import net.fabricmc.fabric.api.event.registry.ItemConstructedCallback;
 
-@Mixin(Block.class)
+@Mixin(Item.class)
 @Deprecated
-public class MixinBlock {
-	@Inject(method = "<init>(Lnet/minecraft/block/Block$Settings;)V", at = @At("RETURN"))
-	public void init(Block.Settings builder, CallbackInfo info) {
-		BlockConstructedCallback.EVENT.invoker().building(builder, (Block) (Object) this);
+public class OldMixinItem {
+	@Inject(method = "<init>(Lnet/minecraft/item/Item$Settings;)V", at = @At("RETURN"))
+	public void init(Item.Settings builder, CallbackInfo info) {
+		ItemConstructedCallback.EVENT.invoker().building(builder, (Item) (Object) this);
 	}
 }

--- a/fabric-object-builders-v0/src/main/resources/fabric-object-builders-v0.mixins.json
+++ b/fabric-object-builders-v0/src/main/resources/fabric-object-builders-v0.mixins.json
@@ -3,8 +3,8 @@
   "package": "net.fabricmc.fabric.mixin.object.builder",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
-    "MixinBlock",
-    "MixinItem"
+    "OldMixinBlock",
+    "OldMixinItem"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
We Fix this by marking the old v0 mixins as `OldMixinTarget`

This is related to this issue:
```
duplicate input class net/fabricmc/fabric/mixin/object/builder/MixinBlock, from /Users/haykam/.gradle/caches/modules-2/files-2.1/net.fabricmc.fabric-api
/fabric-object-builders-v0/0.5.0+796d1cc40c/e8bbfe3e5381024bd07eeaeb28fb9fe4c4d1e3ae/fabric-object-builders-v0-0.5.0+796d1cc40c.jar and /Users/haykam/.g
radle/caches/modules-2/files-2.1/net.fabricmc.fabric-api/fabric-object-builder-api-v1/1.0.0+796d1cc40c/e974ac243291b884d5849109d6c56021edb5071e/fabric-object-builder-api-v1-1.0.0+796d1cc40c.jar
```