### PR TITLE
Cache registry sync packet rather than recreate every time [WIP]

### DIFF
--- a/fabric-registry-sync-v0/build.gradle
+++ b/fabric-registry-sync-v0/build.gradle
@@ -3,5 +3,6 @@ version = getSubprojectVersion(project, "0.7.3")
 
 moduleDependencies(project, [
 		'fabric-api-base',
-		'fabric-networking-api-v1'
+		'fabric-networking-api-v1',
+		'fabric-lifecycle-events-v1'
 ])

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
@@ -59,7 +59,7 @@ public final class RegistrySyncManager {
 
 	private RegistrySyncManager() { }
 
-	public static PacketByteBuf createPacket() {
+	public static PacketByteBuf createData() {
 		LOGGER.debug("Creating registry sync packet");
 
 		CompoundTag tag = toTag(true, null);

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
@@ -59,6 +59,7 @@ public final class RegistrySyncManager {
 
 	private RegistrySyncManager() { }
 
+	/* @Nullable */
 	public static PacketByteBuf createData() {
 		LOGGER.debug("Creating registry sync packet");
 

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
@@ -50,7 +50,7 @@ import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 
 public final class RegistrySyncManager {
 	static final boolean DEBUG = System.getProperty("fabric.registry.debug", "false").equalsIgnoreCase("true");
-	static final Identifier ID = new Identifier("fabric", "registry/sync");
+	public static final Identifier ID = new Identifier("fabric", "registry/sync");
 	private static final Logger LOGGER = LogManager.getLogger("FabricRegistrySync");
 	private static final boolean DEBUG_WRITE_REGISTRY_DATA = System.getProperty("fabric.registry.debug.writeContentsAsCsv", "false").equalsIgnoreCase("true");
 
@@ -59,7 +59,7 @@ public final class RegistrySyncManager {
 
 	private RegistrySyncManager() { }
 
-	public static Packet<?> createPacket() {
+	public static PacketByteBuf createPacket() {
 		LOGGER.debug("Creating registry sync packet");
 
 		CompoundTag tag = toTag(true, null);

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinPlayerManager.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinPlayerManager.java
@@ -46,7 +46,6 @@ public abstract class MixinPlayerManager {
 		// TODO: If integrated and local, don't send the packet (it's ignored)
 		// TODO: Refactor out into network + move registry hook to event
 		if (this.currentSyncPacket != null) {
-			// Shallow copy the buffer
 			player.networkHandler.sendPacket(new CustomPayloadS2CPacket(RegistrySyncManager.ID, new PacketByteBuf(this.currentSyncPacket.duplicate())));
 		}
 	}

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinPlayerManager.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinPlayerManager.java
@@ -47,7 +47,7 @@ public abstract class MixinPlayerManager {
 		// TODO: Refactor out into network + move registry hook to event
 		if (this.currentSyncPacket != null) {
 			// Shallow copy the buffer
-			player.networkHandler.sendPacket(new CustomPayloadS2CPacket(RegistrySyncManager.ID, new PacketByteBuf(this.currentSyncPacket.slice())));
+			player.networkHandler.sendPacket(new CustomPayloadS2CPacket(RegistrySyncManager.ID, new PacketByteBuf(this.currentSyncPacket.duplicate())));
 		}
 	}
 }


### PR DESCRIPTION
This should be more performant than recreating the sync packet every single time a player joins.

Still need to figure out how to handle the fact a registry may change. Though registries are expected to be static when a server has started, nothing prevents registries from being changed then at the moment.

This is bound to the player manager, so restarting the integrated server on a client will recreate the sync packet using the current registry in the session.

I am about 1000% sure `duplicate()` will be bikeshedded.