### PR TITLE
Automatic Modrinth Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,11 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: gradle/wrapper-validation-action@v1
-      - run: ./gradlew checkVersion build publish curseforge github --stacktrace
+      - run: ./gradlew checkVersion build publish curseforge modrinth github --stacktrace
         env:
           MAVEN_URL: ${{ secrets.MAVEN_URL }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
           CURSEFORGE_API_KEY: ${{ secrets.CURSEFORGE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GH_API_KEY }}
+          MODRINTH_API_TOKEN: ${{ secrets.MODRINTH_API_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ plugins {
 	id "net.minecrell.licenser" version "0.4.1"
 	id "org.ajoberstar.grgit" version "3.1.1"
 	id "com.matthewprenger.cursegradle" version "1.4.0"
+	id "com.modrinth.minotaur" version "1.1.0"
 }
 
 def ENV = System.getenv()
@@ -356,6 +357,21 @@ curseforge {
 
 	options {
 		forgeGradleIntegration = false
+	}
+}
+
+import com.modrinth.minotaur.TaskModrinthUpload
+task modrinth(type: TaskModrinthUpload) {
+	if (ENV.MODRINTH_API_TOKEN) token = ENV.MODRINTH_API_TOKEN
+	projectId = "P7dR8mSH"
+	versionNumber = "v${version}"
+	uploadFile = remapJar
+	addGameVersion("1.16.5")
+	addLoader("fabric")
+	versionName = "[$Globals.mcVersion] Fabric API $Globals.baseVersion"
+
+	afterEvaluate {
+		modrinth.dependsOn("remapJar")
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -366,8 +366,11 @@ task modrinth(type: TaskModrinthUpload) {
 	projectId = "P7dR8mSH"
 	versionNumber = "v${version}"
 	uploadFile = remapJar
+	// Possibly add -sources, -dev and -sources-dev here?
+	
 	addGameVersion("1.16.5")
 	addLoader("fabric")
+	
 	versionName = "[$Globals.mcVersion] Fabric API $Globals.baseVersion"
 
 	afterEvaluate {


### PR DESCRIPTION
Since Fabric API is now on Modrinth, I thought this would be nice to have.

----------

This PR adds Modrinth publishing to the `release.yml` workflow, provided a `MODRINTH_API_TOKEN` GitHub secret that should be added to the organization or the repository.

TODO:
- [X] Write Code
- [X] Test
- [ ] Receive Feedback ~~and rewrite the entire thing~~