### PR TITLE
Various Indigo lighting fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,9 @@ plugins {
 def ENV = System.getenv()
 
 class Globals {
-	static def baseVersion = "0.10.10"
-	static def mcVersion = "20w21a"
-	static def yarnVersion = "+build.2"
+	static def baseVersion = "0.10.11"
+	static def mcVersion = "20w22a"
+	static def yarnVersion = "+build.1"
 }
 
 version = Globals.baseVersion + "+" + (ENV.BUILD_NUMBER ? ("build." + ENV.BUILD_NUMBER) : "local") + "-" + getBranch()
@@ -67,7 +67,7 @@ allprojects {
 	dependencies {
 		minecraft "com.mojang:minecraft:$Globals.mcVersion"
 		mappings "net.fabricmc:yarn:${Globals.mcVersion}${Globals.yarnVersion}:v2"
-		modCompile "net.fabricmc:fabric-loader:0.8.2+build.194"
+		modCompile "net.fabricmc:fabric-loader:0.8.4+build.198"
 	}
 
 	configurations {

--- a/fabric-command-api-v1/build.gradle
+++ b/fabric-command-api-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-command-api-v1"
-version = getSubprojectVersion(project, "1.0.2")
+version = getSubprojectVersion(project, "1.0.3")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-command-api-v1/src/main/java/net/fabricmc/fabric/mixin/command/MixinMinecraftDedicatedServer.java
+++ b/fabric-command-api-v1/src/main/java/net/fabricmc/fabric/mixin/command/MixinMinecraftDedicatedServer.java
@@ -28,18 +28,20 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.WorldGenerationProgressListenerFactory;
-import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.dedicated.MinecraftDedicatedServer;
+import net.minecraft.class_5350;
+import net.minecraft.resource.ResourcePackManager;
+import net.minecraft.resource.ResourcePackProfile;
 import net.minecraft.util.UserCache;
-import net.minecraft.class_5219;
+import net.minecraft.world.SaveProperties;
 import net.minecraft.world.level.storage.LevelStorage;
 
 import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback;
 
 @Mixin(MinecraftDedicatedServer.class)
 public abstract class MixinMinecraftDedicatedServer extends MinecraftServer {
-	public MixinMinecraftDedicatedServer(LevelStorage.Session session, class_5219 arg, Proxy proxy, DataFixer dataFixer, CommandManager commandManager, MinecraftSessionService minecraftSessionService, GameProfileRepository gameProfileRepository, UserCache userCache, WorldGenerationProgressListenerFactory worldGenerationProgressListenerFactory) {
-		super(session, arg, proxy, dataFixer, commandManager, minecraftSessionService, gameProfileRepository, userCache, worldGenerationProgressListenerFactory);
+	public MixinMinecraftDedicatedServer(LevelStorage.Session session, SaveProperties saveProperties, ResourcePackManager<ResourcePackProfile> resourcePackManager, Proxy proxy, DataFixer dataFixer, class_5350 arg, MinecraftSessionService minecraftSessionService, GameProfileRepository gameProfileRepository, UserCache userCache, WorldGenerationProgressListenerFactory worldGenerationProgressListenerFactory) {
+		super(session, saveProperties, resourcePackManager, proxy, dataFixer, arg, minecraftSessionService, gameProfileRepository, userCache, worldGenerationProgressListenerFactory);
 	}
 
 	@Inject(method = "setupServer", at = @At("HEAD"))

--- a/fabric-command-api-v1/src/testmod/java/net/fabricmc/fabric/test/command/CommandTest.java
+++ b/fabric-command-api-v1/src/testmod/java/net/fabricmc/fabric/test/command/CommandTest.java
@@ -63,6 +63,11 @@ public class CommandTest implements ModInitializer {
 			}
 		});
 
+		// Disabling the test mod for now, as https://bugs.mojang.com/browse/MC-186109 breaks it
+		if (true) {
+			return;
+		}
+
 		// Use the ServerTickCallback to verify the commands actually exist in the command dispatcher.
 		ServerTickCallback.EVENT.register(server -> {
 			// Don't run the test more than once

--- a/fabric-content-registries-v0/build.gradle
+++ b/fabric-content-registries-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-content-registries-v0"
-version = getSubprojectVersion(project, "0.1.6")
+version = getSubprojectVersion(project, "0.1.7")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/LootEntryTypeRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/LootEntryTypeRegistry.java
@@ -29,5 +29,5 @@ public interface LootEntryTypeRegistry {
 	LootEntryTypeRegistry INSTANCE = LootEntryTypeRegistryImpl.INSTANCE;
 
 	@Deprecated
-	void register(LootEntry.Serializer<?> serializer);
+	void register(LootEntry.class_5337<?> serializer);
 }

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/LootEntryTypeRegistryImpl.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/LootEntryTypeRegistryImpl.java
@@ -32,7 +32,7 @@ public final class LootEntryTypeRegistryImpl implements LootEntryTypeRegistry {
 		Method target = null;
 
 		for (Method m : LootEntries.class.getDeclaredMethods()) {
-			if (m.getParameterCount() == 1 && m.getParameterTypes()[0] == LootEntry.Serializer.class) {
+			if (m.getParameterCount() == 1 && m.getParameterTypes()[0] == LootEntry.class_5337.class) {
 				if (target != null) {
 					throw new RuntimeException("More than one register-like method found in LootEntries!");
 				} else {
@@ -52,7 +52,7 @@ public final class LootEntryTypeRegistryImpl implements LootEntryTypeRegistry {
 	private LootEntryTypeRegistryImpl() { }
 
 	@Override
-	public void register(LootEntry.Serializer<?> serializer) {
+	public void register(LootEntry.class_5337<?> serializer) {
 		try {
 			REGISTER_METHOD.invoke(null, serializer);
 		} catch (Throwable t) {

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/mixin/content/registry/MixinFireBlock.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/mixin/content/registry/MixinFireBlock.java
@@ -57,7 +57,7 @@ public class MixinFireBlock implements FireBlockHooks {
 
 		if (entry != null) {
 			// TODO: use a (BlockState -> int) with this as the default impl
-			if (block.method_28498(Properties.WATERLOGGED) && block.get(Properties.WATERLOGGED)) {
+			if (block.contains(Properties.WATERLOGGED) && block.get(Properties.WATERLOGGED)) {
 				info.setReturnValue(0);
 			} else {
 				info.setReturnValue(entry.getBurnChance());
@@ -71,7 +71,7 @@ public class MixinFireBlock implements FireBlockHooks {
 
 		if (entry != null) {
 			// TODO: use a (BlockState -> int) with this as the default impl
-			if (block.method_28498(Properties.WATERLOGGED) && block.get(Properties.WATERLOGGED)) {
+			if (block.contains(Properties.WATERLOGGED) && block.get(Properties.WATERLOGGED)) {
 				info.setReturnValue(0);
 			} else {
 				info.setReturnValue(entry.getSpreadChance());

--- a/fabric-loot-tables-v1/build.gradle
+++ b/fabric-loot-tables-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-loot-tables-v1"
-version = getSubprojectVersion(project, "0.1.7")
+version = getSubprojectVersion(project, "0.1.8")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/FabricLootPool.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/FabricLootPool.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import net.minecraft.loot.LootPool;
 import net.minecraft.loot.LootTableRange;
-import net.minecraft.loot.condition.LootCondition;
+import net.minecraft.class_5341;
 import net.minecraft.loot.entry.LootEntry;
 import net.minecraft.loot.function.LootFunction;
 
@@ -34,7 +34,7 @@ public interface FabricLootPool {
 	}
 
 	List<LootEntry> getEntries();
-	List<LootCondition> getConditions();
+	List<class_5341> getConditions();
 	List<LootFunction> getFunctions();
 	LootTableRange getRolls();
 }

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/FabricLootPoolBuilder.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/FabricLootPoolBuilder.java
@@ -16,9 +16,9 @@
 
 package net.fabricmc.fabric.api.loot.v1;
 
+import net.minecraft.class_5341;
 import net.minecraft.loot.LootPool;
 import net.minecraft.loot.LootTableRange;
-import net.minecraft.loot.condition.LootCondition;
 import net.minecraft.loot.entry.LootEntry;
 import net.minecraft.loot.function.LootFunction;
 
@@ -46,7 +46,7 @@ public class FabricLootPoolBuilder extends LootPool.Builder {
 	}
 
 	@Override
-	public FabricLootPoolBuilder conditionally(LootCondition.Builder condition) {
+	public FabricLootPoolBuilder conditionally(class_5341.Builder condition) {
 		super.conditionally(condition);
 		return this;
 	}
@@ -62,7 +62,7 @@ public class FabricLootPoolBuilder extends LootPool.Builder {
 		return this;
 	}
 
-	public FabricLootPoolBuilder withCondition(LootCondition condition) {
+	public FabricLootPoolBuilder withCondition(class_5341 condition) {
 		extended.getConditions().add(condition);
 		return this;
 	}

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/LootEntryTypeRegistry.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/LootEntryTypeRegistry.java
@@ -34,5 +34,5 @@ public interface LootEntryTypeRegistry {
 	 *
 	 * @param serializer the loot entry serializer
 	 */
-	void register(LootEntry.Serializer<?> serializer);
+	void register(LootEntry.class_5337<?> serializer);
 }

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/impl/loot/table/LootEntryTypeRegistryImpl.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/impl/loot/table/LootEntryTypeRegistryImpl.java
@@ -29,7 +29,7 @@ public final class LootEntryTypeRegistryImpl implements net.fabricmc.fabric.api.
 		Method target = null;
 
 		for (Method m : LootEntries.class.getDeclaredMethods()) {
-			if (m.getParameterCount() == 1 && m.getParameterTypes()[0] == LootEntry.Serializer.class) {
+			if (m.getParameterCount() == 1 && m.getParameterTypes()[0] == LootEntry.class_5337.class) {
 				if (target != null) {
 					throw new RuntimeException("More than one register-like method found in LootEntries!");
 				} else {
@@ -49,7 +49,7 @@ public final class LootEntryTypeRegistryImpl implements net.fabricmc.fabric.api.
 	private LootEntryTypeRegistryImpl() { }
 
 	@Override
-	public void register(LootEntry.Serializer<?> serializer) {
+	public void register(LootEntry.class_5337<?> serializer) {
 		try {
 			REGISTER_METHOD.invoke(null, serializer);
 		} catch (Throwable t) {

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/mixin/loot/table/LootPoolBuilderHooks.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/mixin/loot/table/LootPoolBuilderHooks.java
@@ -22,7 +22,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
 import net.minecraft.loot.LootPool;
-import net.minecraft.loot.condition.LootCondition;
+import net.minecraft.class_5341;
 import net.minecraft.loot.entry.LootEntry;
 import net.minecraft.loot.function.LootFunction;
 
@@ -31,7 +31,7 @@ public interface LootPoolBuilderHooks {
 	@Accessor
 	List<LootEntry> getEntries();
 	@Accessor
-	List<LootCondition> getConditions();
+	List<class_5341> getConditions();
 	@Accessor
 	List<LootFunction> getFunctions();
 }

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/mixin/loot/table/MixinLootPool.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/mixin/loot/table/MixinLootPool.java
@@ -26,7 +26,7 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 import net.minecraft.loot.LootPool;
 import net.minecraft.loot.LootTableRange;
-import net.minecraft.loot.condition.LootCondition;
+import net.minecraft.class_5341;
 import net.minecraft.loot.entry.LootEntry;
 import net.minecraft.loot.function.LootFunction;
 
@@ -40,7 +40,7 @@ public abstract class MixinLootPool implements FabricLootPool {
 
 	@Shadow
 	@Final
-	private LootCondition[] conditions;
+	private class_5341[] conditions;
 
 	@Shadow
 	@Final
@@ -52,7 +52,7 @@ public abstract class MixinLootPool implements FabricLootPool {
 	}
 
 	@Override
-	public List<LootCondition> getConditions() {
+	public List<class_5341> getConditions() {
 		return Arrays.asList(conditions);
 	}
 

--- a/fabric-object-builder-api-v1/build.gradle
+++ b/fabric-object-builder-api-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-object-builder-api-v1"
-version = getSubprojectVersion(project, "1.3.1")
+version = getSubprojectVersion(project, "1.4.0")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricBlockSettings.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricBlockSettings.java
@@ -285,4 +285,13 @@ public class FabricBlockSettings extends AbstractBlock.Settings {
 	public FabricBlockSettings breakByTool(Tag<Item> tag) {
 		return this.breakByTool(tag, 0);
 	}
+
+	/**
+	 * Make the material require tool to drop and slows down mining speed if the incorrect tool is used.
+	 */
+	@Override
+	public FabricBlockSettings method_29292() {
+		super.method_29292();
+		return this;
+	}
 }

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricMaterialBuilder.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricMaterialBuilder.java
@@ -83,13 +83,4 @@ public class FabricMaterialBuilder extends Material.Builder {
 		super.replaceable();
 		return this;
 	}
-
-	/**
-	 * Make the material require tool to drop and slows down mining speed if the incorrect tool is used.
-	 */
-	@Override
-	public FabricMaterialBuilder requiresTool() {
-		super.requiresTool();
-		return this;
-	}
 }

--- a/fabric-object-builders-v0/build.gradle
+++ b/fabric-object-builders-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-object-builders"
-version = getSubprojectVersion(project, "0.5.2")
+version = getSubprojectVersion(project, "0.6.0")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/block/FabricMaterialBuilder.java
+++ b/fabric-object-builders-v0/src/main/java/net/fabricmc/fabric/api/block/FabricMaterialBuilder.java
@@ -90,12 +90,6 @@ public class FabricMaterialBuilder extends Material.Builder {
 	}
 
 	@Override
-	public FabricMaterialBuilder requiresTool() {
-		this.delegate.requiresTool();
-		return this;
-	}
-
-	@Override
 	public Material build() {
 		return this.delegate.build();
 	}

--- a/fabric-registry-sync-v0/build.gradle
+++ b/fabric-registry-sync-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-registry-sync-v0"
-version = getSubprojectVersion(project, "0.3.3")
+version = getSubprojectVersion(project, "0.3.4")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinIdRegistry.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinIdRegistry.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.BiMap;
@@ -41,8 +42,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.util.Identifier;
 import net.minecraft.util.collection.Int2ObjectBiMap;
+import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.SimpleRegistry;
-import net.minecraft.class_5321;
+import net.minecraft.util.registry.RegistryKey;
 
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
@@ -59,7 +61,9 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 	@Shadow
 	protected Int2ObjectBiMap<T> indexedEntries;
 	@Shadow
-	protected BiMap<Identifier, T> entries;
+	protected BiMap<Identifier, T> entriesById;
+	@Shadow
+	protected BiMap<RegistryKey<T>, T> entriesByKey;
 	@Shadow
 	private int nextId;
 	@Unique
@@ -124,17 +128,17 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 
 	@SuppressWarnings({"unchecked", "ConstantConditions"})
 	@Inject(method = "set", at = @At("HEAD"))
-	public void setPre(int id, class_5321<T> registryId, Object object, CallbackInfoReturnable info) {
+	public void setPre(int id, RegistryKey<T> registryId, Object object, CallbackInfoReturnable info) {
 		int indexedEntriesId = indexedEntries.getId((T) object);
 
 		if (indexedEntriesId >= 0) {
 			throw new RuntimeException("Attempted to register object " + object + " twice! (at raw IDs " + indexedEntriesId + " and " + id + " )");
 		}
 
-		if (!entries.containsKey(registryId.method_29177())) {
+		if (!entriesById.containsKey(registryId.getValue())) {
 			fabric_isObjectNew = true;
 		} else {
-			T oldObject = entries.get(registryId.method_29177());
+			T oldObject = entriesById.get(registryId.getValue());
 
 			if (oldObject != null && oldObject != object) {
 				int oldId = indexedEntries.getId(oldObject);
@@ -143,7 +147,7 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 					throw new RuntimeException("Attempted to register ID " + registryId + " at different raw IDs (" + oldId + ", " + id + ")! If you're trying to override an item, use .set(), not .register()!");
 				}
 
-				fabric_removeObjectEvent.invoker().onEntryRemoved(oldId, registryId.method_29177(), oldObject);
+				fabric_removeObjectEvent.invoker().onEntryRemoved(oldId, registryId.getValue(), oldObject);
 				fabric_isObjectNew = true;
 			} else {
 				fabric_isObjectNew = false;
@@ -153,9 +157,9 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 
 	@SuppressWarnings("unchecked")
 	@Inject(method = "set", at = @At("RETURN"))
-	public void setPost(int id, class_5321<T> registryId, Object object, CallbackInfoReturnable info) {
+	public void setPost(int id, RegistryKey<T> registryId, Object object, CallbackInfoReturnable info) {
 		if (fabric_isObjectNew) {
-			fabric_addObjectEvent.invoker().onEntryAdded(id, registryId.method_29177(), object);
+			fabric_addObjectEvent.invoker().onEntryAdded(id, registryId.getValue(), object);
 		}
 	}
 
@@ -172,7 +176,7 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 			List<String> strings = null;
 
 			for (Identifier remoteId : remoteIndexedEntries.keySet()) {
-				if (!entries.keySet().contains(remoteId)) {
+				if (!entriesById.keySet().contains(remoteId)) {
 					if (strings == null) {
 						strings = new ArrayList<>();
 					}
@@ -194,11 +198,11 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 			break;
 		}
 		case EXACT: {
-			if (!entries.keySet().equals(remoteIndexedEntries.keySet())) {
+			if (!entriesById.keySet().equals(remoteIndexedEntries.keySet())) {
 				List<String> strings = new ArrayList<>();
 
 				for (Identifier remoteId : remoteIndexedEntries.keySet()) {
-					if (!entries.keySet().contains(remoteId)) {
+					if (!entriesById.keySet().contains(remoteId)) {
 						strings.add(" - " + remoteId + " (missing on local)");
 					}
 				}
@@ -230,7 +234,7 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 		// compatibility.
 		if (fabric_prevIndexedEntries == null) {
 			fabric_prevIndexedEntries = new Object2IntOpenHashMap<>();
-			fabric_prevEntries = HashBiMap.create(entries);
+			fabric_prevEntries = HashBiMap.create(entriesById);
 
 			for (Object o : registry) {
 				fabric_prevIndexedEntries.put(registry.getId(o), registry.getRawId(o));
@@ -285,7 +289,8 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 			}
 
 			// note: indexedEntries cannot be safely remove()d from
-			entries.keySet().removeAll(droppedIds);
+			entriesById.keySet().removeAll(droppedIds);
+			entriesByKey.keySet().removeIf(registryKey -> droppedIds.contains(registryKey.getValue()));
 
 			break;
 		}
@@ -312,7 +317,7 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 
 		for (Identifier identifier : orderedRemoteEntries) {
 			int id = remoteIndexedEntries.getInt(identifier);
-			T object = entries.get(identifier);
+			T object = entriesById.get(identifier);
 
 			// Warn if an object is missing from the local registry.
 			// This should only happen in AUTHORITATIVE mode, and as such we
@@ -346,19 +351,26 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 
 			// Emit AddObject events for previously culled objects.
 			for (Identifier id : fabric_prevEntries.keySet()) {
-				if (!entries.containsKey(id)) {
+				if (!entriesById.containsKey(id)) {
 					assert fabric_prevIndexedEntries.containsKey(id);
 					addedIds.add(id);
 				}
 			}
 
-			entries.clear();
-			entries.putAll(fabric_prevEntries);
+			entriesById.clear();
+			entriesByKey.clear();
+
+			entriesById.putAll(fabric_prevEntries);
+
+			for (Map.Entry<Identifier, T> entry : fabric_prevEntries.entrySet()) {
+				//noinspection unchecked
+				entriesByKey.put(RegistryKey.of(RegistryKey.ofRegistry(((Registry) Registry.REGISTRIES).getId(this)), entry.getKey()), entry.getValue());
+			}
 
 			remap(name, fabric_prevIndexedEntries, RemapMode.AUTHORITATIVE);
 
 			for (Identifier id : addedIds) {
-				fabric_getAddObjectEvent().invoker().onEntryAdded(indexedEntries.getId(entries.get(id)), id, entries.get(id));
+				fabric_getAddObjectEvent().invoker().onEntryAdded(indexedEntries.getId(entriesById.get(id)), id, entriesById.get(id));
 			}
 
 			fabric_prevIndexedEntries = null;

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinLevelStorageSession.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinLevelStorageSession.java
@@ -37,7 +37,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtIo;
-import net.minecraft.class_5219;
+import net.minecraft.world.SaveProperties;
 import net.minecraft.world.level.storage.LevelStorage;
 
 import net.fabricmc.fabric.impl.registry.sync.RegistrySyncManager;
@@ -121,7 +121,7 @@ public class MixinLevelStorageSession {
 	}
 
 	@Inject(method = "method_27426", at = @At("HEAD"))
-	public void saveWorld(class_5219 levelProperties, CompoundTag compoundTag, CallbackInfo info) {
+	public void saveWorld(SaveProperties saveProperties, CompoundTag compoundTag, CallbackInfo info) {
 		if (!Files.exists(directory)) {
 			return;
 		}
@@ -131,7 +131,7 @@ public class MixinLevelStorageSession {
 
 	// TODO: stop double save on client?
 	@Inject(method = "readLevelProperties", at = @At("HEAD"))
-	public void readWorldProperties(CallbackInfoReturnable<class_5219> callbackInfo) {
+	public void readWorldProperties(CallbackInfoReturnable<SaveProperties> callbackInfo) {
 		// Load
 		for (int i = 0; i < FABRIC_ID_REGISTRY_BACKUPS; i++) {
 			FABRIC_LOGGER.trace("[fabric-registry-sync] Loading Fabric registry [file " + (i + 1) + "/" + (FABRIC_ID_REGISTRY_BACKUPS + 1) + "]");

--- a/fabric-renderer-indigo/build.gradle
+++ b/fabric-renderer-indigo/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-renderer-indigo"
-version = getSubprojectVersion(project, "0.2.29")
+version = getSubprojectVersion(project, "0.2.30")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/helper/ColorHelper.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/helper/ColorHelper.java
@@ -20,12 +20,6 @@ import java.nio.ByteOrder;
 
 import it.unimi.dsi.fastutil.ints.Int2IntFunction;
 
-import net.minecraft.client.render.model.BakedQuadFactory;
-import net.minecraft.client.util.math.Vector3f;
-import net.minecraft.util.math.Direction;
-
-import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
-
 /**
  * Static routines of general utility for renderer implementations.
  * Renderers are not required to use these helpers, but they were
@@ -33,19 +27,6 @@ import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
  */
 public abstract class ColorHelper {
 	private ColorHelper() { }
-
-	/**
-	 * Implement on quads to use methods that require it.
-	 * Allows for much cleaner method signatures.
-	 */
-	public interface ShadeableQuad extends MutableQuadView {
-		boolean isFaceAligned();
-
-		boolean needsDiffuseShading(int textureIndex);
-	}
-
-	/** Same as vanilla values. */
-	private static final float[] FACE_SHADE_FACTORS = { 0.5F, 1.0F, 0.8F, 0.8F, 0.6F, 0.6F };
 
 	private static final Int2IntFunction colorSwapper = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN ? color -> ((color & 0xFF00FF00) | ((color & 0x00FF0000) >> 16) | ((color & 0xFF) << 16)) : color -> color;
 
@@ -64,107 +45,22 @@ public abstract class ColorHelper {
 			return color1;
 		}
 
-		int alpha = ((color1 >> 24) & 0xFF) * ((color2 >> 24) & 0xFF) / 0xFF;
-		int red = ((color1 >> 16) & 0xFF) * ((color2 >> 16) & 0xFF) / 0xFF;
-		int green = ((color1 >> 8) & 0xFF) * ((color2 >> 8) & 0xFF) / 0xFF;
-		int blue = (color1 & 0xFF) * (color2 & 0xFF) / 0xFF;
+		final int alpha = ((color1 >> 24) & 0xFF) * ((color2 >> 24) & 0xFF) / 0xFF;
+		final int red = ((color1 >> 16) & 0xFF) * ((color2 >> 16) & 0xFF) / 0xFF;
+		final int green = ((color1 >> 8) & 0xFF) * ((color2 >> 8) & 0xFF) / 0xFF;
+		final int blue = (color1 & 0xFF) * (color2 & 0xFF) / 0xFF;
 
 		return (alpha << 24) | (red << 16) | (green << 8) | blue;
 	}
 
 	/** Multiplies three lowest components by shade. High byte (usually alpha) unchanged. */
 	public static int multiplyRGB(int color, float shade) {
-		int alpha = ((color >> 24) & 0xFF);
-		int red = (int) (((color >> 16) & 0xFF) * shade);
-		int green = (int) (((color >> 8) & 0xFF) * shade);
-		int blue = (int) ((color & 0xFF) * shade);
+		final int alpha = ((color >> 24) & 0xFF);
+		final int red = (int) (((color >> 16) & 0xFF) * shade);
+		final int green = (int) (((color >> 8) & 0xFF) * shade);
+		final int blue = (int) ((color & 0xFF) * shade);
 
 		return (alpha << 24) | (red << 16) | (green << 8) | blue;
-	}
-
-	/**
-	 * Same results as {@link BakedQuadFactory#method_3456(Direction)}.
-	 */
-	public static float diffuseShade(Direction direction) {
-		return FACE_SHADE_FACTORS[direction.getId()];
-	}
-
-	/**
-	 * Formula mimics vanilla lighting for plane-aligned quads and
-	 * is vaguely consistent with Phong lighting ambient + diffuse for others.
-	 */
-	public static float normalShade(float normalX, float normalY, float normalZ) {
-		return Math.min(0.5f + Math.abs(normalX) * 0.1f + (normalY > 0 ? 0.5f * normalY : 0) + Math.abs(normalZ) * 0.3f, 1f);
-	}
-
-	public static float normalShade(Vector3f normal) {
-		return normalShade(normal.getX(), normal.getY(), normal.getZ());
-	}
-
-	/**
-	 * @see #diffuseShade
-	 */
-	public static float vertexShade(ShadeableQuad q, int vertexIndex, float faceShade) {
-		return q.hasNormal(vertexIndex) ? normalShade(q.normalX(vertexIndex), q.normalY(vertexIndex), q.normalZ(vertexIndex)) : faceShade;
-	}
-
-	/**
-	 * Returns {@link #diffuseShade(Direction)} if quad is aligned to light face,
-	 * otherwise uses face normal and {@link #normalShade}.
-	 */
-	public static float faceShade(ShadeableQuad quad) {
-		return quad.isFaceAligned() ? diffuseShade(quad.lightFace()) : normalShade(quad.faceNormal());
-	}
-
-	@FunctionalInterface
-	private interface VertexLighter {
-		void shade(ShadeableQuad quad, int vertexIndex, float shade);
-	}
-
-	private static VertexLighter[] VERTEX_LIGHTERS = new VertexLighter[8];
-
-	static {
-		VERTEX_LIGHTERS[0b000] = (q, i, s) -> { };
-		VERTEX_LIGHTERS[0b001] = (q, i, s) -> q.spriteColor(i, 0, multiplyRGB(q.spriteColor(i, 0), s));
-		VERTEX_LIGHTERS[0b010] = (q, i, s) -> q.spriteColor(i, 1, multiplyRGB(q.spriteColor(i, 1), s));
-		VERTEX_LIGHTERS[0b011] = (q, i, s) -> q.spriteColor(i, 0, multiplyRGB(q.spriteColor(i, 0), s)).spriteColor(i, 1, multiplyRGB(q.spriteColor(i, 1), s));
-		VERTEX_LIGHTERS[0b100] = (q, i, s) -> q.spriteColor(i, 2, multiplyRGB(q.spriteColor(i, 2), s));
-		VERTEX_LIGHTERS[0b101] = (q, i, s) -> q.spriteColor(i, 0, multiplyRGB(q.spriteColor(i, 0), s)).spriteColor(i, 2, multiplyRGB(q.spriteColor(i, 2), s));
-		VERTEX_LIGHTERS[0b110] = (q, i, s) -> q.spriteColor(i, 1, multiplyRGB(q.spriteColor(i, 1), s)).spriteColor(i, 2, multiplyRGB(q.spriteColor(i, 2), s));
-		VERTEX_LIGHTERS[0b111] = (q, i, s) -> q.spriteColor(i, 0, multiplyRGB(q.spriteColor(i, 0), s)).spriteColor(i, 1, multiplyRGB(q.spriteColor(i, 1), s)).spriteColor(i, 2, multiplyRGB(q.spriteColor(i, 2), s));
-	}
-
-	/**
-	 * Honors vertex normals and uses non-cubic face normals for non-cubic quads.
-	 *
-	 * @param quad Quad to be shaded/unshaded.
-	 *
-	 * @param undo If true, will reverse prior application.  Does not check that
-	 * prior application actually happened.  Use to "unbake" a quad.
-	 * Some drift of colors may occur due to floating-point precision error.
-	 */
-	public static void applyDiffuseShading(ShadeableQuad quad, boolean undo) {
-		final float faceShade = faceShade(quad);
-		int i = quad.needsDiffuseShading(0) ? 1 : 0;
-
-		if (quad.needsDiffuseShading(1)) {
-			i |= 2;
-		}
-
-		if (quad.needsDiffuseShading(2)) {
-			i |= 4;
-		}
-
-		if (i == 0) {
-			return;
-		}
-
-		final VertexLighter shader = VERTEX_LIGHTERS[i];
-
-		for (int j = 0; j < 4; j++) {
-			final float vertexShade = vertexShade(quad, j, faceShade);
-			shader.shade(quad, j, undo ? 1f / vertexShade : vertexShade);
-		}
 	}
 
 	/**

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MeshBuilderImpl.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MeshBuilderImpl.java
@@ -19,7 +19,6 @@ package net.fabricmc.fabric.impl.client.indigo.renderer.mesh;
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
 import net.fabricmc.fabric.api.renderer.v1.mesh.MeshBuilder;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
-import net.fabricmc.fabric.impl.client.indigo.renderer.helper.ColorHelper;
 import net.fabricmc.fabric.impl.client.indigo.renderer.helper.GeometryHelper;
 
 /**
@@ -38,7 +37,7 @@ public class MeshBuilderImpl implements MeshBuilder {
 	protected void ensureCapacity(int stride) {
 		if (stride > limit - index) {
 			limit *= 2;
-			int[] bigger = new int[limit];
+			final int[] bigger = new int[limit];
 			System.arraycopy(data, 0, bigger, 0, index);
 			data = bigger;
 			maker.data = bigger;
@@ -47,7 +46,7 @@ public class MeshBuilderImpl implements MeshBuilder {
 
 	@Override
 	public Mesh build() {
-		int[] packed = new int[index];
+		final int[] packed = new int[index];
 		System.arraycopy(data, 0, packed, 0, index);
 		index = 0;
 		maker.begin(data, index);
@@ -76,7 +75,6 @@ public class MeshBuilderImpl implements MeshBuilder {
 				geometryFlags(GeometryHelper.computeShapeFlags(this));
 			}
 
-			ColorHelper.applyDiffuseShading(this, false);
 			index += EncodingFormat.TOTAL_STRIDE;
 			ensureCapacity(EncodingFormat.TOTAL_STRIDE);
 			baseIndex = index;

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
@@ -38,16 +38,14 @@ import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.impl.client.indigo.renderer.IndigoRenderer;
 import net.fabricmc.fabric.impl.client.indigo.renderer.RenderMaterialImpl.Value;
-import net.fabricmc.fabric.impl.client.indigo.renderer.helper.GeometryHelper;
 import net.fabricmc.fabric.impl.client.indigo.renderer.helper.NormalHelper;
 import net.fabricmc.fabric.impl.client.indigo.renderer.helper.TextureHelper;
-import net.fabricmc.fabric.impl.client.indigo.renderer.helper.ColorHelper.ShadeableQuad;
 
 /**
  * Almost-concrete implementation of a mutable quad. The only missing part is {@link #emit()},
  * because that depends on where/how it is used. (Mesh encoding vs. render-time transformation).
  */
-public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEmitter, ShadeableQuad {
+public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEmitter {
 	public final void begin(int[] data, int baseIndex) {
 		this.data = data;
 		this.baseIndex = baseIndex;
@@ -113,16 +111,6 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 		System.arraycopy(quadData, startIndex, data, baseIndex + HEADER_STRIDE, QUAD_STRIDE);
 		this.invalidateShape();
 		return this;
-	}
-
-	@Override
-	public boolean isFaceAligned() {
-		return (geometryFlags() & GeometryHelper.AXIS_ALIGNED_FLAG) != 0;
-	}
-
-	@Override
-	public boolean needsDiffuseShading(int textureIndex) {
-		return textureIndex == 0 && !material().disableDiffuse(textureIndex);
 	}
 
 	@Override

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/QuadViewImpl.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/QuadViewImpl.java
@@ -170,7 +170,7 @@ public class QuadViewImpl implements QuadView {
 
 	@Override
 	public void copyTo(MutableQuadView target) {
-		MutableQuadViewImpl quad = (MutableQuadViewImpl) target;
+		final MutableQuadViewImpl quad = (MutableQuadViewImpl) target;
 		// copy everything except the header/material
 		System.arraycopy(data, baseIndex + 1, quad.data, quad.baseIndex + 1, EncodingFormat.TOTAL_STRIDE - 1);
 		quad.isFaceNormalInvalid = this.isFaceNormalInvalid;
@@ -288,7 +288,7 @@ public class QuadViewImpl implements QuadView {
 	}
 
 	public boolean hasShade() {
-		return shade;
+		return shade && !material().disableDiffuse(0);
 	}
 
 	public void shade(boolean shade) {

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AbstractMeshConsumer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AbstractMeshConsumer.java
@@ -29,7 +29,6 @@ import net.fabricmc.fabric.api.renderer.v1.render.RenderContext.QuadTransform;
 import net.fabricmc.fabric.impl.client.indigo.renderer.IndigoRenderer;
 import net.fabricmc.fabric.impl.client.indigo.renderer.RenderMaterialImpl;
 import net.fabricmc.fabric.impl.client.indigo.renderer.aocalc.AoCalculator;
-import net.fabricmc.fabric.impl.client.indigo.renderer.helper.ColorHelper;
 import net.fabricmc.fabric.impl.client.indigo.renderer.helper.GeometryHelper;
 import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.EncodingFormat;
 import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.MeshImpl;
@@ -58,7 +57,6 @@ public abstract class AbstractMeshConsumer extends AbstractQuadRenderer implemen
 		@Override
 		public Maker emit() {
 			lightFace(GeometryHelper.lightFace(this));
-			ColorHelper.applyDiffuseShading(this, false);
 			renderQuad(this);
 			clear();
 			return this;
@@ -69,7 +67,7 @@ public abstract class AbstractMeshConsumer extends AbstractQuadRenderer implemen
 
 	@Override
 	public void accept(Mesh mesh) {
-		MeshImpl m = (MeshImpl) mesh;
+		final MeshImpl m = (MeshImpl) mesh;
 		final int[] data = m.data();
 		final int limit = data.length;
 		int index = 0;

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
@@ -106,7 +106,7 @@ public class ItemRenderContext extends AbstractRenderContext implements RenderCo
 		this.transformMode = transformMode;
 		this.vanillaHandler = vanillaHandler;
 		quadBlendMode = BlendMode.DEFAULT;
-		modelVertexConsumer = selectVertexConsumer(RenderLayers.getItemLayer(itemStack));
+		modelVertexConsumer = selectVertexConsumer(RenderLayers.getItemLayer(itemStack, transformMode != ModelTransformation.Mode.GROUND));
 
 		matrixStack.push();
 		((BakedModel) model).getTransformation().getTransformation(transformMode).apply(invert, matrixStack);

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
@@ -33,11 +33,11 @@ import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.client.render.model.BakedQuad;
 import net.minecraft.client.render.model.json.ModelTransformation;
 import net.minecraft.client.render.model.json.ModelTransformation.Mode;
-import net.minecraft.util.math.Matrix4f;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.Matrix4f;
 
 import net.fabricmc.fabric.api.renderer.v1.material.BlendMode;
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
@@ -144,7 +144,6 @@ public class ItemRenderContext extends AbstractRenderContext implements RenderCo
 		@Override
 		public Maker emit() {
 			lightFace(GeometryHelper.lightFace(this));
-			ColorHelper.applyDiffuseShading(this, false);
 			renderQuad();
 			clear();
 			return this;

--- a/fabric-resource-loader-v0/build.gradle
+++ b/fabric-resource-loader-v0/build.gradle
@@ -1,2 +1,2 @@
 archivesBaseName = "fabric-resource-loader-v0"
-version = getSubprojectVersion(project, "0.1.14")
+version = getSubprojectVersion(project, "0.2.0")

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/MixinMinecraftServer.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/MixinMinecraftServer.java
@@ -16,26 +16,21 @@
 
 package net.fabricmc.fabric.mixin.resource.loader;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 
-import net.minecraft.resource.ResourcePackManager;
-import net.minecraft.resource.ResourcePackProfile;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.resource.ResourcePackProvider;
 
 import net.fabricmc.fabric.impl.resource.loader.ModResourcePackCreator;
 
 @Mixin(MinecraftServer.class)
 public class MixinMinecraftServer {
-	@Shadow
-	private ResourcePackManager<ResourcePackProfile> dataPackManager;
-
-	@Inject(method = "loadWorldDataPacks", at = @At(value = "INVOKE", target = "Lnet/minecraft/resource/ResourcePackManager;registerProvider(Lnet/minecraft/resource/ResourcePackProvider;)V", ordinal = 1))
-	public void appendFabricDataPacks(CallbackInfo info) {
-		dataPackManager.registerProvider(new ModResourcePackCreator(ResourceType.SERVER_DATA));
+	@ModifyArg(method = "method_29438", at = @At(value = "INVOKE", target = "Lnet/minecraft/resource/ResourcePackManager;<init>(Lnet/minecraft/resource/ResourcePackProfile$Factory;[Lnet/minecraft/resource/ResourcePackProvider;)V"))
+	private static ResourcePackProvider[] appendFabricDataPacks(ResourcePackProvider[] packProviders) {
+		return ArrayUtils.add(packProviders, new ModResourcePackCreator(ResourceType.SERVER_DATA));
 	}
 }

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/MixinResourcePackManager.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/MixinResourcePackManager.java
@@ -16,24 +16,25 @@
 
 package net.fabricmc.fabric.mixin.resource.loader;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.resource.ResourcePack;
+import net.minecraft.resource.ResourcePackManager;
 
 import net.fabricmc.fabric.impl.resource.loader.ModResourcePackUtil;
 
-@Mixin(MinecraftClient.class)
-public class MixinMinecraftGame {
-	@Inject(method = "reloadResources", at = @At(value = "INVOKE", target = "Lnet/minecraft/resource/ReloadableResourceManager;beginMonitoredReload(Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Ljava/util/concurrent/CompletableFuture;Ljava/util/List;)Lnet/minecraft/resource/ResourceReloadMonitor;", ordinal = 0), locals = LocalCapture.CAPTURE_FAILHARD)
-	public void reloadResources(CallbackInfoReturnable<CompletableFuture> info, CompletableFuture<java.lang.Void> cf, List<ResourcePack> list) {
+@Mixin(ResourcePackManager.class)
+public class MixinResourcePackManager {
+	@Inject(method = "method_29211", at = @At("RETURN"), cancellable = true)
+	public void method_29211(CallbackInfoReturnable<List<ResourcePack>> infoReturnable) {
+		List<ResourcePack> list = new ArrayList<>(infoReturnable.getReturnValue());
 		ModResourcePackUtil.modifyResourcePackList(list);
+		infoReturnable.setReturnValue(list);
 	}
 }

--- a/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
+++ b/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
@@ -11,6 +11,7 @@
   "client": [
     "MixinFormat4ResourcePack",
     "MixinKeyedResourceReloadListener$Client",
+    "MixinResourcePackManager",
     "MixinMinecraftGame"
   ],
   "injectors": {

--- a/fabric-tool-attribute-api-v1/build.gradle
+++ b/fabric-tool-attribute-api-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-tool-attribute-api-v1"
-version = getSubprojectVersion(project, "1.1.0")
+version = getSubprojectVersion(project, "1.1.1")
 
 dependencies {
     compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-tool-attribute-api-v1/src/testmod/java/net/fabricmc/fabric/test/tool/attribute/ToolAttributeTest.java
+++ b/fabric-tool-attribute-api-v1/src/testmod/java/net/fabricmc/fabric/test/tool/attribute/ToolAttributeTest.java
@@ -41,8 +41,9 @@ public class ToolAttributeTest implements ModInitializer {
 		Registry.register(Registry.ITEM, new Identifier("fabric-tool-attribute-api-v1-testmod", "test_shovel"), new TestShovel(new Item.Settings()));
 		// Register a block that requires a shovel that is as strong or stronger than an iron one.
 		Block block = Registry.register(Registry.BLOCK, new Identifier("fabric-tool-attribute-api-v1-testmod", "hardened_block"),
-				new Block(FabricBlockSettings.of(new FabricMaterialBuilder(MaterialColor.SAND).requiresTool().build(), MaterialColor.STONE)
+				new Block(FabricBlockSettings.of(new FabricMaterialBuilder(MaterialColor.SAND).build(), MaterialColor.STONE)
 						.breakByTool(FabricToolTags.SHOVELS, 2)
+						.method_29292()
 						.strength(0.6F)
 						.sounds(BlockSoundGroup.GRAVEL)));
 		Registry.register(Registry.ITEM, new Identifier("fabric-tool-attribute-api-v1-testmod", "hardened_block"), new BlockItem(block, new Item.Settings()));


### PR DESCRIPTION
In 1.16 Mojang added a shade indicator to bake quads and moved diffuse shading to buffer time instead of pre-multiplying quad vertex colors.  They also made diffuse shade dimension-specific. Diffuse shade may be < 1 in the Nether even for unshaded quads.

This PR makes Indigo handle these changes properly for modded models using the API

- Fixes #638 - don't apply diffuse shading twice
- Changes the flat (non-AO) lighting path to correctly control shade based on render material
- Honor render material diffuse shading selection in AO path
- Remove non-API helper methods that are no longer needed
- Interpolate diffuse shade for models with non-cubic quads or when vertex normals are present
- Bump indigo patch version ( could perhaps merit a minor bump, up to admins)

Before
![2020-05-25_09 34 32](https://user-images.githubusercontent.com/6106235/82838644-b3a31280-9e81-11ea-8790-74c7933b8648.png)

After
![2020-05-25_09 55 01](https://user-images.githubusercontent.com/6106235/82838687-d1707780-9e81-11ea-8453-2e60b3d40296.png)

Before
![2020-05-25_11 44 27](https://user-images.githubusercontent.com/6106235/82838708-de8d6680-9e81-11ea-9b44-c70fce725246.png)

After
![2020-05-25_11 19 01](https://user-images.githubusercontent.com/6106235/82838718-e77e3800-9e81-11ea-8b2b-5c351312f696.png)

Before
![2020-05-25_09 34 41](https://user-images.githubusercontent.com/6106235/82838738-f49b2700-9e81-11ea-9fde-1e8ed00506a8.png)

After
![2020-05-25_09 54 46](https://user-images.githubusercontent.com/6106235/82838743-fa910800-9e81-11ea-8ae1-35d186d6ffc4.png)

Before
![2020-05-25_11 44 56](https://user-images.githubusercontent.com/6106235/82838757-04b30680-9e82-11ea-8f95-63d5d2338f0e.png)

After
![2020-05-25_11 39 43](https://user-images.githubusercontent.com/6106235/82838767-0bda1480-9e82-11ea-8245-513f14784a95.png)

Before
![2020-05-25_11 51 44](https://user-images.githubusercontent.com/6106235/82838773-14cae600-9e82-11ea-8645-1b56ac070ead.png)

After
![2020-05-25_11 53 48](https://user-images.githubusercontent.com/6106235/82838788-1dbbb780-9e82-11ea-9f95-9dd5a3611275.png)


