### PR TITLE
Fix material builder

### DIFF
--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricMaterialBuilder.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricMaterialBuilder.java
@@ -73,7 +73,7 @@ public class FabricMaterialBuilder extends Material.Builder {
 	}
 
 	@Override
-	public Material.Builder notSolid() {
+	public FabricMaterialBuilder notSolid() {
 		super.notSolid();
 		return this;
 	}


### PR DESCRIPTION
The `notSolid` method in `FabricMaterialBuilder` returns `Material.Builder` instead of `FabricMaterialBuilder`. Because this is a builder pattern, returning the super type prevents any subsequent method calls from using `FabricMaterialBuilder` methods.