### PR TITLE
Add clear to MutableQuadView

### DIFF
--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
@@ -266,10 +266,10 @@ public interface MutableQuadView extends QuadView {
 	 */
 	MutableQuadView spriteBake(int spriteIndex, Sprite sprite, int bakeFlags);
 
-    /**
-     * Resets the current instance to default values. The instance will be in
-     * the same state after clearing as an equivalent {@link QuadEmitter} would be
-     * after emitting.
-     */
+	/**
+	 * Resets the current instance to default values. The instance will be in
+	 * the same state after clearing as an equivalent {@link QuadEmitter} would be
+	 * after emitting.
+	 */
 	MutableQuadView clear();
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
@@ -265,4 +265,11 @@ public interface MutableQuadView extends QuadView {
 	 * Behavior for {@code spriteIndex > 0} is currently undefined.
 	 */
 	MutableQuadView spriteBake(int spriteIndex, Sprite sprite, int bakeFlags);
+
+    /**
+     * Resets the current instance to default values. The instance will be in
+     * the same state after clearing as an equivalent {@link QuadEmitter} would be
+     * after emitting.
+     */
+	MutableQuadView clear();
 }

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
@@ -178,6 +178,8 @@ public interface QuadEmitter extends MutableQuadView {
 		return this;
 	}
 
+	QuadEmitter clear();
+
 	/**
 	 * In static mesh building, causes quad to be appended to the mesh being built.
 	 * In a dynamic render context, create a new quad to be output to rendering.

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
@@ -53,7 +53,7 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 		clear();
 	}
 
-    @Override
+	@Override
 	public MutableQuadViewImpl clear() {
 		System.arraycopy(EMPTY, 0, data, baseIndex, EncodingFormat.TOTAL_STRIDE);
 		isGeometryInvalid = true;

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
@@ -53,7 +53,8 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 		clear();
 	}
 
-	public void clear() {
+    @Override
+	public MutableQuadViewImpl clear() {
 		System.arraycopy(EMPTY, 0, data, baseIndex, EncodingFormat.TOTAL_STRIDE);
 		isGeometryInvalid = true;
 		nominalFace = null;
@@ -62,6 +63,7 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 		colorIndex(-1);
 		cullFace(null);
 		material(IndigoRenderer.MATERIAL_STANDARD);
+		return this;
 	}
 
 	@Override


### PR DESCRIPTION
Added a clear method to MutableQuadView and inheritors.

Indigo currently combines the MQV and QE impls anyway, and the clear method actually already exists. This PR provides a safer way to access it.