### PR TITLE
Tweak the screen registry's generics to fix type inference

### DIFF
--- a/fabric-screen-handler-api-v1/build.gradle
+++ b/fabric-screen-handler-api-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-screen-handler-api-v1"
-version = getSubprojectVersion(project, "1.0.1")
+version = getSubprojectVersion(project, "1.1.0")
 
 minecraft {
 	accessWidener = file('src/main/resources/fabric-screen-handler-api-v1.accesswidener')

--- a/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/api/client/screenhandler/v1/ScreenRegistry.java
+++ b/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/api/client/screenhandler/v1/ScreenRegistry.java
@@ -61,9 +61,9 @@ public final class ScreenRegistry {
 	 * @param <H>           the screen handler type
 	 * @param <S>           the screen type
 	 */
-	public static <H extends ScreenHandler, S extends Screen & ScreenHandlerProvider<H>> void register(ScreenHandlerType<? extends H> type, Factory<? super H, ? extends S> screenFactory) {
+	public static <H extends ScreenHandler, S extends Screen & ScreenHandlerProvider<H>> void register(ScreenHandlerType<? extends H> type, Factory<H, S> screenFactory) {
 		// Convert our factory to the vanilla provider here as the vanilla interface won't be available to modders.
-		HandledScreens.<H, S>register(type, screenFactory::create);
+		HandledScreens.register(type, screenFactory::create);
 	}
 
 	/**

--- a/fabric-screen-handler-api-v1/src/testmod/java/net/fabricmc/fabric/test/screenhandler/client/ClientScreenHandlerTest.java
+++ b/fabric-screen-handler-api-v1/src/testmod/java/net/fabricmc/fabric/test/screenhandler/client/ClientScreenHandlerTest.java
@@ -20,21 +20,13 @@ import net.minecraft.client.gui.screen.ingame.Generic3x3ContainerScreen;
 
 import net.fabricmc.fabric.api.client.screenhandler.v1.ScreenRegistry;
 import net.fabricmc.fabric.test.screenhandler.ScreenHandlerTest;
-import net.fabricmc.fabric.test.screenhandler.screen.BoxScreenHandler;
-import net.fabricmc.fabric.test.screenhandler.screen.PositionedBagScreenHandler;
 import net.fabricmc.api.ClientModInitializer;
 
 public class ClientScreenHandlerTest implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
 		ScreenRegistry.register(ScreenHandlerTest.BAG_SCREEN_HANDLER, Generic3x3ContainerScreen::new);
-		ScreenRegistry.<PositionedBagScreenHandler, PositionedScreen<PositionedBagScreenHandler>>register(
-				ScreenHandlerTest.POSITIONED_BAG_SCREEN_HANDLER,
-				PositionedScreen::new
-		);
-		ScreenRegistry.<BoxScreenHandler, PositionedScreen<BoxScreenHandler>>register(
-				ScreenHandlerTest.BOX_SCREEN_HANDLER,
-				PositionedScreen::new
-		);
+		ScreenRegistry.register(ScreenHandlerTest.POSITIONED_BAG_SCREEN_HANDLER, PositionedScreen::new);
+		ScreenRegistry.register(ScreenHandlerTest.BOX_SCREEN_HANDLER, PositionedScreen::new);
 	}
 }

--- a/fabric-screen-handler-api-v1/src/testmod/java/net/fabricmc/fabric/test/screenhandler/client/PositionedScreen.java
+++ b/fabric-screen-handler-api-v1/src/testmod/java/net/fabricmc/fabric/test/screenhandler/client/PositionedScreen.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.test.screenhandler.client;
 
+import java.util.Optional;
+
 import com.mojang.blaze3d.systems.RenderSystem;
 
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
@@ -29,11 +31,20 @@ import net.minecraft.util.math.BlockPos;
 
 import net.fabricmc.fabric.test.screenhandler.screen.PositionedScreenHandler;
 
-public class PositionedScreen<T extends ScreenHandler & PositionedScreenHandler> extends HandledScreen<T> {
+public class PositionedScreen extends HandledScreen<ScreenHandler> {
 	private static final Identifier TEXTURE = new Identifier("minecraft", "textures/gui/container/dispenser.png");
 
-	public PositionedScreen(T handler, PlayerInventory inventory, Text title) {
-		super(handler, inventory, title);
+	public PositionedScreen(ScreenHandler handler, PlayerInventory inventory, Text title) {
+		super(handler, inventory, getPositionText(handler).orElse(title));
+	}
+
+	private static Optional<Text> getPositionText(ScreenHandler handler) {
+		if (handler instanceof PositionedScreenHandler) {
+			BlockPos pos = ((PositionedScreenHandler) handler).getPos();
+			return pos != null ? Optional.of(new LiteralText("(" + pos.toShortString() + ")")) : Optional.empty();
+		} else {
+			return Optional.empty();
+		}
 	}
 
 	@Override
@@ -44,11 +55,10 @@ public class PositionedScreen<T extends ScreenHandler & PositionedScreenHandler>
 	}
 
 	@Override
-	protected void drawForeground(MatrixStack matrices, int mouseX, int mouseY) {
-		BlockPos pos = handler.getPos();
-		Text usedTitle = pos != null ? new LiteralText("(" + pos.toShortString() + ")") : title;
-		textRenderer.draw(matrices, usedTitle, (float) (backgroundWidth / 2 - textRenderer.getWidth(usedTitle) / 2), 6.0F, 0x404040);
-		textRenderer.draw(matrices, playerInventory.getDisplayName(), 8.0F, backgroundHeight - 96 + 2, 0x404040);
+	protected void init() {
+		super.init();
+		// Center the title
+		titleX = (backgroundWidth - textRenderer.getWidth(title)) / 2;
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #845. By removing some unnecessary generic wildcards, calling `ScreenRegistry.register` doesn't require specifying the generics manually anymore as it did before in most cases.

Also updated the test mod to use vanilla's new automatic title drawing and removed the generic parameter of `PositionedScreen` to make method references work there as well.