### PR TITLE
Spin up a dedicated server on github actions + add run tasks for test mods.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/checkout@v1
       - uses: gradle/wrapper-validation-action@v1
       - run: ./gradlew check build publishToMavenLocal --stacktrace --parallel
+      - run: mkdir run && echo "eula=true" >> run/eula.txt
+      - run: ./gradlew runAutoTestServer --stacktrace
       - uses: actions/upload-artifact@v2
         with:
           name: Artifacts

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ version = Globals.baseVersion + "+" + (ENV.GITHUB_RUN_NUMBER ? "" : "local-") + 
 logger.lifecycle("Building Fabric: " + version)
 
 import org.apache.commons.codec.digest.DigestUtils
+import net.fabricmc.loom.task.RunClientTask
+import net.fabricmc.loom.task.RunServerTask
 
 def getSubprojectVersion(project, version) {
 	if (grgit == null) {
@@ -81,6 +83,14 @@ allprojects {
 			compileClasspath += main.compileClasspath
 			runtimeClasspath += main.runtimeClasspath
 		}
+	}
+
+	task runTestmodClient(type: RunClientTask) {
+		classpath sourceSets.testmod.runtimeClasspath
+	}
+
+	task runTestmodServer(type: RunServerTask) {
+		classpath sourceSets.testmod.runtimeClasspath
 	}
 
 	dependencies {
@@ -180,6 +190,15 @@ task javadocJar(type: Jar) {
 }
 
 build.dependsOn javadocJar
+
+// Runs a dedicated headless server with all test mods that closes once complete.
+task runAutoTestServer(type: RunServerTask) {
+	project.subprojects {
+		classpath it.sourceSets.testmod.runtimeClasspath
+	}
+	jvmArgs "-Dfabric.autoTest=true"
+	args "--nogui"
+}
 
 subprojects {
 	dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -196,7 +196,7 @@ task runAutoTestServer(type: RunServerTask) {
 	project.subprojects {
 		classpath it.sourceSets.testmod.runtimeClasspath
 	}
-	jvmArgs "-Dfabric.autoTest=true"
+	jvmArgs "-Dfabric.autoTest"
 	args "--nogui"
 }
 

--- a/fabric-api-base/build.gradle
+++ b/fabric-api-base/build.gradle
@@ -1,2 +1,6 @@
 archivesBaseName = "fabric-api-base"
 version = getSubprojectVersion(project, "0.2.0")
+
+dependencies {
+	testmodCompile project(path: ':fabric-lifecycle-events-v1', configuration: 'dev')
+}

--- a/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiBaseTestInit.java
+++ b/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiBaseTestInit.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.test.base;
 
 import org.spongepowered.asm.mixin.MixinEnvironment;

--- a/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiBaseTestInit.java
+++ b/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiBaseTestInit.java
@@ -1,0 +1,24 @@
+package net.fabricmc.fabric.test.base;
+
+import org.spongepowered.asm.mixin.MixinEnvironment;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+
+public class FabricApiBaseTestInit implements ModInitializer {
+	private int ticks = 0;
+
+	@Override
+	public void onInitialize() {
+		if (Boolean.parseBoolean(System.getProperty("fabric.autoTest", "false"))) {
+			ServerTickEvents.END_SERVER_TICK.register(server -> {
+				ticks++;
+
+				if (ticks == 50) {
+					MixinEnvironment.getCurrentEnvironment().audit();
+					server.stop(false);
+				}
+			});
+		}
+	}
+}

--- a/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiBaseTestInit.java
+++ b/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiBaseTestInit.java
@@ -26,7 +26,7 @@ public class FabricApiBaseTestInit implements ModInitializer {
 
 	@Override
 	public void onInitialize() {
-		if (Boolean.parseBoolean(System.getProperty("fabric.autoTest", "false"))) {
+		if (System.getProperty("fabric.autoTest") != null) {
 			ServerTickEvents.END_SERVER_TICK.register(server -> {
 				ticks++;
 

--- a/fabric-api-base/src/testmod/resources/fabric.mod.json
+++ b/fabric-api-base/src/testmod/resources/fabric.mod.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 1,
+  "id": "fabric-api-base-testmod",
+  "name": "Fabric API Base Test Mod",
+  "version": "1.0.0",
+  "environment": "*",
+  "license": "Apache-2.0",
+  "depends": {
+    "fabric-biome-api-v1": "*"
+  },
+  "entrypoints": {
+    "main": [
+      "net.fabricmc.fabric.test.base.FabricApiBaseTestInit"
+    ]
+  }
+}

--- a/fabric-api-base/src/testmod/resources/fabric.mod.json
+++ b/fabric-api-base/src/testmod/resources/fabric.mod.json
@@ -5,9 +5,6 @@
   "version": "1.0.0",
   "environment": "*",
   "license": "Apache-2.0",
-  "depends": {
-    "fabric-biome-api-v1": "*"
-  },
   "entrypoints": {
     "main": [
       "net.fabricmc.fabric.test.base.FabricApiBaseTestInit"


### PR DESCRIPTION
`runAutoTestServer` runs a dedicated server with all test mods, and then gracefully shuts it down. Mixin will also audit the remaining mixin targets.

See an example run here: https://github.com/modmuss50/fabric/runs/1397667784?check_suite_focus=true