### PR TITLE
Lifecycle Events: Part 2, Electric Boogaloo

### DIFF
--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerLifecycleEvents.java
@@ -104,9 +104,9 @@ public final class ServerLifecycleEvents {
 	 *
 	 * <p>When this event is fired, the currently loaded data packs will not be replaced.
 	 */
-	public static final Event<FailDataPackReload> DATA_PACK_RELOAD_FAIL = EventFactory.createArrayBacked(FailDataPackReload.class, callbacks -> (throwable, server, serverResourceManager) -> {
+	public static final Event<FailDataPackReload> DATA_PACK_RELOAD_FAIL = EventFactory.createArrayBacked(FailDataPackReload.class, callbacks -> (cause, server, serverResourceManager) -> {
 		for (FailDataPackReload callback : callbacks) {
-			callback.failDataPackReload(throwable, server, serverResourceManager);
+			callback.failDataPackReload(cause, server, serverResourceManager);
 		}
 	});
 
@@ -135,6 +135,6 @@ public final class ServerLifecycleEvents {
 	}
 
 	public interface FailDataPackReload {
-		void failDataPackReload(Throwable throwable, MinecraftServer server, ServerResourceManager serverResourceManager);
+		void failDataPackReload(Throwable cause, MinecraftServer server, ServerResourceManager serverResourceManager);
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerLifecycleEvents.java
@@ -78,35 +78,21 @@ public final class ServerLifecycleEvents {
 
 	/**
 	 * Called before a Minecraft server reloads data packs.
-	 *
-	 * <p>This event will be followed by {@link #END_DATA_PACK_RELOAD} if the reload was successful.
-	 * If the data pack reload failed, then {@link #DATA_PACK_RELOAD_FAIL} will be fired.
 	 */
-	public static final Event<BeforeDataPackReload> START_DATA_PACK_RELOAD = EventFactory.createArrayBacked(BeforeDataPackReload.class, callbacks -> (server, serverResourceManager) -> {
-		for (BeforeDataPackReload callback : callbacks) {
-			callback.beforeDataPackReload(server, serverResourceManager);
+	public static final Event<StartDataPackReload> START_DATA_PACK_RELOAD = EventFactory.createArrayBacked(StartDataPackReload.class, callbacks -> (server, serverResourceManager) -> {
+		for (StartDataPackReload callback : callbacks) {
+			callback.startDataPackReload(server, serverResourceManager);
 		}
 	});
 
 	/**
 	 * Called after a Minecraft server has reloaded data packs.
 	 *
-	 * <p>When this event is fired, the reloaded data packs will be applied.
+	 * <p>If reloading data packs was unsuccessful, the current data packs will be kept.
 	 */
-	public static final Event<AfterDataPackReload> END_DATA_PACK_RELOAD = EventFactory.createArrayBacked(AfterDataPackReload.class, callbacks -> (server, serverResourceManager) -> {
-		for (AfterDataPackReload callback : callbacks) {
-			callback.afterDataPackReload(server, serverResourceManager);
-		}
-	});
-
-	/**
-	 * Called when reloading data packs on a Minecraft server has failed.
-	 *
-	 * <p>When this event is fired, the currently loaded data packs will not be replaced.
-	 */
-	public static final Event<FailDataPackReload> DATA_PACK_RELOAD_FAIL = EventFactory.createArrayBacked(FailDataPackReload.class, callbacks -> (cause, server, serverResourceManager) -> {
-		for (FailDataPackReload callback : callbacks) {
-			callback.failDataPackReload(cause, server, serverResourceManager);
+	public static final Event<EndDataPackReload> END_DATA_PACK_RELOAD = EventFactory.createArrayBacked(EndDataPackReload.class, callbacks -> (server, serverResourceManager, success) -> {
+		for (EndDataPackReload callback : callbacks) {
+			callback.endDataPackReload(server, serverResourceManager, success);
 		}
 	});
 
@@ -126,15 +112,20 @@ public final class ServerLifecycleEvents {
 		void onServerStopped(MinecraftServer server);
 	}
 
-	public interface BeforeDataPackReload {
-		void beforeDataPackReload(MinecraftServer server, ServerResourceManager serverResourceManager);
+	public interface StartDataPackReload {
+		void startDataPackReload(MinecraftServer server, ServerResourceManager serverResourceManager);
 	}
 
-	public interface AfterDataPackReload {
-		void afterDataPackReload(MinecraftServer server, ServerResourceManager serverResourceManager);
-	}
-
-	public interface FailDataPackReload {
-		void failDataPackReload(Throwable cause, MinecraftServer server, ServerResourceManager serverResourceManager);
+	public interface EndDataPackReload {
+		/**
+		 * Called after data packs on a Minecraft server have been reloaded.
+		 *
+		 * <p>If the reload was not successful, the old data packs will be kept.
+		 *
+		 * @param server the server
+		 * @param serverResourceManager the server resource manager
+		 * @param success if the reload was successful
+		 */
+		void endDataPackReload(MinecraftServer server, ServerResourceManager serverResourceManager, boolean success);
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerLifecycleEvents.java
@@ -16,7 +16,11 @@
 
 package net.fabricmc.fabric.api.event.lifecycle.v1;
 
+import net.minecraft.resource.ServerResourceManager;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.PlayerManager;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.world.PersistentState;
 
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
@@ -24,6 +28,17 @@ import net.fabricmc.fabric.api.event.EventFactory;
 public final class ServerLifecycleEvents {
 	private ServerLifecycleEvents() {
 	}
+
+	/**
+	 * Called when a Minecraft server is starting.
+	 *
+	 * <p>This occurs before the {@link PlayerManager player manager} and any worlds are loaded.
+	 */
+	public static final Event<ServerStarting> SERVER_STARTING = EventFactory.createArrayBacked(ServerStarting.class, callbacks -> server -> {
+		for (ServerStarting callback : callbacks) {
+			callback.onServerStarting(server);
+		}
+	});
 
 	/**
 	 * Called when a Minecraft server has started and is about to tick for the first time.
@@ -63,6 +78,39 @@ public final class ServerLifecycleEvents {
 		}
 	});
 
+	/**
+	 * Called when a world is loaded by a Minecraft server.
+	 *
+	 * <p>For example, this can be used to load world specific metadata or initialize a {@link PersistentState} on a server world.
+	 */
+	public static final Event<LoadWorld> LOAD_WORLD = EventFactory.createArrayBacked(LoadWorld.class, callbacks -> (server, world) -> {
+		for (LoadWorld callback : callbacks) {
+			callback.onWorldLoaded(server, world);
+		}
+	});
+
+	/**
+	 * Called before a Minecraft server reloads datapacks.
+	 */
+	public static final Event<BeforeResourceReload> BEFORE_RESOURCE_RELOAD = EventFactory.createArrayBacked(BeforeResourceReload.class, callbacks -> (server, serverResourceManager) -> {
+		for (BeforeResourceReload callback : callbacks) {
+			callback.beforeResourceReload(server, serverResourceManager);
+		}
+	});
+
+	/**
+	 * Called after a Minecraft server has reloaded datapacks.
+	 */
+	public static final Event<AfterResourceReload> AFTER_RESOURCE_RELOAD = EventFactory.createArrayBacked(AfterResourceReload.class, callbacks -> (server, serverResourceManager) -> {
+		for (AfterResourceReload callback : callbacks) {
+			callback.afterResourceReload(server, serverResourceManager);
+		}
+	});
+
+	public interface ServerStarting {
+		void onServerStarting(MinecraftServer server);
+	}
+
 	public interface ServerStarted {
 		void onServerStarted(MinecraftServer server);
 	}
@@ -73,5 +121,17 @@ public final class ServerLifecycleEvents {
 
 	public interface ServerStopped {
 		void onServerStopped(MinecraftServer server);
+	}
+
+	public interface LoadWorld {
+		void onWorldLoaded(MinecraftServer server, ServerWorld world);
+	}
+
+	public interface BeforeResourceReload {
+		void beforeResourceReload(MinecraftServer server, ServerResourceManager serverResourceManager);
+	}
+
+	public interface AfterResourceReload {
+		void afterResourceReload(MinecraftServer server, ServerResourceManager serverResourceManager);
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerLifecycleEvents.java
@@ -107,6 +107,17 @@ public final class ServerLifecycleEvents {
 		}
 	});
 
+	/**
+	 * Called before a Minecraft server saves all worlds and world properties.
+	 *
+	 * <p>Mods can use this event to save cached data.
+	 */
+	public static final Event<Save> SAVE = EventFactory.createArrayBacked(Save.class, callbacks -> (server, flush) -> {
+		for (Save callback : callbacks) {
+			callback.onSave(server, flush);
+		}
+	});
+
 	public interface ServerStarting {
 		void onServerStarting(MinecraftServer server);
 	}
@@ -133,5 +144,15 @@ public final class ServerLifecycleEvents {
 
 	public interface AfterResourceReload {
 		void afterResourceReload(MinecraftServer server, ServerResourceManager serverResourceManager);
+	}
+
+	public interface Save {
+		/**
+		 * Called before worlds and world properties are saved.
+		 *
+		 * @param server the server
+		 * @param flush specifies whether the worlds should unload all chunks, typically during shutdown
+		 */
+		void onSave(MinecraftServer server, boolean flush);
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerWorldEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerWorldEvents.java
@@ -31,12 +31,12 @@ public final class ServerWorldEvents {
 	 */
 	public static final Event<Load> LOAD = EventFactory.createArrayBacked(Load.class, callbacks -> (server, world) -> {
 		for (Load callback : callbacks) {
-			callback.onWorldLoaded(server, world);
+			callback.onWorldLoad(server, world);
 		}
 	});
 
 	public interface Load {
-		void onWorldLoaded(MinecraftServer server, ServerWorld world);
+		void onWorldLoad(MinecraftServer server, ServerWorld world);
 	}
 
 	private ServerWorldEvents() {

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerWorldEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerWorldEvents.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.event.lifecycle.v1;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.world.PersistentState;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+public final class ServerWorldEvents {
+	/**
+	 * Called when a world is loaded by a Minecraft server.
+	 *
+	 * <p>For example, this can be used to load world specific metadata or initialize a {@link PersistentState} on a server world.
+	 */
+	public static final Event<Load> LOAD = EventFactory.createArrayBacked(Load.class, callbacks -> (server, world) -> {
+		for (Load callback : callbacks) {
+			callback.onWorldLoaded(server, world);
+		}
+	});
+
+	public interface Load {
+		void onWorldLoaded(MinecraftServer server, ServerWorld world);
+	}
+
+	private ServerWorldEvents() {
+	}
+}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
@@ -108,4 +108,9 @@ public abstract class MinecraftServerMixin {
 	private void afterResourceReload(Collection<String> enabledPacks, ServerResourceManager serverResourceManager, CallbackInfo ci) {
 		ServerLifecycleEvents.AFTER_RESOURCE_RELOAD.invoker().afterResourceReload((MinecraftServer) (Object) this, this.serverResourceManager);
 	}
+
+	@Inject(method = "save", at = @At("HEAD"))
+	private void onSave(boolean bl, boolean flush, boolean bl3, CallbackInfoReturnable<Boolean> cir) {
+		ServerLifecycleEvents.SAVE.invoker().onSave((MinecraftServer) (Object) this, flush);
+	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
@@ -16,18 +16,25 @@
 
 package net.fabricmc.fabric.mixin.event.lifecycle;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.BooleanSupplier;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.Entity;
+import net.minecraft.resource.ServerResourceManager;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.world.ServerWorld;
 
@@ -37,6 +44,14 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 
 @Mixin(MinecraftServer.class)
 public abstract class MinecraftServerMixin {
+	@Shadow
+	private ServerResourceManager serverResourceManager;
+
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;setupServer()Z"), method = "method_29741")
+	private void beforeSetupServer(CallbackInfo info) {
+		ServerLifecycleEvents.SERVER_STARTING.invoker().onServerStarting((MinecraftServer) (Object) this);
+	}
+
 	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;setFavicon(Lnet/minecraft/server/ServerMetadata;)V", ordinal = 0), method = "runServer")
 	private void afterSetupServer(CallbackInfo info) {
 		ServerLifecycleEvents.SERVER_STARTED.invoker().onServerStarted((MinecraftServer) (Object) this);
@@ -72,5 +87,25 @@ public abstract class MinecraftServerMixin {
 		for (BlockEntity blockEntity : serverWorld.blockEntities) {
 			ServerBlockEntityEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(blockEntity, serverWorld);
 		}
+	}
+
+	// The locals you have to manage for an inject are insane. And do it twice. A redirect is much cleaner.
+	// Here is what it looks like with an inject: https://gist.github.com/i509VCB/f80077cc536eb4dba62b794eba5611c1
+	@Redirect(method = "createWorlds", at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"))
+	private <K, V> V onLoadWorld(Map<K, V> worlds, K registryKey, V serverWorld) {
+		final V result = worlds.put(registryKey, serverWorld);
+		ServerLifecycleEvents.LOAD_WORLD.invoker().onWorldLoaded((MinecraftServer) (Object) this, (ServerWorld) serverWorld);
+
+		return result;
+	}
+
+	@Inject(method = "reloadResources", at = @At("HEAD"))
+	private void beforeResourceReload(Collection<String> collection, CallbackInfoReturnable<CompletableFuture<Void>> cir) {
+		ServerLifecycleEvents.BEFORE_RESOURCE_RELOAD.invoker().beforeResourceReload((MinecraftServer) (Object) this, this.serverResourceManager);
+	}
+
+	@Inject(method = "method_29440(Ljava/util/Collection;Lnet/minecraft/resource/ServerResourceManager;)V", at = @At("TAIL"))
+	private void afterResourceReload(Collection<String> enabledPacks, ServerResourceManager serverResourceManager, CallbackInfo ci) {
+		ServerLifecycleEvents.AFTER_RESOURCE_RELOAD.invoker().afterResourceReload((MinecraftServer) (Object) this, this.serverResourceManager);
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
@@ -95,7 +95,7 @@ public abstract class MinecraftServerMixin {
 	@Redirect(method = "createWorlds", at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"))
 	private <K, V> V onLoadWorld(Map<K, V> worlds, K registryKey, V serverWorld) {
 		final V result = worlds.put(registryKey, serverWorld);
-		ServerWorldEvents.LOAD.invoker().onWorldLoaded((MinecraftServer) (Object) this, (ServerWorld) serverWorld);
+		ServerWorldEvents.LOAD.invoker().onWorldLoad((MinecraftServer) (Object) this, (ServerWorld) serverWorld);
 
 		return result;
 	}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
@@ -102,19 +102,19 @@ public abstract class MinecraftServerMixin {
 
 	@Inject(method = "reloadResources", at = @At("HEAD"))
 	private void beforeResourceReload(Collection<String> collection, CallbackInfoReturnable<CompletableFuture<Void>> cir) {
-		ServerLifecycleEvents.START_DATA_PACK_RELOAD.invoker().beforeDataPackReload((MinecraftServer) (Object) this, this.serverResourceManager);
+		ServerLifecycleEvents.START_DATA_PACK_RELOAD.invoker().startDataPackReload((MinecraftServer) (Object) this, this.serverResourceManager);
 	}
 
 	@Inject(method = "method_29440(Ljava/util/Collection;Lnet/minecraft/resource/ServerResourceManager;)V", at = @At("TAIL"))
 	private void afterResourceReload(Collection<String> enabledPacks, ServerResourceManager serverResourceManager, CallbackInfo ci) {
-		ServerLifecycleEvents.END_DATA_PACK_RELOAD.invoker().afterDataPackReload((MinecraftServer) (Object) this, this.serverResourceManager);
+		ServerLifecycleEvents.END_DATA_PACK_RELOAD.invoker().endDataPackReload((MinecraftServer) (Object) this, this.serverResourceManager, true);
 	}
 
 	@Inject(method = "reloadResources", at = @At("TAIL"))
 	private void addResourceReloadFailureCallback(Collection<String> collection, CallbackInfoReturnable<CompletableFuture<Void>> cir) {
 		// Hook into fail
 		cir.getReturnValue().exceptionally(throwable -> {
-			ServerLifecycleEvents.DATA_PACK_RELOAD_FAIL.invoker().failDataPackReload(throwable, (MinecraftServer) (Object) this, this.serverResourceManager);
+			ServerLifecycleEvents.END_DATA_PACK_RELOAD.invoker().endDataPackReload((MinecraftServer) (Object) this, this.serverResourceManager, false);
 			return null;
 		});
 	}

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerBlockEntityLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerBlockEntityLifecycleTests.java
@@ -31,7 +31,7 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 
 public class ServerBlockEntityLifecycleTests implements ModInitializer {
-	private static boolean PRINT_SERVER_BLOCKENTITY_MESSAGES = Boolean.parseBoolean(System.getProperty("fabric-lifecycle-events-testmod.printServerBlockEntityMessages", "false"));
+	private static boolean PRINT_SERVER_BLOCKENTITY_MESSAGES = System.getProperty("fabric-lifecycle-events-testmod.printServerBlockEntityMessages") != null;
 	private List<BlockEntity> serverBlockEntities = new ArrayList<>();
 
 	@Override

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerBlockEntityLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerBlockEntityLifecycleTests.java
@@ -31,6 +31,7 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 
 public class ServerBlockEntityLifecycleTests implements ModInitializer {
+	private static boolean PRINT_SERVER_BLOCKENTITY_MESSAGES = Boolean.parseBoolean(System.getProperty("fabric-lifecycle-events-testmod.printServerBlockEntityMessages", "false"));
 	private List<BlockEntity> serverBlockEntities = new ArrayList<>();
 
 	@Override
@@ -39,28 +40,44 @@ public class ServerBlockEntityLifecycleTests implements ModInitializer {
 
 		ServerBlockEntityEvents.BLOCK_ENTITY_LOAD.register((blockEntity, world) -> {
 			this.serverBlockEntities.add(blockEntity);
-			logger.info("[SERVER] LOADED " + Registry.BLOCK_ENTITY_TYPE.getId(blockEntity.getType()).toString() + " - BlockEntities: " + this.serverBlockEntities.size());
+
+			if (PRINT_SERVER_BLOCKENTITY_MESSAGES) {
+				logger.info("[SERVER] LOADED " + Registry.BLOCK_ENTITY_TYPE.getId(blockEntity.getType()).toString() + " - BlockEntities: " + this.serverBlockEntities.size());
+			}
 		});
 
 		ServerBlockEntityEvents.BLOCK_ENTITY_UNLOAD.register((blockEntity, world) -> {
 			this.serverBlockEntities.remove(blockEntity);
-			logger.info("[SERVER] UNLOADED " + Registry.BLOCK_ENTITY_TYPE.getId(blockEntity.getType()).toString() + " - BlockEntities: " + this.serverBlockEntities.size());
+
+			if (PRINT_SERVER_BLOCKENTITY_MESSAGES) {
+				logger.info("[SERVER] UNLOADED " + Registry.BLOCK_ENTITY_TYPE.getId(blockEntity.getType()).toString() + " - BlockEntities: " + this.serverBlockEntities.size());
+			}
 		});
 
 		ServerTickEvents.END_SERVER_TICK.register(minecraftServer -> {
 			if (minecraftServer.getTicks() % 200 == 0) {
 				int entities = 0;
-				logger.info("[SERVER] Tracked BlockEntities:" + this.serverBlockEntities.size() + " Ticked at: " + minecraftServer.getTicks() + "ticks");
+
+				if (PRINT_SERVER_BLOCKENTITY_MESSAGES) {
+					logger.info("[SERVER] Tracked BlockEntities:" + this.serverBlockEntities.size() + " Ticked at: " + minecraftServer.getTicks() + "ticks");
+				}
 
 				for (ServerWorld world : minecraftServer.getWorlds()) {
 					int worldEntities = world.blockEntities.size();
-					logger.info("[SERVER] Tracked BlockEntities in " + world.getRegistryKey().toString() + " - " + worldEntities);
+
+					if (PRINT_SERVER_BLOCKENTITY_MESSAGES) {
+						logger.info("[SERVER] Tracked BlockEntities in " + world.getRegistryKey().toString() + " - " + worldEntities);
+					}
+
 					entities += worldEntities;
 				}
 
-				logger.info("[SERVER] Actual Total BlockEntities: " + entities);
+				if (PRINT_SERVER_BLOCKENTITY_MESSAGES) {
+					logger.info("[SERVER] Actual Total BlockEntities: " + entities);
+				}
 
 				if (entities != this.serverBlockEntities.size()) {
+					// Always print mismatches
 					logger.error("[SERVER] Mismatch in tracked blockentities and actual blockentities");
 				}
 			}

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerEntityLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerEntityLifecycleTests.java
@@ -30,7 +30,7 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityEvents;
  * Tests related to the lifecycle of entities.
  */
 public class ServerEntityLifecycleTests implements ModInitializer {
-	private static boolean PRINT_SERVER_ENTITY_MESSAGES = Boolean.parseBoolean(System.getProperty("fabric-lifecycle-events-testmod.printServerEntityMessages", "false"));
+	private static boolean PRINT_SERVER_ENTITY_MESSAGES = System.getProperty("fabric-lifecycle-events-testmod.printServerEntityMessages") != null;
 	private List<Entity> serverEntities = new ArrayList<>();
 
 	@Override

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerEntityLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerEntityLifecycleTests.java
@@ -30,6 +30,7 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityEvents;
  * Tests related to the lifecycle of entities.
  */
 public class ServerEntityLifecycleTests implements ModInitializer {
+	private static boolean PRINT_SERVER_ENTITY_MESSAGES = Boolean.parseBoolean(System.getProperty("fabric-lifecycle-events-testmod.printServerEntityMessages", "false"));
 	private List<Entity> serverEntities = new ArrayList<>();
 
 	@Override
@@ -38,7 +39,10 @@ public class ServerEntityLifecycleTests implements ModInitializer {
 
 		ServerEntityEvents.ENTITY_LOAD.register((entity, world) -> {
 			this.serverEntities.add(entity);
-			logger.info("[SERVER] LOADED " + entity.toString() + " - Entities: " + this.serverEntities.size());
+
+			if (PRINT_SERVER_ENTITY_MESSAGES) {
+				logger.info("[SERVER] LOADED " + entity.toString() + " - Entities: " + this.serverEntities.size());
+			}
 		});
 	}
 }

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerLifecycleTests.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents;
 
 /**
  * Tests related to the lifecycle of a server.
@@ -42,16 +43,8 @@ public class ServerLifecycleTests implements ModInitializer {
 			LOGGER.info("Stopped Server!");
 		});
 
-		ServerLifecycleEvents.LOAD_WORLD.register((server, world) -> {
+		ServerWorldEvents.LOAD.register((server, world) -> {
 			LOGGER.info("Loaded world " + world.getRegistryKey().getValue().toString());
-		});
-
-		ServerLifecycleEvents.SAVE.register((server, flush) -> {
-			LOGGER.info("Fired Save event");
-
-			if (flush) {
-				LOGGER.info("This is a flush event");
-			}
 		});
 	}
 }

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerLifecycleTests.java
@@ -45,5 +45,13 @@ public class ServerLifecycleTests implements ModInitializer {
 		ServerLifecycleEvents.LOAD_WORLD.register((server, world) -> {
 			LOGGER.info("Loaded world " + world.getRegistryKey().getValue().toString());
 		});
+
+		ServerLifecycleEvents.SAVE.register((server, flush) -> {
+			LOGGER.info("Fired Save event");
+
+			if (flush) {
+				LOGGER.info("This is a flush event");
+			}
+		});
 	}
 }

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerResourceReloadTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerResourceReloadTests.java
@@ -36,7 +36,7 @@ public class ServerResourceReloadTests implements ModInitializer {
 		});
 
 		// Failure callback can be tested by trying to disable the vanilla datapack
-		ServerLifecycleEvents.DATA_PACK_RELOAD_FAIL.register((throwable, server, serverResourceManager) -> {
+		ServerLifecycleEvents.DATA_PACK_RELOAD_FAIL.register((cause, server, serverResourceManager) -> {
 			LOGGER.error("FAILED TO RELOAD");
 		});
 	}

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerResourceReloadTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerResourceReloadTests.java
@@ -27,12 +27,17 @@ public class ServerResourceReloadTests implements ModInitializer {
 
 	@Override
 	public void onInitialize() {
-		ServerLifecycleEvents.BEFORE_RESOURCE_RELOAD.register((server, serverResourceManager) -> {
+		ServerLifecycleEvents.START_DATA_PACK_RELOAD.register((server, serverResourceManager) -> {
 			LOGGER.info("PREPARING FOR RELOAD");
 		});
 
-		ServerLifecycleEvents.AFTER_RESOURCE_RELOAD.register((server, serverResourceManager) -> {
+		ServerLifecycleEvents.END_DATA_PACK_RELOAD.register((server, serverResourceManager) -> {
 			LOGGER.info("FINISHED RELOAD");
+		});
+
+		// Failure callback can be tested by trying to disable the vanilla datapack
+		ServerLifecycleEvents.DATA_PACK_RELOAD_FAIL.register((throwable, server, serverResourceManager) -> {
+			LOGGER.error("FAILED TO RELOAD");
 		});
 	}
 }

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerResourceReloadTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerResourceReloadTests.java
@@ -22,28 +22,17 @@ import org.apache.logging.log4j.Logger;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 
-/**
- * Tests related to the lifecycle of a server.
- */
-public class ServerLifecycleTests implements ModInitializer {
+public class ServerResourceReloadTests implements ModInitializer {
 	public static final Logger LOGGER = LogManager.getLogger("LifecycleEventsTest");
 
 	@Override
 	public void onInitialize() {
-		ServerLifecycleEvents.SERVER_STARTED.register(server -> {
-			LOGGER.info("Started Server!");
+		ServerLifecycleEvents.BEFORE_RESOURCE_RELOAD.register((server, serverResourceManager) -> {
+			LOGGER.info("PREPARING FOR RELOAD");
 		});
 
-		ServerLifecycleEvents.SERVER_STOPPING.register(server -> {
-			LOGGER.info("Stopping Server!");
-		});
-
-		ServerLifecycleEvents.SERVER_STOPPED.register(server -> {
-			LOGGER.info("Stopped Server!");
-		});
-
-		ServerLifecycleEvents.LOAD_WORLD.register((server, world) -> {
-			LOGGER.info("Loaded world " + world.getRegistryKey().getValue().toString());
+		ServerLifecycleEvents.AFTER_RESOURCE_RELOAD.register((server, serverResourceManager) -> {
+			LOGGER.info("FINISHED RELOAD");
 		});
 	}
 }

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerResourceReloadTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerResourceReloadTests.java
@@ -33,10 +33,10 @@ public class ServerResourceReloadTests implements ModInitializer {
 
 		ServerLifecycleEvents.END_DATA_PACK_RELOAD.register((server, serverResourceManager, success) -> {
 			if (success) {
-				LOGGER.info("FINISHED RELOAD");
+				LOGGER.info("FINISHED RELOAD on {}", Thread.currentThread());
 			} else {
 				// Failure can be tested by trying to disable the vanilla datapack
-				LOGGER.error("FAILED TO RELOAD");
+				LOGGER.error("FAILED TO RELOAD on {}", Thread.currentThread());
 			}
 		});
 	}

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerResourceReloadTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerResourceReloadTests.java
@@ -31,13 +31,13 @@ public class ServerResourceReloadTests implements ModInitializer {
 			LOGGER.info("PREPARING FOR RELOAD");
 		});
 
-		ServerLifecycleEvents.END_DATA_PACK_RELOAD.register((server, serverResourceManager) -> {
-			LOGGER.info("FINISHED RELOAD");
-		});
-
-		// Failure callback can be tested by trying to disable the vanilla datapack
-		ServerLifecycleEvents.DATA_PACK_RELOAD_FAIL.register((cause, server, serverResourceManager) -> {
-			LOGGER.error("FAILED TO RELOAD");
+		ServerLifecycleEvents.END_DATA_PACK_RELOAD.register((server, serverResourceManager, success) -> {
+			if (success) {
+				LOGGER.info("FINISHED RELOAD");
+			} else {
+				// Failure can be tested by trying to disable the vanilla datapack
+				LOGGER.error("FAILED TO RELOAD");
+			}
 		});
 	}
 }

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientBlockEntityLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientBlockEntityLifecycleTests.java
@@ -31,7 +31,7 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.test.event.lifecycle.ServerLifecycleTests;
 
 public class ClientBlockEntityLifecycleTests implements ClientModInitializer {
-	private static boolean PRINT_CLIENT_BLOCKENTITY_MESSAGES = Boolean.parseBoolean(System.getProperty("fabric-lifecycle-events-testmod.printClientBlockEntityMessages", "false"));
+	private static boolean PRINT_CLIENT_BLOCKENTITY_MESSAGES = System.getProperty("fabric-lifecycle-events-testmod.printClientBlockEntityMessages") != null;
 	private List<BlockEntity> clientBlockEntities = new ArrayList<>();
 	private int clientTicks;
 

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientBlockEntityLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientBlockEntityLifecycleTests.java
@@ -31,6 +31,7 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.test.event.lifecycle.ServerLifecycleTests;
 
 public class ClientBlockEntityLifecycleTests implements ClientModInitializer {
+	private static boolean PRINT_CLIENT_BLOCKENTITY_MESSAGES = Boolean.parseBoolean(System.getProperty("fabric-lifecycle-events-testmod.printClientBlockEntityMessages", "false"));
 	private List<BlockEntity> clientBlockEntities = new ArrayList<>();
 	private int clientTicks;
 
@@ -40,22 +41,33 @@ public class ClientBlockEntityLifecycleTests implements ClientModInitializer {
 
 		ClientBlockEntityEvents.BLOCK_ENTITY_LOAD.register((blockEntity, world) -> {
 			this.clientBlockEntities.add(blockEntity);
-			logger.info("[CLIENT]" + " LOADED " + Registry.BLOCK_ENTITY_TYPE.getId(blockEntity.getType()).toString() + " - BlockEntities: " + this.clientBlockEntities.size());
+
+			if (PRINT_CLIENT_BLOCKENTITY_MESSAGES) {
+				logger.info("[CLIENT]" + " LOADED " + Registry.BLOCK_ENTITY_TYPE.getId(blockEntity.getType()).toString() + " - BlockEntities: " + this.clientBlockEntities.size());
+			}
 		});
 
 		ClientBlockEntityEvents.BLOCK_ENTITY_UNLOAD.register((blockEntity, world) -> {
 			this.clientBlockEntities.remove(blockEntity);
-			logger.info("[CLIENT]" + " UNLOADED " + Registry.BLOCK_ENTITY_TYPE.getId(blockEntity.getType()).toString() + " - BlockEntities: " + this.clientBlockEntities.size());
+
+			if (PRINT_CLIENT_BLOCKENTITY_MESSAGES) {
+				logger.info("[CLIENT]" + " UNLOADED " + Registry.BLOCK_ENTITY_TYPE.getId(blockEntity.getType()).toString() + " - BlockEntities: " + this.clientBlockEntities.size());
+			}
 		});
 
 		ClientTickEvents.END_CLIENT_TICK.register(client -> {
 			if (this.clientTicks++ % 200 == 0 && client.world != null) {
 				final int blockEntities = client.world.blockEntities.size();
-				logger.info("[CLIENT] Tracked BlockEntities:" + this.clientBlockEntities.size() + " Ticked at: " + this.clientTicks + "ticks");
-				logger.info("[CLIENT] Actual BlockEntities: " + client.world.blockEntities.size());
+
+				if (PRINT_CLIENT_BLOCKENTITY_MESSAGES) {
+					logger.info("[CLIENT] Tracked BlockEntities:" + this.clientBlockEntities.size() + " Ticked at: " + this.clientTicks + "ticks");
+					logger.info("[CLIENT] Actual BlockEntities: " + client.world.blockEntities.size());
+				}
 
 				if (blockEntities != this.clientBlockEntities.size()) {
-					logger.error("[CLIENT] Mismatch in tracked blockentities and actual blockentities");
+					if (PRINT_CLIENT_BLOCKENTITY_MESSAGES) {
+						logger.error("[CLIENT] Mismatch in tracked blockentities and actual blockentities");
+					}
 				}
 			}
 		});

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientEntityLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientEntityLifecycleTests.java
@@ -38,7 +38,7 @@ import net.fabricmc.fabric.test.event.lifecycle.ServerLifecycleTests;
  */
 @Environment(EnvType.CLIENT)
 public class ClientEntityLifecycleTests implements ClientModInitializer {
-	private static boolean PRINT_CLIENT_ENTITY_MESSAGES = Boolean.parseBoolean(System.getProperty("fabric-lifecycle-events-testmod.printClientEntityMessages", "false"));
+	private static boolean PRINT_CLIENT_ENTITY_MESSAGES = System.getProperty("fabric-lifecycle-events-testmod.printClientEntityMessages") != null;
 	private List<Entity> clientEntities = new ArrayList<>();
 	private int clientTicks;
 

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientEntityLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientEntityLifecycleTests.java
@@ -38,6 +38,7 @@ import net.fabricmc.fabric.test.event.lifecycle.ServerLifecycleTests;
  */
 @Environment(EnvType.CLIENT)
 public class ClientEntityLifecycleTests implements ClientModInitializer {
+	private static boolean PRINT_CLIENT_ENTITY_MESSAGES = Boolean.parseBoolean(System.getProperty("fabric-lifecycle-events-testmod.printClientEntityMessages", "false"));
 	private List<Entity> clientEntities = new ArrayList<>();
 	private int clientTicks;
 
@@ -47,21 +48,31 @@ public class ClientEntityLifecycleTests implements ClientModInitializer {
 
 		ClientEntityEvents.ENTITY_LOAD.register((entity, world) -> {
 			this.clientEntities.add(entity);
-			logger.info("[CLIENT]" + " LOADED " + Registry.ENTITY_TYPE.getId(entity.getType()).toString() + " - Entities: " + this.clientEntities.size());
+
+			if (PRINT_CLIENT_ENTITY_MESSAGES) {
+				logger.info("[CLIENT]" + " LOADED " + Registry.ENTITY_TYPE.getId(entity.getType()).toString() + " - Entities: " + this.clientEntities.size());
+			}
 		});
 
 		ClientEntityEvents.ENTITY_UNLOAD.register((entity, world) -> {
 			this.clientEntities.remove(entity);
-			logger.info("[CLIENT]" + " UNLOADED " + Registry.ENTITY_TYPE.getId(entity.getType()).toString() + " - Entities: " + this.clientEntities.size());
+
+			if (PRINT_CLIENT_ENTITY_MESSAGES) {
+				logger.info("[CLIENT]" + " UNLOADED " + Registry.ENTITY_TYPE.getId(entity.getType()).toString() + " - Entities: " + this.clientEntities.size());
+			}
 		});
 
 		ClientTickEvents.END_CLIENT_TICK.register(client -> {
 			if (this.clientTicks++ % 200 == 0 && client.world != null) {
 				final int entities = Iterables.toArray(client.world.getEntities(), Entity.class).length;
-				logger.info("[CLIENT] Tracked Entities:" + this.clientEntities.size() + " Ticked at: " + this.clientTicks + "ticks");
-				logger.info("[CLIENT] Actual Entities: " + entities);
+
+				if (PRINT_CLIENT_ENTITY_MESSAGES) {
+					logger.info("[CLIENT] Tracked Entities:" + this.clientEntities.size() + " Ticked at: " + this.clientTicks + "ticks");
+					logger.info("[CLIENT] Actual Entities: " + entities);
+				}
 
 				if (entities != this.clientEntities.size()) {
+					// Always print mismatches
 					logger.error("[CLIENT] Mismatch in tracked entities and actual entities");
 				}
 			}

--- a/fabric-lifecycle-events-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-lifecycle-events-v1/src/testmod/resources/fabric.mod.json
@@ -13,7 +13,8 @@
       "net.fabricmc.fabric.test.event.lifecycle.ServerBlockEntityLifecycleTests",
       "net.fabricmc.fabric.test.event.lifecycle.ServerEntityLifecycleTests",
       "net.fabricmc.fabric.test.event.lifecycle.ServerLifecycleTests",
-      "net.fabricmc.fabric.test.event.lifecycle.ServerTickTests"
+      "net.fabricmc.fabric.test.event.lifecycle.ServerTickTests",
+      "net.fabricmc.fabric.test.event.lifecycle.ServerResourceReloadTests"
     ],
     "client": [
       "net.fabricmc.fabric.test.event.lifecycle.client.ClientBlockEntityLifecycleTests",


### PR DESCRIPTION
Adds ~~all the~~ some events from #445, thereby superseding it:

 - `ServerLifecycleEvents.START_DATA_PACK_RELOAD`
 - `ServerLifecycleEvents.END_DATA_PACK_RELOAD`
 ~~`ServerLifecycleEvents.SAVE`~~

Also adds:

- `ServerWorldEvents.WORLD_LOAD` (Called when a world is loaded onto a server)
- `ServerLifecycleEvents.SERVER_STARTING` (Cannot be backported to 1.15 or 1.14 because of dedicated server entrypoint occuring after this).

Also adds system properties to enable load and unload debug messaging for entity and block entity events (So we can debug the other stuff in peace lol).