### PR TITLE
Fix dynamic tools not using their mining speed on modded blocks with mining level 0

### DIFF
--- a/fabric-tool-attribute-api-v1/build.gradle
+++ b/fabric-tool-attribute-api-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-tool-attribute-api-v1"
-version = getSubprojectVersion(project, "1.2.1")
+version = getSubprojectVersion(project, "1.2.2")
 
 dependencies {
     compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-tool-attribute-api-v1/src/main/java/net/fabricmc/fabric/impl/tool/attribute/handlers/ModdedToolsModdedBlocksToolHandler.java
+++ b/fabric-tool-attribute-api-v1/src/main/java/net/fabricmc/fabric/impl/tool/attribute/handlers/ModdedToolsModdedBlocksToolHandler.java
@@ -55,7 +55,7 @@ public class ModdedToolsModdedBlocksToolHandler implements ToolManagerImpl.ToolH
 		if (stack.getItem() instanceof DynamicAttributeTool) {
 			ToolManagerImpl.Entry entry = ToolManagerImpl.entryNullable(state.getBlock());
 
-			if (entry != null && entry.getMiningLevel(tag) > 0) {
+			if (entry != null && entry.getMiningLevel(tag) >= 0) {
 				float multiplier = ((DynamicAttributeTool) stack.getItem()).getMiningSpeedMultiplier(tag, state, stack, user);
 				if (multiplier != 1.0F) return TypedActionResult.success(multiplier);
 			}


### PR DESCRIPTION
We hit this issue with a modded block that:
- Can be harvested without a tool
- Defines PICKAXE + mining level 0 as effective
- Does not have a vanilla material

This causes a dynamic tool (The TechReborn drill in this case) to not get their mining speed and mine with speed 1.