### PR TITLE
Generify more of registry-sync-v0 and remove unchecked casts where possible

### DIFF
--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/RegistryEntryAddedCallback.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/RegistryEntryAddedCallback.java
@@ -27,11 +27,6 @@ public interface RegistryEntryAddedCallback<T> {
 	void onEntryAdded(int rawId, Identifier id, T object);
 
 	static <T> Event<RegistryEntryAddedCallback<T>> event(Registry<T> registry) {
-		if (!(registry instanceof ListenableRegistry)) {
-			throw new IllegalArgumentException("Unsupported registry: " + registry.getClass().getName());
-		}
-
-		//noinspection unchecked
-		return (Event<RegistryEntryAddedCallback<T>>) ((ListenableRegistry) registry).fabric_getAddObjectEvent();
+		return ListenableRegistry.get(registry).fabric_getAddObjectEvent();
 	}
 }

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/RegistryEntryRemovedCallback.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/RegistryEntryRemovedCallback.java
@@ -27,11 +27,6 @@ public interface RegistryEntryRemovedCallback<T> {
 	void onEntryRemoved(int rawId, Identifier id, T object);
 
 	static <T> Event<RegistryEntryRemovedCallback<T>> event(Registry<T> registry) {
-		if (!(registry instanceof ListenableRegistry)) {
-			throw new IllegalArgumentException("Unsupported registry: " + registry.getClass().getName());
-		}
-
-		//noinspection unchecked
-		return (Event<RegistryEntryRemovedCallback<T>>) ((ListenableRegistry) registry).fabric_getRemoveObjectEvent();
+		return ListenableRegistry.get(registry).fabric_getRemoveObjectEvent();
 	}
 }

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/RegistryIdRemapCallback.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/RegistryIdRemapCallback.java
@@ -49,11 +49,6 @@ public interface RegistryIdRemapCallback<T> {
 	}
 
 	static <T> Event<RegistryIdRemapCallback<T>> event(Registry<T> registry) {
-		if (!(registry instanceof ListenableRegistry)) {
-			throw new IllegalArgumentException("Unsupported registry: " + registry.getClass().getName());
-		}
-
-		//noinspection unchecked
-		return ((ListenableRegistry) registry).fabric_getRemapEvent();
+		return ListenableRegistry.get(registry).fabric_getRemapEvent();
 	}
 }

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/ListenableRegistry.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/ListenableRegistry.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.impl.registry.sync;
 
+import net.minecraft.util.registry.Registry;
+
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
 import net.fabricmc.fabric.api.event.registry.RegistryEntryRemovedCallback;
@@ -25,4 +27,13 @@ public interface ListenableRegistry<T> {
 	Event<RegistryEntryAddedCallback<T>> fabric_getAddObjectEvent();
 	Event<RegistryEntryRemovedCallback<T>> fabric_getRemoveObjectEvent();
 	Event<RegistryIdRemapCallback<T>> fabric_getRemapEvent();
+	@SuppressWarnings("unchecked")
+	static <T> ListenableRegistry<T> get(Registry<T> registry) {
+		if (!(registry instanceof ListenableRegistry)) {
+			throw new IllegalArgumentException("Unsupported registry: " + registry.getKey().getValue());
+		}
+
+		// Safe cast: this is implemented via Mixin and T will always match the T in Registry<T>
+		return (ListenableRegistry<T>) registry;
+	}
 }

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/trackers/StateIdTracker.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/trackers/StateIdTracker.java
@@ -70,7 +70,7 @@ public final class StateIdTracker<T, S> implements RegistryIdRemapCallback<T>, R
 	}
 
 	private void recalcStateMap() {
-		((RemovableIdList) stateList).fabric_clear();
+		((RemovableIdList<?>) stateList).fabric_clear();
 
 		Int2ObjectMap<T> sortedBlocks = new Int2ObjectRBTreeMap<>();
 

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinBootstrap.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinBootstrap.java
@@ -37,7 +37,6 @@ import net.fabricmc.fabric.impl.registry.sync.trackers.vanilla.BlockItemTracker;
 
 @Mixin(Bootstrap.class)
 public class MixinBootstrap {
-	@SuppressWarnings("unchecked")
 	@Inject(method = "setOutputStreams", at = @At("RETURN"))
 	private static void initialize(CallbackInfo info) {
 		// These seemingly pointless accesses are done to make sure each

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinIdList.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinIdList.java
@@ -31,13 +31,13 @@ import net.minecraft.util.collection.IdList;
 import net.fabricmc.fabric.impl.registry.sync.RemovableIdList;
 
 @Mixin(IdList.class)
-public class MixinIdList implements RemovableIdList<Object> {
+public class MixinIdList<T> implements RemovableIdList<T> {
 	@Shadow
 	private int nextId;
 	@Shadow
-	private IdentityHashMap<Object, Integer> idMap;
+	private IdentityHashMap<T, Integer> idMap;
 	@Shadow
-	private List<Object> list;
+	private List<T> list;
 
 	@Override
 	public void fabric_clear() {
@@ -47,7 +47,7 @@ public class MixinIdList implements RemovableIdList<Object> {
 	}
 
 	@Unique
-	private void fabric_removeInner(Object o) {
+	private void fabric_removeInner(T o) {
 		int value = idMap.remove(o);
 		list.set(value, null);
 
@@ -57,7 +57,7 @@ public class MixinIdList implements RemovableIdList<Object> {
 	}
 
 	@Override
-	public void fabric_remove(Object o) {
+	public void fabric_remove(T o) {
 		if (idMap.containsKey(o)) {
 			fabric_removeInner(o);
 		}
@@ -65,9 +65,9 @@ public class MixinIdList implements RemovableIdList<Object> {
 
 	@Override
 	public void fabric_removeId(int i) {
-		List<Object> removals = new ArrayList<>();
+		List<T> removals = new ArrayList<>();
 
-		for (Object o : idMap.keySet()) {
+		for (T o : idMap.keySet()) {
 			int j = idMap.get(o);
 
 			if (i == j) {
@@ -86,15 +86,15 @@ public class MixinIdList implements RemovableIdList<Object> {
 	@Override
 	public void fabric_remapIds(Int2IntMap map) {
 		// remap idMap
-		idMap.replaceAll((a, b) -> map.get(b));
+		idMap.replaceAll((a, b) -> map.get((int) b));
 
 		// remap list
 		nextId = 0;
-		List<Object> oldList = new ArrayList<>(list);
+		List<T> oldList = new ArrayList<>(list);
 		list.clear();
 
 		for (int k = 0; k < oldList.size(); k++) {
-			Object o = oldList.get(k);
+			T o = oldList.get(k);
 
 			if (o != null) {
 				int i = map.getOrDefault(k, k);

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinIdRegistry.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinIdRegistry.java
@@ -59,7 +59,7 @@ import net.fabricmc.fabric.impl.registry.sync.RemapStateImpl;
 import net.fabricmc.fabric.impl.registry.sync.RemappableRegistry;
 
 @Mixin(SimpleRegistry.class)
-public abstract class MixinIdRegistry<T> implements RemappableRegistry, ListenableRegistry {
+public abstract class MixinIdRegistry<T> extends Registry<T> implements RemappableRegistry, ListenableRegistry<T> {
 	@Shadow
 	@Final
 	private ObjectList<T> rawIdToEntry;
@@ -77,31 +77,32 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 	@Unique
 	private static Logger FABRIC_LOGGER = LogManager.getLogger();
 
+	public MixinIdRegistry(RegistryKey<? extends Registry<T>> key, Lifecycle lifecycle) {
+		super(key, lifecycle);
+	}
+
 	@Unique
-	private final Event<RegistryEntryAddedCallback> fabric_addObjectEvent = EventFactory.createArrayBacked(RegistryEntryAddedCallback.class,
+	private final Event<RegistryEntryAddedCallback<T>> fabric_addObjectEvent = EventFactory.createArrayBacked(RegistryEntryAddedCallback.class,
 			(callbacks) -> (rawId, id, object) -> {
-				for (RegistryEntryAddedCallback callback : callbacks) {
-					//noinspection unchecked
+				for (RegistryEntryAddedCallback<T> callback : callbacks) {
 					callback.onEntryAdded(rawId, id, object);
 				}
 			}
 	);
 
 	@Unique
-	private final Event<RegistryEntryRemovedCallback> fabric_removeObjectEvent = EventFactory.createArrayBacked(RegistryEntryRemovedCallback.class,
+	private final Event<RegistryEntryRemovedCallback<T>> fabric_removeObjectEvent = EventFactory.createArrayBacked(RegistryEntryRemovedCallback.class,
 			(callbacks) -> (rawId, id, object) -> {
-				for (RegistryEntryRemovedCallback callback : callbacks) {
-					//noinspection unchecked
+				for (RegistryEntryRemovedCallback<T> callback : callbacks) {
 					callback.onEntryRemoved(rawId, id, object);
 				}
 			}
 	);
 
 	@Unique
-	private final Event<RegistryIdRemapCallback> fabric_postRemapEvent = EventFactory.createArrayBacked(RegistryIdRemapCallback.class,
+	private final Event<RegistryIdRemapCallback<T>> fabric_postRemapEvent = EventFactory.createArrayBacked(RegistryIdRemapCallback.class,
 			(callbacks) -> (a) -> {
-				for (RegistryIdRemapCallback callback : callbacks) {
-					//noinspection unchecked
+				for (RegistryIdRemapCallback<T> callback : callbacks) {
 					callback.onRemap(a);
 				}
 			}
@@ -114,30 +115,26 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 
 	@Override
 	public Event<RegistryEntryAddedCallback<T>> fabric_getAddObjectEvent() {
-		//noinspection unchecked
-		return (Event) fabric_addObjectEvent;
+		return fabric_addObjectEvent;
 	}
 
 	@Override
 	public Event<RegistryEntryRemovedCallback<T>> fabric_getRemoveObjectEvent() {
-		//noinspection unchecked
-		return (Event) fabric_removeObjectEvent;
+		return fabric_removeObjectEvent;
 	}
 
 	@Override
 	public Event<RegistryIdRemapCallback<T>> fabric_getRemapEvent() {
-		//noinspection unchecked
-		return (Event) fabric_postRemapEvent;
+		return fabric_postRemapEvent;
 	}
 
 	// The rest of the registry isn't thread-safe, so this one need not be either.
 	@Unique
 	private boolean fabric_isObjectNew = false;
 
-	@SuppressWarnings({"unchecked", "ConstantConditions"})
 	@Inject(method = "set", at = @At("HEAD"))
-	public void setPre(int id, RegistryKey<T> registryId, Object object, Lifecycle lifecycle, CallbackInfoReturnable info) {
-		int indexedEntriesId = entryToRawId.getInt((T) object);
+	public void setPre(int id, RegistryKey<T> registryId, T object, Lifecycle lifecycle, CallbackInfoReturnable<T> info) {
+		int indexedEntriesId = entryToRawId.getInt(object);
 
 		if (indexedEntriesId >= 0) {
 			throw new RuntimeException("Attempted to register object " + object + " twice! (at raw IDs " + indexedEntriesId + " and " + id + " )");
@@ -163,9 +160,8 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 		}
 	}
 
-	@SuppressWarnings("unchecked")
 	@Inject(method = "set", at = @At("RETURN"))
-	public void setPost(int id, RegistryKey<T> registryId, Object object, Lifecycle lifecycle, CallbackInfoReturnable info) {
+	public void setPost(int id, RegistryKey<T> registryId, T object, Lifecycle lifecycle, CallbackInfoReturnable<T> info) {
 		if (fabric_isObjectNew) {
 			fabric_addObjectEvent.invoker().onEntryAdded(id, registryId.getValue(), object);
 		}
@@ -173,9 +169,6 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 
 	@Override
 	public void remap(String name, Object2IntMap<Identifier> remoteIndexedEntries, RemapMode mode) throws RemapException {
-		//noinspection unchecked, ConstantConditions
-		SimpleRegistry<Object> registry = (SimpleRegistry<Object>) (Object) this;
-
 		// Throw on invalid conditions.
 		switch (mode) {
 		case AUTHORITATIVE:
@@ -184,7 +177,7 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 			List<String> strings = null;
 
 			for (Identifier remoteId : remoteIndexedEntries.keySet()) {
-				if (!idToEntry.keySet().contains(remoteId)) {
+				if (!idToEntry.containsKey(remoteId)) {
 					if (strings == null) {
 						strings = new ArrayList<>();
 					}
@@ -210,13 +203,13 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 				List<String> strings = new ArrayList<>();
 
 				for (Identifier remoteId : remoteIndexedEntries.keySet()) {
-					if (!idToEntry.keySet().contains(remoteId)) {
+					if (!idToEntry.containsKey(remoteId)) {
 						strings.add(" - " + remoteId + " (missing on local)");
 					}
 				}
 
-				for (Identifier localId : registry.getIds()) {
-					if (!remoteIndexedEntries.keySet().contains(localId)) {
+				for (Identifier localId : getIds()) {
+					if (!remoteIndexedEntries.containsKey(localId)) {
 						strings.add(" - " + localId + " (missing on remote)");
 					}
 				}
@@ -244,15 +237,15 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 			fabric_prevIndexedEntries = new Object2IntOpenHashMap<>();
 			fabric_prevEntries = HashBiMap.create(idToEntry);
 
-			for (Object o : registry) {
-				fabric_prevIndexedEntries.put(registry.getId(o), registry.getRawId(o));
+			for (T o : this) {
+				fabric_prevIndexedEntries.put(getId(o), getRawId(o));
 			}
 		}
 
 		Int2ObjectMap<Identifier> oldIdMap = new Int2ObjectOpenHashMap<>();
 
-		for (Object o : registry) {
-			oldIdMap.put(registry.getRawId(o), registry.getId(o));
+		for (T o : this) {
+			oldIdMap.put(getRawId(o), getId(o));
 		}
 
 		// If we're AUTHORITATIVE, we append entries which only exist on the
@@ -270,7 +263,7 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 				if (v > maxValue) maxValue = v;
 			}
 
-			for (Identifier id : registry.getIds()) {
+			for (Identifier id : getIds()) {
 				if (!remoteIndexedEntries.containsKey(id)) {
 					FABRIC_LOGGER.warn("Adding " + id + " to saved/remote registry.");
 					remoteIndexedEntries.put(id, ++maxValue);
@@ -283,16 +276,15 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 			// TODO: Is this what mods really want?
 			Set<Identifier> droppedIds = new HashSet<>();
 
-			for (Identifier id : registry.getIds()) {
+			for (Identifier id : getIds()) {
 				if (!remoteIndexedEntries.containsKey(id)) {
-					Object object = registry.get(id);
-					int rid = registry.getRawId(object);
+					T object = get(id);
+					int rid = getRawId(object);
 
 					droppedIds.add(id);
 
 					// Emit RemoveObject events for removed objects.
-					//noinspection unchecked
-					fabric_getRemoveObjectEvent().invoker().onEntryRemoved(rid, id, (T) object);
+					fabric_getRemoveObjectEvent().invoker().onEntryRemoved(rid, id, object);
 				}
 			}
 
@@ -306,9 +298,9 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 
 		Int2IntMap idMap = new Int2IntOpenHashMap();
 
-		for (Object o : rawIdToEntry) {
-			Identifier id = registry.getId(o);
-			int rid = registry.getRawId(o);
+		for (T o : rawIdToEntry) {
+			Identifier id = getId(o);
+			int rid = getRawId(o);
 
 			// see above note
 			if (remoteIndexedEntries.containsKey(id)) {
@@ -351,8 +343,7 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 			}
 		}
 
-		//noinspection unchecked
-		fabric_getRemapEvent().invoker().onRemap(new RemapStateImpl(registry, oldIdMap, idMap));
+		fabric_getRemapEvent().invoker().onRemap(new RemapStateImpl<>(this, oldIdMap, idMap));
 	}
 
 	@Override
@@ -374,8 +365,8 @@ public abstract class MixinIdRegistry<T> implements RemappableRegistry, Listenab
 			idToEntry.putAll(fabric_prevEntries);
 
 			for (Map.Entry<Identifier, T> entry : fabric_prevEntries.entrySet()) {
-				//noinspection unchecked
-				keyToEntry.put(RegistryKey.of(RegistryKey.ofRegistry(((Registry) Registry.REGISTRIES).getId(this)), entry.getKey()), entry.getValue());
+				RegistryKey<T> entryKey = RegistryKey.of(getKey(), entry.getKey());
+				keyToEntry.put(entryKey, entry.getValue());
 			}
 
 			remap(name, fabric_prevIndexedEntries, RemapMode.AUTHORITATIVE);

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinSimpleRegistry.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinSimpleRegistry.java
@@ -25,6 +25,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.SimpleRegistry;
 import net.minecraft.util.registry.RegistryKey;
@@ -58,8 +59,8 @@ public abstract class MixinSimpleRegistry<T> extends Registry<T> {
 			RegistryAttributeHolder holder = RegistryAttributeHolder.get(this);
 
 			if (!holder.hasAttribute(RegistryAttribute.MODDED)) {
-				// noinspection unchecked
-				FARBIC_LOGGER.debug("Registry {} has been marked as modded, registry entry {} was changed", ((Registry) Registry.REGISTRIES).getId(this), registryKey.getValue());
+				Identifier id = getKey().getValue();
+				FARBIC_LOGGER.debug("Registry {} has been marked as modded, registry entry {} was changed", id, registryKey.getValue());
 				RegistryAttributeHolder.get(this).addAttribute(RegistryAttribute.MODDED);
 			}
 		}


### PR DESCRIPTION
Cleaned up use of Generics in registry-sync-v0 and used Registry#getKey where possible instead of reverse-lookup of the registry key.

There's also a Registry#getKey function that returns the registries own registry key, which I used in a few places where previously the ID was being looked up in Registry.ROOT (this makes it easier to support registries that aren't in there, such as biomes later).