### PR TITLE
Indigo Flat-Shading Lighting Fix Fix

### DIFF
--- a/fabric-renderer-indigo/build.gradle
+++ b/fabric-renderer-indigo/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-renderer-indigo"
-version = getSubprojectVersion(project, "0.3.3")
+version = getSubprojectVersion(project, "0.3.4")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AbstractQuadRenderer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AbstractQuadRenderer.java
@@ -173,7 +173,12 @@ public abstract class AbstractQuadRenderer {
 	int flatBrightness(MutableQuadViewImpl quad, BlockState blockState, BlockPos pos) {
 		mpos.set(pos);
 
-		if ((quad.geometryFlags() & LIGHT_FACE_FLAG) != 0 || Block.isShapeFullCube(blockState.getCollisionShape(blockInfo.blockView, pos))) {
+		// To mirror Vanilla's behavior, if the face has a cull-face, always sample the light value
+		// offset in that direction. See net.minecraft.client.render.block.BlockModelRenderer.renderQuadsFlat
+		// for reference.
+		if (quad.cullFace() != null) {
+			mpos.move(quad.cullFace());
+		} else if ((quad.geometryFlags() & LIGHT_FACE_FLAG) != 0 || Block.isShapeFullCube(blockState.getCollisionShape(blockInfo.blockView, pos))) {
 			mpos.move(quad.lightFace());
 		}
 

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainFallbackConsumer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainFallbackConsumer.java
@@ -35,7 +35,6 @@ import net.fabricmc.fabric.api.renderer.v1.render.RenderContext.QuadTransform;
 import net.fabricmc.fabric.impl.client.indigo.renderer.IndigoRenderer;
 import net.fabricmc.fabric.impl.client.indigo.renderer.RenderMaterialImpl.Value;
 import net.fabricmc.fabric.impl.client.indigo.renderer.aocalc.AoCalculator;
-import net.fabricmc.fabric.impl.client.indigo.renderer.helper.GeometryHelper;
 import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.EncodingFormat;
 import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.MutableQuadViewImpl;
 
@@ -144,15 +143,12 @@ public abstract class TerrainFallbackConsumer extends AbstractQuadRenderer imple
 			aoCalc.compute(editorQuad, true);
 			tesselateSmooth(editorQuad, blockInfo.defaultLayer, editorQuad.colorIndex());
 		} else {
-			// vanilla compatibility hack
-			// For flat lighting, cull face drives everything and light face is ignored.
+			// Recomputing whether the quad has a light face is only needed if it doesn't also have a cull face,
+			// as in those cases, the cull face will always be used to offset the light sampling position
 			if (cullFace == null) {
 				editorQuad.invalidateShape();
 				// Can't rely on lazy computation in tesselateFlat() because needs to happen before offsets are applied
 				editorQuad.geometryFlags();
-			} else {
-				editorQuad.geometryFlags(GeometryHelper.LIGHT_FACE_FLAG);
-				editorQuad.lightFace(cullFace);
 			}
 
 			tesselateFlat(editorQuad, blockInfo.defaultLayer, editorQuad.colorIndex());


### PR DESCRIPTION
This fixes #898. Further testing has shown, that for fully undirected quads (cullFace=null), the
editor-quad will be forced to have a lighting face set, which will cause the light sampling position
to be offset in that direction. The old code had explicitly reset geometry for faces with cullFace=null,
and this fixed version of the PR restores the behavior, which fixes grass.

In addition, I discovered that this PR (and the previous one) fix a rendering issue with cauldrons. 
To make it more pronounced, I replaced the cauldron textures with flat white surfaces to clearly
see the diffuse lighting that is applied:

**Vanilla 1.16.1:**
![2020-07-20 21_31_56-Minecraft 1 16 1 - Singleplayer](https://user-images.githubusercontent.com/1261399/87979923-1b1cbd80-cad3-11ea-885a-4a27579e09c6.png)

**Current fabric-api Indigo:**
![2020-07-20 21_34_15-Minecraft_ 1 16 1 - Singleplayer](https://user-images.githubusercontent.com/1261399/87979955-27a11600-cad3-11ea-8f9e-b33c182c7983.png)

*Explanation:* The  inside faces of the cauldron have cullFace=up and lightingFace=west/east/north/south. Due to the current behavior, the lightingFace is forced to the cullFace (=up), which gives all of the inside faces the diffuse lighting for a face that points up.

**With this PR:**
![2020-07-20 21_43_39-Minecraft_ 1 16 1 - Singleplayer](https://user-images.githubusercontent.com/1261399/87980070-4c958900-cad3-11ea-8ec1-9deda6ae6b63.png)

**Original PR Description:**
Make Indigo more closely aligned with vanilla's behavior when
rendering flat-shaded quads. Use the cull-face (if present)
to determine where the light-value is being sampled from,
and use the light-face to apply diffuse lighting.
Also do not force the light-face to be set to the cull-face,
since some blocks use faces where these are both set and different
(see the insides of a Cauldron for example).