### PR TITLE
Add registry for creating entity model layers and texture data

### DIFF
--- a/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/api/client/rendereregistry/v1/EntityModelLayerHelper.java
+++ b/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/api/client/rendereregistry/v1/EntityModelLayerHelper.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.client.rendereregistry.v1;
+
+import java.util.Objects;
+
+import net.minecraft.client.model.TexturedModelData;
+import net.minecraft.client.render.entity.model.EntityModelLayer;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.impl.client.renderer.registry.EntityModelLayerImpl;
+import net.fabricmc.fabric.mixin.client.renderer.registry.EntityModelLayersAccessor;
+
+/**
+ * A helpers for registering entity model layers and providers for the layer's textured model data.
+ *
+ * @deprecated Experimental feature, may be removed or changed without further notice: Snapshot feature.
+ */
+@Deprecated
+@Environment(EnvType.CLIENT)
+public final class EntityModelLayerHelper {
+	/**
+	 * Registers an entity model layer and registers a provider for a {@linkplain TexturedModelData}.
+	 *
+	 * @param modelLayer the entity model layer
+	 * @param provider the provider for the textured model data
+	 */
+	public static void registerModelLayer(EntityModelLayer modelLayer, TexturedModelDataProvider provider) {
+		Objects.requireNonNull(modelLayer, "EntityModelLayer cannot be null");
+		Objects.requireNonNull(provider, "TexturedModelDataProvider cannot be null");
+
+		if (EntityModelLayerImpl.PROVIDERS.putIfAbsent(modelLayer, provider) != null) {
+			throw new IllegalArgumentException(String.format("Cannot replace registration for entity model layer \"%s\"", modelLayer));
+		}
+
+		EntityModelLayersAccessor.getLayers().add(modelLayer);
+	}
+
+	private EntityModelLayerHelper() {
+	}
+
+	@FunctionalInterface
+	@Environment(EnvType.CLIENT)
+	public interface TexturedModelDataProvider {
+		TexturedModelData createModelData();
+	}
+}

--- a/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/api/client/rendereregistry/v1/EntityModelLayerHelper.java
+++ b/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/api/client/rendereregistry/v1/EntityModelLayerHelper.java
@@ -18,6 +18,8 @@ package net.fabricmc.fabric.api.client.rendereregistry.v1;
 
 import java.util.Objects;
 
+import org.jetbrains.annotations.ApiStatus;
+
 import net.minecraft.client.model.TexturedModelData;
 import net.minecraft.client.render.entity.model.EntityModelLayer;
 
@@ -32,6 +34,7 @@ import net.fabricmc.fabric.mixin.client.renderer.registry.EntityModelLayersAcces
  * @deprecated Experimental feature, may be removed or changed without further notice: Snapshot feature.
  */
 @Deprecated
+@ApiStatus.Experimental
 @Environment(EnvType.CLIENT)
 public final class EntityModelLayerHelper {
 	/**
@@ -55,8 +58,14 @@ public final class EntityModelLayerHelper {
 	}
 
 	@FunctionalInterface
+	@ApiStatus.Experimental
 	@Environment(EnvType.CLIENT)
 	public interface TexturedModelDataProvider {
+		/**
+		 * Creates the textured model data for use in a {@link EntityModelLayer}.
+		 *
+		 * @return the textured model data for the entity model layer.
+		 */
 		TexturedModelData createModelData();
 	}
 }

--- a/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/api/client/rendereregistry/v1/EntityModelLayerRegistry.java
+++ b/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/api/client/rendereregistry/v1/EntityModelLayerRegistry.java
@@ -36,7 +36,7 @@ import net.fabricmc.fabric.mixin.client.renderer.registry.EntityModelLayersAcces
 @Deprecated
 @ApiStatus.Experimental
 @Environment(EnvType.CLIENT)
-public final class EntityModelLayerHelper {
+public final class EntityModelLayerRegistry {
 	/**
 	 * Registers an entity model layer and registers a provider for a {@linkplain TexturedModelData}.
 	 *
@@ -54,7 +54,7 @@ public final class EntityModelLayerHelper {
 		EntityModelLayersAccessor.getLayers().add(modelLayer);
 	}
 
-	private EntityModelLayerHelper() {
+	private EntityModelLayerRegistry() {
 	}
 
 	@FunctionalInterface

--- a/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/api/client/rendereregistry/v1/EntityRendererRegistry.java
+++ b/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/api/client/rendereregistry/v1/EntityRendererRegistry.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.client.rendereregistry.v1;
 
+import net.minecraft.client.render.entity.EntityRenderDispatcher;
+import net.minecraft.client.render.entity.EntityRenderer;
 import net.minecraft.client.render.entity.EntityRendererFactory;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;

--- a/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/impl/client/renderer/registry/EntityModelLayerImpl.java
+++ b/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/impl/client/renderer/registry/EntityModelLayerImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.renderer.registry;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraft.client.render.entity.model.EntityModelLayer;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.client.rendereregistry.v1.EntityModelLayerHelper;
+
+@Environment(EnvType.CLIENT)
+public final class EntityModelLayerImpl {
+	public static final Map<EntityModelLayer, EntityModelLayerHelper.TexturedModelDataProvider> PROVIDERS = new HashMap<>();
+
+	private EntityModelLayerImpl() {
+	}
+}

--- a/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/impl/client/renderer/registry/EntityModelLayerImpl.java
+++ b/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/impl/client/renderer/registry/EntityModelLayerImpl.java
@@ -23,11 +23,11 @@ import net.minecraft.client.render.entity.model.EntityModelLayer;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.fabricmc.fabric.api.client.rendereregistry.v1.EntityModelLayerHelper;
+import net.fabricmc.fabric.api.client.rendereregistry.v1.EntityModelLayerRegistry;
 
 @Environment(EnvType.CLIENT)
 public final class EntityModelLayerImpl {
-	public static final Map<EntityModelLayer, EntityModelLayerHelper.TexturedModelDataProvider> PROVIDERS = new HashMap<>();
+	public static final Map<EntityModelLayer, EntityModelLayerRegistry.TexturedModelDataProvider> PROVIDERS = new HashMap<>();
 
 	private EntityModelLayerImpl() {
 	}

--- a/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/mixin/client/renderer/registry/EntityModelLayersAccessor.java
+++ b/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/mixin/client/renderer/registry/EntityModelLayersAccessor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.renderer.registry;
+
+import java.util.Set;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.client.render.entity.model.EntityModelLayer;
+import net.minecraft.client.render.entity.model.EntityModelLayers;
+
+@Mixin(EntityModelLayers.class)
+public interface EntityModelLayersAccessor {
+	@Accessor("LAYERS")
+	static Set<EntityModelLayer> getLayers() {
+		throw new AssertionError("This should not occur!");
+	}
+}

--- a/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/mixin/client/renderer/registry/EntityModelsMixin.java
+++ b/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/mixin/client/renderer/registry/EntityModelsMixin.java
@@ -29,14 +29,14 @@ import net.minecraft.client.model.TexturedModelData;
 import net.minecraft.client.render.entity.model.EntityModelLayer;
 import net.minecraft.client.render.entity.model.EntityModels;
 
-import net.fabricmc.fabric.api.client.rendereregistry.v1.EntityModelLayerHelper;
+import net.fabricmc.fabric.api.client.rendereregistry.v1.EntityModelLayerRegistry;
 import net.fabricmc.fabric.impl.client.renderer.registry.EntityModelLayerImpl;
 
 @Mixin(EntityModels.class)
 abstract class EntityModelsMixin {
 	@Inject(method = "getModels", at = @At(value = "INVOKE", target = "Lcom/google/common/collect/ImmutableMap$Builder;build()Lcom/google/common/collect/ImmutableMap;"), locals = LocalCapture.CAPTURE_FAILEXCEPTION)
 	private static void registerExtraModelData(CallbackInfoReturnable<Map<EntityModelLayer, TexturedModelData>> info, ImmutableMap.Builder<EntityModelLayer, TexturedModelData> builder) {
-		for (Map.Entry<EntityModelLayer, EntityModelLayerHelper.TexturedModelDataProvider> entry : EntityModelLayerImpl.PROVIDERS.entrySet()) {
+		for (Map.Entry<EntityModelLayer, EntityModelLayerRegistry.TexturedModelDataProvider> entry : EntityModelLayerImpl.PROVIDERS.entrySet()) {
 			builder.put(entry.getKey(), entry.getValue().createModelData());
 		}
 	}

--- a/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/mixin/client/renderer/registry/EntityModelsMixin.java
+++ b/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/mixin/client/renderer/registry/EntityModelsMixin.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.renderer.registry;
+
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import net.minecraft.client.model.TexturedModelData;
+import net.minecraft.client.render.entity.model.EntityModelLayer;
+import net.minecraft.client.render.entity.model.EntityModels;
+
+import net.fabricmc.fabric.api.client.rendereregistry.v1.EntityModelLayerHelper;
+import net.fabricmc.fabric.impl.client.renderer.registry.EntityModelLayerImpl;
+
+@Mixin(EntityModels.class)
+abstract class EntityModelsMixin {
+	@Inject(method = "getModels", at = @At(value = "INVOKE", target = "Lcom/google/common/collect/ImmutableMap$Builder;build()Lcom/google/common/collect/ImmutableMap;"), locals = LocalCapture.CAPTURE_FAILEXCEPTION)
+	private static void registerExtraModelData(CallbackInfoReturnable<Map<EntityModelLayer, TexturedModelData>> info, ImmutableMap.Builder<EntityModelLayer, TexturedModelData> builder) {
+		for (Map.Entry<EntityModelLayer, EntityModelLayerHelper.TexturedModelDataProvider> entry : EntityModelLayerImpl.PROVIDERS.entrySet()) {
+			builder.put(entry.getKey(), entry.getValue().createModelData());
+		}
+	}
+}

--- a/fabric-renderer-registries-v1/src/main/resources/fabric-renderer-registries-v1.mixins.json
+++ b/fabric-renderer-registries-v1/src/main/resources/fabric-renderer-registries-v1.mixins.json
@@ -3,6 +3,8 @@
   "package": "net.fabricmc.fabric.mixin.client.renderer.registry",
   "compatibilityLevel": "JAVA_8",
   "client": [
+    "EntityModelLayersAccessor",
+    "EntityModelsMixin",
     "LivingEntityRendererAccessor",
     "MixinBlockEntityRenderers",
     "MixinEntityRenderers"


### PR DESCRIPTION
This adds a new experimental logic to allow registration of entity model layers and the corresponding textured model data provided by the model layers