### PR TITLE
Allow passing UV coordinates as Vec2f

### DIFF
--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
@@ -22,6 +22,7 @@ import net.minecraft.client.render.model.BakedQuad;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.Vec2f;
 
 import net.fabricmc.fabric.api.renderer.v1.Renderer;
 import net.fabricmc.fabric.api.renderer.v1.material.MaterialFinder;
@@ -247,6 +248,16 @@ public interface MutableQuadView extends QuadView {
 	 */
 	MutableQuadView sprite(int vertexIndex, int spriteIndex, float u, float v);
 
+	/**
+	 * Set sprite atlas coordinates. Behavior for {@code spriteIndex > 0} is currently undefined.
+	 *
+	 * Only use this function if you already have a {@link Vec2f}.
+	 * Otherwise, see {@link MutableQuadView#sprite(int, int, float, float)}.
+	 */
+	default QuadEmitter sprite(int vertexIndex, int spriteIndex, Vec2f uv) {
+		return sprite(vertexIndex, spriteIndex, uv.x, uv.y);
+	}
+	
 	/**
 	 * Assigns sprite atlas u,v coordinates to this quad for the given sprite.
 	 * Can handle UV locking, rotation, interpolation, etc. Control this behavior

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
@@ -254,7 +254,7 @@ public interface MutableQuadView extends QuadView {
 	 * Only use this function if you already have a {@link Vec2f}.
 	 * Otherwise, see {@link MutableQuadView#sprite(int, int, float, float)}.
 	 */
-	default QuadEmitter sprite(int vertexIndex, int spriteIndex, Vec2f uv) {
+	default MutableQuadView sprite(int vertexIndex, int spriteIndex, Vec2f uv) {
 		return sprite(vertexIndex, spriteIndex, uv.x, uv.y);
 	}
 	

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
@@ -257,7 +257,7 @@ public interface MutableQuadView extends QuadView {
 	default MutableQuadView sprite(int vertexIndex, int spriteIndex, Vec2f uv) {
 		return sprite(vertexIndex, spriteIndex, uv.x, uv.y);
 	}
-	
+
 	/**
 	 * Assigns sprite atlas u,v coordinates to this quad for the given sprite.
 	 * Can handle UV locking, rotation, interpolation, etc. Control this behavior

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
@@ -251,7 +251,7 @@ public interface MutableQuadView extends QuadView {
 	/**
 	 * Set sprite atlas coordinates. Behavior for {@code spriteIndex > 0} is currently undefined.
 	 *
-	 * Only use this function if you already have a {@link Vec2f}.
+	 * <p>Only use this function if you already have a {@link Vec2f}.
 	 * Otherwise, see {@link MutableQuadView#sprite(int, int, float, float)}.
 	 */
 	default MutableQuadView sprite(int vertexIndex, int spriteIndex, Vec2f uv) {

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
@@ -94,13 +94,13 @@ public interface QuadEmitter extends MutableQuadView {
 	/**
 	 * Set sprite atlas coordinates. Behavior for {@code spriteIndex > 0} is currently undefined.
 	 *
-	 * Only use this function if you already have a {@link Vec2f}.
+	 * <p>Only use this function if you already have a {@link Vec2f}.
 	 * Otherwise, see {@link QuadEmitter#sprite(int, int, float, float)}.
 	 */
 	default QuadEmitter sprite(int vertexIndex, int spriteIndex, Vec2f uv) {
 		return sprite(vertexIndex, spriteIndex, uv.x, uv.y);
 	}
-	
+
 	default QuadEmitter spriteUnitSquare(int spriteIndex) {
 		sprite(0, spriteIndex, 0, 0);
 		sprite(1, spriteIndex, 0, 1);

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
@@ -91,9 +91,15 @@ public interface QuadEmitter extends MutableQuadView {
 	@Override
 	QuadEmitter sprite(int vertexIndex, int spriteIndex, float u, float v);
 
-	/* Avoid using this function unless you aleady have a Vec2f */
-	@Override
-	QuadEmitter sprite(int vertexIndex, int spriteIndex, Vec2f uv);
+	/**
+	 * Set sprite atlas coordinates. Behavior for {@code spriteIndex > 0} is currently undefined.
+	 *
+	 * Only use this function if you already have a {@link Vec2f}.
+	 * Otherwise, see {@link QuadEmitter#sprite(int, int, float, float)}.
+	 */
+	default QuadEmitter sprite(int vertexIndex, int spriteIndex, Vec2f uv) {
+		return sprite(vertexIndex, spriteIndex, uv.x, uv.y);
+	}
 	
 	default QuadEmitter spriteUnitSquare(int spriteIndex) {
 		sprite(0, spriteIndex, 0, 0);

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.api.renderer.v1.mesh;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.Vec2f;
 
 import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
@@ -90,6 +91,10 @@ public interface QuadEmitter extends MutableQuadView {
 	@Override
 	QuadEmitter sprite(int vertexIndex, int spriteIndex, float u, float v);
 
+	/* Avoid using this function unless you aleady have a Vec2f */
+	@Override
+	QuadEmitter sprite(int vertexIndex, int spriteIndex, Vec2f uv);
+	
 	default QuadEmitter spriteUnitSquare(int spriteIndex) {
 		sprite(0, spriteIndex, 0, 0);
 		sprite(1, spriteIndex, 0, 1);

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
@@ -19,7 +19,6 @@ package net.fabricmc.fabric.api.renderer.v1.mesh;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.util.math.Direction;
-import net.minecraft.util.math.Vec2f;
 
 import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
@@ -90,10 +89,6 @@ public interface QuadEmitter extends MutableQuadView {
 
 	@Override
 	QuadEmitter sprite(int vertexIndex, int spriteIndex, float u, float v);
-
-	default QuadEmitter sprite(int vertexIndex, int spriteIndex, Vec2f uv) {
-		return sprite(vertexIndex, spriteIndex, uv.x, uv.y);
-	}
 
 	default QuadEmitter spriteUnitSquare(int spriteIndex) {
 		sprite(0, spriteIndex, 0, 0);

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.api.renderer.v1.mesh;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.Vec2f;
 
 import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
@@ -89,6 +90,10 @@ public interface QuadEmitter extends MutableQuadView {
 
 	@Override
 	QuadEmitter sprite(int vertexIndex, int spriteIndex, float u, float v);
+
+	default QuadEmitter sprite(int vertexIndex, int spriteIndex, Vec2f uv) {
+		return sprite(vertexIndex, spriteIndex, uv.x, uv.y);
+	}
 
 	default QuadEmitter spriteUnitSquare(int spriteIndex) {
 		sprite(0, spriteIndex, 0, 0);


### PR DESCRIPTION
Rotating UV coordinates using vector math becomes extremely annoying when every `sprite` call requires the individual `u` and `v` coordinates to be extracted again.

This change will allow passing UV coordinates in a container that will always be available.