### PR TITLE
Fix javadoc and typo

### DIFF
--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/render/RenderContext.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/render/RenderContext.java
@@ -28,6 +28,8 @@ import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
 
 /**
  * This defines the instance made available to models for buffering vertex data at render time.
+ *
+ * <p>Only the renderer should implement or extend this interface.
  */
 public interface RenderContext {
 	/**
@@ -70,8 +72,6 @@ public interface RenderContext {
 	 *
 	 * <p>Meshes are never mutated by the transformer - only buffered quads. This ensures thread-safe
 	 * use of meshes/models across multiple chunk builders.
-	 *
-	 * <p>Only the renderer should implement or extend this interface.
 	 */
 	void pushTransform(QuadTransform transform);
 

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderEvents.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderEvents.java
@@ -175,11 +175,11 @@ public final class WorldRenderEvents {
 	 * be accomplished by mixin to the block outline render routine itself, typically
 	 * by targeting {@link WorldRenderer#drawShapeOutline}.
 	 */
-	public static final Event<BlockOutline> BLOCK_OUTLINE = EventFactory.createArrayBacked(BlockOutline.class, (worldRenderContext, blockOutlieContext) -> true, callbacks -> (worldRenderContext, blockOutlieContext) -> {
+	public static final Event<BlockOutline> BLOCK_OUTLINE = EventFactory.createArrayBacked(BlockOutline.class, (worldRenderContext, blockOutlineContext) -> true, callbacks -> (worldRenderContext, blockOutlineContext) -> {
 		boolean shouldRender = true;
 
 		for (final BlockOutline callback : callbacks) {
-			if (!callback.onBlockOutline(worldRenderContext, blockOutlieContext)) {
+			if (!callback.onBlockOutline(worldRenderContext, blockOutlineContext)) {
 				shouldRender = false;
 			}
 		}
@@ -298,7 +298,7 @@ public final class WorldRenderEvents {
 	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface BlockOutline {
-		boolean onBlockOutline(WorldRenderContext worldRenderContext, BlockOutlineContext blockOutlieContext);
+		boolean onBlockOutline(WorldRenderContext worldRenderContext, BlockOutlineContext blockOutlineContext);
 	}
 
 	@Environment(EnvType.CLIENT)


### PR DESCRIPTION
Note about implementing or extending the interface `RenderContext` has been moved from a method's javadoc to the class' javadoc to make more sense.
`blockOutlieContext` in `WorldRenderEvents` has been renamed to `blockOutlineContext`.