### PR TITLE
Compatibility with Gradle 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ def moduleDependencies(project, List<String> depNames) {
 	def deps = depNames.iterator().collect { project.dependencies.project(path: ":$it", configuration: 'dev') }
 	project.dependencies {
 		deps.each {
-			compile it
+			implementation it
 		}
 	}
 	project.publishing {
@@ -123,7 +123,7 @@ allprojects {
 	dependencies {
 		minecraft "com.mojang:minecraft:$Globals.mcVersion"
 		mappings "net.fabricmc:yarn:${Globals.mcVersion}${Globals.yarnVersion}:v2"
-		modCompile "net.fabricmc:fabric-loader:${Globals.loaderVersion}"
+		modImplementation "net.fabricmc:fabric-loader:${Globals.loaderVersion}"
 	}
 
 	configurations {
@@ -144,8 +144,8 @@ allprojects {
 
 	afterEvaluate {
 		remapJar {
-			input = file("${project.buildDir}/libs/$archivesBaseName-${version}-dev.jar")
-			archiveName = "${archivesBaseName}-${version}.jar"
+			input = file("${project.buildDir}/libs/$archivesBaseName-${archiveVersion}-dev.jar")
+			archiveFileName = "${archivesBaseName}-${archiveVersion}.jar"
 		}
 
 		artifacts {
@@ -233,7 +233,7 @@ task runAutoTestServer(type: RunServerTask) {
 
 subprojects {
 	dependencies {
-		testmodCompile sourceSets.main.output
+		testmodImplementation sourceSets.main.output
 	}
 
 	task remapMavenJar(type: Copy, dependsOn: remapJar) {
@@ -267,8 +267,8 @@ subprojects {
 
 task remapMavenJar(type: net.fabricmc.loom.task.RemapJarTask, dependsOn: jar) {
 	afterEvaluate {
-		input = file("${project.buildDir}/libs/${archivesBaseName}-${version}-dev.jar")
-		archiveName = "${archivesBaseName}-${version}-maven.jar"
+		input = file("${project.buildDir}/libs/${archivesBaseName}-${archiveVersion}-dev.jar")
+		archiveFileName = "${archivesBaseName}-${archiveVersion}-maven.jar"
 		addNestedDependencies = false
 	}
 }
@@ -327,10 +327,10 @@ sourceSets {
 dependencies {
 	afterEvaluate {
 		subprojects.each {
-			compile project(path: ":${it.name}", configuration: "dev")
+			implementation project(path: ":${it.name}", configuration: "dev")
 			include project("${it.name}:")
 
-			testmodCompile project("${it.name}:").sourceSets.testmod.output
+			testmodImplementation project("${it.name}:").sourceSets.testmod.output
 		}
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -144,8 +144,8 @@ allprojects {
 
 	afterEvaluate {
 		remapJar {
-			input = file("${project.buildDir}/libs/$archivesBaseName-${version}-dev.jar")
-			archiveFileName = "${archivesBaseName}-${archiveVersion}.jar"
+			input = file("${project.buildDir}/libs/$archivesBaseName-${archiveVersion.get()}-dev.jar")
+			archiveFileName = "${archivesBaseName}-${archiveVersion.get()}.jar"
 		}
 
 		artifacts {
@@ -267,8 +267,8 @@ subprojects {
 
 task remapMavenJar(type: net.fabricmc.loom.task.RemapJarTask, dependsOn: jar) {
 	afterEvaluate {
-		input = file("${project.buildDir}/libs/${archivesBaseName}-${archiveVersion}-dev.jar")
-		archiveFileName = "${archivesBaseName}-${archiveVersion}-maven.jar"
+		input = file("${project.buildDir}/libs/${archivesBaseName}-${archiveVersion.get()}-dev.jar")
+		archiveFileName = "${archivesBaseName}-${archiveVersion.get()}-maven.jar"
 		addNestedDependencies = false
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,7 @@ allprojects {
 
 	afterEvaluate {
 		remapJar {
-			input = file("${project.buildDir}/libs/$archivesBaseName-${archiveVersion}-dev.jar")
+			input = file("${project.buildDir}/libs/$archivesBaseName-${version}-dev.jar")
 			archiveFileName = "${archivesBaseName}-${archiveVersion}.jar"
 		}
 

--- a/fabric-api-base/build.gradle
+++ b/fabric-api-base/build.gradle
@@ -2,6 +2,6 @@ archivesBaseName = "fabric-api-base"
 version = getSubprojectVersion(project, "0.2.0")
 
 dependencies {
-	testmodCompile project(path: ':fabric-command-api-v1', configuration: 'dev')
-	testmodCompile project(path: ':fabric-lifecycle-events-v1', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-command-api-v1', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-lifecycle-events-v1', configuration: 'dev')
 }

--- a/fabric-command-api-v1/build.gradle
+++ b/fabric-command-api-v1/build.gradle
@@ -2,7 +2,7 @@ archivesBaseName = "fabric-command-api-v1"
 version = getSubprojectVersion(project, "1.0.10")
 
 dependencies {
-	testmodCompile project(path: ':fabric-lifecycle-events-v1', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-lifecycle-events-v1', configuration: 'dev')
 }
 
 moduleDependencies(project, [

--- a/fabric-dimensions-v1/build.gradle
+++ b/fabric-dimensions-v1/build.gradle
@@ -2,9 +2,9 @@ archivesBaseName = "fabric-dimensions-v1"
 version = getSubprojectVersion(project, "2.0.2")
 
 dependencies {
-	testmodCompile project(path: ':fabric-command-api-v1', configuration: 'dev')
-	testmodCompile project(path: ':fabric-resource-loader-v0', configuration: 'dev')
-	testmodCompile project(path: ':fabric-lifecycle-events-v1', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-command-api-v1', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-resource-loader-v0', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-lifecycle-events-v1', configuration: 'dev')
 }
 
 moduleDependencies(project, [

--- a/fabric-entity-events-v1/build.gradle
+++ b/fabric-entity-events-v1/build.gradle
@@ -6,5 +6,5 @@ moduleDependencies(project, [
 ])
 
 dependencies {
-	testmodCompile project(path: ':fabric-command-api-v1', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-command-api-v1', configuration: 'dev')
 }

--- a/fabric-game-rule-api-v1/build.gradle
+++ b/fabric-game-rule-api-v1/build.gradle
@@ -6,7 +6,7 @@ minecraft {
 }
 
 dependencies {
-	testmodCompile project(path: ':fabric-api-base', configuration: 'dev')
-	testmodCompile project(path: ':fabric-lifecycle-events-v1', configuration: 'dev')
-	testmodCompile project(path: ':fabric-resource-loader-v0', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-api-base', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-lifecycle-events-v1', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-resource-loader-v0', configuration: 'dev')
 }

--- a/fabric-key-binding-api-v1/build.gradle
+++ b/fabric-key-binding-api-v1/build.gradle
@@ -2,7 +2,7 @@ archivesBaseName = "fabric-key-binding-api-v1"
 version = getSubprojectVersion(project, "1.0.2")
 
 dependencies {
-	testmodCompile project(path: ':fabric-api-base', configuration: 'dev')
-	testmodCompile project(path: ':fabric-events-lifecycle-v0', configuration: 'dev')
-	testmodCompile project(path: ':fabric-resource-loader-v0', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-api-base', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-events-lifecycle-v0', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-resource-loader-v0', configuration: 'dev')
 }

--- a/fabric-networking-api-v1/build.gradle
+++ b/fabric-networking-api-v1/build.gradle
@@ -6,7 +6,7 @@ moduleDependencies(project, [
 ])
 
 dependencies {
-	testmodCompile project(path: ':fabric-command-api-v1', configuration: 'dev')
-	testmodCompile project(path: ':fabric-lifecycle-events-v1', configuration: 'dev')
-	testmodCompile project(path: ':fabric-key-binding-api-v1', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-command-api-v1', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-lifecycle-events-v1', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-key-binding-api-v1', configuration: 'dev')
 }

--- a/fabric-object-builder-api-v1/build.gradle
+++ b/fabric-object-builder-api-v1/build.gradle
@@ -2,7 +2,7 @@ archivesBaseName = "fabric-object-builder-api-v1"
 version = getSubprojectVersion(project, "1.9.3")
 
 dependencies {
-	testmodCompile project(path: ':fabric-command-api-v1', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-command-api-v1', configuration: 'dev')
 }
 
 moduleDependencies(project, [

--- a/fabric-renderer-registries-v1/build.gradle
+++ b/fabric-renderer-registries-v1/build.gradle
@@ -2,7 +2,7 @@ archivesBaseName = "fabric-renderer-registries-v1"
 version = getSubprojectVersion(project, "2.2.1")
 
 dependencies {
-	testmodCompile project(path: ':fabric-lifecycle-events-v1', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-lifecycle-events-v1', configuration: 'dev')
 }
 
 moduleDependencies(project, [

--- a/fabric-resource-loader-v0/build.gradle
+++ b/fabric-resource-loader-v0/build.gradle
@@ -2,6 +2,6 @@ archivesBaseName = "fabric-resource-loader-v0"
 version = getSubprojectVersion(project, "0.4.2")
 
 dependencies {
-	testmodCompile project(path: ':fabric-lifecycle-events-v1', configuration: 'dev')
-	testmodCompile project(path: ':fabric-api-base', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-lifecycle-events-v1', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-api-base', configuration: 'dev')
 }

--- a/fabric-tool-attribute-api-v1/build.gradle
+++ b/fabric-tool-attribute-api-v1/build.gradle
@@ -2,8 +2,8 @@ archivesBaseName = "fabric-tool-attribute-api-v1"
 version = getSubprojectVersion(project, "1.2.6")
 
 dependencies {
-	testmodCompile project(path: ':fabric-object-builder-api-v1', configuration: 'dev')
-	testmodCompile project(path: ':fabric-lifecycle-events-v1', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-object-builder-api-v1', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-lifecycle-events-v1', configuration: 'dev')
 }
 
 moduleDependencies(project, [


### PR DESCRIPTION
I used Gradle's CLI `--warning-mode all` option to show deprecation warnings then fixed them.

When importing with Gradle, it still shows the infamous warning:

> ```
> Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
> Use '--warning-mode all' to show the individual deprecation warnings.
> See https://docs.gradle.org/6.8.2/userguide/command_line_interface.html#sec:command_line_warnings
> ```

But I suspect that's got something to do with Loom itself, which will hopefully be fixed in 0.6.


fixes #1316 