### PR TITLE
Fix dynamic tools ignoring vanilla mining level

### DIFF
--- a/fabric-tool-attribute-api-v1/src/main/java/net/fabricmc/fabric/impl/tool/attribute/handlers/ModdedToolsVanillaBlocksToolHandler.java
+++ b/fabric-tool-attribute-api-v1/src/main/java/net/fabricmc/fabric/impl/tool/attribute/handlers/ModdedToolsVanillaBlocksToolHandler.java
@@ -63,8 +63,7 @@ public class ModdedToolsVanillaBlocksToolHandler implements ToolManagerImpl.Tool
 			if (miningLevel < 0) return ActionResult.PASS;
 
 			ToolItem vanillaItem = getVanillaItem(miningLevel);
-			boolean effective = vanillaItem.isEffectiveOn(state) || vanillaItem.getMiningSpeedMultiplier(new ItemStack(vanillaItem), state) != 1.0F;
-			return effective ? ActionResult.SUCCESS : ActionResult.PASS;
+			return vanillaItem.isEffectiveOn(state) ? ActionResult.SUCCESS : ActionResult.PASS;
 		}
 
 		return ActionResult.PASS;


### PR DESCRIPTION
Currently when using dynamic tools on vanilla blocks the `isEffectiveOn` check returns true if a vanilla tool of the given mining level would be effective or if a vanilla tool of the given mining level would have a mining speed multiplier other than 1.

Vanilla pickaxes now return a mining speed higher than 1 on any metal or stone block. As a result dynamic tools are able to mine and drop any vanilla block.

This fixes that bug by removing the mining speed check, it's possible this check is serving a purpose I'm unaware of in which case I'll rework this PR.