### PR TITLE
Cleanup Events

### DIFF
--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
@@ -47,18 +47,70 @@ public final class EventFactory {
 
 	/**
 	 * Create an "array-backed" Event instance.
+	 * The factory will be used for any number of listeners.
+	 * Consider using {@link #createUnbad the more optimized overload} if you need a slight performance increase
+	 * when there are 0 or 1 listeners.
 	 *
 	 * @param type           The listener class type.
 	 * @param invokerFactory The invoker factory, combining multiple listeners into one instance.
 	 * @param <T>            The listener type.
 	 * @return The Event instance.
 	 */
+	public static <T> Event<T> createUnbad(Class<? super T> type, Function<T[], T> invokerFactory) {
+		return EventFactoryImpl.createUnbad(type, invokerFactory);
+	}
+
+	/**
+	 * Create an "array-backed" Event instance, with a custom empty invoker.
+	 * The empty invoker will be used when there are no listeners,
+	 * and when there is only one listener, it will be used directly.
+	 * The factory will only be used when there are at least two listeners.
+	 * Consider using {@link #createUnbad} if this optimization is unsuitable or unneeded.
+	 *
+	 * @param type           The listener class type.
+	 * @param emptyInvoker   The custom empty invoker.
+	 * @param invokerFactory The invoker factory, combining multiple listeners into one instance.
+	 * @param <T>            The listener type.
+	 * @return The Event instance.
+	 */
+	public static <T> Event<T> createUnbad(Class<? super T> type, T emptyInvoker, Function<T[], T> invokerFactory) {
+		return createUnbad(type, invokers -> {
+			if (invokers.length == 0) {
+				return emptyInvoker;
+			} else if (invokers.length == 1) {
+				return invokers[0];
+			} else {
+				return invokerFactory.apply(invokers);
+			}
+		});
+	}
+
+	/**
+	 * Create an "array-backed" Event instance.
+	 * The factory will be used when there are zero listeners, or at least two.
+	 * If there is only one listener, that one will be used as the invoker, and the factory will not be used!
+	 *
+	 * @param type           The listener class type.
+	 * @param invokerFactory The invoker factory, combining multiple listeners into one instance.
+	 * @param <T>            The listener type.
+	 * @return The Event instance.
+	 * @deprecated Use {@link #createUnbad(Class, Function) createUnbad}.
+	 */
+	@Deprecated
 	public static <T> Event<T> createArrayBacked(Class<? super T> type, Function<T[], T> invokerFactory) {
-		return EventFactoryImpl.createArrayBacked(type, invokerFactory);
+		return createUnbad(type, invokers -> {
+			if (invokers.length == 1) {
+				return invokers[0];
+			} else {
+				return invokerFactory.apply(invokers);
+			}
+		});
 	}
 
 	/**
 	 * Create an "array-backed" Event instance with a custom empty invoker.
+	 * The factory will only be used when there at least two invokers.
+	 * If there is only one listener, that one will be used as the invoker, and the factory will not be used!
 	 *
 	 * <p>Having a custom empty invoker (of type (...) -&gt; {}) increases performance
 	 * relative to iterating over an empty array; however, it only really matters
@@ -69,10 +121,11 @@ public final class EventFactory {
 	 * @param invokerFactory The invoker factory, combining multiple listeners into one instance.
 	 * @param <T>            The listener type.
 	 * @return The Event instance.
+	 * @deprecated Use {@link #createUnbad(Class, Object, Function)} instead.
 	 */
-	// TODO: Deprecate this once we have working codegen
+	@Deprecated
 	public static <T> Event<T> createArrayBacked(Class<T> type, T emptyInvoker, Function<T[], T> invokerFactory) {
-		return EventFactoryImpl.createArrayBacked(type, emptyInvoker, invokerFactory);
+		return createUnbad(type, emptyInvoker, invokerFactory);
 	}
 
 	/**

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
@@ -48,7 +48,7 @@ public final class EventFactory {
 	/**
 	 * Create an "array-backed" Event instance.
 	 * The factory will be used for any number of listeners.
-	 * Consider using {@link #createUnbad the more optimized overload} if you need a slight performance increase
+	 * Consider using {@link #createArrayBackedCustomEmptyInvoker(Class, Object, Function)}  the more optimized overload} if you need a slight performance increase
 	 * when there are 0 or 1 listeners.
 	 *
 	 * @param type           The listener class type.
@@ -56,8 +56,8 @@ public final class EventFactory {
 	 * @param <T>            The listener type.
 	 * @return The Event instance.
 	 */
-	public static <T> Event<T> createUnbad(Class<? super T> type, Function<T[], T> invokerFactory) {
-		return EventFactoryImpl.createUnbad(type, invokerFactory);
+	public static <T> Event<T> createArrayBackedUsingTheFactoryEveryTime(Class<? super T> type, Function<T[], T> invokerFactory) {
+		return EventFactoryImpl.createArrayBackedUsingTheFactoryEveryTime(type, invokerFactory);
 	}
 
 	/**
@@ -65,7 +65,7 @@ public final class EventFactory {
 	 * The empty invoker will be used when there are no listeners,
 	 * and when there is only one listener, it will be used directly.
 	 * The factory will only be used when there are at least two listeners.
-	 * Consider using {@link #createUnbad} if this optimization is unsuitable or unneeded.
+	 * Consider using {@link #createArrayBackedUsingTheFactoryEveryTime} if this optimization is unsuitable or unneeded.
 	 *
 	 * @param type           The listener class type.
 	 * @param emptyInvoker   The custom empty invoker.
@@ -73,8 +73,8 @@ public final class EventFactory {
 	 * @param <T>            The listener type.
 	 * @return The Event instance.
 	 */
-	public static <T> Event<T> createUnbad(Class<? super T> type, T emptyInvoker, Function<T[], T> invokerFactory) {
-		return createUnbad(type, invokers -> {
+	public static <T> Event<T> createArrayBackedCustomEmptyInvoker(Class<? super T> type, T emptyInvoker, Function<T[], T> invokerFactory) {
+		return createArrayBackedUsingTheFactoryEveryTime(type, invokers -> {
 			if (invokers.length == 0) {
 				return emptyInvoker;
 			} else if (invokers.length == 1) {
@@ -94,11 +94,11 @@ public final class EventFactory {
 	 * @param invokerFactory The invoker factory, combining multiple listeners into one instance.
 	 * @param <T>            The listener type.
 	 * @return The Event instance.
-	 * @deprecated Use {@link #createUnbad(Class, Function) createUnbad}.
+	 * @deprecated Use {@link #createArrayBackedUsingTheFactoryEveryTime(Class, Function) createUnbad}.
 	 */
 	@Deprecated
 	public static <T> Event<T> createArrayBacked(Class<? super T> type, Function<T[], T> invokerFactory) {
-		return createUnbad(type, invokers -> {
+		return createArrayBackedUsingTheFactoryEveryTime(type, invokers -> {
 			if (invokers.length == 1) {
 				return invokers[0];
 			} else {
@@ -121,11 +121,11 @@ public final class EventFactory {
 	 * @param invokerFactory The invoker factory, combining multiple listeners into one instance.
 	 * @param <T>            The listener type.
 	 * @return The Event instance.
-	 * @deprecated Use {@link #createUnbad(Class, Object, Function)} instead.
+	 * @deprecated Use {@link #createArrayBackedCustomEmptyInvoker(Class, Object, Function)} instead.
 	 */
 	@Deprecated
 	public static <T> Event<T> createArrayBacked(Class<T> type, T emptyInvoker, Function<T[], T> invokerFactory) {
-		return createUnbad(type, emptyInvoker, invokerFactory);
+		return createArrayBackedCustomEmptyInvoker(type, emptyInvoker, invokerFactory);
 	}
 
 	/**

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/ArrayBackedEvent.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/ArrayBackedEvent.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.impl.base.event;
 
 import java.lang.reflect.Array;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
@@ -25,52 +26,31 @@ import java.util.function.Function;
 import net.fabricmc.fabric.api.event.Event;
 
 class ArrayBackedEvent<T> extends Event<T> {
-	private final Class<? super T> type;
 	private final Function<T[], T> invokerFactory;
-	private final T dummyInvoker;
 	private final Lock lock = new ReentrantLock();
 	private T[] handlers;
 
-	ArrayBackedEvent(Class<? super T> type, T dummyInvoker, Function<T[], T> invokerFactory) {
-		this.type = type;
-		this.dummyInvoker = dummyInvoker;
+	@SuppressWarnings("unchecked")
+	ArrayBackedEvent(Class<? super T> type, Function<T[], T> invokerFactory) {
 		this.invokerFactory = invokerFactory;
+		this.handlers = (T[]) Array.newInstance(type, 0);
 		update();
 	}
 
-	@SuppressWarnings("unchecked")
 	void update() {
-		if (handlers == null) {
-			if (dummyInvoker != null) {
-				invoker = dummyInvoker;
-			} else {
-				invoker = invokerFactory.apply((T[]) Array.newInstance(type, 0));
-			}
-		} else if (handlers.length == 1) {
-			invoker = handlers[0];
-		} else {
-			invoker = invokerFactory.apply(handlers);
-		}
+		this.invoker = invokerFactory.apply(handlers);
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public void register(T listener) {
-		if (listener == null) {
-			throw new NullPointerException("Tried to register a null listener!");
-		}
+		Objects.requireNonNull(listener, "Tried to register a null listener!");
 
 		lock.lock();
 
 		try {
-			if (handlers == null) {
-				handlers = (T[]) Array.newInstance(type, 1);
-				handlers[0] = listener;
-			} else {
-				handlers = Arrays.copyOf(handlers, handlers.length + 1);
-				handlers[handlers.length - 1] = listener;
-			}
-
+			// We use a copy-on-write strategy to allow lock-free concurrent reads.
+			handlers = Arrays.copyOf(handlers, handlers.length + 1);
+			handlers[handlers.length - 1] = listener;
 			update();
 		} finally {
 			lock.unlock();

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/EventFactoryImpl.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/EventFactoryImpl.java
@@ -38,7 +38,7 @@ public final class EventFactoryImpl {
 		ARRAY_BACKED_EVENTS.forEach(ArrayBackedEvent::update);
 	}
 
-	public static <T> Event<T> createUnbad(Class<? super T> type, Function<T[], T> invokerFactory) {
+	public static <T> Event<T> createArrayBackedUsingTheFactoryEveryTime(Class<? super T> type, Function<T[], T> invokerFactory) {
 		ArrayBackedEvent<T> event = new ArrayBackedEvent<>(type, invokerFactory);
 		ARRAY_BACKED_EVENTS.add(event);
 		return event;

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/EventFactoryImpl.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/EventFactoryImpl.java
@@ -38,12 +38,8 @@ public final class EventFactoryImpl {
 		ARRAY_BACKED_EVENTS.forEach(ArrayBackedEvent::update);
 	}
 
-	public static <T> Event<T> createArrayBacked(Class<? super T> type, Function<T[], T> invokerFactory) {
-		return createArrayBacked(type, null /* buildEmptyInvoker(type, invokerFactory) */, invokerFactory);
-	}
-
-	public static <T> Event<T> createArrayBacked(Class<? super T> type, T emptyInvoker, Function<T[], T> invokerFactory) {
-		ArrayBackedEvent<T> event = new ArrayBackedEvent<>(type, emptyInvoker, invokerFactory);
+	public static <T> Event<T> createUnbad(Class<? super T> type, Function<T[], T> invokerFactory) {
+		ArrayBackedEvent<T> event = new ArrayBackedEvent<>(type, invokerFactory);
 		ARRAY_BACKED_EVENTS.add(event);
 		return event;
 	}


### PR DESCRIPTION
This PR cleans up the `ArrayBackedEvent` implementation and explores the use of a new `createArrayBacked` function that uses the `invokerFactory` for any number of listeners (the current functions don't call the `invokerFactory` when there is only 1 listener).

The main motivation for this PR is that something like #1322 can best be implemented as an event + an `instanceof` check for easy self-implementation on the relevant argument:
```java
public interface SlotClick {
    // Return false to stop vanilla Item#onClicked processing.
    boolean allowClick(Slot slot, ItemStack heldStack, ClickType type, PlayerInventory inventory);
}

Event<SlotClick> SLOT_CLICK = EventFactory.createArrayBacked(SlotClick.class, listeners -> (slot, heldStack, type, inventory) -> {
    boolean vanillaClick = true;
    if (slot instanceof SlotClick) {
        vanillaClick = ((SlotClick) slot).allowClick(slot, heldStack, type, inventory) && vanillaClick;
    }
    for (SlotClick listener : listeners) {
        vanillaClick = listener.allowClick(slot, heldStack, type, inventory) && vanillaClick;
    }
    return vanillaClick;
})
```

Sadly this won't work currently, as this will not be invoked when there is exactly one registered listener.
This PR explores how this could be improved, by introducing a new function similar to `createArrayBacked` that gives the factory full freedom to manage its listeners. Note how the old behavior is trivial to implement in terms of the new function.

I am suggesting a change in name so that the weird `createArrayBacked` that calls the factory in all cases except when there is 1 listener is not used by mistake.
The other overload can stay for performance-sensitive cases: either you specify an empty invoker AND singleton listeners are directly returned, or the invoker factory is called in every case, but I have deprecated the old name for consistency over the long run.

The new function name is obviously not suitable but I couldn't come up with a better name while writing this, so I decided to make the intent clear. I would like something quite different from the old name. Suggestions are welcome.

I have also massively cleaned up the `ArrayBackedEvent` implementation because frankly it was horrible. Registration performance is irrelevant anyway (as long as it's reasonable).