### PR TITLE
Append full Minecraft version to built API modules.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ def getSubprojectVersion(project, version) {
 	if (latestCommits.isEmpty()) {
 		return version + "+uncommited"
 	} else {
-		return version + "+" + latestCommits.get(0).id.substring(0, 8) + DigestUtils.sha256Hex(Globals.mcVersion).substring(0, 2)
+		return version + "+" + latestCommits.get(0).id.substring(0, 8) + "." + Globals.mcVersion.replaceAll("[^a-zA-Z0-9.-]", "-")
 	}
 }
 


### PR DESCRIPTION
Instead of appending the version hash, append the version itself. This allows mod devs to know what version a Fabric API module was built against. Note that this does not imply a version range that a module is compatible with.

This PR is part of [a plan to improve depending on Fabric API](https://gist.github.com/kvverti/3fc6a05d974210f785a9a751d5e0ae28).