### PR TITLE
Add command to audit mixin environment in game

### DIFF
--- a/fabric-api-base/build.gradle
+++ b/fabric-api-base/build.gradle
@@ -2,5 +2,6 @@ archivesBaseName = "fabric-api-base"
 version = getSubprojectVersion(project, "0.2.0")
 
 dependencies {
+	testmodCompile project(path: ':fabric-command-api-v1', configuration: 'dev')
 	testmodCompile project(path: ':fabric-lifecycle-events-v1', configuration: 'dev')
 }

--- a/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiBaseTestInit.java
+++ b/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiBaseTestInit.java
@@ -16,9 +16,14 @@
 
 package net.fabricmc.fabric.test.base;
 
+import static net.minecraft.server.command.CommandManager.literal;
+
 import org.spongepowered.asm.mixin.MixinEnvironment;
 
+import net.minecraft.text.LiteralText;
+
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 
 public class FabricApiBaseTestInit implements ModInitializer {
@@ -36,5 +41,14 @@ public class FabricApiBaseTestInit implements ModInitializer {
 				}
 			});
 		}
+
+		// Command to call audit the mixin environment
+		CommandRegistrationCallback.EVENT.register((dispatcher, dedicated) -> {
+			dispatcher.register(literal("audit_mixins").executes(context -> {
+				context.getSource().sendFeedback(new LiteralText("Auditing mixin Environment"), false);
+				MixinEnvironment.getCurrentEnvironment().audit();
+				return 1;
+			}));
+		});
 	}
 }

--- a/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiBaseTestInit.java
+++ b/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiBaseTestInit.java
@@ -45,8 +45,17 @@ public class FabricApiBaseTestInit implements ModInitializer {
 		// Command to call audit the mixin environment
 		CommandRegistrationCallback.EVENT.register((dispatcher, dedicated) -> {
 			dispatcher.register(literal("audit_mixins").executes(context -> {
-				context.getSource().sendFeedback(new LiteralText("Auditing mixin Environment"), false);
-				MixinEnvironment.getCurrentEnvironment().audit();
+				context.getSource().sendFeedback(new LiteralText("Auditing mixin environment"), false);
+
+				try {
+					MixinEnvironment.getCurrentEnvironment().audit();
+				} catch (Exception e) {
+					// Use an assertion error to bypass error checking in CommandManager
+					throw new AssertionError("Failed to audit mixin environment", e);
+				}
+
+				context.getSource().sendFeedback(new LiteralText("Successfully audited mixin environment"), false);
+
 				return 1;
 			}));
 		});


### PR DESCRIPTION
This makes testing a bit easier when in game as some mixins may not be loaded immediately when running testmods normally.