### PR TITLE
Fix a WorldRenderEvents.BLOCK_OUTLINE bug

### DIFF
--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderContext.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderContext.java
@@ -120,7 +120,11 @@ public interface WorldRenderContext {
 	 * {@code WorldRenderer.drawBlockOutline}.
 	 */
 	@Environment(EnvType.CLIENT)
-	public interface BlockOutlineContext {
+	interface BlockOutlineContext {
+		/**
+		 * @deprecated Use {@link #consumers()} directly.
+		 */
+		@Deprecated
 		VertexConsumer vertexConsumer();
 
 		Entity entity();

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/impl/client/rendering/WorldRenderContextImpl.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/impl/client/rendering/WorldRenderContextImpl.java
@@ -21,6 +21,7 @@ import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.Frustum;
 import net.minecraft.client.render.GameRenderer;
 import net.minecraft.client.render.LightmapTextureManager;
+import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.WorldRenderer;
@@ -52,7 +53,6 @@ public final class WorldRenderContextImpl implements WorldRenderContext.BlockOut
 	private boolean advancedTranslucency;
 	private ClientWorld world;
 
-	private VertexConsumer vertexConsumer;
 	private Entity entity;
 	private double cameraX;
 	private double cameraY;
@@ -97,7 +97,6 @@ public final class WorldRenderContextImpl implements WorldRenderContext.BlockOut
 	}
 
 	public void prepareBlockOutline(
-			VertexConsumer vertexConsumer,
 			Entity entity,
 			double cameraX,
 			double cameraY,
@@ -105,7 +104,6 @@ public final class WorldRenderContextImpl implements WorldRenderContext.BlockOut
 			BlockPos blockPos,
 			BlockState blockState
 	) {
-		this.vertexConsumer = vertexConsumer;
 		this.entity = entity;
 		this.cameraX = cameraX;
 		this.cameraY = cameraY;
@@ -186,7 +184,7 @@ public final class WorldRenderContextImpl implements WorldRenderContext.BlockOut
 
 	@Override
 	public VertexConsumer vertexConsumer() {
-		return vertexConsumer;
+		return consumers.getBuffer(RenderLayer.getLines());
 	}
 
 	@Override

--- a/fabric-rendering-v1/src/testmod/java/net/fabricmc/fabric/test/rendering/client/WorldRenderEventsTests.java
+++ b/fabric-rendering-v1/src/testmod/java/net/fabricmc/fabric/test/rendering/client/WorldRenderEventsTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.rendering.client;
+
+import net.minecraft.block.Blocks;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.OverlayTexture;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
+import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
+
+public class WorldRenderEventsTests implements ClientModInitializer {
+	private static boolean onBlockOutline(WorldRenderContext wrc, WorldRenderContext.BlockOutlineContext blockOutlineContext) {
+		if (blockOutlineContext.blockState().isOf(Blocks.DIAMOND_BLOCK)) {
+			wrc.matrixStack().push();
+			Vec3d cameraPos = MinecraftClient.getInstance().gameRenderer.getCamera().getPos();
+			BlockPos pos = blockOutlineContext.blockPos();
+			double x = pos.getX() - cameraPos.x;
+			double y = pos.getY() - cameraPos.y;
+			double z = pos.getZ() - cameraPos.z;
+			wrc.matrixStack().translate(x+0.25, y+0.25+1, z+0.25);
+			wrc.matrixStack().scale(0.5f, 0.5f, 0.5f);
+
+			MinecraftClient.getInstance().getBlockRenderManager().renderBlockAsEntity(
+					Blocks.DIAMOND_BLOCK.getDefaultState(),
+					wrc.matrixStack(), wrc.consumers(), 15728880, OverlayTexture.DEFAULT_UV);
+
+			wrc.matrixStack().pop();
+		}
+
+		return true;
+	}
+
+	// Renders a diamond block above diamond blocks when they are looked at.
+	@Override
+	public void onInitializeClient() {
+		WorldRenderEvents.BLOCK_OUTLINE.register(WorldRenderEventsTests::onBlockOutline);
+	}
+}

--- a/fabric-rendering-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-rendering-v1/src/testmod/resources/fabric.mod.json
@@ -13,7 +13,8 @@
       "net.fabricmc.fabric.test.rendering.CustomArmorTests"
     ],
     "client": [
-      "net.fabricmc.fabric.test.rendering.client.CustomArmorTestsClient"
+      "net.fabricmc.fabric.test.rendering.client.CustomArmorTestsClient",
+      "net.fabricmc.fabric.test.rendering.client.WorldRenderEventsTests"
     ]
   }
 }


### PR DESCRIPTION
When `getBuffer` is called on `VertexConsumerProvider.Immediate` (the one used for outline rendering) with a different layer than the active one, it draws the old render layer and then changes its internal state to accept vertices for the format of the new render layer. In particular, this means that the `RenderLayer.getLines()` `VertexConsumer` obtained by vanilla before the `BLOCK_OUTLINE` event but used after the handlers are run may become invalid if the event handlers change the current render layer of the immediate mode VCP.

To reproduce, just put `worldRenderContext.consumers().getBuffer(RenderLayer.getTranslucent())` in an event handler and the game will crash when rendering the default block outline as it tries to emit lines to the immediate mode VCP still configured to emit translucent quads.

This PR:
* Adds a call to `getBuffer(RenderLayer.getLines())` after the invocation of the event handlers to make sure the default block outline emits to the immediate mode VCP in the correct state.
* Changes the implementation of `BlockOutlineContext#vertexConsumer()` to make sure that the VCP is in the correct state after each call, and deprecates the method as there is no reason to keep it.

Full discussion on fabricord: https://discord.com/channels/507304429255393322/566276937035546624/810582855603847169.