### PR TITLE
Auto update meta about new fapi versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: gradle/wrapper-validation-action@v1
-      - run: ./gradlew checkVersion build publish curseforge github publishVersionMap --stacktrace
+      - run: ./gradlew checkVersion build publish curseforge github updateVersionMap --stacktrace
         env:
           MAVEN_URL: ${{ secrets.MAVEN_URL }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,12 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: gradle/wrapper-validation-action@v1
-      - run: ./gradlew checkVersion build publish curseforge github --stacktrace
+      - run: ./gradlew checkVersion build publish curseforge github publishVersionMap --stacktrace
         env:
           MAVEN_URL: ${{ secrets.MAVEN_URL }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
           CURSEFORGE_API_KEY: ${{ secrets.CURSEFORGE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GH_API_KEY }}
+          GRGIT_USER: ${{ secrets.GH_USER }}
+          GRGIT_PASS: ${{ secrets.GH_PASS }}

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ plugins {
 	id "net.minecrell.licenser" version "0.4.1"
 	id "org.ajoberstar.grgit" version "3.1.1"
 	id "com.matthewprenger.cursegradle" version "1.4.0"
+	id "org.ajoberstar.git-publish" version "3.0.0"
 }
 
 def ENV = System.getenv()
@@ -389,6 +390,64 @@ task checkVersion {
 	}
 }
 
+// Authentication is provided by GRGIT_PASS and GRGIT_USER enviro. variables.
+// GRGIT_PASS can be authentication token
+// See https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token#using-a-token-on-the-command-line
+def versionMapRepo = "https://github.com/dexman545/fabric-api-version-map.git" //TODO use official repo
+gitPublish {
+	repoUri = versionMapRepo
+	branch = "main"
+	commitMessage = "Automated addition of new api version from FabricMC repo"
+
+	preserve {
+		include "README.md"
+		include "LICENSE"
+		include "apiVersions.properties"
+		include ".gitignore"
+	}
+}
+
+task updateVersionMap(dependsOn: gitPublishReset) {
+	doLast {
+		def propFile = file("${buildDir}/gitPublish/apiVersions.properties")
+		def mc2Api = new Properties()
+		if (!propFile.exists()) return
+		propFile.withReader {mc2Api.load(it)}
+		String list = mc2Api.getProperty(Globals.mcVersion, "")
+		String separator = list.isEmpty() ? " " : ", "
+		mc2Api.setProperty(Globals.mcVersion, list + separator + version)
+
+		// Do not use Properties#store as it shuffles the file
+		boolean hasVersion = false
+		List<String> outLines = new ArrayList<>();
+		propFile.eachLine {
+			String[] parsed = it.split("=")
+			if (parsed[0].trim() == Globals.mcVersion) {
+				hasVersion = true
+				it = Globals.mcVersion + " = " + list + separator + version
+			}
+			outLines.add(it)
+		}
+
+		propFile.withWriter {
+			if (!hasVersion) { // Add new versions to top of file
+				it.write(Globals.mcVersion + " = " + list + separator + version)
+				it.newLine()
+			}
+			for (String ln : outLines) {
+				it.write(ln)
+				it.newLine()
+			}
+		}
+	}
+}
+
+task publishVersionMap(dependsOn: updateVersionMap) {
+
+}
+
 github.mustRunAfter checkVersion
 publish.mustRunAfter checkVersion
 project.tasks.curseforge.mustRunAfter checkVersion
+updateVersionMap.mustRunAfter gitPublishReset
+publishVersionMap.finalizedBy gitPublishCommit, gitPublishPush

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,6 @@ plugins {
 	id "net.minecrell.licenser" version "0.4.1"
 	id "org.ajoberstar.grgit" version "3.1.1"
 	id "com.matthewprenger.cursegradle" version "1.4.0"
-	id "org.ajoberstar.git-publish" version "3.0.0"
 }
 
 def ENV = System.getenv()
@@ -31,6 +30,7 @@ logger.lifecycle("Building Fabric: " + version)
 import org.apache.commons.codec.digest.DigestUtils
 import net.fabricmc.loom.task.RunClientTask
 import net.fabricmc.loom.task.RunServerTask
+import org.ajoberstar.grgit.Grgit
 
 def getSubprojectVersion(project, version) {
 	if (grgit == null) {
@@ -393,23 +393,26 @@ task checkVersion {
 // Authentication is provided by GRGIT_PASS and GRGIT_USER enviro. variables.
 // GRGIT_PASS can be authentication token
 // See https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token#using-a-token-on-the-command-line
-def versionMapRepo = "https://github.com/dexman545/fabric-api-version-map.git" //TODO use official repo
-gitPublish {
-	repoUri = versionMapRepo
-	branch = "main"
-	commitMessage = "Automated addition of new api version from FabricMC repo"
-
-	preserve {
-		include "README.md"
-		include "LICENSE"
-		include "apiVersions.properties"
-		include ".gitignore"
+task updateVersionMap() {
+	onlyIf {
+		ENV.GRGIT_PASS
 	}
-}
-
-task updateVersionMap(dependsOn: gitPublishReset) {
 	doLast {
-		def propFile = file("${buildDir}/gitPublish/apiVersions.properties")
+		Grgit repo
+		if (!buildDir.toPath().resolve('fabric-api-version-map').toFile().exists()) {
+			//noinspection GroovyAccessibility, GroovyAssignabilityCheck
+			repo = grgit.clone {
+				dir = buildDir.toPath().resolve('fabric-api-version-map').toFile()
+				uri = "https://github.com/dexman545/fabric-api-version-map.git" //TODO use official repo
+			} as Grgit
+		} else {
+			//noinspection GroovyAccessibility, GroovyAssignabilityCheck
+			repo = grgit.open {
+				dir = buildDir.toPath().resolve('fabric-api-version-map').toFile()
+			} as Grgit
+		}
+
+		def propFile = file("${buildDir}/fabric-api-version-map/apiVersions.properties")
 		def mc2Api = new Properties()
 		if (!propFile.exists()) return
 		propFile.withReader {mc2Api.load(it)}
@@ -419,7 +422,7 @@ task updateVersionMap(dependsOn: gitPublishReset) {
 
 		// Do not use Properties#store as it shuffles the file
 		boolean hasVersion = false
-		List<String> outLines = new ArrayList<>();
+		List<String> outLines = new ArrayList<>()
 		propFile.eachLine {
 			String[] parsed = it.split("=")
 			if (parsed[0].trim() == Globals.mcVersion) {
@@ -439,15 +442,13 @@ task updateVersionMap(dependsOn: gitPublishReset) {
 				it.newLine()
 			}
 		}
+		repo.commit(message: 'Automated update', all: true)
+		repo.push()
+		repo.close()
+		buildDir.toPath().resolve('fabric-api-version-map').toFile().deleteDir() // Clean it up
 	}
-}
-
-task publishVersionMap(dependsOn: updateVersionMap) {
-
 }
 
 github.mustRunAfter checkVersion
 publish.mustRunAfter checkVersion
 project.tasks.curseforge.mustRunAfter checkVersion
-updateVersionMap.mustRunAfter gitPublishReset
-publishVersionMap.finalizedBy gitPublishCommit, gitPublishPush


### PR DESCRIPTION
Companion to FabricMC/fabric-meta#10

When a release is built, adds the API version to the list of MC versions based on the MC version it was built against.