### PR TITLE
Fix for #987

### DIFF
--- a/fabric-renderer-api-v1/build.gradle
+++ b/fabric-renderer-api-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-renderer-api-v1"
-version = getSubprojectVersion(project, "0.2.13")
+version = getSubprojectVersion(project, "0.3.0")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
@@ -143,8 +143,20 @@ public interface MutableQuadView extends QuadView {
 	 * This method should be performant whenever caller's vertex representation makes it feasible.
 	 *
 	 * <p>Calling this method does not emit the quad.
+	 *
+	 * @deprecated Use {@link #fromVanilla(BakedQuad, RenderMaterial, Direction, int[], int)}
+	 * which has better encapsulation and removed outdated item flag
 	 */
+	@Deprecated
 	MutableQuadView fromVanilla(int[] quadData, int startIndex, boolean isItem);
+
+	/**
+	 * Enables bulk vertex data transfer using the standard Minecraft vertex formats.
+	 * This method should be performant whenever caller's vertex representation makes it feasible.
+	 *
+	 * <p>Calling this method does not emit the quad.
+	 */
+	MutableQuadView fromVanilla(BakedQuad quad, RenderMaterial material, Direction cullFace);
 
 	/**
 	 * Encodes an integer tag with this quad that can later be retrieved via

--- a/fabric-renderer-indigo/build.gradle
+++ b/fabric-renderer-indigo/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-renderer-indigo"
-version = getSubprojectVersion(project, "0.3.4")
+version = getSubprojectVersion(project, "0.3.5")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-renderer-indigo/build.gradle
+++ b/fabric-renderer-indigo/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-renderer-indigo"
-version = getSubprojectVersion(project, "0.3.5")
+version = getSubprojectVersion(project, "0.4.0")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MeshBuilderImpl.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MeshBuilderImpl.java
@@ -19,7 +19,6 @@ package net.fabricmc.fabric.impl.client.indigo.renderer.mesh;
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
 import net.fabricmc.fabric.api.renderer.v1.mesh.MeshBuilder;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
-import net.fabricmc.fabric.impl.client.indigo.renderer.helper.GeometryHelper;
 
 /**
  * Our implementation of {@link MeshBuilder}, used for static mesh creation and baking.
@@ -69,12 +68,7 @@ public class MeshBuilderImpl implements MeshBuilder {
 	private class Maker extends MutableQuadViewImpl implements QuadEmitter {
 		@Override
 		public Maker emit() {
-			lightFace(GeometryHelper.lightFace(this));
-
-			if (isGeometryInvalid) {
-				geometryFlags(GeometryHelper.computeShapeFlags(this));
-			}
-
+			computeGeometry();
 			index += EncodingFormat.TOTAL_STRIDE;
 			ensureCapacity(EncodingFormat.TOTAL_STRIDE);
 			baseIndex = index;

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
@@ -117,6 +117,7 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 		nominalFace(quad.getFace());
 		colorIndex(quad.getColorIndex());
 		material(material);
+		tag(0);
 		shade(quad.hasShade());
 		isGeometryInvalid = true;
 		return this;

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
@@ -81,18 +81,6 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 		return this;
 	}
 
-	/*
-	 * @deprecated Not part of API but left public case anyone is abusing scope.
-	 * No longer needed and should be removed in 1.17 cycle.
-	 */
-	@Deprecated
-	public final MutableQuadViewImpl lightFace(Direction face) {
-		Preconditions.checkNotNull(face);
-
-		data[baseIndex + HEADER_BITS] = EncodingFormat.lightFace(data[baseIndex + HEADER_BITS], face);
-		return this;
-	}
-
 	@Override
 	public final MutableQuadViewImpl nominalFace(Direction face) {
 		nominalFace = face;
@@ -144,12 +132,7 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 		return this;
 	}
 
-	/*
-	 * @deprecated Not part of API but left public case anyone is abusing scope.
-	 * Scope should be reduced to protected in 1.17 cycle.
-	 */
-	@Deprecated
-	public void normalFlags(int flags) {
+	protected void normalFlags(int flags) {
 		data[baseIndex + HEADER_BITS] = EncodingFormat.normalFlags(data[baseIndex + HEADER_BITS], flags);
 	}
 
@@ -162,11 +145,7 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 
 	/**
 	 * Internal helper method. Copies face normals to vertex normals lacking one.
-	 *
-	 * @deprecated Not part of API but left public case anyone is abusing scope.
-	 * Scope should be reduced to protected in 1.17 cycle.
 	 */
-	@Deprecated
 	public final void populateMissingNormals() {
 		final int normalFlags = this.normalFlags();
 

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
@@ -112,8 +112,7 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 	}
 
 	/**
-	 * @deprecated Use {@link #fromVanilla(BakedQuad, RenderMaterial, Direction, int[], int)}
-	 * which has better encapsulation and removed outdata item flag
+	 * @deprecated will be removed in 1.17 cycle - see docs in interface
 	 */
 	@Deprecated
 	@Override
@@ -123,8 +122,9 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 		return this;
 	}
 
-	public final MutableQuadViewImpl fromVanilla(BakedQuad quad, RenderMaterial material, Direction cullFace, int startIndex) {
-		System.arraycopy(quad.getVertexData(), startIndex, data, baseIndex + HEADER_STRIDE, QUAD_STRIDE);
+	@Override
+	public final MutableQuadViewImpl fromVanilla(BakedQuad quad, RenderMaterial material, Direction cullFace) {
+		System.arraycopy(quad.getVertexData(), 0, data, baseIndex + HEADER_STRIDE, QUAD_STRIDE);
 		cullFace(cullFace);
 		nominalFace(quad.getFace());
 		colorIndex(quad.getColorIndex());

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
@@ -113,7 +113,7 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 	@Override
 	public final MutableQuadViewImpl fromVanilla(BakedQuad quad, RenderMaterial material, Direction cullFace) {
 		System.arraycopy(quad.getVertexData(), 0, data, baseIndex + HEADER_STRIDE, QUAD_STRIDE);
-		cullFace(cullFace);
+		data[baseIndex + HEADER_BITS] = EncodingFormat.cullFace(0, cullFace);
 		nominalFace(quad.getFace());
 		colorIndex(quad.getColorIndex());
 		material(material);

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/QuadViewImpl.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/QuadViewImpl.java
@@ -70,18 +70,6 @@ public class QuadViewImpl implements QuadView {
 	}
 
 	/**
-	 * Used on vanilla quads or other quads that don't have encoded shape info
-	 * to signal that such should be computed when requested.
-	 *
-	 * @deprecated Not part of API but left public case anyone is abusing scope.
-	 * No longer needed and should be removed in 1.17 cycle.
-	 */
-	@Deprecated
-	public final void invalidateShape() {
-		isGeometryInvalid = true;
-	}
-
-	/**
 	 * Like {@link #load(int[], int)} but assumes array and index already set.
 	 * Only does the decoding part.
 	 */
@@ -125,17 +113,6 @@ public class QuadViewImpl implements QuadView {
 			// depends on light face
 			data[baseIndex + HEADER_BITS] = EncodingFormat.geometryFlags(data[baseIndex + HEADER_BITS], GeometryHelper.computeShapeFlags(this));
 		}
-	}
-
-	/**
-	 * Used to override geometric analysis for compatibility edge case.
-	 *
-	 * @deprecated Not part of API but left in case anyone is abusing scope.
-	 * No longer needed and should be removed in 1.17 cycle.
-	 */
-	@Deprecated
-	public void geometryFlags(int flags) {
-		data[baseIndex + HEADER_BITS] = EncodingFormat.geometryFlags(data[baseIndex + HEADER_BITS], flags);
 	}
 
 	@Override

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AbstractMeshConsumer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AbstractMeshConsumer.java
@@ -29,7 +29,6 @@ import net.fabricmc.fabric.api.renderer.v1.render.RenderContext.QuadTransform;
 import net.fabricmc.fabric.impl.client.indigo.renderer.IndigoRenderer;
 import net.fabricmc.fabric.impl.client.indigo.renderer.RenderMaterialImpl;
 import net.fabricmc.fabric.impl.client.indigo.renderer.aocalc.AoCalculator;
-import net.fabricmc.fabric.impl.client.indigo.renderer.helper.GeometryHelper;
 import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.EncodingFormat;
 import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.MeshImpl;
 import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.MutableQuadViewImpl;
@@ -56,7 +55,7 @@ public abstract class AbstractMeshConsumer extends AbstractQuadRenderer implemen
 		// only used via RenderContext.getEmitter()
 		@Override
 		public Maker emit() {
-			lightFace(GeometryHelper.lightFace(this));
+			computeGeometry();
 			renderQuad(this);
 			clear();
 			return this;

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
@@ -45,9 +45,9 @@ import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
 import net.fabricmc.fabric.api.renderer.v1.model.ModelHelper;
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
+import net.fabricmc.fabric.impl.client.indigo.renderer.IndigoRenderer;
 import net.fabricmc.fabric.impl.client.indigo.renderer.RenderMaterialImpl;
 import net.fabricmc.fabric.impl.client.indigo.renderer.helper.ColorHelper;
-import net.fabricmc.fabric.impl.client.indigo.renderer.helper.GeometryHelper;
 import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.EncodingFormat;
 import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.MeshImpl;
 import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.MutableQuadViewImpl;
@@ -143,7 +143,7 @@ public class ItemRenderContext extends AbstractRenderContext implements RenderCo
 
 		@Override
 		public Maker emit() {
-			lightFace(GeometryHelper.lightFace(this));
+			computeGeometry();
 			renderQuad();
 			clear();
 			return this;
@@ -247,14 +247,7 @@ public class ItemRenderContext extends AbstractRenderContext implements RenderCo
 		final Maker editorQuad = this.editorQuad;
 
 		for (final BakedQuad q : quads) {
-			editorQuad.clear();
-			editorQuad.fromVanilla(q.getVertexData(), 0, false);
-			editorQuad.cullFace(cullFace);
-			final Direction lightFace = q.getFace();
-			editorQuad.lightFace(lightFace);
-			editorQuad.nominalFace(lightFace);
-			editorQuad.colorIndex(q.getColorIndex());
-			editorQuad.shade(q.hasShade());
+			editorQuad.fromVanilla(q, IndigoRenderer.MATERIAL_STANDARD, cullFace, 0);
 			renderQuad();
 		}
 	}

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
@@ -247,7 +247,7 @@ public class ItemRenderContext extends AbstractRenderContext implements RenderCo
 		final Maker editorQuad = this.editorQuad;
 
 		for (final BakedQuad q : quads) {
-			editorQuad.fromVanilla(q, IndigoRenderer.MATERIAL_STANDARD, cullFace, 0);
+			editorQuad.fromVanilla(q, IndigoRenderer.MATERIAL_STANDARD, cullFace);
 			renderQuad();
 		}
 	}

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainFallbackConsumer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainFallbackConsumer.java
@@ -87,45 +87,37 @@ public abstract class TerrainFallbackConsumer extends AbstractQuadRenderer imple
 		final BlockState blockState = blockInfo.blockState;
 
 		for (int i = 0; i < 6; i++) {
-			Direction face = ModelHelper.faceFromIndex(i);
-			List<BakedQuad> quads = model.getQuads(blockState, face, random.get());
+			final Direction face = ModelHelper.faceFromIndex(i);
+			final List<BakedQuad> quads = model.getQuads(blockState, face, random.get());
 			final int count = quads.size();
 
 			if (count != 0) {
 				for (int j = 0; j < count; j++) {
-					BakedQuad q = quads.get(j);
+					final BakedQuad q = quads.get(j);
 					renderQuad(q, face, defaultMaterial);
 				}
 			}
 		}
 
-		List<BakedQuad> quads = model.getQuads(blockState, null, random.get());
+		final List<BakedQuad> quads = model.getQuads(blockState, null, random.get());
 		final int count = quads.size();
 
 		if (count != 0) {
 			for (int j = 0; j < count; j++) {
-				BakedQuad q = quads.get(j);
+				final BakedQuad q = quads.get(j);
 				renderQuad(q, null, defaultMaterial);
 			}
 		}
 	}
 
 	private void renderQuad(BakedQuad quad, Direction cullFace, Value defaultMaterial) {
-		final int[] vertexData = quad.getVertexData();
-
-		if (!CompatibilityHelper.canRender(vertexData)) {
+		// TODO: should remove in 1.17 cycle, was for OF compat only
+		if (!CompatibilityHelper.canRender(quad.getVertexData())) {
 			return;
 		}
 
 		final MutableQuadViewImpl editorQuad = this.editorQuad;
-		System.arraycopy(vertexData, 0, editorBuffer, EncodingFormat.HEADER_STRIDE, EncodingFormat.QUAD_STRIDE);
-		editorQuad.cullFace(cullFace);
-		final Direction lightFace = quad.getFace();
-		editorQuad.lightFace(lightFace);
-		editorQuad.nominalFace(lightFace);
-		editorQuad.colorIndex(quad.getColorIndex());
-		editorQuad.material(defaultMaterial);
-		editorQuad.shade(quad.hasShade());
+		editorQuad.fromVanilla(quad, defaultMaterial, cullFace, 0);
 
 		if (!transform.transform(editorQuad)) {
 			return;
@@ -139,14 +131,12 @@ public abstract class TerrainFallbackConsumer extends AbstractQuadRenderer imple
 
 		if (!editorQuad.material().disableAo(0)) {
 			// needs to happen before offsets are applied
-			editorQuad.invalidateShape();
 			aoCalc.compute(editorQuad, true);
 			tesselateSmooth(editorQuad, blockInfo.defaultLayer, editorQuad.colorIndex());
 		} else {
 			// Recomputing whether the quad has a light face is only needed if it doesn't also have a cull face,
 			// as in those cases, the cull face will always be used to offset the light sampling position
 			if (cullFace == null) {
-				editorQuad.invalidateShape();
 				// Can't rely on lazy computation in tesselateFlat() because needs to happen before offsets are applied
 				editorQuad.geometryFlags();
 			}

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainFallbackConsumer.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainFallbackConsumer.java
@@ -117,7 +117,7 @@ public abstract class TerrainFallbackConsumer extends AbstractQuadRenderer imple
 		}
 
 		final MutableQuadViewImpl editorQuad = this.editorQuad;
-		editorQuad.fromVanilla(quad, defaultMaterial, cullFace, 0);
+		editorQuad.fromVanilla(quad, defaultMaterial, cullFace);
 
 		if (!transform.transform(editorQuad)) {
 			return;


### PR DESCRIPTION
This PR fixes a defect that causes Indigo to track in incorrect light face after a transform is applied.

As part of the fix, it simplifies geometry tracking generally and also ~~deprecates some public non-API methods that are no longer needed or which should have reduced scope.  The intention is these methods should be removed or changed in the 1.17 cycle.~~ removes or reduces the scope of some non-API methods that are no longer needed or should not be used externally.

Lastly, it exposes an improved `fromVanilla` method on `MutableQuadView` that is used in the implementation. This version is more compact and offers better encapsulation and consistency.  The existing method is deprecated and should be removed in the 1.17 cycle.

This change has been briefly tested with a [modified fork of AE2](https://github.com/grondag/Applied-Energistics-2/tree/indigo-fix) to confirm it fixes the reported issue, and also with Exotic Blocks and RenderBender which make extensive use of the API.

Before (with modified AE2 fork that removes current hack)
![2020-08-25_09 07 33](https://user-images.githubusercontent.com/6106235/91199439-be548a00-e6b2-11ea-9e95-7c6f089da8d8.png)

After (with same fork)
![2020-08-25_09 09 13](https://user-images.githubusercontent.com/6106235/91199480-cb717900-e6b2-11ea-91bb-27fd8549316b.png)


