### PR TITLE
Remove all inter-module dependencies on fabric-networking-v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Set<String> apiModules = [
     "fabric-api-base",
     "fabric-command-api-v1",
     "fabric-lifecycle-events-v1",
-    "fabric-networking-v0"
+    "fabric-networking-api-v1"
 ]
 
 // Add each module as a dependency
@@ -66,7 +66,7 @@ setOf(
     "fabric-api-base",
     "fabric-command-api-v1",
     "fabric-lifecycle-events-v1",
-    "fabric-networking-v0"
+    "fabric-networking-api-v1"
 ).forEach {
     // Add each module as a dependency
     modImplementation(fabricApi.module(it, FABRIC_API_VERSION))

--- a/fabric-containers-v0/build.gradle
+++ b/fabric-containers-v0/build.gradle
@@ -3,5 +3,5 @@ version = getSubprojectVersion(project, "0.1.10")
 
 moduleDependencies(project, [
 		'fabric-api-base',
-		'fabric-networking-v0'
+		'fabric-networking-api-v1'
 ])

--- a/fabric-containers-v0/src/main/resources/fabric.mod.json
+++ b/fabric-containers-v0/src/main/resources/fabric.mod.json
@@ -18,7 +18,7 @@
   "depends": {
     "fabricloader": ">=0.4.0",
     "fabric-api-base": "*",
-    "fabric-networking-v0": "*"
+    "fabric-networking-api-v1": "*"
   },
   "description": "Adds hooks for containers.",
   "mixins": [

--- a/fabric-dimensions-v1/src/main/resources/fabric.mod.json
+++ b/fabric-dimensions-v1/src/main/resources/fabric.mod.json
@@ -6,9 +6,7 @@
   "depends": {
     "fabricloader": ">=0.4.0",
     "minecraft": ">=1.16-rc.3",
-    "fabric-api-base": "*",
-    "fabric-registry-sync-v0": "*",
-    "fabric-networking-v0": "*"
+    "fabric-api-base": "*"
   },
   "mixins": [
     "fabric-dimensions-v1.mixins.json"

--- a/fabric-screen-handler-api-v1/build.gradle
+++ b/fabric-screen-handler-api-v1/build.gradle
@@ -11,5 +11,5 @@ dependencies {
 
 moduleDependencies(project, [
 		'fabric-api-base',
-		'fabric-networking-v0'
+		'fabric-networking-api-v1'
 ])

--- a/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/impl/screenhandler/Networking.java
+++ b/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/impl/screenhandler/Networking.java
@@ -28,7 +28,7 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 
-import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerFactory;
 
 public final class Networking {
@@ -67,6 +67,6 @@ public final class Networking {
 		buf.writeText(factory.getDisplayName());
 		factory.writeScreenOpeningData(player, buf);
 
-		ServerSidePacketRegistry.INSTANCE.sendToPlayer(player, OPEN_ID, buf);
+		ServerPlayNetworking.send(player, OPEN_ID, buf);
 	}
 }

--- a/fabric-screen-handler-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-screen-handler-api-v1/src/main/resources/fabric.mod.json
@@ -18,7 +18,7 @@
   "depends": {
     "fabricloader": ">=0.8.0",
     "fabric-api-base": "*",
-    "fabric-networking-v0": "*"
+    "fabric-networking-api-v1": "*"
   },
   "entrypoints": {
     "client": ["net.fabricmc.fabric.impl.screenhandler.client.ClientNetworking"]


### PR DESCRIPTION
This migrates all uses of v0 networking to v1 api, and changes the readme to not mention networking-v0 in the example for dependencies.

This effectively makes v0 removable if it breaks in the future beyond repair. Though I expect v0 to last quite a bit longer.

This also fixes an issue where the new screen handler api does not release the packet byte buf after opening the screen.