### PR TITLE
Fix MC-202036 - Shifting biome IDs

### DIFF
--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/PersistentDynamicRegistryHandler.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/PersistentDynamicRegistryHandler.java
@@ -1,0 +1,138 @@
+package net.fabricmc.fabric.impl.registry.sync;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.DynamicRegistryManager;
+import net.minecraft.util.registry.MutableRegistry;
+import net.minecraft.util.registry.Registry;
+
+public class PersistentDynamicRegistryHandler {
+	private static final Logger LOGGER = LogManager.getLogger();
+
+	public static void remapDynamicRegistries(DynamicRegistryManager.Impl dynamicRegistryManager, Path saveDir) {
+		LOGGER.debug("Starting registry remap");
+
+		CompoundTag registryData;
+
+		try {
+			registryData = remapDynamicRegistries(dynamicRegistryManager, readCompoundTag(getDataPath(saveDir)));
+		} catch (RemapException | IOException e) {
+			// TODO try the backups here?
+			throw new RuntimeException(e);
+		}
+
+		writeCompoundTag(registryData, getDataPath(saveDir));
+	}
+
+	@NotNull
+	private static CompoundTag remapDynamicRegistries(DynamicRegistryManager.Impl dynamicRegistryManager, @Nullable CompoundTag existingTag) throws RemapException {
+		CompoundTag registries = new CompoundTag();
+
+		// For now we only care about biomes, but lets keep our options open
+		MutableRegistry<?> registry = dynamicRegistryManager.get(Registry.BIOME_KEY);
+		CompoundTag biomeIdMap = remapRegistry(Registry.BIOME_KEY.getValue(), registry, existingTag);
+		registries.put(Registry.BIOME_KEY.getValue().toString(), biomeIdMap);
+
+		CompoundTag outputTag = new CompoundTag();
+		outputTag.putInt("version", 1);
+		outputTag.put("registries", registries);
+		return registries;
+	}
+
+	/**
+	 * Remaps a registry if existing data is passed in.
+	 * Then writes out the ids in the registry (remapped or a new world).
+	 * Keeps hold of the orphaned registry entries as to not overwrite them.
+	 */
+	@SuppressWarnings("unchecked")
+	private static CompoundTag remapRegistry(Identifier registryId, MutableRegistry registry, @Nullable CompoundTag existingTag) throws RemapException {
+		if (!(registry instanceof RemappableRegistry)) {
+			throw new UnsupportedOperationException("Cannot remap un re-mappable registry");
+		}
+
+		// If we have some existing ids we remap the registry with those
+		if (existingTag != null) {
+			Object2IntMap<Identifier> idMap = new Object2IntOpenHashMap<>();
+
+			for (String key : existingTag.getKeys()) {
+				idMap.put(new Identifier(key), existingTag.getInt(key));
+			}
+
+			((RemappableRegistry) registry).remap(registryId.toString(), idMap, RemappableRegistry.RemapMode.AUTHORITATIVE);
+		}
+
+		// Now start to build up what we are going to save out
+		CompoundTag registryTag = new CompoundTag();
+
+		// Save all ids as they appear in the remapped, or new registry to disk
+		for (Object entry : registry) {
+			//noinspection unchecked
+			Identifier id = registry.getId(entry);
+
+			if (id == null) {
+				continue;
+			}
+
+			int rawId = registry.getRawId(entry);
+			registryTag.putInt(id.toString(), rawId);
+		}
+
+		/*
+		 * Look for existing registry key/values that are not in the current registries.
+		 * This can happen when registry entries are removed, preventing that ID from being re-used by something else.
+		 */
+		if (existingTag != null) {
+			for (String key : existingTag.getKeys()) {
+				if (!registryTag.contains(key)) {
+					LOGGER.debug("Saving orphaned registry entry: " + key);
+					registryTag.putInt(key, registryTag.getInt(key));
+				}
+			}
+		}
+
+		return registryTag;
+	}
+
+	private static Path getDataPath(Path saveDir) {
+		return saveDir.resolve("data").resolve("fabricDynamicRegistry.dat");
+	}
+
+	@Nullable
+	private static CompoundTag readCompoundTag(Path path) throws IOException {
+		if (!Files.exists(path)) {
+			return null;
+		}
+
+		try (InputStream inputStream = Files.newInputStream(path)) {
+			return NbtIo.readCompressed(inputStream);
+		}
+	}
+
+	private static void writeCompoundTag(CompoundTag compoundTag, Path path) {
+		// TODO handle backups?
+		try {
+			Files.createDirectories(path.getParent());
+
+			try (OutputStream outputStream = Files.newOutputStream(path, StandardOpenOption.CREATE)) {
+				NbtIo.writeCompressed(compoundTag, outputStream);
+			}
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/PersistentDynamicRegistryHandler.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/PersistentDynamicRegistryHandler.java
@@ -98,8 +98,10 @@ public class PersistentDynamicRegistryHandler {
 
 		if (LOGGER.isDebugEnabled()) {
 			if (existingTag == null) {
-				LOGGER.debug("No existing data found, assuming new registry with {} entries", registry.getIds().size());
+				LOGGER.debug("No existing data found, assuming new registry with {} entries. modded = {}", registry.getIds().size(), isModded);
 			} else {
+				LOGGER.debug("Existing registry data found. modded = {}", isModded);
+
 				for (T entry : registry) {
 					//noinspection unchecked
 					Identifier id = registry.getId(entry);
@@ -109,6 +111,7 @@ public class PersistentDynamicRegistryHandler {
 
 					if (existingTag.getKeys().contains(id.toString())) {
 						int existingRawId = existingTag.getInt(id.toString());
+
 						if (rawId != existingRawId) {
 							LOGGER.debug("Remapping {} {} -> {}", id.toString(), rawId, existingRawId);
 						} else {
@@ -119,7 +122,6 @@ public class PersistentDynamicRegistryHandler {
 					}
 				}
 			}
-
 		}
 
 		// If we have some existing ids and the registry contains modded/datapack entries we remap the registry with those

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/PersistentDynamicRegistryHandler.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/PersistentDynamicRegistryHandler.java
@@ -83,7 +83,7 @@ public class PersistentDynamicRegistryHandler {
 	 */
 	private static <T> CompoundTag remapRegistry(Identifier registryId, MutableRegistry<T> registry, @Nullable CompoundTag existingTag) throws RemapException {
 		if (!(registry instanceof RemappableRegistry)) {
-			throw new UnsupportedOperationException("Cannot remap un re-mappable registry");
+			throw new UnsupportedOperationException("Cannot remap un re-mappable registry: " + registryId.toString());
 		}
 
 		boolean isModded = registry.getIds().stream().anyMatch(id -> !id.getNamespace().equals("minecraft"));

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/AccessorLevelStorageSession.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/AccessorLevelStorageSession.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.registry.sync;
 
 import java.nio.file.Path;

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/AccessorLevelStorageSession.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/AccessorLevelStorageSession.java
@@ -1,0 +1,14 @@
+package net.fabricmc.fabric.mixin.registry.sync;
+
+import java.nio.file.Path;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.world.level.storage.LevelStorage;
+
+@Mixin(LevelStorage.Session.class)
+public interface AccessorLevelStorageSession {
+	@Accessor("directory")
+	Path getDirectory();
+}

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinMain.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinMain.java
@@ -1,0 +1,40 @@
+package net.fabricmc.fabric.mixin.registry.sync;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
+import com.mojang.authlib.GameProfileRepository;
+import com.mojang.authlib.minecraft.MinecraftSessionService;
+import com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import net.minecraft.resource.DataPackSettings;
+import net.minecraft.resource.ResourcePackManager;
+import net.minecraft.resource.ServerResourceManager;
+import net.minecraft.server.Main;
+import net.minecraft.server.dedicated.EulaReader;
+import net.minecraft.server.dedicated.ServerPropertiesLoader;
+import net.minecraft.util.UserCache;
+import net.minecraft.util.dynamic.RegistryOps;
+import net.minecraft.util.registry.DynamicRegistryManager;
+import net.minecraft.world.level.storage.LevelStorage;
+
+import net.fabricmc.fabric.impl.registry.sync.PersistentDynamicRegistryHandler;
+
+@Mixin(Main.class)
+public class MixinMain {
+	@SuppressWarnings("rawtypes")
+	@Inject(method = "main", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/util/dynamic/RegistryOps;of(Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/resource/ResourceManager;Lnet/minecraft/util/registry/DynamicRegistryManager$Impl;)Lnet/minecraft/util/dynamic/RegistryOps;"), locals = LocalCapture.CAPTURE_FAILHARD)
+	private static void main(String[] args, CallbackInfo ci, OptionParser optionParser, OptionSpec optionSpec, OptionSpec optionSpec2, OptionSpec optionSpec3, OptionSpec optionSpec4, OptionSpec optionSpec5, OptionSpec optionSpec6, OptionSpec optionSpec7, OptionSpec optionSpec8, OptionSpec optionSpec9, OptionSpec optionSpec10, OptionSpec optionSpec11, OptionSpec optionSpec12, OptionSpec optionSpec13, OptionSpec optionSpec14, OptionSet optionSet, DynamicRegistryManager.Impl impl, Path path, ServerPropertiesLoader serverPropertiesLoader, Path path2, EulaReader eulaReader, File file, YggdrasilAuthenticationService yggdrasilAuthenticationService, MinecraftSessionService minecraftSessionService, GameProfileRepository gameProfileRepository, UserCache userCache, String string, LevelStorage levelStorage, LevelStorage.Session session, DataPackSettings dataPackSettings, boolean bl, ResourcePackManager resourcePackManager, DataPackSettings dataPackSettings2, CompletableFuture completableFuture, ServerResourceManager serverResourceManager2, RegistryOps registryOps) {
+		Path saveDir = ((AccessorLevelStorageSession) session).getDirectory();
+		PersistentDynamicRegistryHandler.remapDynamicRegistries(impl, saveDir);
+	}
+}

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinMain.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinMain.java
@@ -47,7 +47,6 @@ import net.fabricmc.fabric.impl.registry.sync.PersistentDynamicRegistryHandler;
 
 @Mixin(Main.class)
 public class MixinMain {
-
 	// just after RegistryOps.of
 	@SuppressWarnings("rawtypes")
 	@Inject(method = "main", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/util/dynamic/RegistryOps;of(Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/resource/ResourceManager;Lnet/minecraft/util/registry/DynamicRegistryManager$Impl;)Lnet/minecraft/util/dynamic/RegistryOps;"), locals = LocalCapture.CAPTURE_FAILHARD)

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinMain.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinMain.java
@@ -47,6 +47,8 @@ import net.fabricmc.fabric.impl.registry.sync.PersistentDynamicRegistryHandler;
 
 @Mixin(Main.class)
 public class MixinMain {
+
+	// just after RegistryOps.of
 	@SuppressWarnings("rawtypes")
 	@Inject(method = "main", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/util/dynamic/RegistryOps;of(Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/resource/ResourceManager;Lnet/minecraft/util/registry/DynamicRegistryManager$Impl;)Lnet/minecraft/util/dynamic/RegistryOps;"), locals = LocalCapture.CAPTURE_FAILHARD)
 	private static void main(String[] args, CallbackInfo ci, OptionParser optionParser, OptionSpec optionSpec, OptionSpec optionSpec2, OptionSpec optionSpec3, OptionSpec optionSpec4, OptionSpec optionSpec5, OptionSpec optionSpec6, OptionSpec optionSpec7, OptionSpec optionSpec8, OptionSpec optionSpec9, OptionSpec optionSpec10, OptionSpec optionSpec11, OptionSpec optionSpec12, OptionSpec optionSpec13, OptionSpec optionSpec14, OptionSet optionSet, DynamicRegistryManager.Impl impl, Path path, ServerPropertiesLoader serverPropertiesLoader, Path path2, EulaReader eulaReader, File file, YggdrasilAuthenticationService yggdrasilAuthenticationService, MinecraftSessionService minecraftSessionService, GameProfileRepository gameProfileRepository, UserCache userCache, String string, LevelStorage levelStorage, LevelStorage.Session session, DataPackSettings dataPackSettings, boolean bl, ResourcePackManager resourcePackManager, DataPackSettings dataPackSettings2, CompletableFuture completableFuture, ServerResourceManager serverResourceManager2, RegistryOps registryOps) {

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinMain.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinMain.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.registry.sync;
 
 import java.io.File;

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinMain.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinMain.java
@@ -16,42 +16,40 @@
 
 package net.fabricmc.fabric.mixin.registry.sync;
 
-import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
-import java.util.concurrent.CompletableFuture;
 
-import joptsimple.OptionParser;
-import joptsimple.OptionSet;
-import joptsimple.OptionSpec;
-import com.mojang.authlib.GameProfileRepository;
-import com.mojang.authlib.minecraft.MinecraftSessionService;
-import com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService;
+import com.mojang.serialization.DynamicOps;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
-import net.minecraft.resource.DataPackSettings;
-import net.minecraft.resource.ResourcePackManager;
-import net.minecraft.resource.ServerResourceManager;
 import net.minecraft.server.Main;
-import net.minecraft.server.dedicated.EulaReader;
-import net.minecraft.server.dedicated.ServerPropertiesLoader;
-import net.minecraft.util.UserCache;
 import net.minecraft.util.dynamic.RegistryOps;
 import net.minecraft.util.registry.DynamicRegistryManager;
 import net.minecraft.world.level.storage.LevelStorage;
+import net.minecraft.nbt.Tag;
+import net.minecraft.resource.ResourceManager;
 
 import net.fabricmc.fabric.impl.registry.sync.PersistentDynamicRegistryHandler;
 
 @Mixin(Main.class)
 public class MixinMain {
-	// just after RegistryOps.of
-	@SuppressWarnings("rawtypes")
-	@Inject(method = "main", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/util/dynamic/RegistryOps;of(Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/resource/ResourceManager;Lnet/minecraft/util/registry/DynamicRegistryManager$Impl;)Lnet/minecraft/util/dynamic/RegistryOps;"), locals = LocalCapture.CAPTURE_FAILHARD)
-	private static void main(String[] args, CallbackInfo ci, OptionParser optionParser, OptionSpec optionSpec, OptionSpec optionSpec2, OptionSpec optionSpec3, OptionSpec optionSpec4, OptionSpec optionSpec5, OptionSpec optionSpec6, OptionSpec optionSpec7, OptionSpec optionSpec8, OptionSpec optionSpec9, OptionSpec optionSpec10, OptionSpec optionSpec11, OptionSpec optionSpec12, OptionSpec optionSpec13, OptionSpec optionSpec14, OptionSet optionSet, DynamicRegistryManager.Impl impl, Path path, ServerPropertiesLoader serverPropertiesLoader, Path path2, EulaReader eulaReader, File file, YggdrasilAuthenticationService yggdrasilAuthenticationService, MinecraftSessionService minecraftSessionService, GameProfileRepository gameProfileRepository, UserCache userCache, String string, LevelStorage levelStorage, LevelStorage.Session session, DataPackSettings dataPackSettings, boolean bl, ResourcePackManager resourcePackManager, DataPackSettings dataPackSettings2, CompletableFuture completableFuture, ServerResourceManager serverResourceManager2, RegistryOps registryOps) {
-		Path saveDir = ((AccessorLevelStorageSession) session).getDirectory();
-		PersistentDynamicRegistryHandler.remapDynamicRegistries(impl, saveDir);
+	@Unique
+	private static Path fabric_saveDir;
+
+	@Redirect(method = "main", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/storage/LevelStorage;createSession(Ljava/lang/String;)Lnet/minecraft/world/level/storage/LevelStorage$Session;"))
+	private static LevelStorage.Session levelStorageCreateSession(LevelStorage levelStorage, String levelName) throws IOException {
+		LevelStorage.Session session = levelStorage.createSession(levelName);
+		fabric_saveDir = ((AccessorLevelStorageSession) session).getDirectory();
+		return session;
+	}
+
+	@Redirect(method = "main", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/dynamic/RegistryOps;of(Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/resource/ResourceManager;Lnet/minecraft/util/registry/DynamicRegistryManager$Impl;)Lnet/minecraft/util/dynamic/RegistryOps;"))
+	private static RegistryOps<Tag> ofRegistryOps(DynamicOps<Tag> delegate, ResourceManager resourceManager, DynamicRegistryManager.Impl impl) {
+		RegistryOps<Tag> registryOps = RegistryOps.of(delegate, resourceManager, impl);
+		PersistentDynamicRegistryHandler.remapDynamicRegistries(impl, fabric_saveDir);
+		return registryOps;
 	}
 }

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/client/MixinMinecraftClient.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/client/MixinMinecraftClient.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.mixin.registry.sync.client;
 
+import java.nio.file.Path;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Mixin;
@@ -23,10 +25,20 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import net.minecraft.resource.DataPackSettings;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.registry.DynamicRegistryManager;
+import net.minecraft.world.SaveProperties;
+import net.minecraft.world.gen.GeneratorOptions;
+import net.minecraft.world.level.LevelInfo;
+import net.minecraft.world.level.storage.LevelStorage;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 
+import net.fabricmc.fabric.impl.registry.sync.PersistentDynamicRegistryHandler;
+import net.fabricmc.fabric.mixin.registry.sync.AccessorLevelStorageSession;
 import net.fabricmc.fabric.impl.registry.sync.RegistrySyncManager;
 import net.fabricmc.fabric.impl.registry.sync.RemapException;
 
@@ -43,5 +55,18 @@ public class MixinMinecraftClient {
 		} catch (RemapException e) {
 			FABRIC_LOGGER.warn("Failed to unmap Fabric registries!", e);
 		}
+	}
+
+	@Inject(method = "createSaveProperties", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/util/dynamic/RegistryOps;of(Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/resource/ResourceManager;Lnet/minecraft/util/registry/DynamicRegistryManager$Impl;)Lnet/minecraft/util/dynamic/RegistryOps;"))
+	private static void createSaveProperties(LevelStorage.Session session, DynamicRegistryManager.Impl impl, ResourceManager resourceManager, DataPackSettings dataPackSettings, CallbackInfoReturnable<SaveProperties> cir) {
+		Path saveDir = ((AccessorLevelStorageSession) session).getDirectory();
+		PersistentDynamicRegistryHandler.remapDynamicRegistries(impl, saveDir);
+	}
+
+	// synthetic in method_29607
+	@Inject(method = "method_31125", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/util/dynamic/RegistryOps;of(Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/resource/ResourceManager;Lnet/minecraft/util/registry/DynamicRegistryManager$Impl;)Lnet/minecraft/util/dynamic/RegistryOps;"))
+	private static void method_31125(DynamicRegistryManager.Impl impl, GeneratorOptions generatorOptions, LevelInfo levelInfo, LevelStorage.Session session, DynamicRegistryManager.Impl impl2, ResourceManager resourceManager, DataPackSettings dataPackSettings, CallbackInfoReturnable<SaveProperties> cir) {
+		Path saveDir = ((AccessorLevelStorageSession) session).getDirectory();
+		PersistentDynamicRegistryHandler.remapDynamicRegistries(impl, saveDir);
 	}
 }

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/client/MixinMinecraftClient.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/client/MixinMinecraftClient.java
@@ -63,7 +63,7 @@ public class MixinMinecraftClient {
 		PersistentDynamicRegistryHandler.remapDynamicRegistries(impl, saveDir);
 	}
 
-	// synthetic in method_29607
+	// synthetic in method_29607 just after RegistryOps.of
 	@Inject(method = "method_31125", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/util/dynamic/RegistryOps;of(Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/resource/ResourceManager;Lnet/minecraft/util/registry/DynamicRegistryManager$Impl;)Lnet/minecraft/util/dynamic/RegistryOps;"))
 	private static void method_31125(DynamicRegistryManager.Impl impl, GeneratorOptions generatorOptions, LevelInfo levelInfo, LevelStorage.Session session, DynamicRegistryManager.Impl impl2, ResourceManager resourceManager, DataPackSettings dataPackSettings, CallbackInfoReturnable<SaveProperties> cir) {
 		Path saveDir = ((AccessorLevelStorageSession) session).getDirectory();

--- a/fabric-registry-sync-v0/src/main/resources/fabric-registry-sync-v0.mixins.json
+++ b/fabric-registry-sync-v0/src/main/resources/fabric-registry-sync-v0.mixins.json
@@ -3,11 +3,13 @@
   "package": "net.fabricmc.fabric.mixin.registry.sync",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "AccessorLevelStorageSession",
     "AccessorRegistry",
     "MixinBootstrap",
     "MixinDynamicRegistryManager",
     "MixinIdList",
     "MixinIdRegistry",
+    "MixinMain",
     "MixinPlayerManager",
     "MixinLevelStorageSession",
     "MixinRegistry",


### PR DESCRIPTION
This is loosly bassed off the existing registrys sync stuff, but just the required bits, and trying to be minimal. I have tried to leave some comments explainng whats doing what, hopefully its fairly easy to follow.

This is missing the backing up of the data files, do we still need/want this? (Minecraft does appear to show a warning screen with an option to backup if changing this stuff?)

I look forward to your reviews and testing.