### PR TITLE
Extra block settings

### DIFF
--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricBlockSettings.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricBlockSettings.java
@@ -66,6 +66,7 @@ public class FabricBlockSettings extends AbstractBlock.Settings {
 		thisAccessor.setDynamicBounds(otherAccessor.getDynamicBounds());
 		thisAccessor.setOpaque(otherAccessor.getOpaque());
 		thisAccessor.setIsAir(otherAccessor.getIsAir());
+		thisAccessor.setToolRequired(otherAccessor.isToolRequired());
 
 		// Now attempt to copy fabric specific data
 		BlockSettingsInternals otherInternals = (BlockSettingsInternals) settings;

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricBlockSettings.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricBlockSettings.java
@@ -23,6 +23,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Material;
 import net.minecraft.block.MaterialColor;
+import net.minecraft.block.piston.PistonBehavior;
 import net.minecraft.entity.EntityType;
 import net.minecraft.item.Item;
 import net.minecraft.sound.BlockSoundGroup;
@@ -294,5 +295,32 @@ public class FabricBlockSettings extends AbstractBlock.Settings {
 	 */
 	public FabricBlockSettings breakByTool(Tag<Item> tag) {
 		return this.breakByTool(tag, 0);
+	}
+
+	/**
+	 * Sets the piston behavior of the block, if not set it defaults to the value of
+	 * {@link Material#getPistonBehavior()} for the block's material.
+	 */
+	public FabricBlockSettings pistonBehavior(PistonBehavior pistonBehavior) {
+		FabricBlockInternals.computeExtraData(this).setPistonBehavior(pistonBehavior);
+		return this;
+	}
+
+	/**
+	 * Sets whether the block is replaceable, if not set it defaults to the value of {@link Material#isReplaceable()}
+	 * for the block's material.
+	 */
+	public FabricBlockSettings replaceable(boolean replaceable) {
+		FabricBlockInternals.computeExtraData(this).setReplaceable(replaceable);
+		return this;
+	}
+
+	/**
+	 * Sets whether the block is solid, if not set it defaults to the value of {@link Material#isSolid()} for the
+	 * block's material.
+	 */
+	public FabricBlockSettings solid(boolean solid) {
+		FabricBlockInternals.computeExtraData(this).setSolid(solid);
+		return this;
 	}
 }

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/impl/object/builder/AbstractBlockInternals.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/impl/object/builder/AbstractBlockInternals.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.impl.object.builder;
 
 import net.minecraft.block.BlockState;

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/impl/object/builder/AbstractBlockInternals.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/impl/object/builder/AbstractBlockInternals.java
@@ -1,0 +1,12 @@
+package net.fabricmc.fabric.impl.object.builder;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.piston.PistonBehavior;
+
+public interface AbstractBlockInternals {
+	void setPistonBehavior(PistonBehavior pistonBehavior);
+	boolean isReplaceable(BlockState state);
+	void setReplaceable(boolean replaceable);
+	boolean isSolid(BlockState state);
+	void setSolid(boolean solid);
+}

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/impl/object/builder/FabricBlockInternals.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/impl/object/builder/FabricBlockInternals.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.piston.PistonBehavior;
 import net.minecraft.item.Item;
 import net.minecraft.tag.Tag;
 
@@ -51,12 +52,27 @@ public final class FabricBlockInternals {
 			for (MiningLevel tml : data.miningLevels) {
 				ToolManagerImpl.entry(block).putBreakByTool(tml.tag, tml.level);
 			}
+
+			if (data.pistonBehavior != null) {
+				((AbstractBlockInternals) block).setPistonBehavior(data.pistonBehavior);
+			}
+
+			if (data.replaceable != null) {
+				((AbstractBlockInternals) block).setReplaceable(data.replaceable);
+			}
+
+			if (data.solid != null) {
+				((AbstractBlockInternals) block).setSolid(data.solid);
+			}
 		}
 	}
 
 	public static final class ExtraData {
 		private final List<MiningLevel> miningLevels = new ArrayList<>();
 		/* @Nullable */ private Boolean breakByHand;
+		/* @Nullable */ private PistonBehavior pistonBehavior;
+		/* @Nullable */ private Boolean replaceable;
+		/* @Nullable */ private Boolean solid;
 
 		public ExtraData(Block.Settings settings) {
 		}
@@ -67,6 +83,18 @@ public final class FabricBlockInternals {
 
 		public void addMiningLevel(Tag<Item> tag, int level) {
 			miningLevels.add(new MiningLevel(tag, level));
+		}
+
+		public void setPistonBehavior(PistonBehavior pistonBehavior) {
+			this.pistonBehavior = pistonBehavior;
+		}
+
+		public void setReplaceable(boolean replaceable) {
+			this.replaceable = replaceable;
+		}
+
+		public void setSolid(boolean solid) {
+			this.solid = solid;
 		}
 	}
 

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/impl/object/builder/FabricBlockInternals.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/impl/object/builder/FabricBlockInternals.java
@@ -72,13 +72,13 @@ public final class FabricBlockInternals {
 	public static final class ExtraData {
 		private final List<MiningLevel> miningLevels = new ArrayList<>();
 		@Nullable
-    private Boolean breakByHand;
-    @Nullable
-    private PistonBehavior pistonBehavior;
+		private Boolean breakByHand;
 		@Nullable
-    private Boolean replaceable;
+		private PistonBehavior pistonBehavior;
 		@Nullable
-    private Boolean solid;
+		private Boolean replaceable;
+		@Nullable
+		private Boolean solid;
 
 		public ExtraData(Block.Settings settings) {
 		}

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/AbstractBlockMixin.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/AbstractBlockMixin.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.object.builder;
+
+import net.fabricmc.fabric.impl.object.builder.AbstractBlockInternals;
+import net.fabricmc.fabric.impl.object.builder.BlockSettingsInternals;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.block.AbstractBlock;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Material;
+import net.minecraft.block.piston.PistonBehavior;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemPlacementContext;
+
+@Mixin(AbstractBlock.class)
+public abstract class AbstractBlockMixin implements AbstractBlockInternals {
+	@Shadow
+	@Final
+	protected Material material;
+	/* @Nullable */ private PistonBehavior pistonBehavior;
+	/* @Nullable */ private Boolean replaceable;
+	/* @Nullable */ private Boolean solid;
+
+	@Override
+	public void setPistonBehavior(PistonBehavior pistonBehavior) {
+		this.pistonBehavior = pistonBehavior;
+	}
+
+	@Inject(method = "getPistonBehavior(Lnet/minecraft/block/BlockState;)Lnet/minecraft/block/piston/PistonBehavior;", at = @At("RETURN"), cancellable = true)
+	public void pistonBehaviorInject(BlockState state, CallbackInfoReturnable<PistonBehavior> cir) {
+		if(this.pistonBehavior != null) {
+			cir.setReturnValue(this.pistonBehavior);
+		}
+	}
+
+	@Override
+	public boolean isReplaceable(BlockState state) {
+		if(replaceable != null) {
+			return replaceable;
+		}
+		return this.material.isReplaceable();
+	}
+
+	@Override
+	public void setReplaceable(boolean replaceable) {
+		this.replaceable = replaceable;
+	}
+
+	@Override
+	public boolean isSolid(BlockState state) {
+		if(solid != null) {
+			return solid;
+		}
+		return this.material.isSolid();
+	}
+
+	@Override
+	public void setSolid(boolean solid) {
+		this.solid = solid;
+	}
+
+	@Inject(method = "canReplace(Lnet/minecraft/block/BlockState;Lnet/minecraft/item/ItemPlacementContext;)Z", at = @At("RETURN"), cancellable = true)
+	public void canReplaceInject(BlockState state, ItemPlacementContext context, CallbackInfoReturnable<Boolean> cir) {
+		cir.setReturnValue(this.isReplaceable(state) && (context.getStack().isEmpty() || context.getStack().getItem() != this.asItem()));
+	}
+
+	@Inject(method = "canBucketPlace(Lnet/minecraft/block/BlockState;Lnet/minecraft/fluid/Fluid;)Z", at = @At("RETURN"), cancellable = true)
+	public void canBucketPlaceInject(BlockState state, Fluid fluid, CallbackInfoReturnable<Boolean> cir) {
+		cir.setReturnValue(this.isReplaceable(state) || !this.isSolid(state));
+	}
+
+	@Shadow
+	public abstract Item asItem();
+}

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/AbstractBlockMixin.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/AbstractBlockMixin.java
@@ -16,15 +16,11 @@
 
 package net.fabricmc.fabric.mixin.object.builder;
 
-import net.fabricmc.fabric.impl.object.builder.AbstractBlockInternals;
-import net.fabricmc.fabric.impl.object.builder.BlockSettingsInternals;
-
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.block.AbstractBlock;
@@ -34,6 +30,8 @@ import net.minecraft.block.piston.PistonBehavior;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemPlacementContext;
+
+import net.fabricmc.fabric.impl.object.builder.AbstractBlockInternals;
 
 @Mixin(AbstractBlock.class)
 public abstract class AbstractBlockMixin implements AbstractBlockInternals {
@@ -51,16 +49,17 @@ public abstract class AbstractBlockMixin implements AbstractBlockInternals {
 
 	@Inject(method = "getPistonBehavior(Lnet/minecraft/block/BlockState;)Lnet/minecraft/block/piston/PistonBehavior;", at = @At("RETURN"), cancellable = true)
 	public void pistonBehaviorInject(BlockState state, CallbackInfoReturnable<PistonBehavior> cir) {
-		if(this.pistonBehavior != null) {
+		if (this.pistonBehavior != null) {
 			cir.setReturnValue(this.pistonBehavior);
 		}
 	}
 
 	@Override
 	public boolean isReplaceable(BlockState state) {
-		if(replaceable != null) {
+		if (replaceable != null) {
 			return replaceable;
 		}
+
 		return this.material.isReplaceable();
 	}
 
@@ -71,9 +70,10 @@ public abstract class AbstractBlockMixin implements AbstractBlockInternals {
 
 	@Override
 	public boolean isSolid(BlockState state) {
-		if(solid != null) {
+		if (solid != null) {
 			return solid;
 		}
+
 		return this.material.isSolid();
 	}
 

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/AbstractBlockMixin.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/AbstractBlockMixin.java
@@ -22,7 +22,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.AbstractBlock;

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/AbstractBlockMixin.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/AbstractBlockMixin.java
@@ -23,6 +23,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Material;
@@ -38,9 +40,12 @@ public abstract class AbstractBlockMixin implements AbstractBlockInternals {
 	@Shadow
 	@Final
 	protected Material material;
-	/* @Nullable */ private PistonBehavior pistonBehavior;
-	/* @Nullable */ private Boolean replaceable;
-	/* @Nullable */ private Boolean solid;
+	@Nullable
+	private PistonBehavior pistonBehavior;
+	@Nullable
+	private Boolean replaceable;
+	@Nullable
+	private Boolean solid;
 
 	@Override
 	public void setPistonBehavior(PistonBehavior pistonBehavior) {

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/AbstractBlockSettingsAccessor.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/AbstractBlockSettingsAccessor.java
@@ -73,6 +73,9 @@ public interface AbstractBlockSettingsAccessor {
 	@Accessor
 	boolean getIsAir();
 
+	@Accessor
+	boolean isToolRequired();
+
 	/* SETTERS */
 	@Accessor
 	void setMaterial(Material material);
@@ -103,8 +106,11 @@ public interface AbstractBlockSettingsAccessor {
 
 	@Accessor
 	void setLootTableId(Identifier lootTableId);
-	/* INVOKERS */
 
+	@Accessor
+	void setToolRequired(boolean toolRequired);
+
+	/* INVOKERS */
 	@Invoker
 	Block.Settings invokeSounds(BlockSoundGroup group);
 

--- a/fabric-object-builder-api-v1/src/main/resources/fabric-object-builder-v1.mixins.json
+++ b/fabric-object-builder-api-v1/src/main/resources/fabric-object-builder-v1.mixins.json
@@ -3,10 +3,21 @@
   "package": "net.fabricmc.fabric.mixin.object.builder",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
-    "AbstractBlockAccessor", "AbstractBlockMixin", "AbstractBlockSettingsAccessor", "AbstractBlockSettingsMixin",
-    "CriteriaAccessor", "DefaultAttributeRegistryAccessor", "DefaultAttributeRegistryMixin", "MaterialBuilderAccessor",
-    "MixinBlock", "PointOfInterestTypeAccessor", "SpawnRestrictionAccessor", "TradeOffersAccessor", "TradeOffersMixin",
-    "TypeAwareTradeMixin", "VillagerProfessionAccessor"
+    "AbstractBlockAccessor",
+    "AbstractBlockMixin",
+    "AbstractBlockSettingsAccessor",
+    "AbstractBlockSettingsMixin",
+    "CriteriaAccessor",
+    "DefaultAttributeRegistryAccessor",
+    "DefaultAttributeRegistryMixin",
+    "MaterialBuilderAccessor",
+    "MixinBlock",
+    "PointOfInterestTypeAccessor",
+    "SpawnRestrictionAccessor",
+    "TradeOffersAccessor",
+    "TradeOffersMixin",
+    "TypeAwareTradeMixin",
+    "VillagerProfessionAccessor"
   ],
   "client": [
     "ModelPredicateProviderRegistryAccessor",

--- a/fabric-object-builder-api-v1/src/main/resources/fabric-object-builder-v1.mixins.json
+++ b/fabric-object-builder-api-v1/src/main/resources/fabric-object-builder-v1.mixins.json
@@ -3,20 +3,10 @@
   "package": "net.fabricmc.fabric.mixin.object.builder",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
-    "AbstractBlockAccessor",
-    "AbstractBlockSettingsAccessor",
-    "AbstractBlockSettingsMixin",
-    "CriteriaAccessor",
-    "DefaultAttributeRegistryAccessor",
-    "DefaultAttributeRegistryMixin",
-    "MaterialBuilderAccessor",
-    "MixinBlock",
-    "PointOfInterestTypeAccessor",
-    "SpawnRestrictionAccessor",
-    "TradeOffersAccessor",
-    "TradeOffersMixin",
-    "TypeAwareTradeMixin",
-    "VillagerProfessionAccessor"
+    "AbstractBlockAccessor", "AbstractBlockMixin", "AbstractBlockSettingsAccessor", "AbstractBlockSettingsMixin",
+    "CriteriaAccessor", "DefaultAttributeRegistryAccessor", "DefaultAttributeRegistryMixin", "MaterialBuilderAccessor",
+    "MixinBlock", "PointOfInterestTypeAccessor", "SpawnRestrictionAccessor", "TradeOffersAccessor", "TradeOffersMixin",
+    "TypeAwareTradeMixin", "VillagerProfessionAccessor"
   ],
   "client": [
     "ModelPredicateProviderRegistryAccessor",

--- a/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/BlockSettingsTest.java
+++ b/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/BlockSettingsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.test.object.builder;
 
 import net.minecraft.block.Block;

--- a/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/BlockSettingsTest.java
+++ b/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/BlockSettingsTest.java
@@ -1,12 +1,12 @@
 package net.fabricmc.fabric.test.object.builder;
 
-import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.Material;
 import net.minecraft.block.piston.PistonBehavior;
 import net.minecraft.util.registry.Registry;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 
 public class BlockSettingsTest implements ModInitializer {
 	public static final Block TEST_BLOCK_1 = new Block(FabricBlockSettings.of(Material.WOOD).pistonBehavior(PistonBehavior.DESTROY).replaceable(true).solid(false));

--- a/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/BlockSettingsTest.java
+++ b/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/BlockSettingsTest.java
@@ -1,0 +1,20 @@
+package net.fabricmc.fabric.test.object.builder;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.Material;
+import net.minecraft.block.piston.PistonBehavior;
+import net.minecraft.util.registry.Registry;
+
+public class BlockSettingsTest implements ModInitializer {
+	public static final Block TEST_BLOCK_1 = new Block(FabricBlockSettings.of(Material.WOOD).pistonBehavior(PistonBehavior.DESTROY).replaceable(true).solid(false));
+	public static final Block TEST_BLOCK_2 = new Block(FabricBlockSettings.of(Material.AIR).pistonBehavior(PistonBehavior.PUSH_ONLY).replaceable(false).solid(true));
+
+	@Override
+	public void onInitialize() {
+		Registry.register(Registry.BLOCK, ObjectBuilderTestConstants.id("test_block_1"), TEST_BLOCK_1);
+		Registry.register(Registry.BLOCK, ObjectBuilderTestConstants.id("test_block_2"), TEST_BLOCK_2);
+	}
+}

--- a/fabric-object-builder-api-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-object-builder-api-v1/src/testmod/resources/fabric.mod.json
@@ -23,7 +23,8 @@
     "main": [
       "net.fabricmc.fabric.test.object.builder.CriterionRegistryTest::init",
       "net.fabricmc.fabric.test.object.builder.VillagerTypeTest1",
-      "net.fabricmc.fabric.test.object.builder.VillagerTypeTest2"
+      "net.fabricmc.fabric.test.object.builder.VillagerTypeTest2",
+      "net.fabricmc.fabric.test.object.builder.BlockSettingsTest"
     ]
   }
 }


### PR DESCRIPTION
Adds new things to FabricBlockSettings to allow for overriding values from a block's material.
Currently includes Piston Behavior, Replaceable, and Solid.
A Test Mod is included, featuring 2 different blocks that use these new settings.

So if you want a block of the `WOOD` material to be immovable by pistons, you don't have to make a new Block class and override `getPistonBehavior` just to do it, you just slap it in the block settings.

As a side effect, also adds methods for `isReplaceable` and stuff (with a `BlockState` argument!) for easy checking of things that are otherwise annoying to check as well as simpler overriding for those things.