### PR TITLE
Add a Crossbow API to the Item API

### DIFF
--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ShotProjectileEvents.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ShotProjectileEvents.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.item.v1;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.projectile.PersistentProjectileEntity;
+import net.minecraft.item.ItemStack;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+public final class ShotProjectileEvents {
+	private ShotProjectileEvents() {
+	}
+
+	/**
+	 * This event modifies the projectile entity shot from a crossbow.
+	 */
+	public static final Event<ModifyProjectileFromCrossbow> CROSSBOW_MODIFY_SHOT_PROJECTILE = EventFactory.createArrayBacked(ModifyProjectileFromCrossbow.class, callbacks -> (bowStack, projectileStack, user, persistentProjectileEntity) -> {
+		for (ModifyProjectileFromCrossbow callback : callbacks) {
+			callback.modifyProjectileShot(bowStack, projectileStack, user, persistentProjectileEntity);
+		}
+	});
+
+	/**
+	 * This event replaces the projectile entity shot from a crossbow. Any modifications done in this step without returning a new entity can be erased.
+	 * Do not use this event to only modify the arrow entity, as {@link ShotProjectileEvents#CROSSBOW_MODIFY_SHOT_PROJECTILE} is the proper event.
+	 */
+	public static final Event<ReplaceProjectileFromCrossbow> CROSSBOW_REPLACE_SHOT_PROJECTILE = EventFactory.createArrayBacked(ReplaceProjectileFromCrossbow.class, callbacks -> (bowStack, projectileStack, user, persistentProjectileEntity) -> {
+		for (ReplaceProjectileFromCrossbow callback : callbacks) {
+			PersistentProjectileEntity replacedEntity = callback.replaceProjectileShot(bowStack, projectileStack, user, persistentProjectileEntity);
+
+			if (replacedEntity != null) {
+				return replacedEntity;
+			}
+		}
+
+		return persistentProjectileEntity;
+	});
+
+	public interface ReplaceProjectileFromCrossbow {
+		/**
+		 * In this method you can replace the arrow shot from your custom crossbow. Applies all of the vanilla arrow modifiers first.
+		 *
+		 * @param crossbowStack              The ItemStack for the Crossbow Item
+		 * @param projectileStack            The ItemStack for the projectile currently being shot
+		 * @param user                       The user of the crossbow
+		 * @param persistentProjectileEntity The arrow entity to be spawned
+		 * @return The new projectile entity. Return null if you do not change the entity.
+		 */
+		PersistentProjectileEntity replaceProjectileShot(ItemStack crossbowStack, ItemStack projectileStack, LivingEntity user, @NotNull PersistentProjectileEntity persistentProjectileEntity);
+	}
+
+	public interface ModifyProjectileFromCrossbow {
+		/**
+		 * In this method you can modify the behavior of arrows shot from your custom crossbow. Applies all of the vanilla arrow modifiers first.
+		 *
+		 * @param crossbowStack              The ItemStack for the Crossbow Item
+		 * @param projectileStack            The ItemStack for the projectile currently being shot
+		 * @param user                       The user of the crossbow
+		 * @param persistentProjectileEntity The arrow entity to be spawned
+		 */
+		void modifyProjectileShot(ItemStack crossbowStack, ItemStack projectileStack, LivingEntity user, @NotNull PersistentProjectileEntity persistentProjectileEntity);
+	}
+}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ShotProjectileEvents.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ShotProjectileEvents.java
@@ -58,11 +58,11 @@ public final class ShotProjectileEvents {
 		/**
 		 * In this method you can replace the arrow shot from your custom crossbow. Applies all of the vanilla arrow modifiers first.
 		 *
-		 * @param crossbowStack              The ItemStack for the Crossbow Item
-		 * @param projectileStack            The ItemStack for the projectile currently being shot
-		 * @param user                       The user of the crossbow
-		 * @param persistentProjectileEntity The arrow entity to be spawned
-		 * @return The new projectile entity. Return null if you do not change the entity.
+		 * @param crossbowStack              the ItemStack for the Crossbow Item
+		 * @param projectileStack            the ItemStack for the projectile currently being shot
+		 * @param user                       the user of the crossbow
+		 * @param persistentProjectileEntity the arrow entity to be spawned
+		 * @return the new projectile entity. Return null if you do not change the entity.
 		 */
 		PersistentProjectileEntity replaceProjectileShot(ItemStack crossbowStack, ItemStack projectileStack, LivingEntity user, @NotNull PersistentProjectileEntity persistentProjectileEntity);
 	}
@@ -71,10 +71,10 @@ public final class ShotProjectileEvents {
 		/**
 		 * In this method you can modify the behavior of arrows shot from your custom crossbow. Applies all of the vanilla arrow modifiers first.
 		 *
-		 * @param crossbowStack              The ItemStack for the Crossbow Item
-		 * @param projectileStack            The ItemStack for the projectile currently being shot
-		 * @param user                       The user of the crossbow
-		 * @param persistentProjectileEntity The arrow entity to be spawned
+		 * @param crossbowStack              the ItemStack for the Crossbow Item
+		 * @param projectileStack            the ItemStack for the projectile currently being shot
+		 * @param user                       the user of the crossbow
+		 * @param persistentProjectileEntity the arrow entity to be spawned
 		 */
 		void modifyProjectileShot(ItemStack crossbowStack, ItemStack projectileStack, LivingEntity user, @NotNull PersistentProjectileEntity persistentProjectileEntity);
 	}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ShotProjectileEvents.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ShotProjectileEvents.java
@@ -62,7 +62,7 @@ public final class ShotProjectileEvents {
 		 * @param projectileStack            The ItemStack for the projectile currently being shot
 		 * @param user                       The user of the crossbow
 		 * @param persistentProjectileEntity The arrow entity to be spawned
-		 * @return The new projectile entity. Return null if you do not change the entity.
+		 * @return the new projectile entity. Return {@code null} if you do not change the entity.
 		 */
 		PersistentProjectileEntity replaceProjectileShot(ItemStack crossbowStack, ItemStack projectileStack, LivingEntity user, @NotNull PersistentProjectileEntity persistentProjectileEntity);
 	}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/crossbow/FabricCrossbowExtensions.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/crossbow/FabricCrossbowExtensions.java
@@ -38,10 +38,10 @@ public interface FabricCrossbowExtensions extends ShotProjectileEvents.ModifyPro
 	 * Allows editing of the projectile entity shot from the crossbow. Applies all crossbow
 	 * projectile properties first.
 	 *
-	 * @param crossbowStack              The ItemStack for the crossbow
-	 * @param projectileStack            The stack for the projectile
-	 * @param entity                     The entity shooting the crossbow
-	 * @param persistentProjectileEntity The projectile entity to be shot
+	 * @param crossbowStack              the ItemStack for the crossbow
+	 * @param projectileStack            the stack for the projectile
+	 * @param entity                     the entity shooting the crossbow
+	 * @param persistentProjectileEntity the projectile entity to be shot
 	 */
 	void modifyProjectileShot(ItemStack crossbowStack, ItemStack projectileStack, LivingEntity entity, @NotNull PersistentProjectileEntity persistentProjectileEntity);
 
@@ -50,9 +50,9 @@ public interface FabricCrossbowExtensions extends ShotProjectileEvents.ModifyPro
 	 * To get the projectile from the crossbow, call {@link CrossbowItem#hasProjectile(ItemStack, Item)} passing in {@code stack} and the {@link Item} for the projectile. <br>
 	 * The default implementation follows the vanilla values for the projectiles
 	 *
-	 * @param stack  The ItemStack for the crossbow
-	 * @param entity The Entity shooting the crossbow
-	 * @return The speed of the projectile
+	 * @param stack  the ItemStack for the crossbow
+	 * @param entity the Entity shooting the crossbow
+	 * @return the speed of the projectile
 	 */
 	default float getProjectileSpeed(ItemStack stack, LivingEntity entity) {
 		return stack.getItem() == Items.CROSSBOW && CrossbowItem.hasProjectile(stack, Items.FIREWORK_ROCKET) ? 1.6F : 3.15F;

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/crossbow/FabricCrossbowExtensions.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/crossbow/FabricCrossbowExtensions.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.item.v1.crossbow;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.projectile.PersistentProjectileEntity;
+import net.minecraft.item.CrossbowItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+
+/**
+ * An interface to implement on all custom crossbows. <br>
+ * Note: This is meant to be used on a CrossbowItem class, otherwise the functionality won't work
+ *
+ * @see SimpleCrossbowItem
+ */
+public interface FabricCrossbowExtensions {
+	/**
+	 * Allows editing of the projectile entity shot from the crossbow. Applies all crossbow
+	 * projectile properties first.
+	 *
+	 * @param crossbowStack              The ItemStack for the crossbow
+	 * @param entity                     The entity shooting the crossbow
+	 * @param projectileStack            The stack for the projectile
+	 * @param persistentProjectileEntity The projectile entity to be shot
+	 */
+	void modifyShotProjectile(ItemStack crossbowStack, LivingEntity entity, ItemStack projectileStack, PersistentProjectileEntity persistentProjectileEntity);
+
+	/**
+	 * Allows modifying the speed of the crossbow projectile. <br>
+	 * To get the projectile from the crossbow, call {@link CrossbowItem#hasProjectile(ItemStack, Item)} passing in {@code stack} and the {@link Item} for the projectile. <br>
+	 * The default implementation follows the vanilla values for the projectiles
+	 *
+	 * @param stack  The ItemStack for the crossbow
+	 * @param entity The Entity shooting the crossbow
+	 * @return The speed of the projectile
+	 */
+	default float getProjectileSpeed(ItemStack stack, LivingEntity entity) {
+		return stack.getItem() == Items.CROSSBOW && CrossbowItem.hasProjectile(stack, Items.FIREWORK_ROCKET) ? 1.6F : 3.15F;
+	}
+}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/crossbow/FabricCrossbowExtensions.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/crossbow/FabricCrossbowExtensions.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.item.v1.crossbow;
 
+import org.jetbrains.annotations.NotNull;
+
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.projectile.PersistentProjectileEntity;
 import net.minecraft.item.CrossbowItem;
@@ -23,23 +25,25 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 
+import net.fabricmc.fabric.api.item.v1.ShotProjectileEvents;
+
 /**
  * An interface to implement on all custom crossbows. <br>
  * Note: This is meant to be used on a CrossbowItem class, otherwise the functionality won't work
  *
  * @see SimpleCrossbowItem
  */
-public interface FabricCrossbowExtensions {
+public interface FabricCrossbowExtensions extends ShotProjectileEvents.ModifyProjectileFromCrossbow {
 	/**
 	 * Allows editing of the projectile entity shot from the crossbow. Applies all crossbow
 	 * projectile properties first.
 	 *
 	 * @param crossbowStack              The ItemStack for the crossbow
-	 * @param entity                     The entity shooting the crossbow
 	 * @param projectileStack            The stack for the projectile
+	 * @param entity                     The entity shooting the crossbow
 	 * @param persistentProjectileEntity The projectile entity to be shot
 	 */
-	void modifyShotProjectile(ItemStack crossbowStack, LivingEntity entity, ItemStack projectileStack, PersistentProjectileEntity persistentProjectileEntity);
+	void modifyProjectileShot(ItemStack crossbowStack, ItemStack projectileStack, LivingEntity entity, @NotNull PersistentProjectileEntity persistentProjectileEntity);
 
 	/**
 	 * Allows modifying the speed of the crossbow projectile. <br>

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/crossbow/SimpleCrossbowItem.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/crossbow/SimpleCrossbowItem.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.item.v1.crossbow;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.projectile.PersistentProjectileEntity;
+import net.minecraft.item.CrossbowItem;
+import net.minecraft.item.ItemStack;
+
+/**
+ * This is the default implementation for FabricCrossbow, allowing for the easy creation of new bows with no new modded functionality.
+ */
+public class SimpleCrossbowItem extends CrossbowItem implements FabricCrossbowExtensions {
+	public SimpleCrossbowItem(Settings settings) {
+		super(settings);
+	}
+
+	@Override
+	public void modifyShotProjectile(ItemStack crossbowStack, LivingEntity entity, ItemStack projectileStack, PersistentProjectileEntity persistentProjectileEntity) {
+	}
+}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/crossbow/SimpleCrossbowItem.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/crossbow/SimpleCrossbowItem.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.item.v1.crossbow;
 
+import org.jetbrains.annotations.NotNull;
+
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.projectile.PersistentProjectileEntity;
 import net.minecraft.item.CrossbowItem;
@@ -30,6 +32,12 @@ public class SimpleCrossbowItem extends CrossbowItem implements FabricCrossbowEx
 	}
 
 	@Override
-	public void modifyShotProjectile(ItemStack crossbowStack, LivingEntity entity, ItemStack projectileStack, PersistentProjectileEntity persistentProjectileEntity) {
+	public void modifyProjectileShot(ItemStack crossbowStack, ItemStack projectileStack, LivingEntity user, @NotNull PersistentProjectileEntity persistentProjectileEntity) {
+		if (crossbowStack.getItem() == this) {
+			onProjectileShot(crossbowStack, projectileStack, user, persistentProjectileEntity);
+		}
+	}
+
+	public void onProjectileShot(ItemStack bowStack, ItemStack arrowStack, LivingEntity user, PersistentProjectileEntity persistentProjectileEntity) {
 	}
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/crossbow/CrossbowItemMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/crossbow/CrossbowItemMixin.java
@@ -31,15 +31,16 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.Hand;
 import net.minecraft.world.World;
 
+import net.fabricmc.fabric.api.item.v1.ShotProjectileEvents;
 import net.fabricmc.fabric.api.item.v1.crossbow.FabricCrossbowExtensions;
 
 @Mixin(CrossbowItem.class)
 public abstract class CrossbowItemMixin {
-	@Inject(method = "createArrow", at = @At(value = "RETURN"), locals = LocalCapture.CAPTURE_FAILSOFT)
+	@Inject(method = "createArrow", at = @At(value = "RETURN"), locals = LocalCapture.CAPTURE_FAILSOFT, cancellable = true)
 	private static void createArrow(World world, LivingEntity entity, ItemStack crossbow, ItemStack projectileStack, CallbackInfoReturnable<PersistentProjectileEntity> cir, ArrowItem arrowItem, PersistentProjectileEntity persistentProjectileEntity) {
-		if ((crossbow.getItem() instanceof FabricCrossbowExtensions)) {
-			((FabricCrossbowExtensions) crossbow.getItem()).modifyShotProjectile(crossbow, entity, projectileStack, persistentProjectileEntity);
-		}
+		persistentProjectileEntity = ShotProjectileEvents.CROSSBOW_REPLACE_SHOT_PROJECTILE.invoker().replaceProjectileShot(crossbow, projectileStack, entity, persistentProjectileEntity);
+		ShotProjectileEvents.CROSSBOW_MODIFY_SHOT_PROJECTILE.invoker().modifyProjectileShot(crossbow, projectileStack, entity, persistentProjectileEntity);
+		cir.setReturnValue(persistentProjectileEntity);
 	}
 
 	//Redirecting this method in order to get the item stack and shooting entity

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/crossbow/CrossbowItemMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/crossbow/CrossbowItemMixin.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.crossbow;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.projectile.PersistentProjectileEntity;
+import net.minecraft.item.ArrowItem;
+import net.minecraft.item.CrossbowItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Hand;
+import net.minecraft.world.World;
+
+import net.fabricmc.fabric.api.item.v1.crossbow.FabricCrossbowExtensions;
+
+@Mixin(CrossbowItem.class)
+public abstract class CrossbowItemMixin {
+	@Inject(method = "createArrow", at = @At(value = "RETURN"), locals = LocalCapture.CAPTURE_FAILSOFT)
+	private static void createArrow(World world, LivingEntity entity, ItemStack crossbow, ItemStack projectileStack, CallbackInfoReturnable<PersistentProjectileEntity> cir, ArrowItem arrowItem, PersistentProjectileEntity persistentProjectileEntity) {
+		if ((crossbow.getItem() instanceof FabricCrossbowExtensions)) {
+			((FabricCrossbowExtensions) crossbow.getItem()).modifyShotProjectile(crossbow, entity, projectileStack, persistentProjectileEntity);
+		}
+	}
+
+	//Redirecting this method in order to get the item stack and shooting entity
+	@Redirect(method = "use", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/CrossbowItem;shootAll(Lnet/minecraft/world/World;Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/item/ItemStack;FF)V"))
+	private void shootAll(World world, LivingEntity entity, Hand hand, ItemStack stack, float speed, float divergence) {
+		float _speed = stack.getItem() instanceof FabricCrossbowExtensions ? ((FabricCrossbowExtensions) stack.getItem()).getProjectileSpeed(stack, entity) : speed;
+		CrossbowItem.shootAll(world, entity, hand, stack, _speed, 1.0F);
+	}
+}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/crossbow/CrossbowItemMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/crossbow/CrossbowItemMixin.java
@@ -46,7 +46,7 @@ public abstract class CrossbowItemMixin {
 	//Redirecting this method in order to get the item stack and shooting entity
 	@Redirect(method = "use", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/CrossbowItem;shootAll(Lnet/minecraft/world/World;Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/item/ItemStack;FF)V"))
 	private void shootAll(World world, LivingEntity entity, Hand hand, ItemStack stack, float speed, float divergence) {
-		float _speed = stack.getItem() instanceof FabricCrossbowExtensions ? ((FabricCrossbowExtensions) stack.getItem()).getProjectileSpeed(stack, entity) : speed;
-		CrossbowItem.shootAll(world, entity, hand, stack, _speed, 1.0F);
+		float newSpeed = stack.getItem() instanceof FabricCrossbowExtensions ? ((FabricCrossbowExtensions) stack.getItem()).getProjectileSpeed(stack, entity) : speed;
+		CrossbowItem.shootAll(world, entity, hand, stack, newSpeed, 1.0F);
 	}
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/crossbow/EntityUseCrossbowMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/crossbow/EntityUseCrossbowMixin.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.crossbow;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.entity.mob.PiglinEntity;
+import net.minecraft.entity.mob.PillagerEntity;
+import net.minecraft.item.CrossbowItem;
+import net.minecraft.item.RangedWeaponItem;
+
+// Allows Crossbow users to use custom crossbows
+@Mixin({PiglinEntity.class, PillagerEntity.class})
+public class EntityUseCrossbowMixin {
+	@Inject(method = "canUseRangedWeapon", at = @At("HEAD"))
+	public void canUseRangedWeapon(RangedWeaponItem weapon, CallbackInfoReturnable<Boolean> cir) {
+		if (weapon instanceof CrossbowItem) {
+			cir.setReturnValue(true);
+		}
+	}
+}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/crossbow/client/PlayerEntityRendererMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/crossbow/client/PlayerEntityRendererMixin.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.crossbow.client;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.client.network.AbstractClientPlayerEntity;
+import net.minecraft.client.render.entity.PlayerEntityRenderer;
+import net.minecraft.client.render.entity.model.BipedEntityModel;
+import net.minecraft.item.CrossbowItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Hand;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.item.v1.crossbow.FabricCrossbowExtensions;
+
+@Environment(EnvType.CLIENT)
+@Mixin(PlayerEntityRenderer.class)
+public class PlayerEntityRendererMixin {
+	@Inject(method = "getArmPose", at = @At("HEAD"), cancellable = true)
+	private static void getArmPose(AbstractClientPlayerEntity abstractClientPlayerEntity, Hand hand, CallbackInfoReturnable<BipedEntityModel.ArmPose> cir) {
+		ItemStack stackInHand = abstractClientPlayerEntity.getStackInHand(hand);
+
+		if (!abstractClientPlayerEntity.handSwinging && stackInHand.getItem() instanceof FabricCrossbowExtensions && CrossbowItem.isCharged(stackInHand)) {
+			cir.setReturnValue(BipedEntityModel.ArmPose.CROSSBOW_HOLD);
+		}
+	}
+}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ProjectileUtilMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ProjectileUtilMixin.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.item;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.projectile.ProjectileUtil;
+import net.minecraft.item.Item;
+import net.minecraft.item.Items;
+import net.minecraft.util.Hand;
+
+import net.fabricmc.fabric.api.item.v1.crossbow.FabricCrossbowExtensions;
+
+@Mixin(ProjectileUtil.class)
+public abstract class ProjectileUtilMixin {
+	private static final Hand[] HANDS = {Hand.MAIN_HAND, Hand.OFF_HAND}; // Cache the hands to not create the hands array each time the loop is run
+
+	// Because the uses of this method are hardcoded, checking each hand for the Fabric interfaces of the items is needed.
+	// Note: this does not cancel for the vanilla items unless they are holding a custom implementation of the items
+	@Inject(method = "getHandPossiblyHolding", at = @At(value = "HEAD"), cancellable = true)
+	private static void getHandPossiblyHolding(LivingEntity entity, Item item, CallbackInfoReturnable<Hand> cir) {
+		for (Hand hand : HANDS) {
+			if (item == Items.CROSSBOW) { // Make sure we only check for crossbows when searching for crossbows and allow for other items like bows in future
+				if (entity.getStackInHand(hand).getItem() instanceof FabricCrossbowExtensions) {
+					cir.setReturnValue(hand);
+					return;
+				}
+			}
+		}
+	}
+}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/client/HeldItemRendererMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/client/HeldItemRendererMixin.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.item.client;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.client.render.item.HeldItemRenderer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+
+import net.fabricmc.fabric.api.item.v1.crossbow.FabricCrossbowExtensions;
+
+@Mixin(HeldItemRenderer.class)
+public class HeldItemRendererMixin {
+	@Redirect(method = "renderFirstPersonItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getItem()Lnet/minecraft/item/Item;"))
+	private Item renderFirstPersonItem(ItemStack heldItem) {
+		if (heldItem.getItem() instanceof FabricCrossbowExtensions) {
+			return Items.CROSSBOW; // Return true to invoke crossbow rendering path
+		}
+
+		return heldItem.getItem();
+	}
+
+	@Redirect(method = "renderItem(FLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider$Immediate;Lnet/minecraft/client/network/ClientPlayerEntity;I)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getItem()Lnet/minecraft/item/Item;"))
+	private Item renderItem(ItemStack heldItem) {
+		return (heldItem.getItem() instanceof FabricCrossbowExtensions) ? Items.CROSSBOW : heldItem.getItem();
+	}
+}

--- a/fabric-item-api-v1/src/main/resources/fabric-item-api-v1-crossbow.mixins.json
+++ b/fabric-item-api-v1/src/main/resources/fabric-item-api-v1-crossbow.mixins.json
@@ -1,0 +1,15 @@
+{
+  "required": true,
+  "package": "net.fabricmc.fabric.mixin.crossbow",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "CrossbowItemMixin",
+    "EntityUseCrossbowMixin"
+  ],
+  "client": [
+    "client.PlayerEntityRendererMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.mixins.json
+++ b/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.mixins.json
@@ -5,9 +5,11 @@
   "mixins": [
     "ItemStackMixin",
     "ItemMixin",
-    "MobEntityMixin"
+    "MobEntityMixin",
+    "ProjectileUtilMixin"
   ],
   "client": [
+    "client.HeldItemRendererMixin",
     "client.ItemStackMixin"
   ],
   "injectors": {

--- a/fabric-item-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-item-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,8 @@
     "FabricMC"
   ],
   "mixins": [
-    "fabric-item-api-v1.mixins.json"
+    "fabric-item-api-v1.mixins.json",
+    "fabric-item-api-v1-crossbow.mixins.json"
   ],
   "depends": {
     "fabricloader": ">=0.4.0",

--- a/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/FabricCrossbowTests.java
+++ b/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/FabricCrossbowTests.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.test.item;
 
+import org.jetbrains.annotations.NotNull;
+
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.projectile.PersistentProjectileEntity;
 import net.minecraft.item.Item;
@@ -30,7 +32,7 @@ import net.fabricmc.fabric.api.item.v1.crossbow.SimpleCrossbowItem;
 public class FabricCrossbowTests implements ModInitializer {
 	public static final Item TEST_CROSSBOW = new SimpleCrossbowItem(new Item.Settings().group(ItemGroup.COMBAT)) {
 		@Override
-		public void modifyShotProjectile(ItemStack crossbowStack, LivingEntity entity, ItemStack projectileStack, PersistentProjectileEntity persistentProjectileEntity) {
+		public void modifyProjectileShot(ItemStack crossbowStack, ItemStack projectileStack, LivingEntity entity, @NotNull PersistentProjectileEntity persistentProjectileEntity) {
 			persistentProjectileEntity.setDamage(1000);
 		}
 

--- a/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/FabricCrossbowTests.java
+++ b/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/FabricCrossbowTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.item;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.projectile.PersistentProjectileEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.item.v1.crossbow.SimpleCrossbowItem;
+
+public class FabricCrossbowTests implements ModInitializer {
+	public static final Item TEST_CROSSBOW = new SimpleCrossbowItem(new Item.Settings().group(ItemGroup.COMBAT)) {
+		@Override
+		public void modifyShotProjectile(ItemStack crossbowStack, LivingEntity entity, ItemStack projectileStack, PersistentProjectileEntity persistentProjectileEntity) {
+			persistentProjectileEntity.setDamage(1000);
+		}
+
+		@Override
+		public float getProjectileSpeed(ItemStack stack, LivingEntity entity) {
+			return 10f;
+		}
+	};
+
+	@Override
+	public void onInitialize() {
+		// Registers a custom crossbow.
+		Registry.register(Registry.ITEM, new Identifier("fabric-extensibility-api-v1-testmod", "test_crossbow"), TEST_CROSSBOW);
+	}
+}

--- a/fabric-item-api-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-item-api-v1/src/testmod/resources/fabric.mod.json
@@ -10,13 +10,12 @@
   },
   "entrypoints": {
     "main": [
-      "net.fabricmc.fabric.test.item.FabricItemSettingsTests"
+      "net.fabricmc.fabric.test.item.FabricItemSettingsTests",
+      "net.fabricmc.fabric.test.item.CustomDamageTest",
+      "net.fabricmc.fabric.test.item.FabricCrossbowTests"
     ],
     "client": [
       "net.fabricmc.fabric.test.item.client.TooltipTests"
-    ],
-    "main": [
-      "net.fabricmc.fabric.test.item.CustomDamageTest"
     ]
   }
 }


### PR DESCRIPTION
Very similar to #1210, in fact, some classes are the same, just with the other pr's logic removed (I will update the other or once one is merged). Luckily crossbows are less :mojank: and the logic for firing them is not attached to the users, but the item itself, reducing the complexity of the event system.