### PR TITLE
Add more tag helper methods that let you pass only a path String

### DIFF
--- a/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/api/tag/TagRegistry.java
+++ b/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/api/tag/TagRegistry.java
@@ -36,6 +36,8 @@ import net.fabricmc.fabric.mixin.tag.extension.AccessorFluidTags;
  * Helper methods for registering Tags.
  */
 public final class TagRegistry {
+	public static final String COMMON_NAMESPACE = "c";
+
 	private TagRegistry() { }
 
 	public static <T> Tag.Identified<T> create(Identifier id, Supplier<TagGroup<T>> containerSupplier) {
@@ -46,15 +48,35 @@ public final class TagRegistry {
 		return create(id, BlockTags::getTagGroup);
 	}
 
+	public static Tag<Block> block(String path) {
+		return block(globalId(path));
+	}
+
 	public static Tag<EntityType<?>> entityType(Identifier id) {
 		return create(id, EntityTypeTags::getTagGroup);
+	}
+
+	public static Tag<EntityType<?>> entityType(String path) {
+		return entityType(globalId(path));
 	}
 
 	public static Tag<Fluid> fluid(Identifier id) {
 		return create(id, () -> AccessorFluidTags.getRequiredTags().getGroup());
 	}
 
+	public static Tag<Fluid> fluid(String path) {
+		return fluid(globalId(path));
+	}
+
 	public static Tag<Item> item(Identifier id) {
 		return create(id, ItemTags::getTagGroup);
+	}
+
+	public static Tag<Item> item(String path) {
+		return item(globalId(path));
+	}
+
+	private static Identifier globalId(String path) {
+		return new Identifier(COMMON_NAMESPACE, path);
 	}
 }

--- a/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/api/tag/TagRegistry.java
+++ b/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/api/tag/TagRegistry.java
@@ -36,8 +36,6 @@ import net.fabricmc.fabric.mixin.tag.extension.AccessorFluidTags;
  * Helper methods for registering Tags.
  */
 public final class TagRegistry {
-	public static final String COMMON_NAMESPACE = "c";
-
 	private TagRegistry() { }
 
 	public static <T> Tag.Identified<T> create(Identifier id, Supplier<TagGroup<T>> containerSupplier) {
@@ -77,6 +75,10 @@ public final class TagRegistry {
 	}
 
 	private static Identifier globalId(String path) {
-		return new Identifier(COMMON_NAMESPACE, path);
+		return new Identifier(getCommonNamespace(), path);
+	}
+
+	public static String getCommonNamespace() {
+		throw new UnsupportedOperationException("A common namespace for tags has not been chosen yet.");
 	}
 }


### PR DESCRIPTION
Adds:
> helper method to create new tags conveniently by just passing the path part

\- Player

Common namespace getter's effectively a placeholder for putting a decided convention into in the future.