### PR TITLE
Fix getBoundKey() recursion

### DIFF
--- a/fabric-key-binding-api-v1/build.gradle
+++ b/fabric-key-binding-api-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-key-binding-api-v1"
-version = getSubprojectVersion(project, "1.0.0")
+version = getSubprojectVersion(project, "1.0.1")
 
 dependencies {
 	testmodCompile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-key-binding-api-v1/src/main/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingHelper.java
+++ b/fabric-key-binding-api-v1/src/main/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingHelper.java
@@ -53,6 +53,6 @@ public final class KeyBindingHelper {
 	 * @return configured KeyCode
 	 */
 	public static InputUtil.Key getBoundKeyOf(KeyBinding keyBinding) {
-		return ((KeyCodeAccessor) keyBinding).fabric$getBoundKey();
+		return ((KeyCodeAccessor) keyBinding).fabric_getBoundKey();
 	}
 }

--- a/fabric-key-binding-api-v1/src/main/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingHelper.java
+++ b/fabric-key-binding-api-v1/src/main/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingHelper.java
@@ -53,6 +53,6 @@ public final class KeyBindingHelper {
 	 * @return configured KeyCode
 	 */
 	public static InputUtil.Key getBoundKeyOf(KeyBinding keyBinding) {
-		return ((KeyCodeAccessor) keyBinding).getBoundKey();
+		return ((KeyCodeAccessor) keyBinding).fabric$getBoundKey();
 	}
 }

--- a/fabric-key-binding-api-v1/src/main/java/net/fabricmc/fabric/mixin/client/keybinding/KeyCodeAccessor.java
+++ b/fabric-key-binding-api-v1/src/main/java/net/fabricmc/fabric/mixin/client/keybinding/KeyCodeAccessor.java
@@ -24,6 +24,6 @@ import net.minecraft.client.util.InputUtil;
 
 @Mixin(KeyBinding.class)
 public interface KeyCodeAccessor {
-	@Accessor
-	InputUtil.Key getBoundKey();
+	@Accessor("boundKey")
+	InputUtil.Key fabric$getBoundKey();
 }

--- a/fabric-key-binding-api-v1/src/main/java/net/fabricmc/fabric/mixin/client/keybinding/KeyCodeAccessor.java
+++ b/fabric-key-binding-api-v1/src/main/java/net/fabricmc/fabric/mixin/client/keybinding/KeyCodeAccessor.java
@@ -25,5 +25,5 @@ import net.minecraft.client.util.InputUtil;
 @Mixin(KeyBinding.class)
 public interface KeyCodeAccessor {
 	@Accessor("boundKey")
-	InputUtil.Key fabric$getBoundKey();
+	InputUtil.Key fabric_getBoundKey();
 }


### PR DESCRIPTION
This fixes the crash by:
```
java.lang.StackOverflowError: Initializing game
    at net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper.getBoundKeyOf(KeyBindingHelper.java:56)
    at net.fabricmc.fabric.api.client.keybinding.FabricKeyBinding.getBoundKey(FabricKeyBinding.java:46)
    at net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper.getBoundKeyOf(KeyBindingHelper.java:56)
    at net.fabricmc.fabric.api.client.keybinding.FabricKeyBinding.getBoundKey(FabricKeyBinding.java:46)
    at net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper.getBoundKeyOf(KeyBindingHelper.java:56)
    at net.fabricmc.fabric.api.client.keybinding.FabricKeyBinding.getBoundKey(FabricKeyBinding.java:46)
```

Somehow the mixin will call the method in the old v0 keybinding getBoundKey() instead of getting from the accessor.

Signed-off-by: shedaniel <daniel@shedaniel.me>