### PR TITLE
Add FabricItemSettings.fuel() as an alternative for FuelRegistry

### DIFF
--- a/fabric-item-api-v1/build.gradle
+++ b/fabric-item-api-v1/build.gradle
@@ -2,5 +2,8 @@ archivesBaseName = "fabric-item-api-v1"
 version = getSubprojectVersion(project, "1.2.1")
 
 moduleDependencies(project, [
-		'fabric-api-base'
+		'fabric-api-base',
+		'fabric-content-registries-v0',
+		'fabric-lifecycle-events-v1',
+		'fabric-resource-loader-v0'
 ])

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItemSettings.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItemSettings.java
@@ -61,7 +61,7 @@ public class FabricItemSettings extends Item.Settings {
 	 * @see net.fabricmc.fabric.api.registry.FuelRegistry
 	 */
 	public FabricItemSettings fuel(int cookTime) {
-		FabricItemInternals.setFuelCookTime(cookTime);
+		FabricItemInternals.computeExtraData(this).fuel(cookTime);
 		return this;
 	}
 

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItemSettings.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItemSettings.java
@@ -53,6 +53,18 @@ public class FabricItemSettings extends Item.Settings {
 		return this;
 	}
 
+	/**
+	 * Sets this item as a fuel, with a provided {@code cookTime}.
+	 *
+	 * @param cookTime the number of ticks before this item will be consumed in a furnace
+	 * @return this builder
+	 * @see net.fabricmc.fabric.api.registry.FuelRegistry
+	 */
+	public FabricItemSettings fuel(int cookTime) {
+		FabricItemInternals.setFuelCookTime(cookTime);
+		return this;
+	}
+
 	// Overrides of vanilla methods
 
 	@Override

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItemSettings.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItemSettings.java
@@ -54,14 +54,14 @@ public class FabricItemSettings extends Item.Settings {
 	}
 
 	/**
-	 * Sets this item as a fuel, with a provided {@code cookTime}.
+	 * Sets this item as a fuel, with a provided {@code burnTime}.
 	 *
-	 * @param cookTime the number of ticks before this item will be consumed in a furnace
+	 * @param burnTime the number of ticks before this item will be consumed in a furnace fuel slot
 	 * @return this builder
 	 * @see net.fabricmc.fabric.api.registry.FuelRegistry
 	 */
-	public FabricItemSettings fuel(int cookTime) {
-		FabricItemInternals.computeExtraData(this).fuel(cookTime);
+	public FabricItemSettings fuel(int burnTime) {
+		FabricItemInternals.computeExtraData(this).fuel(burnTime);
 		return this;
 	}
 

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItemSettings.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItemSettings.java
@@ -56,7 +56,6 @@ public class FabricItemSettings extends Item.Settings {
 	/**
 	 * Sets this item as a fuel, with a provided {@code burnTime}.
 	 *
-	 * @param burnTime the number of ticks before this item will be consumed in a furnace fuel slot
 	 * @return this builder
 	 * @see net.fabricmc.fabric.api.registry.FuelRegistry
 	 */

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/FabricItemInternals.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/FabricItemInternals.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.impl.item;
 
 import java.util.WeakHashMap;
 
+import net.fabricmc.fabric.api.registry.FuelRegistry;
 import net.minecraft.item.Item;
 
 import net.fabricmc.fabric.api.item.v1.CustomDamageHandler;
@@ -25,6 +26,7 @@ import net.fabricmc.fabric.api.item.v1.EquipmentSlotProvider;
 
 public final class FabricItemInternals {
 	private static final WeakHashMap<Item.Settings, ExtraData> extraData = new WeakHashMap<>();
+	private static int fuelCookTime = -1;
 
 	private FabricItemInternals() {
 	}
@@ -33,12 +35,20 @@ public final class FabricItemInternals {
 		return extraData.computeIfAbsent(settings, s -> new ExtraData());
 	}
 
+	public static void setFuelCookTime(int cookTime) {
+		fuelCookTime = cookTime;
+	}
+
 	public static void onBuild(Item.Settings settings, Item item) {
 		ExtraData data = extraData.get(settings);
 
 		if (data != null) {
 			((ItemExtensions) item).fabric_setEquipmentSlotProvider(data.equipmentSlotProvider);
 			((ItemExtensions) item).fabric_setCustomDamageHandler(data.customDamageHandler);
+		}
+
+		if (fuelCookTime != -1) {
+			FuelRegistry.INSTANCE.add(item, fuelCookTime);
 		}
 	}
 

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/FabricItemInternals.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/FabricItemInternals.java
@@ -41,8 +41,8 @@ public final class FabricItemInternals {
 			((ItemExtensions) item).fabric_setEquipmentSlotProvider(data.equipmentSlotProvider);
 			((ItemExtensions) item).fabric_setCustomDamageHandler(data.customDamageHandler);
 
-			if (data.fuelCookTime != -1) {
-				FuelRegistry.INSTANCE.add(item, data.fuelCookTime);
+			if (data.fuelBurnTime != -1) {
+				FuelRegistry.INSTANCE.add(item, data.fuelBurnTime);
 			}
 		}
 	}
@@ -50,7 +50,7 @@ public final class FabricItemInternals {
 	public static final class ExtraData {
 		private /* @Nullable */ EquipmentSlotProvider equipmentSlotProvider;
 		private /* @Nullable */ CustomDamageHandler customDamageHandler;
-		private int fuelCookTime = -1;
+		private int fuelBurnTime = -1;
 
 		public void equipmentSlot(EquipmentSlotProvider equipmentSlotProvider) {
 			this.equipmentSlotProvider = equipmentSlotProvider;
@@ -60,8 +60,8 @@ public final class FabricItemInternals {
 			this.customDamageHandler = handler;
 		}
 
-		public void fuel(int cookTime) {
-			this.fuelCookTime = cookTime;
+		public void fuel(int burnTime) {
+			this.fuelBurnTime = burnTime;
 		}
 	}
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/FabricItemInternals.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/FabricItemInternals.java
@@ -18,11 +18,11 @@ package net.fabricmc.fabric.impl.item;
 
 import java.util.WeakHashMap;
 
-import net.fabricmc.fabric.api.registry.FuelRegistry;
 import net.minecraft.item.Item;
 
 import net.fabricmc.fabric.api.item.v1.CustomDamageHandler;
 import net.fabricmc.fabric.api.item.v1.EquipmentSlotProvider;
+import net.fabricmc.fabric.api.registry.FuelRegistry;
 
 public final class FabricItemInternals {
 	private static final WeakHashMap<Item.Settings, ExtraData> extraData = new WeakHashMap<>();

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/FabricItemInternals.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/FabricItemInternals.java
@@ -26,7 +26,6 @@ import net.fabricmc.fabric.api.registry.FuelRegistry;
 
 public final class FabricItemInternals {
 	private static final WeakHashMap<Item.Settings, ExtraData> extraData = new WeakHashMap<>();
-	private static int fuelCookTime = -1;
 
 	private FabricItemInternals() {
 	}
@@ -35,26 +34,23 @@ public final class FabricItemInternals {
 		return extraData.computeIfAbsent(settings, s -> new ExtraData());
 	}
 
-	public static void setFuelCookTime(int cookTime) {
-		fuelCookTime = cookTime;
-	}
-
 	public static void onBuild(Item.Settings settings, Item item) {
 		ExtraData data = extraData.get(settings);
 
 		if (data != null) {
 			((ItemExtensions) item).fabric_setEquipmentSlotProvider(data.equipmentSlotProvider);
 			((ItemExtensions) item).fabric_setCustomDamageHandler(data.customDamageHandler);
-		}
 
-		if (fuelCookTime != -1) {
-			FuelRegistry.INSTANCE.add(item, fuelCookTime);
+			if (data.fuelCookTime != -1) {
+				FuelRegistry.INSTANCE.add(item, data.fuelCookTime);
+			}
 		}
 	}
 
 	public static final class ExtraData {
 		private /* @Nullable */ EquipmentSlotProvider equipmentSlotProvider;
 		private /* @Nullable */ CustomDamageHandler customDamageHandler;
+		private int fuelCookTime = -1;
 
 		public void equipmentSlot(EquipmentSlotProvider equipmentSlotProvider) {
 			this.equipmentSlotProvider = equipmentSlotProvider;
@@ -62,6 +58,10 @@ public final class FabricItemInternals {
 
 		public void customDamage(CustomDamageHandler handler) {
 			this.customDamageHandler = handler;
+		}
+
+		public void fuel(int cookTime) {
+			this.fuelCookTime = cookTime;
 		}
 	}
 }

--- a/fabric-item-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-item-api-v1/src/main/resources/fabric.mod.json
@@ -20,7 +20,8 @@
   ],
   "depends": {
     "fabricloader": ">=0.4.0",
-    "fabric-api-base": "*"
+    "fabric-api-base": "*",
+    "fabric-content-registries-v0": "*"
   },
   "description": "Hooks for items",
   "custom": {

--- a/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/FabricItemSettingsTests.java
+++ b/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/FabricItemSettingsTests.java
@@ -29,7 +29,7 @@ public class FabricItemSettingsTests implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		// Registers an item with a custom equipment slot.
-		Item testItem = new Item(new FabricItemSettings().group(ItemGroup.MISC).equipmentSlot(stack -> EquipmentSlot.CHEST));
+		Item testItem = new Item(new FabricItemSettings().group(ItemGroup.MISC).fuel(300).equipmentSlot(stack -> EquipmentSlot.CHEST));
 		Registry.register(Registry.ITEM, new Identifier("fabric-item-api-v1-testmod", "test_item"), testItem);
 	}
 }

--- a/fabric-item-api-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-item-api-v1/src/testmod/resources/fabric.mod.json
@@ -10,13 +10,11 @@
   },
   "entrypoints": {
     "main": [
-      "net.fabricmc.fabric.test.item.FabricItemSettingsTests"
+      "net.fabricmc.fabric.test.item.FabricItemSettingsTests",
+      "net.fabricmc.fabric.test.item.CustomDamageTest"
     ],
     "client": [
       "net.fabricmc.fabric.test.item.client.TooltipTests"
-    ],
-    "main": [
-      "net.fabricmc.fabric.test.item.CustomDamageTest"
     ]
   }
 }


### PR DESCRIPTION
This is just more handy to be able to register an item as fuel directly in its builder