### PR TITLE
Add Netherite mining level to vanilla blocks ToolHandler

### DIFF
--- a/fabric-tool-attribute-api-v1/build.gradle
+++ b/fabric-tool-attribute-api-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-tool-attribute-api-v1"
-version = getSubprojectVersion(project, "1.2.0")
+version = getSubprojectVersion(project, "1.2.1")
 
 dependencies {
     compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-tool-attribute-api-v1/src/main/java/net/fabricmc/fabric/impl/tool/attribute/ToolHandlers.java
+++ b/fabric-tool-attribute-api-v1/src/main/java/net/fabricmc/fabric/impl/tool/attribute/ToolHandlers.java
@@ -40,7 +40,8 @@ public class ToolHandlers implements ModInitializer {
 						Items.WOODEN_PICKAXE,
 						Items.STONE_PICKAXE,
 						Items.IRON_PICKAXE,
-						Items.DIAMOND_PICKAXE
+						Items.DIAMOND_PICKAXE,
+						Items.NETHERITE_PICKAXE
 				)
 		));
 		ToolManagerImpl.tag(FabricToolTags.AXES).register(new ModdedToolsVanillaBlocksToolHandler(
@@ -48,7 +49,8 @@ public class ToolHandlers implements ModInitializer {
 						Items.WOODEN_AXE,
 						Items.STONE_AXE,
 						Items.IRON_AXE,
-						Items.DIAMOND_AXE
+						Items.DIAMOND_AXE,
+						Items.NETHERITE_AXE
 				)
 		));
 		ToolManagerImpl.tag(FabricToolTags.SHOVELS).register(new ModdedToolsVanillaBlocksToolHandler(
@@ -56,7 +58,8 @@ public class ToolHandlers implements ModInitializer {
 						Items.WOODEN_SHOVEL,
 						Items.STONE_SHOVEL,
 						Items.IRON_SHOVEL,
-						Items.DIAMOND_SHOVEL
+						Items.DIAMOND_SHOVEL,
+						Items.NETHERITE_SHOVEL
 				)
 		));
 		ToolManagerImpl.tag(FabricToolTags.HOES).register(new ModdedToolsVanillaBlocksToolHandler(
@@ -64,7 +67,8 @@ public class ToolHandlers implements ModInitializer {
 						Items.WOODEN_HOE,
 						Items.STONE_HOE,
 						Items.IRON_HOE,
-						Items.DIAMOND_HOE
+						Items.DIAMOND_HOE,
+						Items.NETHERITE_HOE
 				)
 		));
 		ToolManagerImpl.tag(FabricToolTags.SWORDS).register(new ModdedToolsVanillaBlocksToolHandler(
@@ -72,7 +76,8 @@ public class ToolHandlers implements ModInitializer {
 						Items.WOODEN_SWORD,
 						Items.STONE_SWORD,
 						Items.IRON_SWORD,
-						Items.DIAMOND_SWORD
+						Items.DIAMOND_SWORD,
+						Items.NETHERITE_SWORD
 				)
 		));
 		ToolManagerImpl.tag(FabricToolTags.SHEARS).register(new ShearsVanillaBlocksToolHandler());

--- a/fabric-tool-attribute-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-tool-attribute-api-v1/src/main/resources/fabric.mod.json
@@ -5,7 +5,7 @@
   "version": "${version}",
   "environment": "*",
   "license": "Apache-2.0",
-  "icon": "assets/fabric-tool-attribute0api-v1/icon.png",
+  "icon": "assets/fabric-tool-attribute-api-v1/icon.png",
   "contact": {
     "homepage": "https://fabricmc.net",
     "irc": "irc://irc.esper.net:6667/fabric",


### PR DESCRIPTION
1.16 added a new mining level above diamond. We should allow modded tools to mine vanilla blocks of this level. Note that there are currently no vanilla blocks that require this mining level so this won't change anything until level 4 vanilla blocks are added.