### PR TITLE
Add community's tag naming conventions to javadoc

### DIFF
--- a/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/api/tag/TagRegistry.java
+++ b/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/api/tag/TagRegistry.java
@@ -35,9 +35,9 @@ import net.fabricmc.fabric.mixin.tag.extension.AccessorFluidTags;
 /**
  * Helper methods for registering Tags.
  *
- * <p>The convention for namespaces of common tags (e.g. ingots) is {@code c}.
+ * <p>The convention for namespaces of common tags (e.g. ingots) is not yet decided.
  *
- * <p>The convention for paths is to use plural terms, such as {@code c:iron_ingots}, keeping in line with the majority of vanilla tags such as {@code minecraft:slabs} and {@code minecraft:gold_ores}.
+ * <p>The convention for paths is not yet decided.
  */
 public final class TagRegistry {
 	private TagRegistry() { }

--- a/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/api/tag/TagRegistry.java
+++ b/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/api/tag/TagRegistry.java
@@ -37,7 +37,7 @@ import net.fabricmc.fabric.mixin.tag.extension.AccessorFluidTags;
  *
  * <p>The convention for namespaces of common tags (e.g. ingots) is {@code c}.
  *
- * <p>The convention for paths is plural terms, e.g. {@code c:iron_ingots}, following the majority of vanilla's tags, e.g. {@code minecraft:slabs}, {@code minecraft:gold_ores}
+ * <p>The convention for paths is to use plural terms, such as {@code c:iron_ingots}, keeping in line with the majority of vanilla tags such as {@code minecraft:slabs} and {@code minecraft:gold_ores}.
  */
 public final class TagRegistry {
 	private TagRegistry() { }

--- a/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/api/tag/TagRegistry.java
+++ b/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/api/tag/TagRegistry.java
@@ -35,9 +35,11 @@ import net.fabricmc.fabric.mixin.tag.extension.AccessorFluidTags;
 /**
  * Helper methods for registering Tags.
  *
- * <p>The convention for namespaces of common tags (e.g. ingots) is not yet decided.
+ * <p>Although not officially endorsed by Fabric, many mods use the following tag naming conventions for common tags such as ores or ingots:
  *
- * <p>The convention for paths is not yet decided.
+ * <p>For a common namespace, their convention is currently {@code c}.
+ *
+ * <p>For paths, their convention is currently the use of plural terms, such as {@code c:iron_ingots}, keeping in line with the majority of vanilla tags such as {@code minecraft:slabs} and {@code minecraft:gold_ores}.
  */
 public final class TagRegistry {
 	private TagRegistry() { }

--- a/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/api/tag/TagRegistry.java
+++ b/fabric-tag-extensions-v0/src/main/java/net/fabricmc/fabric/api/tag/TagRegistry.java
@@ -34,6 +34,10 @@ import net.fabricmc.fabric.mixin.tag.extension.AccessorFluidTags;
 
 /**
  * Helper methods for registering Tags.
+ *
+ * <p>The convention for namespaces of common tags (e.g. ingots) is {@code c}.
+ *
+ * <p>The convention for paths is plural terms, e.g. {@code c:iron_ingots}, following the majority of vanilla's tags, e.g. {@code minecraft:slabs}, {@code minecraft:gold_ores}
  */
 public final class TagRegistry {
 	private TagRegistry() { }


### PR DESCRIPTION
Effectively a placeholder that can be replaced by a decided convention in the future.