### PR TITLE
Lifecycle events: Add event when client has changed worlds

### DIFF
--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientLifecycleEvents.java
@@ -53,8 +53,8 @@ public final class ClientLifecycleEvents {
 	});
 
 	/**
-	 * Called when the current player in the Minecraft game is moved to a different world.
-	 * This occurs before the client's {@link MinecraftClient#world current world} is disposed and a new world is created.
+	 * Called when the current player in the Minecraft game has moved to a different world.
+	 * This occurs when a new world has been created, but before the client's {@link MinecraftClient#world current world} is disposed.
 	 */
 	public static final Event<ChangeWorld> CHANGE_WORLD = EventFactory.createArrayBacked(ChangeWorld.class, callbacks -> (client, world, destination) -> {
 		for (ChangeWorld callback : callbacks) {
@@ -78,7 +78,7 @@ public final class ClientLifecycleEvents {
 	@FunctionalInterface
 	public interface ChangeWorld {
 		/**
-		 * Called when the current player in the Minecraft game is moved to a different world.
+		 * Called when the current player in the Minecraft game has moved to a different world.
 		 * A mod may use this event for reference cleanup on the current world.
 		 *
 		 * @param client the Minecraft client

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientLifecycleEvents.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.api.client.event.lifecycle.v1;
 
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.world.ClientWorld;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -51,13 +52,39 @@ public final class ClientLifecycleEvents {
 		}
 	});
 
+	/**
+	 * Called when the current player in the Minecraft game is moved to a different world.
+	 * This occurs before the client's {@link MinecraftClient#world current world} is disposed and a new world is created.
+	 */
+	public static final Event<ChangeWorld> CHANGE_WORLD = EventFactory.createArrayBacked(ChangeWorld.class, callbacks -> (client, world, destination) -> {
+		for (ChangeWorld callback : callbacks) {
+			callback.onChangeWorld(client, world, destination);
+		}
+	});
+
+	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface ClientStarted {
 		void onClientStarted(MinecraftClient client);
 	}
 
+	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface ClientStopping {
 		void onClientStopping(MinecraftClient client);
+	}
+
+	@Environment(EnvType.CLIENT)
+	@FunctionalInterface
+	public interface ChangeWorld {
+		/**
+		 * Called when the current player in the Minecraft game is moved to a different world.
+		 * A mod may use this event for reference cleanup on the current world.
+		 *
+		 * @param client the Minecraft client
+		 * @param origin the world the player is currently in
+		 * @param destination the world the player is being moved to
+		 */
+		void onChangeWorld(MinecraftClient client, ClientWorld origin, ClientWorld destination);
 	}
 }


### PR DESCRIPTION
Somewhat requested by @LambdAurora, the event added in this pull request is called when the client's world is changed. This may be used for reference cleanup when the client has changed worlds in case a mod tracks the current client world.