### PR TITLE
Allow specifying the render layer in FabricBlockSettings

### DIFF
--- a/fabric-object-builder-api-v1/build.gradle
+++ b/fabric-object-builder-api-v1/build.gradle
@@ -7,7 +7,8 @@ dependencies {
 
 moduleDependencies(project, [
 		'fabric-api-base',
-		'fabric-tool-attribute-api-v1'
+		'fabric-tool-attribute-api-v1',
+		'fabric-blockrenderlayer-v1'
 ])
 
 minecraft {

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricBlockSettings.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricBlockSettings.java
@@ -23,6 +23,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Material;
 import net.minecraft.block.MaterialColor;
+import net.minecraft.client.render.RenderLayer;
 import net.minecraft.entity.EntityType;
 import net.minecraft.item.Item;
 import net.minecraft.sound.BlockSoundGroup;
@@ -311,5 +312,29 @@ public class FabricBlockSettings extends AbstractBlock.Settings {
 	 */
 	public FabricBlockSettings breakByTool(Tag<Item> tag) {
 		return this.breakByTool(tag, 0);
+	}
+
+	/**
+	 * Sets the block's render layer to {@link RenderLayer#getCutout()}
+	 */
+	public FabricBlockSettings cutout() {
+		FabricBlockInternals.computeExtraData(this).renderLayerType(FabricBlockInternals.RenderLayerType.CUTOUT);
+		return this;
+	}
+
+	/**
+	 * Sets the block's render layer to {@link RenderLayer#getCutoutMipped()}
+	 */
+	public FabricBlockSettings cutoutMipped() {
+		FabricBlockInternals.computeExtraData(this).renderLayerType(FabricBlockInternals.RenderLayerType.CUTOUT_MIPPED);
+		return this;
+	}
+
+	/**
+	 * Sets the block's render layer to {@link RenderLayer#getTranslucent()}
+	 */
+	public FabricBlockSettings translucent() {
+		FabricBlockInternals.computeExtraData(this).renderLayerType(FabricBlockInternals.RenderLayerType.TRANSLUCENT);
+		return this;
 	}
 }

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricBlockSettings.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricBlockSettings.java
@@ -315,7 +315,7 @@ public class FabricBlockSettings extends AbstractBlock.Settings {
 	}
 
 	/**
-	 * Sets the block's render layer to {@link RenderLayer#getCutout()}
+	 * Sets the block's render layer to {@link RenderLayer#getCutout()}.
 	 */
 	public FabricBlockSettings cutout() {
 		FabricBlockInternals.computeExtraData(this).renderLayerType(FabricBlockInternals.RenderLayerType.CUTOUT);
@@ -323,7 +323,7 @@ public class FabricBlockSettings extends AbstractBlock.Settings {
 	}
 
 	/**
-	 * Sets the block's render layer to {@link RenderLayer#getCutoutMipped()}
+	 * Sets the block's render layer to {@link RenderLayer#getCutoutMipped()}.
 	 */
 	public FabricBlockSettings cutoutMipped() {
 		FabricBlockInternals.computeExtraData(this).renderLayerType(FabricBlockInternals.RenderLayerType.CUTOUT_MIPPED);
@@ -331,7 +331,7 @@ public class FabricBlockSettings extends AbstractBlock.Settings {
 	}
 
 	/**
-	 * Sets the block's render layer to {@link RenderLayer#getTranslucent()}
+	 * Sets the block's render layer to {@link RenderLayer#getTranslucent()}.
 	 */
 	public FabricBlockSettings translucent() {
 		FabricBlockInternals.computeExtraData(this).renderLayerType(FabricBlockInternals.RenderLayerType.TRANSLUCENT);

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/impl/object/builder/FabricBlockInternals.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/impl/object/builder/FabricBlockInternals.java
@@ -19,13 +19,19 @@ package net.fabricmc.fabric.impl.object.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
+import net.minecraft.client.render.RenderLayer;
 import net.minecraft.item.Item;
 import net.minecraft.tag.Tag;
 
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
 import net.fabricmc.fabric.impl.tool.attribute.ToolManagerImpl;
+import net.fabricmc.loader.api.FabricLoader;
 
 public final class FabricBlockInternals {
 	private FabricBlockInternals() {
@@ -53,13 +59,50 @@ public final class FabricBlockInternals {
 			for (MiningLevel tml : data.miningLevels) {
 				ToolManagerImpl.entry(block).putBreakByTool(tml.tag, tml.level);
 			}
+
+			if (FabricLoader.getInstance().getEnvironmentType() == EnvType.CLIENT && data.renderLayerType != null) {
+				registerRenderLayer(data.renderLayerType, block);
+			}
 		}
+	}
+
+	private static void registerRenderLayer(@NotNull RenderLayerType type, Block block) {
+		BlockRenderLayerMap.INSTANCE.putBlock(block, type.asRenderLayer());
+	}
+
+	public enum RenderLayerType {
+		CUTOUT {
+			@Environment(EnvType.CLIENT)
+			@Override
+			public RenderLayer asRenderLayer() {
+				return RenderLayer.getCutout();
+			}
+		},
+		CUTOUT_MIPPED {
+			@Environment(EnvType.CLIENT)
+			@Override
+			public RenderLayer asRenderLayer() {
+				return RenderLayer.getCutoutMipped();
+			}
+		},
+		TRANSLUCENT {
+			@Environment(EnvType.CLIENT)
+			@Override
+			public RenderLayer asRenderLayer() {
+				return RenderLayer.getTranslucent();
+			}
+		};
+
+		@Environment(EnvType.CLIENT)
+		public abstract RenderLayer asRenderLayer();
 	}
 
 	public static final class ExtraData {
 		private final List<MiningLevel> miningLevels = new ArrayList<>();
 		@Nullable
 		private Boolean breakByHand;
+		@Nullable
+		private RenderLayerType renderLayerType;
 
 		public ExtraData(Block.Settings settings) {
 		}
@@ -70,6 +113,10 @@ public final class FabricBlockInternals {
 
 		public void addMiningLevel(Tag<Item> tag, int level) {
 			miningLevels.add(new MiningLevel(tag, level));
+		}
+
+		public void renderLayerType(RenderLayerType renderLayerType) {
+			this.renderLayerType = renderLayerType;
 		}
 	}
 

--- a/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/BlockSettingsTest.java
+++ b/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/BlockSettingsTest.java
@@ -1,0 +1,18 @@
+package net.fabricmc.fabric.test.object.builder;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.Material;
+import net.minecraft.util.registry.Registry;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
+
+import static net.fabricmc.fabric.test.object.builder.ObjectBuilderTestConstants.id;
+
+public class BlockSettingsTest implements ModInitializer {
+	@Override
+	public void onInitialize() {
+		// This block should not cause a crash on a dedicated server
+		Registry.register(Registry.BLOCK, id("cutout_block"), new Block(FabricBlockSettings.of(Material.STONE).cutout()));
+	}
+}

--- a/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/BlockSettingsTest.java
+++ b/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/BlockSettingsTest.java
@@ -23,12 +23,10 @@ import net.minecraft.util.registry.Registry;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 
-import static net.fabricmc.fabric.test.object.builder.ObjectBuilderTestConstants.id;
-
 public class BlockSettingsTest implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		// This block should not cause a crash on a dedicated server
-		Registry.register(Registry.BLOCK, id("cutout_block"), new Block(FabricBlockSettings.of(Material.STONE).nonOpaque().cutout()));
+		Registry.register(Registry.BLOCK, ObjectBuilderTestConstants.id("cutout_block"), new Block(FabricBlockSettings.of(Material.STONE).nonOpaque().cutout()));
 	}
 }

--- a/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/BlockSettingsTest.java
+++ b/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/BlockSettingsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.test.object.builder;
 
 import net.minecraft.block.Block;

--- a/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/BlockSettingsTest.java
+++ b/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/BlockSettingsTest.java
@@ -13,6 +13,6 @@ public class BlockSettingsTest implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		// This block should not cause a crash on a dedicated server
-		Registry.register(Registry.BLOCK, id("cutout_block"), new Block(FabricBlockSettings.of(Material.STONE).cutout()));
+		Registry.register(Registry.BLOCK, id("cutout_block"), new Block(FabricBlockSettings.of(Material.STONE).nonOpaque().cutout()));
 	}
 }

--- a/fabric-object-builder-api-v1/src/testmod/resources/assets/fabric-object-builder-api-v1-testmod/blockstates/cutout_block.json
+++ b/fabric-object-builder-api-v1/src/testmod/resources/assets/fabric-object-builder-api-v1-testmod/blockstates/cutout_block.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "minecraft:block/dead_bush"
+    }
+  }
+}

--- a/fabric-object-builder-api-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-object-builder-api-v1/src/testmod/resources/fabric.mod.json
@@ -23,7 +23,8 @@
     "main": [
       "net.fabricmc.fabric.test.object.builder.CriterionRegistryTest::init",
       "net.fabricmc.fabric.test.object.builder.VillagerTypeTest1",
-      "net.fabricmc.fabric.test.object.builder.VillagerTypeTest2"
+      "net.fabricmc.fabric.test.object.builder.VillagerTypeTest2",
+      "net.fabricmc.fabric.test.object.builder.BlockSettingsTest"
     ]
   }
 }


### PR DESCRIPTION
Adds three methods to allow giving the block a different render layer

The testmod does not crash on a dedicated server
![server480](https://user-images.githubusercontent.com/62552372/100219372-ebc40480-2f3b-11eb-8177-642437c21fc2.gif)
