### PR TITLE
Allow getting BakedModels using Identifiers

### DIFF
--- a/fabric-models-v0/build.gradle
+++ b/fabric-models-v0/build.gradle
@@ -4,3 +4,8 @@ version = getSubprojectVersion(project, "0.2.1")
 moduleDependencies(project, [
 		'fabric-api-base'
 ])
+
+dependencies {
+	testmodCompile project(path: ':fabric-renderer-registries-v1', configuration: 'dev')
+	testmodCompile project(path: ':fabric-resource-loader-v0', configuration: 'dev')
+}

--- a/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/BakedModelManagerHelper.java
+++ b/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/BakedModelManagerHelper.java
@@ -25,11 +25,16 @@ import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.impl.client.model.BakedModelManagerHooks;
 
-public final class ModelHelper {
+public final class BakedModelManagerHelper {
 	/**
-	 * An alternative to {@link BakedModelManager#getModel(ModelIdentifier)} that accepts an {@link Identifier} instead.
-	 * Models loaded using {@link ExtraModelProvider} do not have a corresponding ModelIdentifier, so that method cannot be used to retrieve them.
+	 * An alternative to {@link BakedModelManager#getModel(ModelIdentifier)} that accepts an
+	 * {@link Identifier} instead. Models loaded using {@link ExtraModelProvider} do not have a
+	 * corresponding {@link ModelIdentifier}, so the vanilla method cannot be used to retrieve them.
 	 * The Identifier that was used to load them can be used in this method to retrieve them.
+	 *
+	 * <p><b>This method, as well as its vanilla counterpart, should only be used after the
+	 * {@link BakedModelManager} has completed reloading.</b> Otherwise, the result will be
+	 * null or an old model.
 	 *
 	 * @param manager the manager that holds models
 	 * @param id the id of the model
@@ -40,5 +45,5 @@ public final class ModelHelper {
 		return ((BakedModelManagerHooks) manager).fabric_getModel(id);
 	}
 
-	private ModelHelper() { }
+	private BakedModelManagerHelper() { }
 }

--- a/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/ModelHelper.java
+++ b/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/ModelHelper.java
@@ -31,9 +31,9 @@ public final class ModelHelper {
 	 * Models loaded using {@link ExtraModelProvider} do not have a corresponding ModelIdentifier, so that method cannot be used to retrieve them.
 	 * The Identifier that was used to load them can be used in this method to retrieve them.
 	 *
-	 * @param manager The manager that holds models.
-	 * @param id The id of the model.
-	 * @return The model.
+	 * @param manager the manager that holds models
+	 * @param id the id of the model
+	 * @return the model
 	 */
 	@Nullable
 	public static BakedModel getModel(BakedModelManager manager, Identifier id) {

--- a/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/ModelHelper.java
+++ b/fabric-models-v0/src/main/java/net/fabricmc/fabric/api/client/model/ModelHelper.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.client.model;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.render.model.BakedModelManager;
+import net.minecraft.client.util.ModelIdentifier;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.impl.client.model.BakedModelManagerHooks;
+
+public final class ModelHelper {
+	/**
+	 * An alternative to {@link BakedModelManager#getModel(ModelIdentifier)} that accepts an {@link Identifier} instead.
+	 * Models loaded using {@link ExtraModelProvider} do not have a corresponding ModelIdentifier, so that method cannot be used to retrieve them.
+	 * The Identifier that was used to load them can be used in this method to retrieve them.
+	 *
+	 * @param manager The manager that holds models.
+	 * @param id The id of the model.
+	 * @return The model.
+	 */
+	@Nullable
+	public static BakedModel getModel(BakedModelManager manager, Identifier id) {
+		return ((BakedModelManagerHooks) manager).fabric_getModel(id);
+	}
+
+	private ModelHelper() { }
+}

--- a/fabric-models-v0/src/main/java/net/fabricmc/fabric/impl/client/model/BakedModelManagerHooks.java
+++ b/fabric-models-v0/src/main/java/net/fabricmc/fabric/impl/client/model/BakedModelManagerHooks.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.model;
+
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.util.Identifier;
+
+public interface BakedModelManagerHooks {
+	BakedModel fabric_getModel(Identifier id);
+}

--- a/fabric-models-v0/src/main/java/net/fabricmc/fabric/mixin/client/model/MixinBakedModelManager.java
+++ b/fabric-models-v0/src/main/java/net/fabricmc/fabric/mixin/client/model/MixinBakedModelManager.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.model;
+
+import java.util.Map;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.render.model.BakedModelManager;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.impl.client.model.BakedModelManagerHooks;
+
+@Mixin(BakedModelManager.class)
+public class MixinBakedModelManager implements BakedModelManagerHooks {
+	@Shadow
+	private Map<Identifier, BakedModel> models;
+
+	@Override
+	public BakedModel fabric_getModel(Identifier id) {
+		return models.get(id);
+	}
+}

--- a/fabric-models-v0/src/main/resources/fabric-models-v0.mixins.json
+++ b/fabric-models-v0/src/main/resources/fabric-models-v0.mixins.json
@@ -3,6 +3,7 @@
   "package": "net.fabricmc.fabric.mixin.client.model",
   "compatibilityLevel": "JAVA_8",
   "client": [
+    "MixinBakedModelManager",
     "MixinModelLoader"
   ],
   "injectors": {

--- a/fabric-models-v0/src/testmod/java/net/fabricmc/fabric/test/model/BakedModelFeatureRenderer.java
+++ b/fabric-models-v0/src/testmod/java/net/fabricmc/fabric/test/model/BakedModelFeatureRenderer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.model;
+
+import java.util.function.Supplier;
+
+import net.minecraft.client.render.TexturedRenderLayers;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.entity.feature.FeatureRenderer;
+import net.minecraft.client.render.entity.feature.FeatureRendererContext;
+import net.minecraft.client.render.entity.model.EntityModel;
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.client.util.math.Vector3f;
+import net.minecraft.entity.LivingEntity;
+
+public class BakedModelFeatureRenderer<T extends LivingEntity, M extends EntityModel<T>> extends FeatureRenderer<T, M> {
+	private Supplier<BakedModel> modelSupplier;
+
+	public BakedModelFeatureRenderer(FeatureRendererContext<T, M> context, Supplier<BakedModel> modelSupplier) {
+		super(context);
+		this.modelSupplier = modelSupplier;
+	}
+
+	@Override
+	public void render(MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, T entity, float limbAngle, float limbDistance, float tickDelta, float animationProgress, float headYaw, float headPitch) {
+		BakedModel model = modelSupplier.get();
+		VertexConsumer vertices = vertexConsumers.getBuffer(TexturedRenderLayers.getEntityCutout());
+		matrices.push();
+		//matrices.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(headYaw));
+		//matrices.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(headPitch));
+		matrices.multiply(Vector3f.POSITIVE_Y.getRadialQuaternion(animationProgress * 0.07F));
+		matrices.scale(-0.75F, -0.75F, 0.75F);
+		float aboveHead = (float) (Math.sin(animationProgress * 0.08F)) * 0.5F + 0.5F;
+		matrices.translate(-0.5F, 0.75F + aboveHead, -0.5F);
+		BakedModelRenderer.renderBakedModel(model, vertices, matrices.peek(), light);
+		matrices.pop();
+	}
+}

--- a/fabric-models-v0/src/testmod/java/net/fabricmc/fabric/test/model/BakedModelRenderer.java
+++ b/fabric-models-v0/src/testmod/java/net/fabricmc/fabric/test/model/BakedModelRenderer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.model;
+
+import java.util.Random;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import net.minecraft.client.render.OverlayTexture;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.render.model.BakedQuad;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.math.Direction;
+
+public class BakedModelRenderer {
+	private static final Direction[] CULL_FACES = ArrayUtils.add(Direction.values(), null);
+	private static final Random RANDOM = new Random();
+
+	public static void renderBakedModel(BakedModel model, VertexConsumer vertices, MatrixStack.Entry entry, int light) {
+		for (Direction cullFace : CULL_FACES) {
+			RANDOM.setSeed(42L);
+
+			for (BakedQuad quad : model.getQuads(null, cullFace, RANDOM)) {
+				vertices.quad(entry, quad, 1.0F, 1.0F, 1.0F, light, OverlayTexture.DEFAULT_UV);
+			}
+		}
+	}
+}

--- a/fabric-models-v0/src/testmod/java/net/fabricmc/fabric/test/model/ModelTestModClient.java
+++ b/fabric-models-v0/src/testmod/java/net/fabricmc/fabric/test/model/ModelTestModClient.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.model;
+
+import net.minecraft.client.render.entity.PlayerEntityRenderer;
+import net.minecraft.resource.ResourceType;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.model.ModelLoadingRegistry;
+import net.fabricmc.fabric.api.client.rendereregistry.v1.LivingEntityFeatureRendererRegistrationCallback;
+import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
+
+public class ModelTestModClient implements ClientModInitializer {
+	public static final String ID = "fabric-models-v0-testmod";
+
+	public static final Identifier MODEL_ID = new Identifier(ID, "half_red_sand");
+
+	@Override
+	public void onInitializeClient() {
+		ModelLoadingRegistry.INSTANCE.registerModelProvider((manager, out) -> {
+			out.accept(MODEL_ID);
+		});
+
+		ResourceManagerHelper.get(ResourceType.CLIENT_RESOURCES).registerReloadListener(SpecificModelReloadListener.INSTANCE);
+
+		LivingEntityFeatureRendererRegistrationCallback.EVENT.register((entityType, entityRenderer, registrationHelper) -> {
+			if (entityRenderer instanceof PlayerEntityRenderer) {
+				registrationHelper.register(new BakedModelFeatureRenderer<>((PlayerEntityRenderer) entityRenderer, SpecificModelReloadListener.INSTANCE::getSpecificModel));
+			}
+		});
+	}
+}

--- a/fabric-models-v0/src/testmod/java/net/fabricmc/fabric/test/model/SpecificModelReloadListener.java
+++ b/fabric-models-v0/src/testmod/java/net/fabricmc/fabric/test/model/SpecificModelReloadListener.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.model;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.resource.SinglePreparationResourceReloadListener;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.Unit;
+import net.minecraft.util.profiler.Profiler;
+
+import net.fabricmc.fabric.api.client.model.BakedModelManagerHelper;
+import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
+import net.fabricmc.fabric.api.resource.ResourceReloadListenerKeys;
+
+public class SpecificModelReloadListener extends SinglePreparationResourceReloadListener<Unit> implements IdentifiableResourceReloadListener {
+	public static final SpecificModelReloadListener INSTANCE = new SpecificModelReloadListener();
+	public static final Identifier ID = new Identifier(ModelTestModClient.ID, "specific_model");
+
+	private BakedModel specificModel;
+
+	public BakedModel getSpecificModel() {
+		return specificModel;
+	}
+
+	@Override
+	protected Unit prepare(ResourceManager manager, Profiler profiler) {
+		return Unit.INSTANCE;
+	}
+
+	@Override
+	protected void apply(Unit loader, ResourceManager manager, Profiler profiler) {
+		specificModel = BakedModelManagerHelper.getModel(MinecraftClient.getInstance().getBakedModelManager(), ModelTestModClient.MODEL_ID);
+	}
+
+	@Override
+	public Identifier getFabricId() {
+		return ID;
+	}
+
+	@Override
+	public Collection<Identifier> getFabricDependencies() {
+		return Arrays.asList(ResourceReloadListenerKeys.MODELS);
+	}
+}

--- a/fabric-models-v0/src/testmod/resources/assets/fabric-models-v0-testmod/models/half_red_sand.json
+++ b/fabric-models-v0/src/testmod/resources/assets/fabric-models-v0-testmod/models/half_red_sand.json
@@ -1,0 +1,20 @@
+{
+  "textures": {
+    "sand": "minecraft:block/sand",
+    "red_sand": "minecraft:block/red_sand"
+  },
+  "elements": [
+    {
+      "from": [ 0, 0, 0 ],
+      "to": [ 16, 16, 16 ],
+      "faces": {
+        "down": { "texture": "#sand" },
+        "up": { "texture": "#red_sand" },
+        "north": { "texture": "#sand" },
+        "south": { "texture": "#red_sand" },
+        "west": { "texture": "#sand" },
+        "east": { "texture": "#red_sand" }
+      }
+    }
+  ]
+}

--- a/fabric-models-v0/src/testmod/resources/fabric.mod.json
+++ b/fabric-models-v0/src/testmod/resources/fabric.mod.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": 1,
+  "id": "fabric-models-v0-testmod",
+  "name": "Fabric Models (v0) Test Mod",
+  "version": "1.0.0",
+  "environment": "client",
+  "license": "Apache-2.0",
+  "depends": {
+    "fabric-models-v0": "*",
+    "fabric-renderer-registries-v1": "*",
+    "fabric-resource-loader-v0": "*"
+  },
+  "entrypoints": {
+    "client": [
+      "net.fabricmc.fabric.test.model.ModelTestModClient"
+    ]
+  }
+}


### PR DESCRIPTION
If a model is loaded using an `ExtraModelProvider`, there is no way to retrieve it from the `BakedModelManager` after it is baked because it does not have a corresponding `ModelIdentifier`. This pull request adds a `ModelHelper` that allows retrieving a model via `Identifier` instead of `ModelIdentifier`. This works by exposing the full functionality of `BakedModelManager`'s internal model map, which stores `Identifier`s as keys, even though vanilla's retrieval method requires a `ModelIdentifier`. The same `Identifier` used to load the model can be used in `ModelHelper#getModel` to get the baked model.