### PR TITLE
Make event registration thread safe

### DIFF
--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/Event.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/Event.java
@@ -28,7 +28,7 @@ public abstract class Event<T> {
 	 * always refer to an instance containing all code that should be
 	 * executed upon event emission.
 	 */
-	protected T invoker;
+	protected volatile T invoker;
 
 	/**
 	 * Returns the invoker instance.


### PR DESCRIPTION
This will ensure that concurrent registrations are safe and ensure safe publication of the updated invoker. My chosen approach should be the most appropriate until Java 9, which could tweak the invoker access to use release/acquire instead of the full volatile.

Issue originally spotted by @Technici4n 