### PR TITLE
Indigo Flat-Shading Lighting Fix

### DIFF
--- a/fabric-renderer-indigo/build.gradle
+++ b/fabric-renderer-indigo/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-renderer-indigo"
-version = getSubprojectVersion(project, "0.3.3")
+version = getSubprojectVersion(project, "0.3.4")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AbstractQuadRenderer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AbstractQuadRenderer.java
@@ -173,7 +173,12 @@ public abstract class AbstractQuadRenderer {
 	int flatBrightness(MutableQuadViewImpl quad, BlockState blockState, BlockPos pos) {
 		mpos.set(pos);
 
-		if ((quad.geometryFlags() & LIGHT_FACE_FLAG) != 0 || Block.isShapeFullCube(blockState.getCollisionShape(blockInfo.blockView, pos))) {
+		// To mirror Vanilla's behavior, if the face has a cull-face, always sample the light value
+		// offset in that direction. See net.minecraft.client.render.block.BlockModelRenderer.renderFlat
+		// for reference.
+		if (quad.cullFace() != null) {
+			mpos.move(quad.cullFace());
+		} else if ((quad.geometryFlags() & LIGHT_FACE_FLAG) != 0 || Block.isShapeFullCube(blockState.getCollisionShape(blockInfo.blockView, pos))) {
 			mpos.move(quad.lightFace());
 		}
 

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainFallbackConsumer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainFallbackConsumer.java
@@ -35,7 +35,6 @@ import net.fabricmc.fabric.api.renderer.v1.render.RenderContext.QuadTransform;
 import net.fabricmc.fabric.impl.client.indigo.renderer.IndigoRenderer;
 import net.fabricmc.fabric.impl.client.indigo.renderer.RenderMaterialImpl.Value;
 import net.fabricmc.fabric.impl.client.indigo.renderer.aocalc.AoCalculator;
-import net.fabricmc.fabric.impl.client.indigo.renderer.helper.GeometryHelper;
 import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.EncodingFormat;
 import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.MutableQuadViewImpl;
 
@@ -144,17 +143,6 @@ public abstract class TerrainFallbackConsumer extends AbstractQuadRenderer imple
 			aoCalc.compute(editorQuad, true);
 			tesselateSmooth(editorQuad, blockInfo.defaultLayer, editorQuad.colorIndex());
 		} else {
-			// vanilla compatibility hack
-			// For flat lighting, cull face drives everything and light face is ignored.
-			if (cullFace == null) {
-				editorQuad.invalidateShape();
-				// Can't rely on lazy computation in tesselateFlat() because needs to happen before offsets are applied
-				editorQuad.geometryFlags();
-			} else {
-				editorQuad.geometryFlags(GeometryHelper.LIGHT_FACE_FLAG);
-				editorQuad.lightFace(cullFace);
-			}
-
 			tesselateFlat(editorQuad, blockInfo.defaultLayer, editorQuad.colorIndex());
 		}
 	}


### PR DESCRIPTION
Make Indigo more closely aligned with vanilla's behavior when
rendering flat-shaded quads. Use the cull-face (if present)
to determine where the light-value is being sampled from,
and use the light-face to apply diffuse lighting.