### PR TITLE
Update key-binding-api-v1 example

### DIFF
--- a/fabric-key-binding-api-v1/build.gradle
+++ b/fabric-key-binding-api-v1/build.gradle
@@ -3,6 +3,6 @@ version = getSubprojectVersion(project, "1.0.2")
 
 dependencies {
 	testmodCompile project(path: ':fabric-api-base', configuration: 'dev')
-	testmodCompile project(path: ':fabric-events-lifecycle-v0', configuration: 'dev')
+	testmodCompile project(path: ':fabric-lifecycle-events-v1', configuration: 'dev')
 	testmodCompile project(path: ':fabric-resource-loader-v0', configuration: 'dev')
 }

--- a/fabric-key-binding-api-v1/src/testmod/java/net/fabricmc/fabric/test/client/keybinding/KeyBindingsTest.java
+++ b/fabric-key-binding-api-v1/src/testmod/java/net/fabricmc/fabric/test/client/keybinding/KeyBindingsTest.java
@@ -25,7 +25,7 @@ import net.minecraft.text.LiteralText;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
-import net.fabricmc.fabric.api.event.client.ClientTickCallback;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 
 public class KeyBindingsTest implements ClientModInitializer {
 	@Override
@@ -34,7 +34,7 @@ public class KeyBindingsTest implements ClientModInitializer {
 		KeyBinding binding2 = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.test_keybinding_2", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_U, "key.category.second.test"));
 		KeyBinding stickyBinding = KeyBindingHelper.registerKeyBinding(new StickyKeyBinding("key.fabric-key-binding-api-v1-testmod.test_keybinding_sticky", GLFW.GLFW_KEY_R, "key.category.first.test", () -> true));
 
-		ClientTickCallback.EVENT.register(client -> {
+		ClientTickEvents.END_CLIENT_TICK.register(client -> {
 			while (binding1.wasPressed()) {
 				client.player.sendMessage(new LiteralText("Key 1 was pressed!"), false);
 			}

--- a/fabric-key-binding-api-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-key-binding-api-v1/src/testmod/resources/fabric.mod.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "depends": {
     "fabric-api-base": "*",
-    "fabric-events-lifecycle-v0": "*",
+    "fabric-lifecycle-events-v1": "*",
     "fabric-key-binding-api-v1": "*"
   },
   "entrypoints": {


### PR DESCRIPTION
* Switches from events-lifecycle-v0 to lifecycle-events-v1