### PR TITLE
Add FabricDamageSourceBuilder

### DIFF
--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/entity/FabricDamageSourceBuilder.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/entity/FabricDamageSourceBuilder.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.object.builder.v1.entity;
+
+import net.minecraft.entity.damage.DamageSource;
+
+/**
+ * Allows creating custom Damage Sources without subclassing it.
+ */
+public class FabricDamageSourceBuilder extends DamageSource {
+	public FabricDamageSourceBuilder(String name) {
+		super(name);
+	}
+
+	@Override
+	public FabricDamageSourceBuilder setProjectile() {
+		super.setProjectile();
+		return this;
+	}
+
+	@Override
+	public FabricDamageSourceBuilder setExplosive() {
+		super.setExplosive();
+		return this;
+	}
+
+	@Override
+	public FabricDamageSourceBuilder setBypassesArmor() {
+		super.setBypassesArmor();
+		return this;
+	}
+
+	@Override
+	public FabricDamageSourceBuilder setOutOfWorld() {
+		super.setOutOfWorld();
+		return this;
+	}
+
+	@Override
+	public FabricDamageSourceBuilder setUnblockable() {
+		super.setUnblockable();
+		return this;
+	}
+
+	@Override
+	public FabricDamageSourceBuilder setFire() {
+		super.setFire();
+		return this;
+	}
+
+	@Override
+	public FabricDamageSourceBuilder setScaledWithDifficulty() {
+		super.setScaledWithDifficulty();
+		return this;
+	}
+
+	@Override
+	public FabricDamageSourceBuilder setUsesMagic() {
+		super.setUsesMagic();
+		return this;
+	}
+}


### PR DESCRIPTION
I created this very simple PR to avoid Boilerplate code when creating custom DamageSources in my mod.  

The issue is that almost all setters in the vanilla DamageSource class are protected, so in order to create your own you need to subclass DamageSource and copy all the setter methods into your class.  

I have included methods which were already public in the superclass to make this more maintainable in case the access modifiers in vanilla code change.