### PR TITLE
Fix crashes by actually targetting the correct class in tag mixin

### DIFF
--- a/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/mixin/tag/extension/MixinTagImpl.java
+++ b/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/mixin/tag/extension/MixinTagImpl.java
@@ -25,7 +25,7 @@ import net.minecraft.tag.SetTag;
 import net.fabricmc.fabric.api.tag.FabricTag;
 import net.fabricmc.fabric.impl.tag.extension.FabricTagHooks;
 
-@Mixin(value = {SetTag.class}, targets = {"net.minecraft.tag.Tag$1", "net.minecraft.tag.GlobalTagAccessor$CachedTag"})
+@Mixin(value = {SetTag.class}, targets = {"net.minecraft.tag.Tag$1", "net.minecraft.tag.RequiredTagList$TagWrapper"})
 public abstract class MixinTagImpl<T> implements FabricTag<T>, FabricTagHooks, Tag<T> {
 	@Unique
 	private int fabric_clearCount;


### PR DESCRIPTION
~~This was renamed in yarn almost a month ago, so who knows how many times it's crashed~~

Grondag has said that the game will crash if you use `TagRegistry` without this fix.