### PR TITLE
Allow more flexibility when registering BERs

### DIFF
--- a/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/api/client/rendereregistry/v1/BlockEntityRendererRegistry.java
+++ b/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/api/client/rendereregistry/v1/BlockEntityRendererRegistry.java
@@ -40,5 +40,5 @@ public interface BlockEntityRendererRegistry {
 	 *                            class is already loaded
 	 * @param <E> the {@link BlockEntity}
 	 */
-	<E extends BlockEntity> void register(BlockEntityType<E> blockEntityType, Function<BlockEntityRenderDispatcher, BlockEntityRenderer<E>> blockEntityRenderer);
+	<E extends BlockEntity> void register(BlockEntityType<E> blockEntityType, Function<BlockEntityRenderDispatcher, BlockEntityRenderer<? super E>> blockEntityRenderer);
 }

--- a/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/impl/client/renderer/registry/BlockEntityRendererRegistryImpl.java
+++ b/fabric-renderer-registries-v1/src/main/java/net/fabricmc/fabric/impl/client/renderer/registry/BlockEntityRendererRegistryImpl.java
@@ -32,7 +32,7 @@ public class BlockEntityRendererRegistryImpl implements BlockEntityRendererRegis
 	private static BiConsumer<BlockEntityType<?>, Function<BlockEntityRenderDispatcher, ? extends BlockEntityRenderer<?>>> handler = (type, function) -> map.put(type, function);
 
 	@Override
-	public <E extends BlockEntity> void register(BlockEntityType<E> blockEntityType, Function<BlockEntityRenderDispatcher, BlockEntityRenderer<E>> blockEntityRenderer) {
+	public <E extends BlockEntity> void register(BlockEntityType<E> blockEntityType, Function<BlockEntityRenderDispatcher, BlockEntityRenderer<? super E>> blockEntityRenderer) {
 		handler.accept(blockEntityType, blockEntityRenderer);
 	}
 


### PR DESCRIPTION
This pull request allows the `BlockEntityRendererRegistry` to accept `BlockEntityRenderer`s that render for a super type of the `BlockEntity` that the current `BlockEntityType` refers to. This makes sense, because one renderer can work for multiple types of `BlockEntity`s (that have the same super type) or an abstract renderer that has one type of `BlockEntity` that it renders for can change its behavior based on implementations of abstract methods. The workaround for this currently is to cast both arguments to raw types, which is not ideal.