### PR TITLE
Clarify an aspect about the block renderer registry

### DIFF
--- a/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/api/client/rendereregistry/v1/BlockEntityRendererRegistry.java
+++ b/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/api/client/rendereregistry/v1/BlockEntityRendererRegistry.java
@@ -35,9 +35,9 @@ public interface BlockEntityRendererRegistry {
 	 * Register a BlockEntityRenderer for a BlockEntityType. Can be called clientside before the world is rendered.
 	 *
 	 * @param blockEntityType the {@link BlockEntityType} to register a renderer for
-	 * @param blockEntityRenderer a function that returns a {@link BlockEntityRenderer}. This will be called
-	 *                            when {@link BlockEntityRenderDispatcher} is initialized, or immediately if the class
-	 *                            was already loaded.
+	 * @param blockEntityRenderer a function that returns a {@link BlockEntityRenderer}, called
+	 *                            when {@link BlockEntityRenderDispatcher} is initialized or immediately if the dispatcher
+	 *                            class is already loaded
 	 * @param <E> the {@link BlockEntity}
 	 */
 	<E extends BlockEntity> void register(BlockEntityType<E> blockEntityType, Function<BlockEntityRenderDispatcher, BlockEntityRenderer<E>> blockEntityRenderer);

--- a/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/api/client/rendereregistry/v1/BlockEntityRendererRegistry.java
+++ b/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/api/client/rendereregistry/v1/BlockEntityRendererRegistry.java
@@ -32,10 +32,12 @@ public interface BlockEntityRendererRegistry {
 	BlockEntityRendererRegistry INSTANCE = new BlockEntityRendererRegistryImpl();
 
 	/**
-	 * Register a BlockEntityRenderer for a BlockEntityType. Can be called clientside before the world is rendered
+	 * Register a BlockEntityRenderer for a BlockEntityType. Can be called clientside before the world is rendered.
 	 *
 	 * @param blockEntityType the {@link BlockEntityType} to register a renderer for
-	 * @param blockEntityRenderer a function that returns a {@link BlockEntityRenderer}
+	 * @param blockEntityRenderer a function that returns a {@link BlockEntityRenderer}. This will be called
+	 *                            when {@link BlockEntityRenderDispatcher} is initialized, or immediately if the class
+	 *                            was already loaded.
 	 * @param <E> the {@link BlockEntity}
 	 */
 	<E extends BlockEntity> void register(BlockEntityType<E> blockEntityType, Function<BlockEntityRenderDispatcher, BlockEntityRenderer<E>> blockEntityRenderer);


### PR DESCRIPTION
This hit us because our block entity renderer constructors access the client, and it was unclear to me that the factory would be called immediately if some other mod already had accessed the class initializer.