### PR TITLE
Move new method in FabricBlockSettings to correct place in class.

### DIFF
--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricBlockSettings.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricBlockSettings.java
@@ -243,6 +243,15 @@ public class FabricBlockSettings extends AbstractBlock.Settings {
 		return this;
 	}
 
+	/**
+	 * Make the material require tool to drop and slows down mining speed if the incorrect tool is used.
+	 */
+	@Override
+	public FabricBlockSettings method_29292() {
+		super.method_29292();
+		return this;
+	}
+
 	/* FABRIC DELEGATE WRAPPERS */
 
 	public FabricBlockSettings materialColor(MaterialColor color) {
@@ -284,14 +293,5 @@ public class FabricBlockSettings extends AbstractBlock.Settings {
 	 */
 	public FabricBlockSettings breakByTool(Tag<Item> tag) {
 		return this.breakByTool(tag, 0);
-	}
-
-	/**
-	 * Make the material require tool to drop and slows down mining speed if the incorrect tool is used.
-	 */
-	@Override
-	public FabricBlockSettings method_29292() {
-		super.method_29292();
-		return this;
 	}
 }


### PR DESCRIPTION
The lower methods in the class are commented with their categories:

`FABRIC DELEGATE WRAPPERS` for additional methods to allow editing fields not actually exposed in vanilla.

`FABRIC HELPERS` for methods to handle things like mining levels.

Per these two categories, the new method does not belong in `FABRIC HELPERS` and has been moved accordingly