### PR TITLE
Fix #1273 (Make MultipartBakedModel and WeightedBackedModel implement FabricBakedModel properly)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Gradle
 .gradle
 
+# VSCode
+.settings/
+.vscode/
+
 # Eclipse
 .checkstyle
 .classpath

--- a/fabric-renderer-api-v1/build.gradle
+++ b/fabric-renderer-api-v1/build.gradle
@@ -10,5 +10,9 @@ dependencies {
 	testmodCompile project(path: ':fabric-models-v0', configuration: 'dev')
 	testmodCompile project(path: ':fabric-networking-blockentity-v0', configuration: 'dev')
 	testmodCompile project(path: ':fabric-object-builder-api-v1', configuration: 'dev')
+	testmodCompile project(path: ':fabric-renderer-indigo', configuration: 'dev')
 	testmodCompile project(path: ':fabric-rendering-data-attachment-v1', configuration: 'dev')
+	testmodCompile project(path: ':fabric-resource-loader-v0', configuration: 'dev')
+	testmodCompile project(path: ':fabric-tag-extensions-v0', configuration: 'dev')
+	testmodCompile project(path: ':fabric-tool-attribute-api-v1', configuration: 'dev')
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinMultipartBakedModel.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinMultipartBakedModel.java
@@ -55,7 +55,7 @@ public class MixinMultipartBakedModel implements FabricBakedModel {
 
 	@Override
 	public void emitBlockQuads(BlockRenderView blockView, BlockState state, BlockPos pos, Supplier<Random> randomSupplier, RenderContext context) {
-		BitSet bitSet = (BitSet) this.stateCache.get(state);
+		BitSet bitSet = this.stateCache.get(state);
 
 		if (bitSet == null) {
 			bitSet = new BitSet();

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinMultipartBakedModel.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinMultipartBakedModel.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.renderer.client;
+
+import java.util.BitSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.render.model.MultipartBakedModel;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.BlockRenderView;
+
+import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
+import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
+
+@Mixin(MultipartBakedModel.class)
+public class MixinMultipartBakedModel implements FabricBakedModel {
+	@Shadow
+	@Final
+	private List<Pair<Predicate<BlockState>, BakedModel>> components;
+
+	@Shadow
+	@Final
+	private Map<BlockState, BitSet> stateCache;
+
+	@Override
+	public boolean isVanillaAdapter() {
+		return false;
+	}
+
+	@Override
+	public void emitBlockQuads(BlockRenderView blockView, BlockState state, BlockPos pos, Supplier<Random> randomSupplier, RenderContext context) {
+		BitSet bitSet = (BitSet) this.stateCache.get(state);
+
+		if (bitSet == null) {
+			bitSet = new BitSet();
+
+			for (int i = 0; i < this.components.size(); i++) {
+				Pair<Predicate<BlockState>, BakedModel> pair = components.get(i);
+
+				if (pair.getLeft().test(state)) {
+					((FabricBakedModel) pair.getRight()).emitBlockQuads(blockView, state, pos, randomSupplier, context);
+					bitSet.set(i);
+				}
+			}
+
+			stateCache.put(state, bitSet);
+		} else {
+			for (int i = 0; i < this.components.size(); i++) {
+				if (bitSet.get(i)) ((FabricBakedModel) components.get(i).getRight()).emitBlockQuads(blockView, state, pos, randomSupplier, context);
+			}
+		}
+	}
+
+	@Override
+	public void emitItemQuads(ItemStack stack, Supplier<Random> randomSupplier, RenderContext context) {
+		// Vanilla doesn't render MultipartBakedModel's as the BlockState in getQuads
+		// will be null
+		// Also it doesn't use MultipartBakedModel's for items anyways
+	}
+}

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinMultipartBakedModel.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinMultipartBakedModel.java
@@ -57,7 +57,7 @@ public class MixinMultipartBakedModel implements FabricBakedModel {
 
 	@Override
 	public boolean isVanillaAdapter() {
-		return false;
+		return isVanilla;
 	}
 
 	@Inject(at = @At("RETURN"), method = "<init>")

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinWeightedBakedModel.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinWeightedBakedModel.java
@@ -50,11 +50,10 @@ public class MixinWeightedBakedModel implements FabricBakedModel {
 	@Unique
 	boolean isVanilla = true;
 
-	@SuppressWarnings("rawtypes")
 	@Inject(at = @At("RETURN"), method = "<init>")
-	private void onInit(List models, CallbackInfo cb) {
+	private void onInit(List<WeightedBakedModelEntryAccessor> models, CallbackInfo cb) {
 		for (int i = 0; i < models.size(); i++) {
-			if (!((FabricBakedModel) ((WeightedBakedModelEntryAccessor) models.get(i)).getModel()).isVanillaAdapter()) {
+			if (!((FabricBakedModel) models.get(i).getModel()).isVanillaAdapter()) {
 				isVanilla = false;
 				break;
 			}

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinWeightedBakedModel.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinWeightedBakedModel.java
@@ -43,10 +43,9 @@ public class MixinWeightedBakedModel implements FabricBakedModel {
 	@Shadow
 	@Final
 	private int totalWeight;
-	@SuppressWarnings("rawtypes")
 	@Shadow
 	@Final
-	private List models; // WeightedBakedModel.Entry is not visible
+	private List<WeightedPicker.Entry> models; // WeightedBakedModel.Entry is not visible
 	@Unique
 	boolean isVanilla = true;
 

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinWeightedBakedModel.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinWeightedBakedModel.java
@@ -39,9 +39,10 @@ public class MixinWeightedBakedModel implements FabricBakedModel {
 	@Shadow
 	@Final
 	private int totalWeight;
+	@SuppressWarnings("rawtypes")
 	@Shadow
 	@Final
-	private List models; // WeightedBakedModel.Entry is not visable
+	private List models; // WeightedBakedModel.Entry is not visible
 
 	@Override
 	public boolean isVanillaAdapter() {

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinWeightedBakedModel.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinWeightedBakedModel.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.renderer.client;
+
+import java.util.List;
+import java.util.Random;
+import java.util.function.Supplier;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.client.render.model.WeightedBakedModel;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.collection.WeightedPicker;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.BlockRenderView;
+
+import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
+import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
+
+@Mixin(WeightedBakedModel.class)
+public class MixinWeightedBakedModel implements FabricBakedModel {
+	@Shadow
+	@Final
+	private int totalWeight;
+	@Shadow
+	@Final
+	private List models; // WeightedBakedModel.Entry is not visable
+
+	@Override
+	public boolean isVanillaAdapter() {
+		return false;
+	}
+
+	@Override
+	public void emitBlockQuads(BlockRenderView blockView, BlockState state, BlockPos pos, Supplier<Random> randomSupplier, RenderContext context) {
+		((FabricBakedModel) ((WeightedBakedModelEntryAccessor) WeightedPicker.getAt(this.models, Math.abs((int) randomSupplier.get().nextLong()) % this.totalWeight)).getModel()).emitBlockQuads(blockView, state, pos, randomSupplier, context);
+	}
+
+	@Override
+	public void emitItemQuads(ItemStack stack, Supplier<Random> randomSupplier, RenderContext context) {
+		((FabricBakedModel) ((WeightedBakedModelEntryAccessor) WeightedPicker.getAt(this.models, Math.abs((int) randomSupplier.get().nextLong()) % this.totalWeight)).getModel()).emitItemQuads(stack, randomSupplier, context);
+	}
+}

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinWeightedBakedModel.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinWeightedBakedModel.java
@@ -23,6 +23,10 @@ import java.util.function.Supplier;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.client.render.model.WeightedBakedModel;
@@ -43,10 +47,23 @@ public class MixinWeightedBakedModel implements FabricBakedModel {
 	@Shadow
 	@Final
 	private List models; // WeightedBakedModel.Entry is not visible
+	@Unique
+	boolean isVanilla = true;
+
+	@SuppressWarnings("rawtypes")
+	@Inject(at = @At("RETURN"), method = "<init>")
+	private void onInit(List models, CallbackInfo cb) {
+		for (int i = 0; i < models.size(); i++) {
+			if (!((FabricBakedModel) ((WeightedBakedModelEntryAccessor) models.get(i)).getModel()).isVanillaAdapter()) {
+				isVanilla = false;
+				break;
+			}
+		}
+	}
 
 	@Override
 	public boolean isVanillaAdapter() {
-		return false;
+		return isVanilla;
 	}
 
 	@Override

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/WeightedBakedModelEntryAccessor.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/WeightedBakedModelEntryAccessor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.renderer.client;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.client.render.model.BakedModel;
+
+@Mixin(targets = "net/minecraft/client/render/model/WeightedBakedModel$Entry")
+public interface WeightedBakedModelEntryAccessor {
+	@Accessor
+	BakedModel getModel();
+}

--- a/fabric-renderer-api-v1/src/main/resources/fabric-renderer-api-v1.mixins.json
+++ b/fabric-renderer-api-v1/src/main/resources/fabric-renderer-api-v1.mixins.json
@@ -4,7 +4,10 @@
   "compatibilityLevel": "JAVA_8",
   "client": [
     "client.MixinBakedModel",
-    "client.MixinSpriteAtlasTexture"
+    "client.MixinMultipartBakedModel",
+    "client.MixinWeightedBakedModel",
+    "client.MixinSpriteAtlasTexture",
+    "client.WeightedBakedModelEntryAccessor"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/FrameBlock.java
+++ b/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/FrameBlock.java
@@ -27,14 +27,20 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
 
+import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
+
 public final class FrameBlock extends Block implements BlockEntityProvider {
-	public FrameBlock(Settings settings) {
-		super(settings);
+	public final Identifier id;
+
+	public FrameBlock(Identifier id) {
+		super(FabricBlockSettings.copyOf(Blocks.IRON_BLOCK).nonOpaque());
+		this.id = id;
 	}
 
 	@Override

--- a/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/FrameBlockEntity.java
+++ b/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/FrameBlockEntity.java
@@ -83,7 +83,7 @@ public final class FrameBlockEntity extends BlockEntity implements RenderAttachm
 
 	@Override
 	public void fromClientTag(CompoundTag tag) {
-		System.out.println("Recieved sync packet");
+		System.out.println("Received sync packet");
 
 		if (tag.contains("block", NbtType.STRING)) {
 			this.block = Registry.BLOCK.get(new Identifier(tag.getString("block")));

--- a/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/RendererTest.java
+++ b/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/RendererTest.java
@@ -16,14 +16,14 @@
 
 package net.fabricmc.fabric.test.renderer.simple;
 
-import net.minecraft.block.Block;
-import net.minecraft.block.Blocks;
 import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 
 /**
  * A simple testmod that renders a simple block rendered using the fabric renderer api.
@@ -33,12 +33,24 @@ import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
  * <p>There are no fancy shaders or glow that is provided by this renderer test.
  */
 public final class RendererTest implements ModInitializer {
-	public static final Block FRAME = new FrameBlock(FabricBlockSettings.copyOf(Blocks.IRON_BLOCK).nonOpaque());
-	public static final BlockEntityType<FrameBlockEntity> FRAME_BLOCK_ENTITY = BlockEntityType.Builder.create(FrameBlockEntity::new, FRAME).build(null);
+	public static final FrameBlock[] FRAMES = new FrameBlock[] {
+			new FrameBlock(id("frame")),
+			new FrameBlock(id("frame_multipart")),
+			new FrameBlock(id("frame_weighted")),
+	};
+	public static final BlockEntityType<FrameBlockEntity> FRAME_BLOCK_ENTITY = BlockEntityType.Builder.create(FrameBlockEntity::new, FRAMES).build(null);
 
 	@Override
 	public void onInitialize() {
-		Registry.register(Registry.BLOCK, new Identifier("fabric-renderer-api-v1-testmod", "frame"), FRAME);
-		Registry.register(Registry.BLOCK_ENTITY_TYPE, new Identifier("fabric-renderer-api-v1-testmod", "frame"), FRAME_BLOCK_ENTITY);
+		for (FrameBlock frameBlock : FRAMES) {
+			Registry.register(Registry.BLOCK, frameBlock.id, frameBlock);
+			Registry.register(Registry.ITEM, frameBlock.id, new BlockItem(frameBlock, new Item.Settings().group(ItemGroup.MISC)));
+		}
+
+		Registry.register(Registry.BLOCK_ENTITY_TYPE, id("frame"), FRAME_BLOCK_ENTITY);
+	}
+
+	public static Identifier id(String path) {
+		return new Identifier("fabric-renderer-api-v1-testmod", path);
 	}
 }

--- a/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/client/FrameModelResourceProvider.java
+++ b/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/client/FrameModelResourceProvider.java
@@ -22,7 +22,6 @@ import net.minecraft.client.render.model.UnbakedModel;
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.api.client.model.ModelProviderContext;
-import net.fabricmc.fabric.api.client.model.ModelProviderException;
 import net.fabricmc.fabric.api.client.model.ModelResourceProvider;
 
 /**
@@ -33,7 +32,7 @@ final class FrameModelResourceProvider implements ModelResourceProvider {
 
 	@Nullable
 	@Override
-	public UnbakedModel loadModelResource(Identifier resourceId, ModelProviderContext context) throws ModelProviderException {
+	public UnbakedModel loadModelResource(Identifier resourceId, ModelProviderContext context) {
 		if (resourceId.equals(FRAME_MODEL_ID)) {
 			return new FrameUnbakedModel();
 		}

--- a/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/client/RendererClientTest.java
+++ b/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/client/RendererClientTest.java
@@ -21,12 +21,16 @@ import net.minecraft.client.render.RenderLayer;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
 import net.fabricmc.fabric.api.client.model.ModelLoadingRegistry;
+import net.fabricmc.fabric.test.renderer.simple.FrameBlock;
 import net.fabricmc.fabric.test.renderer.simple.RendererTest;
 
 public final class RendererClientTest implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
 		ModelLoadingRegistry.INSTANCE.registerResourceProvider(manager -> new FrameModelResourceProvider());
-		BlockRenderLayerMap.INSTANCE.putBlock(RendererTest.FRAME, RenderLayer.getCutoutMipped());
+
+		for (FrameBlock frameBlock : RendererTest.FRAMES) {
+			BlockRenderLayerMap.INSTANCE.putBlock(frameBlock, RenderLayer.getCutoutMipped());
+		}
 	}
 }

--- a/fabric-renderer-api-v1/src/testmod/resources/assets/fabric-renderer-api-v1-testmod/blockstates/frame_multipart.json
+++ b/fabric-renderer-api-v1/src/testmod/resources/assets/fabric-renderer-api-v1-testmod/blockstates/frame_multipart.json
@@ -1,0 +1,10 @@
+{
+  "__comment": "We test that MultipartBakedModel works correctly.",
+  "multipart": [
+    {
+      "apply": {
+        "model": "fabric-renderer-api-v1-testmod:block/frame"
+      }
+    }
+  ]
+}

--- a/fabric-renderer-api-v1/src/testmod/resources/assets/fabric-renderer-api-v1-testmod/blockstates/frame_weighted.json
+++ b/fabric-renderer-api-v1/src/testmod/resources/assets/fabric-renderer-api-v1-testmod/blockstates/frame_weighted.json
@@ -1,0 +1,13 @@
+{
+  "__comment": "We test that WeightedBakedModel works correctly, hence the two variants.",
+  "variants": {
+    "": [
+      {
+        "model": "fabric-renderer-api-v1-testmod:block/frame"
+      },
+      {
+        "model": "fabric-renderer-api-v1-testmod:block/frame"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Makes `MultipartBakedModel`s and `WeightedBakedModel`s use frapi.