### PR TITLE
Optimization in fabric api redirect for block entity unload

### DIFF
--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/WorldMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/WorldMixin.java
@@ -85,7 +85,7 @@ public abstract class WorldMixin {
 			return blockEntityList.removeAll(removals);
 		}
 
-		// Allocating a set when dealing with huge amounts of loaded block entities and then using removeIf is more performant than List#removeAll
+		// List -> List.removeAll is slower than reallocating the List as a Set and then doing a Set -> List.removalAll when dealing with large amounts of loaded block entities.
 		final Set<BlockEntity> removalSet = new ReferenceOpenHashSet<>(removals);
 		return blockEntityList.removeAll(removalSet);
 	}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/WorldMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/WorldMixin.java
@@ -81,13 +81,8 @@ public abstract class WorldMixin {
 
 		// Mimic vanilla logic - with some perf boosts
 		// Gate perf boost behind a minimum amount of removals
-		if (removals.size() <= 4) {
-			return blockEntityList.removeAll(removals);
-		}
-
 		// List -> List.removeAll is slower than reallocating the List as a Set and then doing a Set -> List.removalAll when dealing with large amounts of loaded block entities.
-		final Set<BlockEntity> removalSet = new ReferenceOpenHashSet<>(removals);
-		return blockEntityList.removeAll(removalSet);
+		return blockEntityList.removeAll(removals.size() <= 4 ? removals : new ReferenceOpenHashSet<>(removals));
 	}
 
 	@Inject(at = @At("RETURN"), method = "tickBlockEntities")

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/WorldMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/WorldMixin.java
@@ -19,7 +19,9 @@ package net.fabricmc.fabric.mixin.event.lifecycle;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
+import it.unimi.dsi.fastutil.objects.ReferenceArraySet;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -77,8 +79,13 @@ public abstract class WorldMixin {
 			}
 		}
 
-		// Mimic vanilla logic
-		return blockEntityList.removeAll(removals);
+		// Mimic vanilla logic - with some perf boosts
+		// Allocating a set when dealing with huge amounts of loaded block entities and then using removeIf is more performant than List#removeAll
+		final Set<BlockEntity> removalSet = new ReferenceArraySet<>(removals);
+		return blockEntityList.removeIf(removalSet::contains);
+
+		// Original code
+		// return blockEntityList.removeAll(removals);
 	}
 
 	@Inject(at = @At("RETURN"), method = "tickBlockEntities")

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/WorldMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/WorldMixin.java
@@ -21,7 +21,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import it.unimi.dsi.fastutil.objects.ReferenceArraySet;
+import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -80,12 +80,14 @@ public abstract class WorldMixin {
 		}
 
 		// Mimic vanilla logic - with some perf boosts
-		// Allocating a set when dealing with huge amounts of loaded block entities and then using removeIf is more performant than List#removeAll
-		final Set<BlockEntity> removalSet = new ReferenceArraySet<>(removals);
-		return blockEntityList.removeIf(removalSet::contains);
+		// Gate perf boost behind a minimum amount of removals
+		if (removals.size() <= 4) {
+			return blockEntityList.removeAll(removals);
+		}
 
-		// Original code
-		// return blockEntityList.removeAll(removals);
+		// Allocating a set when dealing with huge amounts of loaded block entities and then using removeIf is more performant than List#removeAll
+		final Set<BlockEntity> removalSet = new ReferenceOpenHashSet<>(removals);
+		return blockEntityList.removeAll(removalSet);
 	}
 
 	@Inject(at = @At("RETURN"), method = "tickBlockEntities")

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/WorldMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/WorldMixin.java
@@ -19,7 +19,6 @@ package net.fabricmc.fabric.mixin.event.lifecycle;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 
 import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
 import org.spongepowered.asm.mixin.Mixin;


### PR DESCRIPTION
This replaces the simple `removeAll` in vanilla and replaces it with a set allocation and use of removeIf + set lookup for reducing overhead in removing from the list of a world's block entities that fabric api redirects for it's block entity events.

We may want to consider only allocating the list of the world's block entity list is only so big? Apparently this issue occurs with 20k block entities on AOF3 NA.

This is result of the following spark profile: https://spark.lucko.me/#SwMPsVKNM1

@Technici4n came up with the general idea for the optimization, it needs to be combed through with the profiler.

Specifically for @sfPlayer1: you should make sure this fix isn't insane or if a better solution exists.

I think a good test for this is to fill a several chunks with a load of block entities and unload and load em frequently.

This is not needed in 1.17, but since block entities are stored by chunk in that version, things may be faster.