### PR TITLE
Player Join Event - 1.16

### DIFF
--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/server/PlayerJoinCallback.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/server/PlayerJoinCallback.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.event.server;
+
+import net.minecraft.network.ClientConnection;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+/**
+ * This event is called when a player joins the server.
+ *
+ * <p>It hooks in at the end of {@link net.minecraft.server.PlayerManager#onPlayerConnect(ClientConnection, ServerPlayerEntity)} through {@link net.fabricmc.fabric.mixin.event.lifecycle.MixinPlayerManager}.
+ */
+public interface PlayerJoinCallback {
+	Event<PlayerJoinCallback> EVENT = EventFactory.createArrayBacked(PlayerJoinCallback.class,
+			(listeners) -> (playerEntity) -> {
+				for (PlayerJoinCallback event : listeners) {
+					event.onPlayerJoin(playerEntity);
+				}
+			}
+	);
+
+	void onPlayerJoin(ServerPlayerEntity player);
+}

--- a/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MixinPlayerManager.java
+++ b/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MixinPlayerManager.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.event.lifecycle;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.network.ClientConnection;
+import net.minecraft.server.PlayerManager;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import net.fabricmc.fabric.api.event.server.PlayerJoinCallback;
+
+@Mixin(PlayerManager.class)
+public abstract class MixinPlayerManager {
+	@Inject(at = @At("RETURN"), method = "onPlayerConnect")
+	private void onPlayerConnect(ClientConnection connection, ServerPlayerEntity player, CallbackInfo ci) {
+		PlayerJoinCallback.EVENT.invoker().onPlayerJoin(player);
+	}
+}

--- a/fabric-events-lifecycle-v0/src/main/resources/fabric-events-lifecycle-v0.mixins.json
+++ b/fabric-events-lifecycle-v0/src/main/resources/fabric-events-lifecycle-v0.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinMinecraftServer",
+    "MixinPlayerManager",
     "MixinWorld"
   ],
   "client": [

--- a/fabric-events-lifecycle-v0/src/testmod/java/net/fabricmc/fabric/test/event/LifecycleEventsTest.java
+++ b/fabric-events-lifecycle-v0/src/testmod/java/net/fabricmc/fabric/test/event/LifecycleEventsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.event;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.text.LiteralText;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.server.PlayerJoinCallback;
+
+public class LifecycleEventsTest implements ModInitializer {
+	@Override
+	public void onInitialize() {
+		/*
+		This callback is triggered when a player joins the server.
+		It sends the ServerPlayerEntity a welcome message, and then gives them an apple.
+		*/
+		PlayerJoinCallback.EVENT.register(player -> {
+			player.sendMessage(new LiteralText(String.format("Welcome to the server, %s!", player.getDisplayName().asString())), false);
+			player.giveItemStack(new ItemStack(Items.APPLE));
+		});
+	}
+}

--- a/fabric-events-lifecycle-v0/src/testmod/resources/fabric.mod.json
+++ b/fabric-events-lifecycle-v0/src/testmod/resources/fabric.mod.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 1,
+  "id": "fabric-events-lifecycle-v0-testmod",
+  "name": "Fabric Events Lifecycle (v0) Test Mod",
+  "version": "1.0.0",
+  "environment": "*",
+  "license": "Apache-2.0",
+  "depends": {
+    "fabric-events-lifecycle-v0": "*"
+  },
+  "entrypoints": {
+    "main": [
+      "net.fabricmc.fabric.test.LifecycleEventsTest"
+    ]
+  }
+}

--- a/fabric-events-lifecycle-v0/src/testmod/resources/fabric.mod.json
+++ b/fabric-events-lifecycle-v0/src/testmod/resources/fabric.mod.json
@@ -10,7 +10,7 @@
   },
   "entrypoints": {
     "main": [
-      "net.fabricmc.fabric.test.LifecycleEventsTest"
+      "net.fabricmc.fabric.test.event.LifecycleEventsTest"
     ]
   }
 }


### PR DESCRIPTION
**Overview**
This is a simple player join event targeted at 1.16. It hooks in at the end of `PlayerManager#onPlayerConnect`. All style/license checks pass, and the testmod works.

**Use Cases**
A few use cases of this include:
   - giving items to the player when they first join
   - sending welcome messages to players on login
   - broadcasting join messages

I know several people who use this as an inject spot (including myself) for doing things on player join, so it seems like an appropriate addition to the API.
 
**Examples**
*The following code is a snippet of the test mod.*
```java
@Override
public void onInitialize() {
	PlayerJoinCallback.EVENT.register(player -> {
		player.giveItemStack(new ItemStack(Items.APPLE));
	});
}
```

**Notes**
I opted to inject into the end of `onPlayerConnect` because I can't think of any valid reasons to go before it, besides making the event cancellable, which wasn't something I wanted.  I think the earliest you could go (while keeping it practical as a post join event) would be when the player's world is set halfway down the method.

I figured a network PR or a custom mixin would be better suited for denying logins (or something similar), but I could provide a pre-connect and post-connect event instead of a single post-connect event if needed.