### PR TITLE
Add ItemApiLookup

### DIFF
--- a/fabric-api-lookup-api-v1/README.md
+++ b/fabric-api-lookup-api-v1/README.md
@@ -4,7 +4,7 @@ This is useful when the same API could be implemented more than once or implemen
 See also the [package-info.java file](src/main/java/net/fabricmc/fabric/api/lookup/v1/package-info.java).
 
 * What we call an API is any object that can be offered or queried, possibly by different mods, to be used in an agreed-upon manner.
-* This module allows flexible retrieving of such APIs from blocks in the world, represented by the generic type `A`.
+* This module allows flexible retrieving of such APIs, represented by the generic type `A`, from blocks in the world or from items.
 * It also provides building blocks for defining custom ways of retrieving APIs from other game objects.
 
 # Retrieving APIs from blocks
@@ -12,12 +12,19 @@ See the javadoc of `BlockApiLookup` for a full usage example.
 
 ## [`BlockApiLookup`](src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiLookup.java)
 The primary way of querying API instances for blocks in the world.
-It exposes a `find` function to retrieve an API instance, and multiple `register*` functions to register Apis for blocks and block entities.
+It exposes a `find` function to retrieve an API instance, and multiple `register*` functions to register APIs for blocks and block entities.
 
 Instances can be obtained using the `get` function.
 
 ## [`BlockApiCache`](src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiCache.java)
 A `BlockApiLookup` bound to a position and a server world, allowing much faster repeated API queries.
+
+# Retrieving APIs from items
+See the javadoc of `ItemApiLookup` for a full usage example.
+
+## [`ItemApiLookup`](src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java)
+The way to query API instances from items.
+It exposes a `find` function to retrieve an API instance, and multiple `register*` functions to register APIs for items.
 
 # Retrieving APIs from custom objects
 The subpackage `custom` provides helper classes to accelerate implementations of `ApiLookup`s for custom objects,

--- a/fabric-api-lookup-api-v1/README.md
+++ b/fabric-api-lookup-api-v1/README.md
@@ -4,7 +4,7 @@ This is useful when the same API could be implemented more than once or implemen
 See also the [package-info.java file](src/main/java/net/fabricmc/fabric/api/lookup/v1/package-info.java).
 
 * What we call an API is any object that can be offered or queried, possibly by different mods, to be used in an agreed-upon manner.
-* This module allows flexible retrieving of such APIs, represented by the generic type `A`, from blocks in the world or from items.
+* This module allows flexible retrieving of such APIs, represented by the generic type `A`, from blocks in the world or from item stacks.
 * It also provides building blocks for defining custom ways of retrieving APIs from other game objects.
 
 # Retrieving APIs from blocks
@@ -23,7 +23,7 @@ A `BlockApiLookup` bound to a position and a server world, allowing much faster 
 See the javadoc of `ItemApiLookup` for a full usage example.
 
 ## [`ItemApiLookup`](src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java)
-The way to query API instances from items.
+The way to query API instances from item stacks.
 It exposes a `find` function to retrieve an API instance, and multiple `register*` functions to register APIs for items.
 
 # Retrieving APIs from custom objects

--- a/fabric-api-lookup-api-v1/build.gradle
+++ b/fabric-api-lookup-api-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-api-lookup-api-v1"
-version = getSubprojectVersion(project, "1.1.0")
+version = getSubprojectVersion(project, "1.2.0")
 
 moduleDependencies(project, [
 	'fabric-api-base',

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
@@ -133,7 +133,7 @@ public interface ItemApiLookup<A, C> {
 	 * The mapping from the parameters of the query to the API is handled by the passed {@link ItemApiProvider}.
 	 *
 	 * @param provider The provider.
-	 * @param items The blocks.
+	 * @param items The items.
 	 */
 	void registerForItems(ItemApiProvider<A, C> provider, ItemConvertible... items);
 
@@ -143,6 +143,16 @@ public interface ItemApiLookup<A, C> {
 	 * @param fallbackProvider The fallback provider.
 	 */
 	void registerFallback(ItemApiProvider<A, C> fallbackProvider);
+
+	/**
+	 * Return the API class of this lookup.
+	 */
+	Class<A> apiClass();
+
+	/**
+	 * Return the context class of this lookup.
+	 */
+	Class<C> contextClass();
 
 	@FunctionalInterface
 	interface ItemApiProvider<A, C> {

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
@@ -108,6 +108,10 @@ public interface ItemApiLookup<A, C> {
 	/**
 	 * Attempt to retrieve an API from an item stack.
 	 *
+	 * <p>Note: An API may or may not allow the item stack to be modified by the provider or the returned instance.
+	 * To know if it is allowed or not, implementors should refer to the documentation of the API itself,
+	 * and API authors are encouraged to document this behavior.
+	 *
 	 * @param itemStack The item stack.
 	 * @param context Additional context for the query, defined by type parameter C.
 	 * @return The retrieved API, or {@code null} if no API was found.
@@ -140,15 +144,19 @@ public interface ItemApiLookup<A, C> {
 	void registerFallback(ItemApiProvider<A, C> fallbackProvider);
 
 	@FunctionalInterface
-	interface ItemApiProvider<T, C> {
+	interface ItemApiProvider<A, C> {
 		/**
 		 * Return an API of type {@code A} if available for the given item stack with the given context, or {@code null} otherwise.
+		 *
+		 * <p>Note: An API may or may not allow the item stack to be modified by the provider or the returned instance.
+		 * To know if it is allowed or not, implementors should refer to the documentation of the API itself,
+		 * and API authors are encouraged to document this behavior.
 		 *
 		 * @param itemStack The item stack.
 		 * @param context Additional context passed to the query.
 		 * @return An API of type {@code A}, or {@code null} if no API is available.
 		 */
 		@Nullable
-		T find(ItemStack itemStack, C context);
+		A find(ItemStack itemStack, C context);
 	}
 }

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
@@ -108,9 +108,10 @@ public interface ItemApiLookup<A, C> {
 	/**
 	 * Attempt to retrieve an API from an item stack.
 	 *
-	 * <p>Note: An API may or may not allow the item stack to be modified by the provider or the returned instance.
-	 * To know if it is allowed or not, implementors should refer to the documentation of the API itself,
-	 * and API authors are encouraged to document this behavior.
+	 * <p>Note: An API may or may not allow the item stack to be modified by the returned instance.
+	 * API authors are strongly encouraged to document this behavior so that implementors can refer
+	 * to the API documentation.
+	 * <br>While providers may capture a reference to the stack, it is expected that they do not modify it directly.
 	 *
 	 * @param itemStack The item stack.
 	 * @param context Additional context for the query, defined by type parameter C.
@@ -148,9 +149,10 @@ public interface ItemApiLookup<A, C> {
 		/**
 		 * Return an API of type {@code A} if available for the given item stack with the given context, or {@code null} otherwise.
 		 *
-		 * <p>Note: An API may or may not allow the item stack to be modified by the provider or the returned instance.
-		 * To know if it is allowed or not, implementors should refer to the documentation of the API itself,
-		 * and API authors are encouraged to document this behavior.
+		 * <p>Note: An API may or may not allow the item stack to be modified by the returned instance.
+		 * API authors are strongly encouraged to document this behavior so that implementors can refer
+		 * to the API documentation.
+		 * <br>While providers may capture a reference to the stack, it is expected that they do not modify it directly.
 		 *
 		 * @param itemStack The item stack.
 		 * @param context Additional context passed to the query.

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.lookup.v1.item;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.item.Item;
+import net.minecraft.util.Identifier;
+import net.minecraft.item.ItemConvertible;
+
+import net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup;
+import net.fabricmc.fabric.impl.lookup.item.ItemApiLookupImpl;
+
+/**
+ * An object that allows retrieving APIs from blocks in a world.
+ * Instances of this interface can be obtained through {@link #get}.
+ *
+ * <p>When trying to {@link #find} an API for an item, the provider registered for that item will be queried if it exists.
+ * If it doesn't exist, or if it returns {@code null}, the fallback providers will be queried in order.
+ *
+ * <p><h3>Usage Example</h3>
+ * Let us reuse {@code FluidContainer} from {@linkplain BlockApiLookup the BlockApiLookup example}.
+ * We will query {@code FluidContainer} instances from (item, tag) pairs.
+ *
+ * <pre>{@code
+ * public interface FluidContainer {
+ *     boolean containsFluids(); // return true if not empty
+ * }}</pre>
+ * We need to create the ItemApiLookup, with context type {@code @Nullable CompoundTag}.
+ *
+ * <pre>{@code
+ * public final class MyApi {
+ *     public static final ItemApiLookup<FluidContainer, @Nullable CompoundTag> FLUID_CONTAINER_ITEM = ItemApiLookup.get(new Identifier("mymod:fluid_container"), FluidContainer.class, CompoundTag.class);
+ * }}</pre>
+ * API instances are easy to access:
+ *
+ * <pre>{@code
+ * FluidContainer container = MyApi.FLUID_CONTAINER_ITEM.find(item, tag);
+ * if (container != null) {
+ *     // Do something with the container
+ *     if (container.containsFluids()) {
+ *         System.out.println("It contains fluids!");
+ *     }
+ * }}</pre>
+ * For the query to return a useful result, we must expose the API:
+ *
+ * <pre>{@code
+ * // If the item directly implements the interface, registerSelf can be used.
+ * public class InfiniteWaterItem implements FluidContainer {
+ *     ＠Override
+ *     public boolean containsFluids() {
+ *         return true; // This item always contains fluids!
+ *     }
+ * }
+ * MyApi.FLUID_CONTAINER_ITEM.registerSelf(INFINITE_WATER_ITEM);
+ *
+ * // Otherwise, registerForItems can be used.
+ * MyApi.FLUID_CONTAINER_ITEM.registerForItems((item, tag) -> {
+ *     // return a FluidContainer for your item, or null if there is none
+ * }, ITEM_INSTANCE, ANOTHER_ITEM_INSTANCE); // register as many items as you want
+ *
+ * // General fallback, to interface with anything, for example another ItemApiLookup.
+ * MyApi.FLUID_CONTAINER_ITEM.registerFallback((item, tag) -> {
+ *     // return something if available, or null
+ * });}</pre>
+ *
+ * <p><h3>Generic context types</h3>
+ * Note that {@code FluidContainer} and {@code @Nullable CompoundTag} were completely arbitrary in this example.
+ * We can define any {@code ItemApiLookup&lt;A, C&gt;}, where {@code A} is the type of the queried API, and {@code C} is the type of the additional context
+ * (the tag parameter in the previous example).
+ * If no context is necessary, {@code Void} should be used, and {@code null} instances should be passed.
+ *
+ * @param <A> The type of the API.
+ * @param <C> The type of the additional context object.
+ */
+@ApiStatus.NonExtendable
+public interface ItemApiLookup<A, C> {
+	/**
+	 * Retrieve the {@link ItemApiLookup} associated with an identifier, or create it if it didn't exist yet.
+	 *
+	 * @param lookupId The unique identifier of the lookup.
+	 * @param apiClass The class of the API.
+	 * @param contextClass The class of the additional context.
+	 * @return The unique lookup with the passed lookupId.
+	 * @throws IllegalArgumentException If another {@code apiClass} or another {@code contextClass} was already registered with the same identifier.
+	 */
+	static <A, C> ItemApiLookup<A, C> get(Identifier lookupId, Class<A> apiClass, Class<C> contextClass) {
+		return ItemApiLookupImpl.get(lookupId, apiClass, contextClass);
+	}
+
+	/**
+	 * Attempt to retrieve an API from an item.
+	 *
+	 * @param item The item.
+	 * @param context Additional context for the query, defined by type parameter C.
+	 * @return The retrieved API, or {@code null} if no API was found.
+	 */
+	@Nullable
+	A find(Item item, C context);
+
+	/**
+	 * Expose the API for the passed items directly implementing it.
+	 *
+	 * @param items Items for which to expose the API.
+	 * @throws IllegalArgumentException If the API class is not assignable from a class of one of the items.
+	 */
+	void registerSelf(ItemConvertible... items);
+
+	/**
+	 * Expose the API for the passed items.
+	 * The mapping from the parameters of the query to the API is handled by the passed {@link ItemApiProvider}.
+	 *
+	 * @param provider The provider.
+	 * @param items The blocks.
+	 */
+	void registerForItems(ItemApiProvider<A, C> provider, ItemConvertible... items);
+
+	/**
+	 * Expose the API for all queries: the fallbacks providers will be invoked if no object was found using the regular providers.
+	 *
+	 * @param fallbackProvider The fallback provider.
+	 */
+	void registerFallback(ItemApiProvider<A, C> fallbackProvider);
+
+	@FunctionalInterface
+	interface ItemApiProvider<T, C> {
+		/**
+		 * Return an API of type {@code A} if available for the given item with the given context, or {@code null} otherwise.
+		 *
+		 * @param item The queried item.
+		 * @param context Additional context passed to the query.
+		 * @return An API of type {@code A}, or {@code null} if no API is available.
+		 */
+		@Nullable
+		T find(Item item, C context);
+	}
+}

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/package-info.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/package-info.java
@@ -23,7 +23,7 @@
  * <p><h2>Definitions and purpose</h2>
  * <ul>
  *     <li>What we call an <i>API</i> is any object that can be offered or queried, possibly by different mods, to be used in an agreed-upon manner.</li>
- *     <li>This module allows flexible retrieving of such APIs from blocks in the world, represented by the generic type {@code A}.</li>
+ *     <li>This module allows flexible retrieving of such APIs, represented by the generic type {@code A}, from blocks in the world or from items.</li>
  *     <li>It also provides building blocks for defining custom ways of retrieving APIs from other game objects.</li>
  * </ul>
  * </p>
@@ -41,6 +41,21 @@
  * 	   <li>{@code BlockApiLookup} instances can be accessed through {@link net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup#get BlockApiLookup#get()}.
  *     For optimal performance, it is better to store them in a {@code public static final} field instead of querying them multiple times.</li>
  *     <li>See {@link net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup BlockApiLookup} for example code.</li>
+ * </ul>
+ * </p>
+ *
+ * <p><h2>Retrieving APIs from items</h2>
+ * <ul>
+ *     <li>Item API queries work similarly to block queries.</li>
+ *     <li>An item query for an API is an operation that takes an item, and additional context of type {@code C}, and uses that
+ *     to find an object of type {@code A}, {@code null} if there was no such object.</li>
+ *     <li>{@link net.fabricmc.fabric.api.lookup.v1.item.ItemApiLookup ItemApiLookup&lt;A, C&gt;} instances
+ *     provide a {@link net.fabricmc.fabric.api.lookup.v1.item.ItemApiLookup#find find()} function that does exactly that,
+ *     and registration happens primarily through {@link net.fabricmc.fabric.api.lookup.v1.item.ItemApiLookup#registerSelf registerSelf()} and
+ *     {@link net.fabricmc.fabric.api.lookup.v1.item.ItemApiLookup#registerForItems registerForItems()}.</li>
+ *     <li>These instances can be accessed through {@link net.fabricmc.fabric.api.lookup.v1.item.ItemApiLookup#get ItemApiLookup#get()}
+ *     and should be stored in a {@code public static final} field.</li>
+ *     <li>See {@link net.fabricmc.fabric.api.lookup.v1.item.ItemApiLookup ItemApiLookup} for example code.</li>
  * </ul>
  * </p>
  *

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/package-info.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/package-info.java
@@ -23,7 +23,7 @@
  * <p><h2>Definitions and purpose</h2>
  * <ul>
  *     <li>What we call an <i>API</i> is any object that can be offered or queried, possibly by different mods, to be used in an agreed-upon manner.</li>
- *     <li>This module allows flexible retrieving of such APIs, represented by the generic type {@code A}, from blocks in the world or from items.</li>
+ *     <li>This module allows flexible retrieving of such APIs, represented by the generic type {@code A}, from blocks in the world or from item stacks.</li>
  *     <li>It also provides building blocks for defining custom ways of retrieving APIs from other game objects.</li>
  * </ul>
  * </p>
@@ -44,10 +44,10 @@
  * </ul>
  * </p>
  *
- * <p><h2>Retrieving APIs from items</h2>
+ * <p><h2>Retrieving APIs from item stacks</h2>
  * <ul>
  *     <li>Item API queries work similarly to block queries.</li>
- *     <li>An item query for an API is an operation that takes an item, and additional context of type {@code C}, and uses that
+ *     <li>An item query for an API is an operation that takes an item stack, and additional context of type {@code C}, and uses that
  *     to find an object of type {@code A}, {@code null} if there was no such object.</li>
  *     <li>{@link net.fabricmc.fabric.api.lookup.v1.item.ItemApiLookup ItemApiLookup&lt;A, C&gt;} instances
  *     provide a {@link net.fabricmc.fabric.api.lookup.v1.item.ItemApiLookup#find find()} function that does exactly that,

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
@@ -44,12 +44,14 @@ public class ItemApiLookupImpl<A, C> implements ItemApiLookup<A, C> {
 	}
 
 	private final Class<A> apiClass;
+	private final Class<C> contextClass;
 	private final ApiProviderMap<Item, ItemApiProvider<A, C>> providerMap = ApiProviderMap.create();
 	private final List<ItemApiProvider<A, C>> fallbackProviders = new CopyOnWriteArrayList<>();
 
 	@SuppressWarnings("unchecked")
 	private ItemApiLookupImpl(Class<?> apiClass, Class<?> contextClass) {
 		this.apiClass = (Class<A>) apiClass;
+		this.contextClass = (Class<C>) contextClass;
 	}
 
 	@Override
@@ -120,5 +122,15 @@ public class ItemApiLookupImpl<A, C> implements ItemApiLookup<A, C> {
 		Objects.requireNonNull(fallbackProvider, "ItemApiProvider may not be null.");
 
 		fallbackProviders.add(fallbackProvider);
+	}
+
+	@Override
+	public Class<A> apiClass() {
+		return apiClass;
+	}
+
+	@Override
+	public Class<C> contextClass() {
+		return contextClass;
 	}
 }

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
@@ -54,7 +54,7 @@ public class ItemApiLookupImpl<A, C> implements ItemApiLookup<A, C> {
 
 	@Override
 	public @Nullable A find(ItemStack itemStack, C context) {
-		Objects.requireNonNull(itemStack, "Item stack may not be null.");
+		Objects.requireNonNull(itemStack, "ItemStack may not be null.");
 
 		@Nullable
 		ItemApiProvider<A, C> provider = providerMap.get(itemStack.getItem());

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.lookup.item;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemConvertible;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+import net.fabricmc.fabric.api.lookup.v1.custom.ApiLookupMap;
+import net.fabricmc.fabric.api.lookup.v1.custom.ApiProviderMap;
+import net.fabricmc.fabric.api.lookup.v1.item.ItemApiLookup;
+
+public class ItemApiLookupImpl<A, C> implements ItemApiLookup<A, C> {
+	private static final Logger LOGGER = LogManager.getLogger("fabric-api-lookup-api-v1/item");
+	private static final ApiLookupMap<ItemApiLookup<?, ?>> LOOKUPS = ApiLookupMap.create(ItemApiLookupImpl::new);
+
+	@SuppressWarnings("unchecked")
+	public static <A, C> ItemApiLookup<A, C> get(Identifier lookupId, Class<A> apiClass, Class<C> contextClass) {
+		return (ItemApiLookup<A, C>) LOOKUPS.getLookup(lookupId, apiClass, contextClass);
+	}
+
+	private final Class<A> apiClass;
+	private final ApiProviderMap<Item, ItemApiProvider<A, C>> providerMap = ApiProviderMap.create();
+	private final List<ItemApiProvider<A, C>> fallbackProviders = new CopyOnWriteArrayList<>();
+
+	@SuppressWarnings("unchecked")
+	private ItemApiLookupImpl(Class<?> apiClass, Class<?> contextClass) {
+		this.apiClass = (Class<A>) apiClass;
+	}
+
+	@Override
+	public @Nullable A find(Item item, C context) {
+		Objects.requireNonNull(item, "Item may not be null.");
+
+		@Nullable
+		ItemApiProvider<A, C> provider = providerMap.get(item);
+
+		if (provider != null) {
+			A instance = provider.find(item, context);
+
+			if (instance != null) {
+				return instance;
+			}
+		}
+
+		for (ItemApiProvider<A, C> fallbackProvider : fallbackProviders) {
+			A instance = fallbackProvider.find(item, context);
+
+			if (instance != null) {
+				return instance;
+			}
+		}
+
+		return null;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void registerSelf(ItemConvertible... items) {
+		for (ItemConvertible itemConvertible : items) {
+			Item item = itemConvertible.asItem();
+
+			if (!apiClass.isAssignableFrom(item.getClass())) {
+				String errorMessage = String.format(
+						"Failed to register self-implementing items. API class %s is not assignable from item class %s.",
+						apiClass.getCanonicalName(),
+						item.getClass().getCanonicalName()
+				);
+				throw new IllegalArgumentException(errorMessage);
+			}
+		}
+
+		registerForItems((item, context) -> (A) item, items);
+	}
+
+	@Override
+	public void registerForItems(ItemApiProvider<A, C> provider, ItemConvertible... items) {
+		Objects.requireNonNull(provider, "ItemApiProvider may not be null.");
+
+		if (items.length == 0) {
+			throw new IllegalArgumentException("Must register at least one ItemConvertible instance with an ItemApiProvider.");
+		}
+
+		for (ItemConvertible itemConvertible : items) {
+			Item item = itemConvertible.asItem();
+			Objects.requireNonNull(item, "Item convertible in item form may not be null.");
+
+			if (providerMap.putIfAbsent(item, provider) != null) {
+				LOGGER.warn("Encountered duplicate API provider registration for item: " + Registry.ITEM.getId(item));
+			}
+		}
+	}
+
+	@Override
+	public void registerFallback(ItemApiProvider<A, C> fallbackProvider) {
+		Objects.requireNonNull(fallbackProvider, "ItemApiProvider may not be null.");
+
+		fallbackProviders.add(fallbackProvider);
+	}
+}

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemConvertible;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 
@@ -52,14 +53,14 @@ public class ItemApiLookupImpl<A, C> implements ItemApiLookup<A, C> {
 	}
 
 	@Override
-	public @Nullable A find(Item item, C context) {
-		Objects.requireNonNull(item, "Item may not be null.");
+	public @Nullable A find(ItemStack itemStack, C context) {
+		Objects.requireNonNull(itemStack, "Item stack may not be null.");
 
 		@Nullable
-		ItemApiProvider<A, C> provider = providerMap.get(item);
+		ItemApiProvider<A, C> provider = providerMap.get(itemStack.getItem());
 
 		if (provider != null) {
-			A instance = provider.find(item, context);
+			A instance = provider.find(itemStack, context);
 
 			if (instance != null) {
 				return instance;
@@ -67,7 +68,7 @@ public class ItemApiLookupImpl<A, C> implements ItemApiLookup<A, C> {
 		}
 
 		for (ItemApiProvider<A, C> fallbackProvider : fallbackProviders) {
-			A instance = fallbackProvider.find(item, context);
+			A instance = fallbackProvider.find(itemStack, context);
 
 			if (instance != null) {
 				return instance;
@@ -93,7 +94,7 @@ public class ItemApiLookupImpl<A, C> implements ItemApiLookup<A, C> {
 			}
 		}
 
-		registerForItems((item, context) -> (A) item, items);
+		registerForItems((itemStack, context) -> (A) itemStack.getItem(), items);
 	}
 
 	@Override

--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/FabricApiLookupTest.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/FabricApiLookupTest.java
@@ -34,6 +34,7 @@ import net.fabricmc.fabric.test.lookup.api.ItemApis;
 import net.fabricmc.fabric.test.lookup.api.ItemInsertable;
 import net.fabricmc.fabric.test.lookup.compat.InventoryExtractableProvider;
 import net.fabricmc.fabric.test.lookup.compat.InventoryInsertableProvider;
+import net.fabricmc.fabric.test.lookup.item.FabricItemApiLookupTest;
 
 public class FabricApiLookupTest implements ModInitializer {
 	public static final String MOD_ID = "fabric-lookup-api-v1-testmod";
@@ -47,6 +48,7 @@ public class FabricApiLookupTest implements ModInitializer {
 	public static final CobbleGenBlock COBBLE_GEN_BLOCK = new CobbleGenBlock(FabricBlockSettings.of(Material.METAL));
 	public static final BlockItem COBBLE_GEN_ITEM = new BlockItem(COBBLE_GEN_BLOCK, new Item.Settings().group(ItemGroup.MISC));
 	public static BlockEntityType<CobbleGenBlockEntity> COBBLE_GEN_BLOCK_ENTITY_TYPE;
+	// Testing for item api lookups is done in the `item` package.
 
 	@Override
 	public void onInitialize() {
@@ -69,6 +71,8 @@ public class FabricApiLookupTest implements ModInitializer {
 
 		testLookupRegistry();
 		testSelfRegistration();
+
+		FabricItemApiLookupTest.onInitialize();
 	}
 
 	private static void testLookupRegistry() {
@@ -98,7 +102,7 @@ public class FabricApiLookupTest implements ModInitializer {
 		}, "The BlockApiLookup should have prevented self-registration of incompatible block entity types.");
 	}
 
-	private static void ensureException(Runnable runnable, String message) {
+	public static void ensureException(Runnable runnable, String message) {
 		boolean failed = false;
 
 		try {

--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/item/FabricItemApiLookupTest.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/item/FabricItemApiLookupTest.java
@@ -49,7 +49,7 @@ public class FabricItemApiLookupTest {
 		// Test registerSelf
 		Inspectable.LOOKUP.registerSelf(HELLO_ITEM);
 		// Tools report their mining level
-		Inspectable.LOOKUP.registerFallback((stack, tag) -> {
+		Inspectable.LOOKUP.registerFallback((stack, ignored) -> {
 			Item item = stack.getItem();
 
 			if (item instanceof ToolItem) {

--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/item/FabricItemApiLookupTest.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/item/FabricItemApiLookupTest.java
@@ -19,7 +19,7 @@ package net.fabricmc.fabric.test.lookup.item;
 import static net.fabricmc.fabric.test.lookup.FabricApiLookupTest.ensureException;
 
 import net.minecraft.block.Material;
-import net.minecraft.item.ItemStack;
+import net.minecraft.item.Item;
 import net.minecraft.item.Items;
 import net.minecraft.item.ToolItem;
 import net.minecraft.text.LiteralText;
@@ -39,10 +39,7 @@ public class FabricItemApiLookupTest {
 		Registry.register(Registry.ITEM, new Identifier(FabricApiLookupTest.MOD_ID, "hello"), HELLO_ITEM);
 
 		// Diamonds and diamond blocks can be inspected and will also print their name.
-		Inspectable.LOOKUP.registerForItems((item, tag) -> () -> {
-			ItemStack stack = new ItemStack(item);
-			stack.setTag(tag);
-
+		Inspectable.LOOKUP.registerForItems((stack, ignored) -> () -> {
 			if (stack.hasCustomName()) {
 				return stack.getName();
 			} else {
@@ -52,7 +49,9 @@ public class FabricItemApiLookupTest {
 		// Test registerSelf
 		Inspectable.LOOKUP.registerSelf(HELLO_ITEM);
 		// Tools report their mining level
-		Inspectable.LOOKUP.registerFallback((item, tag) -> {
+		Inspectable.LOOKUP.registerFallback((stack, tag) -> {
+			Item item = stack.getItem();
+
 			if (item instanceof ToolItem) {
 				return () -> new LiteralText("Tool mining level: " + ((ToolItem) item).getMaterial().getMiningLevel());
 			} else {

--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/item/FabricItemApiLookupTest.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/item/FabricItemApiLookupTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.lookup.item;
+
+import static net.fabricmc.fabric.test.lookup.FabricApiLookupTest.ensureException;
+
+import net.minecraft.block.Material;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.item.ToolItem;
+import net.minecraft.text.LiteralText;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
+import net.fabricmc.fabric.test.lookup.FabricApiLookupTest;
+
+public class FabricItemApiLookupTest {
+	// Use /setblock to place it in the world.
+	public static final InspectorBlock INSPECTOR = new InspectorBlock(FabricBlockSettings.of(Material.METAL));
+	public static final InspectableItem HELLO_ITEM = new InspectableItem("Hello Fabric API tester!");
+
+	public static void onInitialize() {
+		Registry.register(Registry.BLOCK, new Identifier(FabricApiLookupTest.MOD_ID, "inspector"), INSPECTOR);
+		Registry.register(Registry.ITEM, new Identifier(FabricApiLookupTest.MOD_ID, "hello"), HELLO_ITEM);
+
+		// Diamonds and diamond blocks can be inspected and will also print their name.
+		Inspectable.LOOKUP.registerForItems((item, tag) -> () -> {
+			ItemStack stack = new ItemStack(item);
+			stack.setTag(tag);
+
+			if (stack.hasCustomName()) {
+				return stack.getName();
+			} else {
+				return new LiteralText("Unnamed gem.");
+			}
+		}, Items.DIAMOND, Items.DIAMOND_BLOCK);
+		// Test registerSelf
+		Inspectable.LOOKUP.registerSelf(HELLO_ITEM);
+		// Tools report their mining level
+		Inspectable.LOOKUP.registerFallback((item, tag) -> {
+			if (item instanceof ToolItem) {
+				return () -> new LiteralText("Tool mining level: " + ((ToolItem) item).getMaterial().getMiningLevel());
+			} else {
+				return null;
+			}
+		});
+
+		testSelfRegistration();
+	}
+
+	private static void testSelfRegistration() {
+		ensureException(() -> {
+			Inspectable.LOOKUP.registerSelf(Items.WATER_BUCKET);
+		}, "The ItemApiLookup should have prevented self-registration of incompatible items.");
+	}
+}

--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/item/Inspectable.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/item/Inspectable.java
@@ -16,9 +16,6 @@
 
 package net.fabricmc.fabric.test.lookup.item;
 
-import org.jetbrains.annotations.Nullable;
-
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
@@ -33,6 +30,6 @@ public interface Inspectable {
 	 */
 	Text inspect();
 
-	ItemApiLookup<Inspectable, @Nullable CompoundTag> LOOKUP =
-			ItemApiLookup.get(new Identifier("testmod:inspectable"), Inspectable.class, CompoundTag.class);
+	ItemApiLookup<Inspectable, Void> LOOKUP =
+			ItemApiLookup.get(new Identifier("testmod:inspectable"), Inspectable.class, Void.class);
 }

--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/item/Inspectable.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/item/Inspectable.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.lookup.item;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.api.lookup.v1.item.ItemApiLookup;
+
+/**
+ * An item that may provide an arbitrary text for display.
+ */
+public interface Inspectable {
+	/**
+	 * @return A text to print when a player right-clicks the Inspector block with this item.
+	 */
+	Text inspect();
+
+	ItemApiLookup<Inspectable, @Nullable CompoundTag> LOOKUP =
+			ItemApiLookup.get(new Identifier("testmod:inspectable"), Inspectable.class, CompoundTag.class);
+}

--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/item/InspectableItem.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/item/InspectableItem.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.lookup.item;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
+
+public class InspectableItem extends Item implements Inspectable {
+	private final String inspectionResult;
+
+	public InspectableItem(String inspectionResult) {
+		super(new Settings().group(ItemGroup.MISC));
+		this.inspectionResult = inspectionResult;
+	}
+
+	@Override
+	public Text inspect() {
+		return new LiteralText(inspectionResult);
+	}
+}

--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/item/InspectorBlock.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/item/InspectorBlock.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.lookup.item;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class InspectorBlock extends Block {
+	public InspectorBlock(Settings settings) {
+		super(settings);
+	}
+
+	@Override
+	public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit) {
+		ItemStack stack = player.getStackInHand(hand);
+		Inspectable inspectable = Inspectable.LOOKUP.find(stack.getItem(), stack.getTag());
+
+		if (inspectable != null) {
+			if (!world.isClient()) {
+				player.sendMessage(inspectable.inspect(), true);
+			}
+
+			return ActionResult.success(world.isClient());
+		}
+
+		return ActionResult.PASS;
+	}
+}

--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/item/InspectorBlock.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/item/InspectorBlock.java
@@ -34,7 +34,7 @@ public class InspectorBlock extends Block {
 	@Override
 	public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit) {
 		ItemStack stack = player.getStackInHand(hand);
-		Inspectable inspectable = Inspectable.LOOKUP.find(stack.getItem(), stack.getTag());
+		Inspectable inspectable = Inspectable.LOOKUP.find(stack, null);
 
 		if (inspectable != null) {
 			if (!world.isClient()) {


### PR DESCRIPTION
This PR extends #1234 to Item-provided APIs. The only (rather straightforward) API addition is [`ItemApiLookup`](https://github.com/FabLabsMC/fabric/blob/item-api-lookup/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java), there you can also find example code.

~~I decided to only have `Item` as the mandatory first parameter of queries, and let other information such as NBT or count be provided by the generic context `C`. I am pretty sure most APIs will be able to find an expressive context that suits them better.~~ The queries now have an `ItemStack` parameter.

There is no `ItemApiCache` because there are no expensive block state and block entity queries to cache.