### PR TITLE
Tweak entity type builder generics to eliminate explicit type arguments

### DIFF
--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/entity/FabricEntityTypeBuilder.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/entity/FabricEntityTypeBuilder.java
@@ -136,10 +136,10 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 		return this;
 	}
 
-	public FabricEntityTypeBuilder<T> entityFactory(EntityType.EntityFactory<T> factory) {
+	public <N extends T> FabricEntityTypeBuilder<N> entityFactory(EntityType.EntityFactory<N> factory) {
 		Objects.requireNonNull(factory, "Entity Factory cannot be null");
-		this.factory = factory;
-		return this;
+		this.factory = (EntityType.EntityFactory<T>) factory;
+		return (FabricEntityTypeBuilder<N>) this;
 	}
 
 	/**
@@ -258,13 +258,13 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 	 *
 	 * @return a new {@link EntityType}
 	 */
-	public <N extends T> EntityType<N> build() {
+	public EntityType<T> build() {
 		if (this.saveable) {
 			// SNIP! Modded datafixers are not supported anyway.
 			// TODO: Flesh out once modded datafixers exist.
 		}
 
-		EntityType<N> type = new FabricEntityType<>((EntityType.EntityFactory<N>) this.factory, this.spawnGroup, this.saveable, this.summonable, this.fireImmune, this.spawnableFarFromPlayer, this.specificSpawnBlocks, dimensions, trackRange, trackedUpdateRate, forceTrackedVelocityUpdates);
+		EntityType<T> type = new FabricEntityType<>(this.factory, this.spawnGroup, this.saveable, this.summonable, this.fireImmune, this.spawnableFarFromPlayer, this.specificSpawnBlocks, dimensions, trackRange, trackedUpdateRate, forceTrackedVelocityUpdates);
 
 		return type;
 	}
@@ -289,9 +289,9 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 		}
 
 		@Override
-		public FabricEntityTypeBuilder.Living<T> entityFactory(EntityType.EntityFactory<T> factory) {
+		public <N extends T> FabricEntityTypeBuilder.Living<N> entityFactory(EntityType.EntityFactory<N> factory) {
 			super.entityFactory(factory);
-			return this;
+			return (Living<N>) this;
 		}
 
 		@Override
@@ -397,8 +397,8 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 		}
 
 		@Override
-		public <N extends T> EntityType<N> build() {
-			final EntityType<N> type = super.build();
+		public EntityType<T> build() {
+			final EntityType<T> type = super.build();
 
 			if (this.defaultAttributeBuilder != null) {
 				FabricDefaultAttributeRegistry.register(type, this.defaultAttributeBuilder.get());
@@ -429,9 +429,9 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 		}
 
 		@Override
-		public FabricEntityTypeBuilder.Mob<T> entityFactory(EntityType.EntityFactory<T> factory) {
+		public <N extends T> FabricEntityTypeBuilder.Mob<N> entityFactory(EntityType.EntityFactory<N> factory) {
 			super.entityFactory(factory);
-			return this;
+			return (Mob<N>) this;
 		}
 
 		@Override
@@ -535,11 +535,11 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 		}
 
 		@Override
-		public <N extends T> EntityType<N> build() {
-			EntityType<N> type = super.build();
+		public EntityType<T> build() {
+			EntityType<T> type = super.build();
 
 			if (this.spawnPredicate != null) {
-				SpawnRestrictionAccessor.callRegister((EntityType) type, this.restrictionLocation, this.restrictionHeightmap, this.spawnPredicate);
+				SpawnRestrictionAccessor.callRegister(type, this.restrictionLocation, this.restrictionHeightmap, this.spawnPredicate);
 			}
 
 			return type;

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/entity/FabricEntityTypeBuilder.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/entity/FabricEntityTypeBuilder.java
@@ -258,13 +258,13 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 	 *
 	 * @return a new {@link EntityType}
 	 */
-	public EntityType<T> build() {
+	public <N extends T> EntityType<N> build() {
 		if (this.saveable) {
 			// SNIP! Modded datafixers are not supported anyway.
 			// TODO: Flesh out once modded datafixers exist.
 		}
 
-		EntityType<T> type = new FabricEntityType<>(this.factory, this.spawnGroup, this.saveable, this.summonable, this.fireImmune, this.spawnableFarFromPlayer, this.specificSpawnBlocks, dimensions, trackRange, trackedUpdateRate, forceTrackedVelocityUpdates);
+		EntityType<N> type = new FabricEntityType<>((EntityType.EntityFactory<N>) this.factory, this.spawnGroup, this.saveable, this.summonable, this.fireImmune, this.spawnableFarFromPlayer, this.specificSpawnBlocks, dimensions, trackRange, trackedUpdateRate, forceTrackedVelocityUpdates);
 
 		return type;
 	}
@@ -397,8 +397,8 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 		}
 
 		@Override
-		public EntityType<T> build() {
-			final EntityType<T> type = super.build();
+		public <N extends T> EntityType<N> build() {
+			final EntityType<N> type = super.build();
 
 			if (this.defaultAttributeBuilder != null) {
 				FabricDefaultAttributeRegistry.register(type, this.defaultAttributeBuilder.get());
@@ -535,11 +535,11 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 		}
 
 		@Override
-		public EntityType<T> build() {
-			EntityType<T> type = super.build();
+		public <N extends T> EntityType<N> build() {
+			EntityType<N> type = super.build();
 
 			if (this.spawnPredicate != null) {
-				SpawnRestrictionAccessor.callRegister(type, this.restrictionLocation, this.restrictionHeightmap, this.spawnPredicate);
+				SpawnRestrictionAccessor.callRegister((EntityType) type, this.restrictionLocation, this.restrictionHeightmap, this.spawnPredicate);
 			}
 
 			return type;

--- a/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/EntityTypeBuilderGenericsTest.java
+++ b/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/EntityTypeBuilderGenericsTest.java
@@ -33,7 +33,6 @@ import net.fabricmc.fabric.api.object.builder.v1.entity.FabricEntityTypeBuilder;
 // This test is intentionally not an entrypoint to verify the generics of the entity type builder propagate properly
 final class EntityTypeBuilderGenericsTest {
 	static EntityType<Entity> ENTITY_1 = FabricEntityTypeBuilder.create().build();
-	static EntityType<LivingEntity> LIVING_ENTITY_USING_NORMAL_BUILDER = FabricEntityTypeBuilder.create().build();
 	static EntityType<LivingEntity> LIVING_ENTITY_1 = FabricEntityTypeBuilder.createLiving().build();
 	static EntityType<TestEntity> TEST_ENTITY_1 = FabricEntityTypeBuilder.createLiving()
 			.entityFactory(TestEntity::new)
@@ -43,12 +42,15 @@ final class EntityTypeBuilderGenericsTest {
 			.entityFactory(TestEntity::new)
 			.spawnGroup(SpawnGroup.CREATURE)
 			.build();
-	// Not typically intended but it works
-	static EntityType<? extends MobEntity> MOB_TEST = FabricEntityTypeBuilder.createMob()
+	static EntityType<TestMob> OLD_MOB = FabricEntityTypeBuilder.<TestMob>createMob()
 			.disableSaving()
+			.entityFactory(TestMob::new)
+			.build();
+	static EntityType<TestMob> MOB_TEST = FabricEntityTypeBuilder.createMob()
+			.disableSaving()
+			.entityFactory(TestMob::new)
 			.build();
 
-	@SuppressWarnings("EntityConstructor")
 	private static class TestEntity extends LivingEntity {
 		protected TestEntity(EntityType<? extends LivingEntity> entityType, World world) {
 			super(entityType, world);
@@ -71,6 +73,12 @@ final class EntityTypeBuilderGenericsTest {
 		@Override
 		public Arm getMainArm() {
 			return Arm.RIGHT;
+		}
+	}
+
+	private static class TestMob extends MobEntity {
+		protected TestMob(EntityType<? extends MobEntity> entityType, World world) {
+			super(entityType, world);
 		}
 	}
 }

--- a/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/EntityTypeBuilderGenericsTest.java
+++ b/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/EntityTypeBuilderGenericsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.object.builder;
+
+import java.util.Collections;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.SpawnGroup;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Arm;
+import net.minecraft.world.World;
+
+import net.fabricmc.fabric.api.object.builder.v1.entity.FabricEntityTypeBuilder;
+
+// This test is intentionally not an entrypoint to verify the generics of the entity type builder propagate properly
+final class EntityTypeBuilderGenericsTest {
+	static EntityType<Entity> ENTITY_1 = FabricEntityTypeBuilder.create().build();
+	static EntityType<LivingEntity> LIVING_ENTITY_USING_NORMAL_BUILDER = FabricEntityTypeBuilder.create().build();
+	static EntityType<LivingEntity> LIVING_ENTITY_1 = FabricEntityTypeBuilder.createLiving().build();
+	static EntityType<TestEntity> TEST_ENTITY_1 = FabricEntityTypeBuilder.createLiving()
+			.entityFactory(TestEntity::new)
+			.spawnGroup(SpawnGroup.CREATURE)
+			.build();
+	static EntityType<TestEntity> OLD_TEST = FabricEntityTypeBuilder.<TestEntity>createLiving()
+			.entityFactory(TestEntity::new)
+			.spawnGroup(SpawnGroup.CREATURE)
+			.build();
+	// Not typically intended but it works
+	static EntityType<? extends MobEntity> MOB_TEST = FabricEntityTypeBuilder.createMob()
+			.disableSaving()
+			.build();
+
+	@SuppressWarnings("EntityConstructor")
+	private static class TestEntity extends LivingEntity {
+		protected TestEntity(EntityType<? extends LivingEntity> entityType, World world) {
+			super(entityType, world);
+		}
+
+		@Override
+		public Iterable<ItemStack> getArmorItems() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public ItemStack getEquippedStack(EquipmentSlot slot) {
+			return ItemStack.EMPTY;
+		}
+
+		@Override
+		public void equipStack(EquipmentSlot slot, ItemStack stack) {
+		}
+
+		@Override
+		public Arm getMainArm() {
+			return Arm.RIGHT;
+		}
+	}
+}


### PR DESCRIPTION
This is most definitely not a great solution as it allows people to over-specify the type argument and therefore cause class cast exceptions at creation time.

The intention here is to remove the need for explicit type arguments:

Before:
```java
// Omit type argument and this fails to compile
static EntityType<TestEntity> OLD_TEST = FabricEntityTypeBuilder.<TestEntity>createLiving()
		.entityFactory(TestEntity::new)
		.spawnGroup(SpawnGroup.CREATURE)
		.build();
```

After:
```java
// Changes make this compile
static EntityType<TestEntity> TEST_ENTITY_1 = FabricEntityTypeBuilder.createLiving()
		.entityFactory(TestEntity::new)
		.spawnGroup(SpawnGroup.CREATURE)
		.build();
```