### PR TITLE
Added client side block place and break events

### DIFF
--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/client/player/ClientBlockBreakEvent.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/client/player/ClientBlockBreakEvent.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.event.client.player;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+public final class ClientBlockBreakEvent {
+	private ClientBlockBreakEvent() { }
+
+	/**
+	 * Callback before a block is to begin breaking.
+	 *
+	 * <p>If any listener cancels a block breaking action, that block breaking
+	 * action is canceled and {@link #ON_CANCEL} event is fired. Otherwise the
+	 * {@link #ON_PROGRESS} event is fired with a progress of 0.
+	 */
+	public static final Event<OnStart> ON_START = EventFactory.createArrayBacked(
+			OnStart.class,
+			listeners -> (world, player, pos, state, progress) -> {
+				for (OnStart event : listeners) {
+					boolean result = event.onBlockBreakStart(world, player, pos, state, progress);
+
+					if (!result) {
+						return false;
+					}
+				}
+
+				return true;
+			}
+	);
+
+	/**
+	 * Callback during a blocks breaking stages
+	 *
+	 * <p>If any listener cancels a block progress action, that block
+	 * action is canceled and {@link #ON_CANCEL} event is fired.
+	 */
+	public static final Event<OnProgress> ON_PROGRESS = EventFactory.createArrayBacked(
+			OnProgress.class,
+			listeners -> (world, player, pos, state, progress) -> {
+				for (OnProgress event : listeners) {
+					boolean result = event.onBlockBreakProgress(world, player, pos, state, progress);
+
+					if (!result) {
+						return false;
+					}
+				}
+
+				return true;
+			}
+	);
+
+	/**
+	 * Callback after a block is broken.
+	 * At the point of invocation you can ensure the client block has been destroyed from the world
+	 */
+	public static final Event<OnBreak> ON_BREAK = EventFactory.createArrayBacked(
+			OnBreak.class,
+			listeners -> (world, player, pos, state, progress) -> {
+				for (OnBreak event : listeners) {
+					event.onBlockBreak(world, player, pos, state, progress);
+				}
+			}
+	);
+
+	/**
+	 * Callback when a block break has been canceled.
+	 *
+	 * <p>Can be used to stop a client from breaking a block if maybe a mod only wants to
+	 * let you break a certain block at a certain time.
+	 */
+	public static final Event<OnCancel> ON_CANCEL = EventFactory.createArrayBacked(
+			OnCancel.class,
+			listeners -> (world, player, pos, state, progress) -> {
+				for (OnCancel event : listeners) {
+					event.onBlockBreakCancel(world, player, pos, state, progress);
+				}
+			}
+	);
+
+	@FunctionalInterface
+	public interface OnStart {
+		/**
+		 * Called before a block is to begin breaking.
+		 *
+		 * <p>The block has not been removed or destroyed yet and is simply the player
+		 * initiating the breaking of a block</p>
+		 *
+		 * @param world    the world in which the block is to be broken
+		 * @param player   the player breaking the block
+		 * @param pos      the position at which the block is to be broken
+		 * @param state    the block state <strong>before</strong> the block is placed
+		 * @param progress the progress of the break between 0.0-1.0 (Will always be 0 for this event)
+		 *
+		 * @return {@code false} to cancel block placing action, or {@code true} to pass to next listener
+		 */
+		boolean onBlockBreakStart(World world, PlayerEntity player, BlockPos pos, BlockState state, float progress);
+	}
+
+	@FunctionalInterface
+	public interface OnProgress {
+		/**
+		 * Called during a blocks breaking stages.
+		 *
+		 * <p>The block has not been removed or destroyed yet and is simply the player
+		 * continuing the breaking of a block</p>
+		 *
+		 * @param world    the world in which the block is placed
+		 * @param player   the player placing the block
+		 * @param pos      the position at which the block is placed
+		 * @param state    the block state <strong>before</strong> the block is placed
+		 * @param progress the progress of the break between 0.0-1.0
+		 *
+		 * @return {@code false} to cancel block placing action, or {@code true} to pass to next listener
+		 */
+		boolean onBlockBreakProgress(World world, PlayerEntity player, BlockPos pos, BlockState state, float progress);
+	}
+
+	@FunctionalInterface
+	public interface OnBreak {
+		/**
+		 * Called after a block has been broken.
+		 *
+		 * @param world    the world where the block was broken
+		 * @param player   the player who broke the block
+		 * @param pos      the position where the block was broken
+		 * @param state    the block state <strong>before</strong> the block was broken
+		 * @param progress the progress of the break between 0.0-1.0 (Will always be 1 for this event)
+		 */
+		void onBlockBreak(World world, PlayerEntity player, BlockPos pos, BlockState state, float progress);
+	}
+
+	@FunctionalInterface
+	public interface OnCancel {
+		/**
+		 * Called when a block break has been canceled.
+		 * <p>This can be from both the {@link #ON_START} and {@link #ON_PROGRESS} events.</p>
+		 *
+		 * @param world    the world where the block was going to be broken
+		 * @param player   the player who was going to break the block
+		 * @param pos      the position where the block was going to be broken
+		 * @param state    the block state of the block that was going to be broken
+		 * @param progress the progress of the break before it was canceled between 0.0-1.0
+		 */
+		void onBlockBreakCancel(World world, PlayerEntity player, BlockPos pos, BlockState state, float progress);
+	}
+}

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/client/player/ClientBlockPlaceEvent.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/client/player/ClientBlockPlaceEvent.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.event.client.player;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+public final class ClientBlockPlaceEvent {
+	private ClientBlockPlaceEvent() { }
+
+	/**
+	 * Callback before a block is placed.
+	 * Called on both client and server
+	 *
+	 * <p>If any listener cancels a block placing action, that block placing
+	 * action is canceled and {@link #CANCELED} event is fired. Otherwise, the
+	 * {@link #AFTER} event is fired.</p>
+	 */
+	public static final Event<Before> BEFORE = EventFactory.createArrayBacked(
+			Before.class,
+			listeners -> (world, player, pos, state) -> {
+				for (Before event : listeners) {
+					boolean result = event.beforeBlockPlace(world, player, pos, state);
+
+					if (!result) {
+						return false;
+					}
+				}
+
+				return true;
+			}
+	);
+
+	/**
+	 * Callback after a block is placed.
+	 *
+	 * <p>Called on both client and server
+	 */
+	public static final Event<After> AFTER = EventFactory.createArrayBacked(
+			After.class,
+			listeners -> (world, player, pos, state) -> {
+				for (After event : listeners) {
+					event.afterBlockPlace(world, player, pos, state);
+				}
+			}
+	);
+
+	/**
+	 * Callback when a block place has been canceled.
+	 *
+	 * <p>Called on both client and server. May be used on logical server to send packets to revert client-side block changes.
+	 */
+	public static final Event<Canceled> CANCELED = EventFactory.createArrayBacked(
+			Canceled.class,
+			listeners -> (world, player, pos, state) -> {
+				for (Canceled event : listeners) {
+					event.onBlockPlaceCanceled(world, player, pos, state);
+				}
+			}
+	);
+
+	@FunctionalInterface
+	public interface Before {
+		/**
+		 * Called before a block is placed and allows canceling the block placing.
+		 *
+		 * <p>Implementations should not modify the world or assume the block place has completed or failed.</p>
+		 *
+		 * @param world the world in which the block is placed
+		 * @param player the player placing the block
+		 * @param pos the position at which the block is placed
+		 * @param state the block state <strong>before</strong> the block is placed
+		 * @return {@code false} to cancel block placing action, or {@code true} to pass to next listener
+		 */
+		boolean beforeBlockPlace(World world, PlayerEntity player, BlockPos pos, BlockState state);
+	}
+
+	@FunctionalInterface
+	public interface After {
+		/**
+		 * Called after a block is successfully placed.
+		 *
+		 * @param world the world where the block was placed
+		 * @param player the player who placed the block
+		 * @param pos the position where the block was placed
+		 * @param state the block state <strong>before</strong> the block was placed
+		 */
+		void afterBlockPlace(World world, PlayerEntity player, BlockPos pos, BlockState state);
+	}
+
+	@FunctionalInterface
+	public interface Canceled {
+		/**
+		 * Called when a block place has been canceled.
+		 *
+		 * @param world the world where the block was going to be placed
+		 * @param player the player who was going to place the block
+		 * @param pos the position where the block was going to be placed
+		 * @param state the block state of the block that was going to be place
+		 */
+		void onBlockPlaceCanceled(World world, PlayerEntity player, BlockPos pos, BlockState state);
+	}
+}

--- a/fabric-events-interaction-v0/src/testmod/java/net/fabricmc/fabric/test/event/interaction/ClientBlockBreakEvents.java
+++ b/fabric-events-interaction-v0/src/testmod/java/net/fabricmc/fabric/test/event/interaction/ClientBlockBreakEvents.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.event.interaction;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import net.minecraft.block.Blocks;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.client.player.ClientBlockBreakEvent;
+
+public class ClientBlockBreakEvents implements ModInitializer {
+	public static final Logger LOGGER = LogManager.getLogger("InteractionEventsTest");
+
+	@Override
+	public void onInitialize() {
+		ClientBlockBreakEvent.ON_START.register((world, player, pos, state, progress) -> {
+			LOGGER.info("Client Block break event started at "
+								+ pos.getX() + ", " + pos.getY() + ", " + pos.getZ()
+								+ " (" + progress * 100 + "%)");
+			return state.getBlock() != Blocks.SANDSTONE_SLAB;
+		});
+
+		ClientBlockBreakEvent.ON_PROGRESS.register((world, player, pos, state, progress) -> {
+			LOGGER.info("Client Block break event in progress at "
+								+ pos.getX() + ", " + pos.getY() + ", " + pos.getZ()
+								+ " (" + progress * 100 + "%)");
+			return state.getBlock() != Blocks.SANDSTONE_STAIRS;
+		});
+
+		ClientBlockBreakEvent.ON_CANCEL.register((world, player, pos, state, progress) -> {
+			LOGGER.info("Client Block break event canceled at "
+								+ pos.getX() + ", " + pos.getY() + ", " + pos.getZ()
+								+ " (" + progress * 100 + "%)");
+		});
+
+		ClientBlockBreakEvent.ON_BREAK.register((world, player, pos, state, progress) -> {
+			LOGGER.info("Client Block broken at "
+								+ pos.getX() + ", " + pos.getY() + ", " + pos.getZ()
+								+ " (" + progress * 100 + "%)");
+		});
+	}
+}

--- a/fabric-events-interaction-v0/src/testmod/java/net/fabricmc/fabric/test/event/interaction/ClientBlockPlaceEvents.java
+++ b/fabric-events-interaction-v0/src/testmod/java/net/fabricmc/fabric/test/event/interaction/ClientBlockPlaceEvents.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.event.interaction;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import net.minecraft.block.Blocks;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.client.player.ClientBlockPlaceEvent;
+
+public class ClientBlockPlaceEvents implements ModInitializer {
+	public static final Logger LOGGER = LogManager.getLogger("InteractionEventsTest");
+
+	@Override
+	public void onInitialize() {
+		ClientBlockPlaceEvent.BEFORE.register((world, player, pos, state) -> {
+			LOGGER.info("Client Block place event started at " + pos.getX() + ", " + pos.getY() + ", " + pos.getZ());
+			return state.getBlock() != Blocks.SPONGE;
+		});
+
+		ClientBlockPlaceEvent.CANCELED.register((world, player, pos, state) -> {
+			LOGGER.info("Client Block place event canceled at " + pos.getX() + ", " + pos.getY() + ", " + pos.getZ());
+		});
+
+		ClientBlockPlaceEvent.AFTER.register((world, player, pos, state) -> {
+			LOGGER.info("Client Block placed at " + pos.getX() + ", " + pos.getY() + ", " + pos.getZ());
+		});
+	}
+}

--- a/fabric-events-interaction-v0/src/testmod/resources/fabric.mod.json
+++ b/fabric-events-interaction-v0/src/testmod/resources/fabric.mod.json
@@ -10,7 +10,9 @@
   },
   "entrypoints": {
     "main": [
-      "net.fabricmc.fabric.test.event.interaction.PlayerBreakBlockTests"
+      "net.fabricmc.fabric.test.event.interaction.PlayerBreakBlockTests",
+      "net.fabricmc.fabric.test.event.interaction.ClientBlockPlaceEvents",
+      "net.fabricmc.fabric.test.event.interaction.ClientBlockBreakEvents"
     ]
   }
 }


### PR DESCRIPTION
Raised from https://github.com/FabricMC/fabric/pull/1069#issuecomment-690337405

This is a collection of client side events which client side mods can use to detect block breaks and placements.

The added events are as follows:

```
ClientBlockPlaceEvent.BEFORE
ClientBlockPlaceEvent.CANCELED
ClientBlockPlaceEvent.AFTER

ClientBlockBreakEvent.ON_START
ClientBlockBreakEvent.ON_PROGRESS
ClientBlockBreakEvent.ON_CANCEL
ClientBlockBreakEvent.ON_BREAK
```