### PR TITLE
Drop use of remote buildscripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -355,8 +355,6 @@ curseforge {
 	}
 }
 
-apply from: "https://github.com/FabricMC/fabric-docs/raw/master/gradle/ideconfig.gradle"
-
 import org.kohsuke.github.GHReleaseBuilder
 import org.kohsuke.github.GitHub
 


### PR DESCRIPTION
Literally the same thing as https://github.com/FabricMC/fabric-loader/pull/335 but we have licenser at a decent version already on api