### PR TITLE
Add contact links to issue template page

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: true
 contact_links:
   - name: FabricMC Discord
     url: https://discord.gg/v6v4pMv
-    about: Please ask here for help with installing Fabric
+    about: Please ask here for help with installing Fabric.
   - name: Github Discussions
     url: https://github.com/FabricMC/fabric/discussions
     about: Please look here for frequently asked questions and questions on how to use Fabric API.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: FabricMC Discord
+    url: https://discord.gg/v6v4pMv
+    about: Please ask here for help with installing Fabric
+  - name: Github Discussions
+    url: https://github.com/FabricMC/fabric/discussions
+    about: Please look here for frequently asked questions and questions on how to use Fabric Api.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,6 @@ contact_links:
   - name: FabricMC Discord
     url: https://discord.gg/v6v4pMv
     about: Please ask here for help with installing Fabric.
-  - name: Github Discussions
+  - name: GitHub Discussions
     url: https://github.com/FabricMC/fabric/discussions
     about: Please look here for frequently asked questions and questions on how to use Fabric API.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,4 +5,4 @@ contact_links:
     about: Please ask here for help with installing Fabric
   - name: Github Discussions
     url: https://github.com/FabricMC/fabric/discussions
-    about: Please look here for frequently asked questions and questions on how to use Fabric Api.
+    about: Please look here for frequently asked questions and questions on how to use Fabric API.


### PR DESCRIPTION
This should help direct people who are asking for help to the discord or GitHub Discussions if it is not directly related to issues with or feature requests for Fabric API.

Screenshot (Outdated):
![image](https://user-images.githubusercontent.com/30619168/103123242-4b035a80-4649-11eb-87af-7b13fe681c2a.png)
