### PR TITLE
networking: Clarify packet type callback JD

### DIFF
--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/event/network/C2SPacketTypeCallback.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/event/network/C2SPacketTypeCallback.java
@@ -25,9 +25,11 @@ import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
 /**
- * Event for listening to packet type registrations and unregistrations
- * (also known as "minecraft:register" and "minecraft:unregister")
- * in the client -&gt; server direction.
+ * Event for listening to packet type registration and unregistration notifications
+ * (also known as "minecraft:register" and "minecraft:unregister") sent by a client.
+ *
+ * <p>Registrations received will be for <em>server -&gt; client</em> packets
+ * that the sending client can understand.
  */
 public interface C2SPacketTypeCallback {
 	Event<C2SPacketTypeCallback> REGISTERED = EventFactory.createArrayBacked(

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/event/network/S2CPacketTypeCallback.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/event/network/S2CPacketTypeCallback.java
@@ -24,9 +24,11 @@ import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
 /**
- * Event for listening to packet type registrations and unregistrations
- * (also known as "minecraft:register" and "minecraft:unregister")
- * in the server -&gt; client direction.
+ * Event for listening to packet type registration and unregistration notifications
+ * (also known as "minecraft:register" and "minecraft:unregister") sent by a server.
+ *
+ * <p>Registrations received will be for <em>client -&gt; server</em> packets
+ * that the sending server can understand.
  */
 public interface S2CPacketTypeCallback {
 	Event<S2CPacketTypeCallback> REGISTERED = EventFactory.createArrayBacked(


### PR DESCRIPTION
Quick tweak to the packet type callbacks -- I read the callback class names as referring to the direction of the packet identifiers provided, not the direction of the `minecraft:register` packet which they actually refer to.

It seems like the naming is clear more clear in the upcoming networking-api v1 PR, but hopefully these doc changes will clarify for anyone trying to use networking callbacks in the meantime.