### PR TITLE
Change event behavior for one listener, introduce `AutoInvokingEvent`, update `ArrayBackedEvent` implementation

### DIFF
--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/AutoInvokingEvent.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/AutoInvokingEvent.java
@@ -1,6 +1,10 @@
 package net.fabricmc.fabric.api.event;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Indicates that this {@link Event} is auto-invoking:

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/AutoInvokingEvent.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/AutoInvokingEvent.java
@@ -1,0 +1,35 @@
+package net.fabricmc.fabric.api.event;
+
+import java.lang.annotation.*;
+
+/**
+ * Indicates that this {@link Event} is auto-invoking:
+ * it calls the event callback implemented by a context parameter type automatically and without registration.
+ *
+ * <p>This means that this event can be listened to in two ways:
+ * <ul>
+ *     <li>If the consumer is the context parameter and it implements the callback, it will be automatically invoked, don't register manually.
+ *     <li>Otherwise, there is no invocation and the listener needs manual registration as usual.
+ * </ul>
+ *
+ * <p>Do note that there may be more than one context parameter.
+ *
+ * <p>A typical use case is feature augmentation, for example to expose raw clicks to slots.
+ * The event callback has a slot parameter - the context parameter - and the event itself is carrying this annotation.
+ * All the slot needs to receive slot clicks is to implement {@code SlotClickCallback} on itself.
+ * It shouldn't do any explicit event registration like {@code SLOT_CLICK_EVENT.register(this::onSlotClick)},
+ * otherwise it will see extraneous callback invocations.
+ *
+ * <p>In general, an auto-invoking event bridges the gap between the flexibility of an event with global reach,
+ * and the convenience of implementing an interface that gets detected automatically.
+ *
+ * <p>This is a documentation-only annotation, the event factory has to implement the functionality explicitly by checking the parameter type and invoking it.
+ * On top of adding this annotation, the event field or method should document which parameters are context parameters,
+ * and under which circumstances they are invoked.
+ */
+// TODO: explore enforcing that auto-invoked listeners don't register themselves.
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.METHOD })
+public @interface AutoInvokingEvent {
+}

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/AutoInvokingEvent.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/AutoInvokingEvent.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.api.event;
 
 import java.lang.annotation.Documented;

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
@@ -47,70 +47,25 @@ public final class EventFactory {
 
 	/**
 	 * Create an "array-backed" Event instance.
-	 * The factory will be used for any number of listeners.
-	 * Consider using {@link #createArrayBackedCustomEmptyInvoker(Class, Object, Function)}  the more optimized overload} if you need a slight performance increase
-	 * when there are 0 or 1 listeners.
+	 * The factory will be used to create the invoker for any number of listeners.
+	 *
+	 * Consider using {@linkplain #createArrayBacked(Class, Object, Function) a custom empty invoker}
+	 * if performance of this event is critical.
 	 *
 	 * @param type           The listener class type.
 	 * @param invokerFactory The invoker factory, combining multiple listeners into one instance.
 	 * @param <T>            The listener type.
 	 * @return The Event instance.
 	 */
-	public static <T> Event<T> createArrayBackedUsingTheFactoryEveryTime(Class<? super T> type, Function<T[], T> invokerFactory) {
-		return EventFactoryImpl.createArrayBackedUsingTheFactoryEveryTime(type, invokerFactory);
-	}
-
-	/**
-	 * Create an "array-backed" Event instance, with a custom empty invoker.
-	 * The empty invoker will be used when there are no listeners,
-	 * and when there is only one listener, it will be used directly.
-	 * The factory will only be used when there are at least two listeners.
-	 * Consider using {@link #createArrayBackedUsingTheFactoryEveryTime} if this optimization is unsuitable or unneeded.
-	 *
-	 * @param type           The listener class type.
-	 * @param emptyInvoker   The custom empty invoker.
-	 * @param invokerFactory The invoker factory, combining multiple listeners into one instance.
-	 * @param <T>            The listener type.
-	 * @return The Event instance.
-	 */
-	public static <T> Event<T> createArrayBackedCustomEmptyInvoker(Class<? super T> type, T emptyInvoker, Function<T[], T> invokerFactory) {
-		return createArrayBackedUsingTheFactoryEveryTime(type, invokers -> {
-			if (invokers.length == 0) {
-				return emptyInvoker;
-			} else if (invokers.length == 1) {
-				return invokers[0];
-			} else {
-				return invokerFactory.apply(invokers);
-			}
-		});
-	}
-
-	/**
-	 * Create an "array-backed" Event instance.
-	 * The factory will be used when there are zero listeners, or at least two.
-	 * If there is only one listener, that one will be used as the invoker, and the factory will not be used!
-	 *
-	 * @param type           The listener class type.
-	 * @param invokerFactory The invoker factory, combining multiple listeners into one instance.
-	 * @param <T>            The listener type.
-	 * @return The Event instance.
-	 * @deprecated Use {@link #createArrayBackedUsingTheFactoryEveryTime(Class, Function) createUnbad}.
-	 */
-	@Deprecated
 	public static <T> Event<T> createArrayBacked(Class<? super T> type, Function<T[], T> invokerFactory) {
-		return createArrayBackedUsingTheFactoryEveryTime(type, invokers -> {
-			if (invokers.length == 1) {
-				return invokers[0];
-			} else {
-				return invokerFactory.apply(invokers);
-			}
-		});
+		return EventFactoryImpl.createArrayBacked(type, invokerFactory);
 	}
 
 	/**
 	 * Create an "array-backed" Event instance with a custom empty invoker.
+	 * If there is no listener, the custom invoker will be used.
+	 * If there is only one listener, that one will be used as the invoker.
 	 * The factory will only be used when there at least two invokers.
-	 * If there is only one listener, that one will be used as the invoker, and the factory will not be used!
 	 *
 	 * <p>Having a custom empty invoker (of type (...) -&gt; {}) increases performance
 	 * relative to iterating over an empty array; however, it only really matters
@@ -121,11 +76,17 @@ public final class EventFactory {
 	 * @param invokerFactory The invoker factory, combining multiple listeners into one instance.
 	 * @param <T>            The listener type.
 	 * @return The Event instance.
-	 * @deprecated Use {@link #createArrayBackedCustomEmptyInvoker(Class, Object, Function)} instead.
 	 */
-	@Deprecated
 	public static <T> Event<T> createArrayBacked(Class<T> type, T emptyInvoker, Function<T[], T> invokerFactory) {
-		return createArrayBackedCustomEmptyInvoker(type, emptyInvoker, invokerFactory);
+		return createArrayBacked(type, invokers -> {
+			if (invokers.length == 0) {
+				return emptyInvoker;
+			} else if (invokers.length == 1) {
+				return invokers[0];
+			} else {
+				return invokerFactory.apply(invokers);
+			}
+		});
 	}
 
 	/**

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
@@ -47,18 +47,70 @@ public final class EventFactory {
 
 	/**
 	 * Create an "array-backed" Event instance.
+	 * The factory will be used for any number of listeners.
+	 * Consider using {@link #createUnbad the more optimized overload} if you need a slight performance increase
+	 * when there are 0 or 1 listeners.
 	 *
 	 * @param type           The listener class type.
 	 * @param invokerFactory The invoker factory, combining multiple listeners into one instance.
 	 * @param <T>            The listener type.
 	 * @return The Event instance.
 	 */
+	public static <T> Event<T> createUnbad(Class<? super T> type, Function<T[], T> invokerFactory) {
+		return EventFactoryImpl.createUnbad(type, invokerFactory);
+	}
+
+	/**
+	 * Create an "array-backed" Event instance, with a custom empty invoker.
+	 * The empty invoker will be used when there are no listeners,
+	 * and when there is only one listener, it will be used directly.
+	 * The factory will only be used when there are at least two listeners.
+	 * Consider using {@link #createUnbad} if this optimization is unsuitable or unneeded.
+	 *
+	 * @param type           The listener class type.
+	 * @param emptyInvoker   The custom empty invoker.
+	 * @param invokerFactory The invoker factory, combining multiple listeners into one instance.
+	 * @param <T>            The listener type.
+	 * @return The Event instance.
+	 */
+	public static <T> Event<T> createUnbad(Class<? super T> type, T emptyInvoker, Function<T[], T> invokerFactory) {
+		return createUnbad(type, invokers -> {
+			if (invokers.length == 0) {
+				return emptyInvoker;
+			} else if (invokers.length == 1) {
+				return invokers[0];
+			} else {
+				return invokerFactory.apply(invokers);
+			}
+		});
+	}
+
+	/**
+	 * Create an "array-backed" Event instance.
+	 * The factory will be used when there are zero listeners, or at least two.
+	 * If there is only one listener, that one will be used as the invoker, and the factory will not be used!
+	 *
+	 * @param type           The listener class type.
+	 * @param invokerFactory The invoker factory, combining multiple listeners into one instance.
+	 * @param <T>            The listener type.
+	 * @return The Event instance.
+	 * @deprecated Use {@link #createUnbad(Class, Function) createUnbad}.
+	 */
+	@Deprecated
 	public static <T> Event<T> createArrayBacked(Class<? super T> type, Function<T[], T> invokerFactory) {
-		return EventFactoryImpl.createArrayBacked(type, invokerFactory);
+		return createUnbad(type, invokers -> {
+			if (invokers.length == 1) {
+				return invokers[0];
+			} else {
+				return invokerFactory.apply(invokers);
+			}
+		});
 	}
 
 	/**
 	 * Create an "array-backed" Event instance with a custom empty invoker.
+	 * The factory will only be used when there at least two invokers.
+	 * If there is only one listener, that one will be used as the invoker, and the factory will not be used!
 	 *
 	 * <p>Having a custom empty invoker (of type (...) -&gt; {}) increases performance
 	 * relative to iterating over an empty array; however, it only really matters
@@ -69,10 +121,11 @@ public final class EventFactory {
 	 * @param invokerFactory The invoker factory, combining multiple listeners into one instance.
 	 * @param <T>            The listener type.
 	 * @return The Event instance.
+	 * @deprecated Use {@link #createUnbad(Class, Object, Function)} instead.
 	 */
-	// TODO: Deprecate this once we have working codegen
+	@Deprecated
 	public static <T> Event<T> createArrayBacked(Class<T> type, T emptyInvoker, Function<T[], T> invokerFactory) {
-		return EventFactoryImpl.createArrayBacked(type, emptyInvoker, invokerFactory);
+		return createUnbad(type, emptyInvoker, invokerFactory);
 	}
 
 	/**

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
@@ -48,7 +48,7 @@ public final class EventFactory {
 	/**
 	 * Create an "array-backed" Event instance.
 	 * The factory will be used for any number of listeners.
-	 * Consider using {@link #createUnbad the more optimized overload} if you need a slight performance increase
+	 * Consider using {@link #createArrayBackedCustomEmptyInvoker(Class, Object, Function)}  the more optimized overload} if you need a slight performance increase
 	 * when there are 0 or 1 listeners.
 	 *
 	 * @param type           The listener class type.
@@ -56,8 +56,8 @@ public final class EventFactory {
 	 * @param <T>            The listener type.
 	 * @return The Event instance.
 	 */
-	public static <T> Event<T> createUnbad(Class<? super T> type, Function<T[], T> invokerFactory) {
-		return EventFactoryImpl.createUnbad(type, invokerFactory);
+	public static <T> Event<T> createArrayBackedUsingTheFactoryEveryTime(Class<? super T> type, Function<T[], T> invokerFactory) {
+		return EventFactoryImpl.createArrayBackedUsingTheFactoryEveryTime(type, invokerFactory);
 	}
 
 	/**
@@ -65,7 +65,7 @@ public final class EventFactory {
 	 * The empty invoker will be used when there are no listeners,
 	 * and when there is only one listener, it will be used directly.
 	 * The factory will only be used when there are at least two listeners.
-	 * Consider using {@link #createUnbad} if this optimization is unsuitable or unneeded.
+	 * Consider using {@link #createArrayBackedUsingTheFactoryEveryTime} if this optimization is unsuitable or unneeded.
 	 *
 	 * @param type           The listener class type.
 	 * @param emptyInvoker   The custom empty invoker.
@@ -73,8 +73,8 @@ public final class EventFactory {
 	 * @param <T>            The listener type.
 	 * @return The Event instance.
 	 */
-	public static <T> Event<T> createUnbad(Class<? super T> type, T emptyInvoker, Function<T[], T> invokerFactory) {
-		return createUnbad(type, invokers -> {
+	public static <T> Event<T> createArrayBackedCustomEmptyInvoker(Class<? super T> type, T emptyInvoker, Function<T[], T> invokerFactory) {
+		return createArrayBackedUsingTheFactoryEveryTime(type, invokers -> {
 			if (invokers.length == 0) {
 				return emptyInvoker;
 			} else if (invokers.length == 1) {
@@ -94,11 +94,11 @@ public final class EventFactory {
 	 * @param invokerFactory The invoker factory, combining multiple listeners into one instance.
 	 * @param <T>            The listener type.
 	 * @return The Event instance.
-	 * @deprecated Use {@link #createUnbad(Class, Function) createUnbad}.
+	 * @deprecated Use {@link #createArrayBackedUsingTheFactoryEveryTime(Class, Function) createUnbad}.
 	 */
 	@Deprecated
 	public static <T> Event<T> createArrayBacked(Class<? super T> type, Function<T[], T> invokerFactory) {
-		return createUnbad(type, invokers -> {
+		return createArrayBackedUsingTheFactoryEveryTime(type, invokers -> {
 			if (invokers.length == 1) {
 				return invokers[0];
 			} else {
@@ -121,11 +121,11 @@ public final class EventFactory {
 	 * @param invokerFactory The invoker factory, combining multiple listeners into one instance.
 	 * @param <T>            The listener type.
 	 * @return The Event instance.
-	 * @deprecated Use {@link #createUnbad(Class, Object, Function)} instead.
+	 * @deprecated Use {@link #createArrayBackedCustomEmptyInvoker(Class, Object, Function)} instead.
 	 */
 	@Deprecated
 	public static <T> Event<T> createArrayBacked(Class<T> type, T emptyInvoker, Function<T[], T> invokerFactory) {
-		return createUnbad(type, emptyInvoker, invokerFactory);
+		return createArrayBackedCustomEmptyInvoker(type, emptyInvoker, invokerFactory);
 	}
 
 	/**

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
@@ -49,7 +49,7 @@ public final class EventFactory {
 	 * Create an "array-backed" Event instance.
 	 * The factory will be used to create the invoker for any number of listeners.
 	 *
-	 * Consider using {@linkplain #createArrayBacked(Class, Object, Function) a custom empty invoker}
+	 * <p>Consider using {@linkplain #createArrayBacked(Class, Object, Function) a custom empty invoker}
 	 * if performance of this event is critical.
 	 *
 	 * @param type           The listener class type.

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
@@ -47,9 +47,9 @@ public final class EventFactory {
 
 	/**
 	 * Create an "array-backed" Event instance.
-	 * The factory will be used to create the invoker for any number of listeners.
 	 *
-	 * <p>Consider using {@linkplain #createArrayBacked(Class, Object, Function) a custom empty invoker}
+	 * <p>If your factory simply delegates to the listeners without adding custom behavior,
+	 * consider using {@linkplain #createArrayBacked(Class, Object, Function) the other overload}
 	 * if performance of this event is critical.
 	 *
 	 * @param type           The listener class type.
@@ -62,10 +62,14 @@ public final class EventFactory {
 	}
 
 	/**
-	 * Create an "array-backed" Event instance with a custom empty invoker.
-	 * If there is no listener, the custom invoker will be used.
-	 * If there is only one listener, that one will be used as the invoker.
-	 * The factory will only be used when there at least two invokers.
+	 * Create an "array-backed" Event instance with a custom empty invoker,
+	 * for an event whose {@code invokerFactory} only delegates to the listeners.
+	 * <ul>
+	 *   <li>If there is no listener, the custom empty invoker will be used.</li>
+	 *   <li><b>If there is only one listener, that one will be used as the invoker
+	 *   and the factory will not be called.</b></li>
+	 *   <li>Only when there are at least two listeners will the factory be used.</li>
+	 * </ul>
 	 *
 	 * <p>Having a custom empty invoker (of type (...) -&gt; {}) increases performance
 	 * relative to iterating over an empty array; however, it only really matters
@@ -78,13 +82,13 @@ public final class EventFactory {
 	 * @return The Event instance.
 	 */
 	public static <T> Event<T> createArrayBacked(Class<T> type, T emptyInvoker, Function<T[], T> invokerFactory) {
-		return createArrayBacked(type, invokers -> {
-			if (invokers.length == 0) {
+		return createArrayBacked(type, listeners -> {
+			if (listeners.length == 0) {
 				return emptyInvoker;
-			} else if (invokers.length == 1) {
-				return invokers[0];
+			} else if (listeners.length == 1) {
+				return listeners[0];
 			} else {
-				return invokerFactory.apply(invokers);
+				return invokerFactory.apply(listeners);
 			}
 		});
 	}

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/ArrayBackedEvent.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/ArrayBackedEvent.java
@@ -32,6 +32,10 @@ class ArrayBackedEvent<T> extends Event<T> {
 
 	@SuppressWarnings("unchecked")
 	ArrayBackedEvent(Class<? super T> type, Function<T[], T> invokerFactory) {
+		if (type.isPrimitive()) {
+			throw new IllegalArgumentException("Cannot create an ArrayBackedEvent with a primitive type: " + type.getCanonicalName());
+		}
+
 		this.invokerFactory = invokerFactory;
 		this.handlers = (T[]) Array.newInstance(type, 0);
 		update();

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/ArrayBackedEvent.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/ArrayBackedEvent.java
@@ -48,7 +48,6 @@ class ArrayBackedEvent<T> extends Event<T> {
 		lock.lock();
 
 		try {
-			// We use a copy-on-write strategy to allow lock-free concurrent reads.
 			handlers = Arrays.copyOf(handlers, handlers.length + 1);
 			handlers[handlers.length - 1] = listener;
 			update();

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/ArrayBackedEvent.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/ArrayBackedEvent.java
@@ -32,10 +32,6 @@ class ArrayBackedEvent<T> extends Event<T> {
 
 	@SuppressWarnings("unchecked")
 	ArrayBackedEvent(Class<? super T> type, Function<T[], T> invokerFactory) {
-		if (type.isPrimitive()) {
-			throw new IllegalArgumentException("Cannot create an ArrayBackedEvent with a primitive type: " + type.getCanonicalName());
-		}
-
 		this.invokerFactory = invokerFactory;
 		this.handlers = (T[]) Array.newInstance(type, 0);
 		update();

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/ArrayBackedEvent.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/ArrayBackedEvent.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.impl.base.event;
 
 import java.lang.reflect.Array;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
@@ -25,52 +26,31 @@ import java.util.function.Function;
 import net.fabricmc.fabric.api.event.Event;
 
 class ArrayBackedEvent<T> extends Event<T> {
-	private final Class<? super T> type;
 	private final Function<T[], T> invokerFactory;
-	private final T dummyInvoker;
 	private final Lock lock = new ReentrantLock();
 	private T[] handlers;
 
-	ArrayBackedEvent(Class<? super T> type, T dummyInvoker, Function<T[], T> invokerFactory) {
-		this.type = type;
-		this.dummyInvoker = dummyInvoker;
+	@SuppressWarnings("unchecked")
+	ArrayBackedEvent(Class<? super T> type, Function<T[], T> invokerFactory) {
 		this.invokerFactory = invokerFactory;
+		this.handlers = (T[]) Array.newInstance(type, 0);
 		update();
 	}
 
-	@SuppressWarnings("unchecked")
 	void update() {
-		if (handlers == null) {
-			if (dummyInvoker != null) {
-				invoker = dummyInvoker;
-			} else {
-				invoker = invokerFactory.apply((T[]) Array.newInstance(type, 0));
-			}
-		} else if (handlers.length == 1) {
-			invoker = handlers[0];
-		} else {
-			invoker = invokerFactory.apply(handlers);
-		}
+		this.invoker = invokerFactory.apply(handlers);
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public void register(T listener) {
-		if (listener == null) {
-			throw new NullPointerException("Tried to register a null listener!");
-		}
+		Objects.requireNonNull(listener, "Tried to register a null listener!");
 
 		lock.lock();
 
 		try {
-			if (handlers == null) {
-				handlers = (T[]) Array.newInstance(type, 1);
-				handlers[0] = listener;
-			} else {
-				handlers = Arrays.copyOf(handlers, handlers.length + 1);
-				handlers[handlers.length - 1] = listener;
-			}
-
+			// We use a copy-on-write strategy to allow lock-free concurrent reads.
+			handlers = Arrays.copyOf(handlers, handlers.length + 1);
+			handlers[handlers.length - 1] = listener;
 			update();
 		} finally {
 			lock.unlock();

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/EventFactoryImpl.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/EventFactoryImpl.java
@@ -38,7 +38,7 @@ public final class EventFactoryImpl {
 		ARRAY_BACKED_EVENTS.forEach(ArrayBackedEvent::update);
 	}
 
-	public static <T> Event<T> createUnbad(Class<? super T> type, Function<T[], T> invokerFactory) {
+	public static <T> Event<T> createArrayBackedUsingTheFactoryEveryTime(Class<? super T> type, Function<T[], T> invokerFactory) {
 		ArrayBackedEvent<T> event = new ArrayBackedEvent<>(type, invokerFactory);
 		ARRAY_BACKED_EVENTS.add(event);
 		return event;

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/EventFactoryImpl.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/EventFactoryImpl.java
@@ -38,7 +38,7 @@ public final class EventFactoryImpl {
 		ARRAY_BACKED_EVENTS.forEach(ArrayBackedEvent::update);
 	}
 
-	public static <T> Event<T> createArrayBackedUsingTheFactoryEveryTime(Class<? super T> type, Function<T[], T> invokerFactory) {
+	public static <T> Event<T> createArrayBacked(Class<? super T> type, Function<T[], T> invokerFactory) {
 		ArrayBackedEvent<T> event = new ArrayBackedEvent<>(type, invokerFactory);
 		ARRAY_BACKED_EVENTS.add(event);
 		return event;

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/EventFactoryImpl.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/impl/base/event/EventFactoryImpl.java
@@ -38,12 +38,8 @@ public final class EventFactoryImpl {
 		ARRAY_BACKED_EVENTS.forEach(ArrayBackedEvent::update);
 	}
 
-	public static <T> Event<T> createArrayBacked(Class<? super T> type, Function<T[], T> invokerFactory) {
-		return createArrayBacked(type, null /* buildEmptyInvoker(type, invokerFactory) */, invokerFactory);
-	}
-
-	public static <T> Event<T> createArrayBacked(Class<? super T> type, T emptyInvoker, Function<T[], T> invokerFactory) {
-		ArrayBackedEvent<T> event = new ArrayBackedEvent<>(type, emptyInvoker, invokerFactory);
+	public static <T> Event<T> createUnbad(Class<? super T> type, Function<T[], T> invokerFactory) {
+		ArrayBackedEvent<T> event = new ArrayBackedEvent<>(type, invokerFactory);
 		ARRAY_BACKED_EVENTS.add(event);
 		return event;
 	}


### PR DESCRIPTION
This PR changes the behavior of `EventFactory.createArrayBacked` so that the factory is invoked even when there is one listener.

The main motivation for this PR is that something like #1322 can best be implemented as an event + an `instanceof` check for easy self-implementation on the relevant argument:
```java
public interface SlotClick {
    // Return false to stop vanilla Item#onClicked processing.
    boolean allowClick(Slot slot, ItemStack heldStack, ClickType type, PlayerInventory inventory);
}

@AutoInvokingEvent // This PR adds this annotation as well!
Event<SlotClick> SLOT_CLICK = EventFactory.createArrayBacked(SlotClick.class, listeners -> (slot, heldStack, type, inventory) -> {
    boolean vanillaClick = true;
    if (slot instanceof SlotClick) {
        vanillaClick = ((SlotClick) slot).allowClick(slot, heldStack, type, inventory) && vanillaClick;
    }
    for (SlotClick listener : listeners) {
        vanillaClick = listener.allowClick(slot, heldStack, type, inventory) && vanillaClick;
    }
    return vanillaClick;
})
```

Sadly this won't work currently, as the invoker factory will not be invoked when there is exactly one registered listener. I don't think this behavior change should break anything.

This PR also introduces [`AutoInvokingEvent`](https://github.com/Technici4n/fabric/blob/event-cleanup/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/AutoInvokingEvent.java) to document such events.

I have also simplified the `ArrayBackedEvent` implementation by moving the empty listener/singleton listener to the body of the custom empty invoker overload, and by removing the special case where `listeners` could be `null` by allocating an empty array in the constructor.

Edit: Closes #1311.