### PR TITLE
Fix loot table API for 1.16

### DIFF
--- a/fabric-loot-tables-v1/build.gradle
+++ b/fabric-loot-tables-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-loot-tables-v1"
-version = getSubprojectVersion(project, "0.1.10")
+version = getSubprojectVersion(project, "1.0.0")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/LootEntryTypeRegistry.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/LootEntryTypeRegistry.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.api.loot.v1;
 
 import net.minecraft.loot.entry.LootPoolEntry;
+import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.impl.loot.table.LootEntryTypeRegistryImpl;
 
@@ -30,9 +31,10 @@ public interface LootEntryTypeRegistry {
 	LootEntryTypeRegistry INSTANCE = LootEntryTypeRegistryImpl.INSTANCE;
 
 	/**
-	 * Registers a loot entry type by its serializer.
+	 * Registers a loot entry type serializer by its ID.
 	 *
+	 * @param id the loot entry's ID
 	 * @param serializer the loot entry serializer
 	 */
-	void register(LootPoolEntry.Serializer<?> serializer);
+	void register(Identifier id, LootPoolEntry.Serializer<?> serializer);
 }

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/LootEntryTypeRegistry.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/api/loot/v1/LootEntryTypeRegistry.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.api.loot.v1;
 
 import net.minecraft.loot.entry.LootPoolEntry;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.JsonSerializer;
 
 import net.fabricmc.fabric.impl.loot.table.LootEntryTypeRegistryImpl;
 
@@ -36,5 +37,5 @@ public interface LootEntryTypeRegistry {
 	 * @param id the loot entry's ID
 	 * @param serializer the loot entry serializer
 	 */
-	void register(Identifier id, LootPoolEntry.Serializer<?> serializer);
+	void register(Identifier id, JsonSerializer<? extends LootPoolEntry> serializer);
 }

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/impl/loot/table/LootEntryTypeRegistryImpl.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/impl/loot/table/LootEntryTypeRegistryImpl.java
@@ -18,8 +18,9 @@ package net.fabricmc.fabric.impl.loot.table;
 
 import net.minecraft.loot.entry.LootPoolEntry;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.JsonSerializer;
 
-import net.fabricmc.fabric.mixin.loot.table.LootPoolEntryTypesHooks;
+import net.fabricmc.fabric.mixin.loot.table.LootPoolEntryTypesAccessor;
 
 public final class LootEntryTypeRegistryImpl implements net.fabricmc.fabric.api.loot.v1.LootEntryTypeRegistry {
 	public static final LootEntryTypeRegistryImpl INSTANCE = new LootEntryTypeRegistryImpl();
@@ -27,7 +28,7 @@ public final class LootEntryTypeRegistryImpl implements net.fabricmc.fabric.api.
 	private LootEntryTypeRegistryImpl() { }
 
 	@Override
-	public void register(Identifier id, LootPoolEntry.Serializer<?> serializer) {
-		LootPoolEntryTypesHooks.register(id.toString(), serializer);
+	public void register(Identifier id, JsonSerializer<? extends LootPoolEntry> serializer) {
+		LootPoolEntryTypesAccessor.register(id.toString(), serializer);
 	}
 }

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/mixin/loot/table/LootPoolEntryTypesAccessor.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/mixin/loot/table/LootPoolEntryTypesAccessor.java
@@ -25,7 +25,7 @@ import net.minecraft.loot.entry.LootPoolEntryTypes;
 import net.minecraft.util.JsonSerializer;
 
 @Mixin(LootPoolEntryTypes.class)
-public interface LootPoolEntryTypesHooks {
+public interface LootPoolEntryTypesAccessor {
 	@Invoker("register")
 	static LootPoolEntryType register(String id, JsonSerializer<? extends LootPoolEntry> serializer) {
 		throw new UnsupportedOperationException("Mixin dummy");

--- a/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/mixin/loot/table/LootPoolEntryTypesHooks.java
+++ b/fabric-loot-tables-v1/src/main/java/net/fabricmc/fabric/mixin/loot/table/LootPoolEntryTypesHooks.java
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.impl.loot.table;
+package net.fabricmc.fabric.mixin.loot.table;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
 
 import net.minecraft.loot.entry.LootPoolEntry;
-import net.minecraft.util.Identifier;
+import net.minecraft.loot.entry.LootPoolEntryType;
+import net.minecraft.loot.entry.LootPoolEntryTypes;
+import net.minecraft.util.JsonSerializer;
 
-import net.fabricmc.fabric.mixin.loot.table.LootPoolEntryTypesHooks;
-
-public final class LootEntryTypeRegistryImpl implements net.fabricmc.fabric.api.loot.v1.LootEntryTypeRegistry {
-	public static final LootEntryTypeRegistryImpl INSTANCE = new LootEntryTypeRegistryImpl();
-
-	private LootEntryTypeRegistryImpl() { }
-
-	@Override
-	public void register(Identifier id, LootPoolEntry.Serializer<?> serializer) {
-		LootPoolEntryTypesHooks.register(id.toString(), serializer);
+@Mixin(LootPoolEntryTypes.class)
+public interface LootPoolEntryTypesHooks {
+	@Invoker("register")
+	static LootPoolEntryType register(String id, JsonSerializer<? extends LootPoolEntry> serializer) {
+		throw new UnsupportedOperationException("Mixin dummy");
 	}
 }

--- a/fabric-loot-tables-v1/src/main/resources/fabric-loot-tables-v1.mixins.json
+++ b/fabric-loot-tables-v1/src/main/resources/fabric-loot-tables-v1.mixins.json
@@ -4,7 +4,7 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "LootPoolBuilderHooks",
-    "LootPoolEntryTypesHooks",
+    "LootPoolEntryTypesAccessor",
     "LootSupplierBuilderHooks",
     "MixinLootManager",
     "MixinLootPool",

--- a/fabric-loot-tables-v1/src/main/resources/fabric-loot-tables-v1.mixins.json
+++ b/fabric-loot-tables-v1/src/main/resources/fabric-loot-tables-v1.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "LootPoolBuilderHooks",
+    "LootPoolEntryTypesHooks",
     "LootSupplierBuilderHooks",
     "MixinLootManager",
     "MixinLootPool",

--- a/fabric-loot-tables-v1/src/testmod/java/net/fabricmc/fabric/test/loot/LootTest.java
+++ b/fabric-loot-tables-v1/src/testmod/java/net/fabricmc/fabric/test/loot/LootTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.loot;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import net.minecraft.item.Items;
+import net.minecraft.loot.ConstantLootTableRange;
+import net.minecraft.loot.LootGsons;
+import net.minecraft.loot.LootPool;
+import net.minecraft.loot.condition.LootCondition;
+import net.minecraft.loot.condition.SurvivesExplosionLootCondition;
+import net.minecraft.loot.entry.ItemEntry;
+import net.minecraft.loot.entry.LootPoolEntry;
+import net.minecraft.loot.entry.TagEntry;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.JsonHelper;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.loot.v1.FabricLootPoolBuilder;
+import net.fabricmc.fabric.api.loot.v1.LootEntryTypeRegistry;
+import net.fabricmc.fabric.api.loot.v1.event.LootTableLoadingCallback;
+
+public class LootTest implements ModInitializer {
+	private static final Logger LOGGER = LogManager.getLogger();
+
+	private static final Gson LOOT_GSON = LootGsons.getTableGsonBuilder().create();
+	private static final String LOOT_ENTRY_JSON = "{\"type\":\"minecraft:item\",\"name\":\"minecraft:apple\"}";
+
+	@Override
+	public void onInitialize() {
+		// Test loot entry
+		LootEntryTypeRegistry.INSTANCE.register(new Identifier("fabric", "extended_tag"), new TestSerializer());
+
+		// Test loot table load event
+		LootTableLoadingCallback.EVENT.register((resourceManager, manager, id, supplier, setter) -> {
+			if ("minecraft:blocks/dirt".equals(id.toString())) {
+				LootPoolEntry entryFromString = LOOT_GSON.fromJson(LOOT_ENTRY_JSON, LootPoolEntry.class);
+
+				LootPool pool = FabricLootPoolBuilder.builder()
+						.withEntry(ItemEntry.builder(Items.FEATHER).build())
+						.withEntry(entryFromString)
+						.rolls(ConstantLootTableRange.create(1))
+						.withCondition(SurvivesExplosionLootCondition.builder().build())
+						.build();
+
+				supplier.withPool(pool);
+			}
+		});
+	}
+
+	private static class TestSerializer extends LootPoolEntry.Serializer<TagEntry> {
+		private static final TagEntry.Serializer SERIALIZER = new TagEntry.Serializer();
+
+		@Override
+		public void addEntryFields(JsonObject json, TagEntry entry, JsonSerializationContext context) {
+			SERIALIZER.addEntryFields(json, entry, context);
+			json.addProperty("fabric", true);
+		}
+
+		@Override
+		public TagEntry fromJson(JsonObject var1, JsonDeserializationContext var2, LootCondition[] var3) {
+			LOGGER.info("Is this a Fabric loot entry? " + JsonHelper.getBoolean(var1, "fabric", true));
+			return SERIALIZER.fromJson(var1, var2, var3);
+		}
+	}
+}

--- a/fabric-loot-tables-v1/src/testmod/resources/data/minecraft/loot_tables/blocks/stone.json
+++ b/fabric-loot-tables-v1/src/testmod/resources/data/minecraft/loot_tables/blocks/stone.json
@@ -1,0 +1,44 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "name": "minecraft:stone"
+            },
+            {
+              "type": "fabric:extended_tag",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                }
+              ],
+              "name": "minecraft:wool",
+              "expand": false
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/fabric-loot-tables-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-loot-tables-v1/src/testmod/resources/fabric.mod.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 1,
+  "id": "fabric-loot-tables-v1-testmod",
+  "name": "Fabric Loot Tables API (v1) Test Mod",
+  "version": "1.0.0",
+  "environment": "*",
+  "license": "Apache-2.0",
+  "depends": {
+    "fabric-loot-tables-v1": "*"
+  },
+  "entrypoints": {
+    "main": [
+      "net.fabricmc.fabric.test.loot.LootTest"
+    ]
+  }
+}


### PR DESCRIPTION
Also reintroduces the loot API test mod.
May be considered a temporary fix before #629 is merged.