### PR TITLE
Fix dev env crash on Windows.

### DIFF
--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/GroupResourcePack.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/GroupResourcePack.java
@@ -23,11 +23,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 
 import net.minecraft.resource.Resource;
@@ -46,7 +46,7 @@ import net.fabricmc.fabric.mixin.resource.loader.NamespaceResourceManagerAccesso
 public abstract class GroupResourcePack implements ResourcePack {
 	protected final ResourceType type;
 	protected final List<ModResourcePack> packs;
-	protected final Object2ObjectMap<String, List<ModResourcePack>> namespacedPacks = new Object2ObjectOpenHashMap<>();
+	protected final Map<String, List<ModResourcePack>> namespacedPacks = new Object2ObjectOpenHashMap<>();
 
 	public GroupResourcePack(ResourceType type, List<ModResourcePack> packs) {
 		this.type = type;

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModResourcePackUtil.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModResourcePackUtil.java
@@ -59,7 +59,7 @@ public final class ModResourcePackUtil {
 			Path path = container.getRootPath();
 
 			if (subPath != null) {
-				Path childPath = path.resolve(subPath.replaceAll("/", path.getFileSystem().getSeparator())).toAbsolutePath().normalize();
+				Path childPath = path.resolve(subPath.replace("/", path.getFileSystem().getSeparator())).toAbsolutePath().normalize();
 
 				if (!childPath.startsWith(path) || !Files.exists(childPath)) {
 					continue;


### PR DESCRIPTION
The stack trace that led to this PR:

```
java.lang.IllegalArgumentException: Last character in replacement string can't be \, character to be escaped is required.
	at java.lang.String.checkLastChar(String.java:56)
	at java.lang.String.replaceAll(String.java:3558)
	at net.fabricmc.fabric.impl.resource.loader.ModResourcePackUtil.appendModResourcePacks(ModResourcePackUtil.java:60)
	at net.minecraft.client.resource.ClientBuiltinResourcePackProvider.getProgrammerArtModResourcePacks(ClientBuiltinResourcePackProvider.java:565)
	at net.minecraft.client.resource.ClientBuiltinResourcePackProvider.handler$zef000$onSupplyZipProgrammerArtPack(ClientBuiltinResourcePackProvider.java:553)
	at net.minecraft.client.resource.ClientBuiltinResourcePackProvider.method_25457(ClientBuiltinResourcePackProvider.java:229)
	at net.minecraft.client.resource.ClientBuiltinResourcePackProvider$$Lambda$2697/000000000000000000.get(Unknown Source)
	at net.minecraft.resource.ResourcePackProfile.of(ResourcePackProfile.java:36)
	at net.minecraft.client.resource.ClientBuiltinResourcePackProvider.getProgrammerArtResourcePackProfile(ClientBuiltinResourcePackProvider.java:242)
	at net.minecraft.client.resource.ClientBuiltinResourcePackProvider.getProgrammerArtResourcePackProfile(ClientBuiltinResourcePackProvider.java:229)
	at net.minecraft.client.resource.ClientBuiltinResourcePackProvider.register(ClientBuiltinResourcePackProvider.java:84)
	at net.minecraft.resource.ResourcePackManager.providePackProfiles(ResourcePackManager.java:45)
	at net.minecraft.resource.ResourcePackManager.scanPacks(ResourcePackManager.java:38)
	at net.minecraft.client.MinecraftClient.<init>(MinecraftClient.java:481)
	at net.minecraft.client.main.Main.main(Main.java:177)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at net.fabricmc.loader.game.MinecraftGameProvider.launch(MinecraftGameProvider.java:224)
	at net.fabricmc.loader.launch.knot.Knot.init(Knot.java:141)
	at net.fabricmc.loader.launch.knot.KnotClient.main(KnotClient.java:27)
	at net.fabricmc.devlaunchinjector.Main.main(Main.java:86)
```

Noticed it was the only place where `replaceAll` was used, other places with similar code prior to latest releases always used `replace`.