### PR TITLE
Add ServerPlayerEvents.ALLOW_DEATH event

### DIFF
--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -62,14 +62,14 @@ public final class ServerPlayerEvents {
 	 *     apply</li>
 	 * </ul>
 	 */
-	public static final Event<CancelDeath> CANCEL_DEATH = EventFactory.createArrayBacked(CancelDeath.class, callbacks -> (player, damageSource, damageAmount) -> {
-		for (CancelDeath callback : callbacks) {
-			if (callback.cancelDeath(player, damageSource, damageAmount)) {
-				return true;
+	public static final Event<AllowDeath> ALLOW_DEATH = EventFactory.createArrayBacked(AllowDeath.class, callbacks -> (player, damageSource, damageAmount) -> {
+		for (AllowDeath callback : callbacks) {
+			if (!callback.allowDeath(player, damageSource, damageAmount)) {
+				return false;
 			}
 		}
 
-		return false;
+		return true;
 	});
 
 	@FunctionalInterface
@@ -97,16 +97,16 @@ public final class ServerPlayerEvents {
 	}
 
 	@FunctionalInterface
-	public interface CancelDeath {
+	public interface AllowDeath {
 		/**
 		 * Called when a player takes fatal damage (before totems of undying can take effect).
 		 *
 		 * @param player the player
 		 * @param damageSource the fatal damage damageSource
 		 * @param damageAmount the damageAmount of damage that has killed the player
-		 * @return true if the death should be cancelled, false otherwise.
+		 * @return true if the death should go ahead, false otherwise.
 		 */
-		boolean cancelDeath(ServerPlayerEntity player, DamageSource damageSource, float damageAmount);
+		boolean allowDeath(ServerPlayerEntity player, DamageSource damageSource, float damageAmount);
 	}
 
 	private ServerPlayerEvents() {

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -68,6 +68,7 @@ public final class ServerPlayerEvents {
 				return true;
 			}
 		}
+
 		return false;
 	});
 

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -53,14 +53,14 @@ public final class ServerPlayerEvents {
 	 * <p>Mods can cancel this to keep the player alive.
 	 *
 	 * <p>Vanilla checks for player health <= 0 each frame (with {@link LivingEntity#isDead()}), and kills if true -
-	 * so the player will die next frame if this is cancelled. It's assumed that the listener will do something to
-	 * prevent this, for example:
+	 * so the player will still die next tick if this event is cancelled. It's assumed that the listener will do
+	 * something to prevent this, for example:
 	 *
-	 * <li>
-	 *     <ul>a minigame mod teleporting the player into a 'respawn room' and setting their health to 20.0</ul>
-	 *     <ul>a mod that changes death mechanics switching the player over to the mod's play-mode, where death doesn't
-	 *     apply</ul>
-	 * </li>
+	 * <ul>
+	 *     <li>a minigame mod teleporting the player into a 'respawn room' and setting their health to 20.0</li>
+	 *     <li>a mod that changes death mechanics switching the player over to the mod's play-mode, where death doesn't
+	 *     apply</li>
+	 * </ul>
 	 */
 	public static final Event<CancelDeath> CANCEL_DEATH = EventFactory.createArrayBacked(CancelDeath.class, callbacks -> (player, damageSource, damageAmount) -> {
 		for (CancelDeath callback : callbacks) {

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.fabric.api.entity.event.v1;
 
-import net.fabricmc.fabric.api.util.TriState;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 
@@ -54,12 +53,13 @@ public final class ServerPlayerEvents {
 	 */
 	public static final Event<BeforeDeath> BEFORE_DEATH = EventFactory.createArrayBacked(BeforeDeath.class, callbacks -> (oldPlayer, damageSource, amount) -> {
 		boolean result = true;
+
 		for (BeforeDeath callback : callbacks) {
 			result &= callback.beforeDeath(oldPlayer, damageSource, amount);
 		}
+
 		return result;
 	});
-
 
 	@FunctionalInterface
 	public interface CopyFrom {

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -62,9 +62,9 @@ public final class ServerPlayerEvents {
 	 *     apply</ul>
 	 * </li>
 	 */
-	public static final Event<CancelDeath> CANCEL_DEATH = EventFactory.createArrayBacked(CancelDeath.class, callbacks -> (oldPlayer, damageSource, damageAmount) -> {
+	public static final Event<CancelDeath> CANCEL_DEATH = EventFactory.createArrayBacked(CancelDeath.class, callbacks -> (player, damageSource, damageAmount) -> {
 		for (CancelDeath callback : callbacks) {
-			if (callback.cancelDeath(oldPlayer, damageSource, damageAmount)) {
+			if (callback.cancelDeath(player, damageSource, damageAmount)) {
 				return true;
 			}
 		}

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -52,7 +52,7 @@ public final class ServerPlayerEvents {
 	 *
 	 * <p>Mods can cancel this to keep the player alive.
 	 *
-	 * <p>Vanilla checks for player health <= 0 each frame (with {@link LivingEntity#isDead()}), and kills if true -
+	 * <p>Vanilla checks for player health {@code <= 0} each tick (with {@link LivingEntity#isDead()}), and kills if true -
 	 * so the player will die next frame if this is cancelled. It's assumed that the listener will do something to
 	 * prevent this, for example:
 	 *

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -52,7 +52,7 @@ public final class ServerPlayerEvents {
 	 *
 	 * <p>Mods can cancel this to keep the player alive.
 	 *
-	 * <p>Vanilla checks for player health {@code <= 0} each frame (with {@link LivingEntity#isDead()}), and kills if true -
+	 * <p>Vanilla checks for player health {@code <= 0} each tick (with {@link LivingEntity#isDead()}), and kills if true -
 	 * so the player will still die next tick if this event is cancelled. It's assumed that the listener will do
 	 * something to prevent this, for example:
 	 *

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.entity.event.v1;
 
+import net.fabricmc.fabric.api.util.TriState;
+import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 
 import net.fabricmc.fabric.api.event.Event;
@@ -45,6 +47,20 @@ public final class ServerPlayerEvents {
 		}
 	});
 
+	/**
+	 * An event that is called when a player takes fatal damage.
+	 *
+	 * <p>Mods can cancel this to keep the player alive.
+	 */
+	public static final Event<BeforeDeath> BEFORE_DEATH = EventFactory.createArrayBacked(BeforeDeath.class, callbacks -> (oldPlayer, damageSource, amount) -> {
+		boolean result = true;
+		for (BeforeDeath callback : callbacks) {
+			result &= callback.beforeDeath(oldPlayer, damageSource, amount);
+		}
+		return result;
+	});
+
+
 	@FunctionalInterface
 	public interface CopyFrom {
 		/**
@@ -67,6 +83,19 @@ public final class ServerPlayerEvents {
 		 * @param alive whether the old player is still alive
 		 */
 		void afterRespawn(ServerPlayerEntity oldPlayer, ServerPlayerEntity newPlayer, boolean alive);
+	}
+
+	@FunctionalInterface
+	public interface BeforeDeath {
+		/**
+		 * Called when a player takes fatal damage.
+		 *
+		 * @param player the player
+		 * @param source the fatal damage source
+		 * @param amount the amount of damage that has killed the player
+		 * @return whether or not the player should die
+		 */
+		boolean beforeDeath(ServerPlayerEntity player, DamageSource source, float amount);
 	}
 
 	private ServerPlayerEvents() {

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -48,7 +48,7 @@ abstract class LivingEntityMixin extends EntityMixin {
 	@Redirect(method = "damage", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;isDead()Z", ordinal = 1))
 	boolean beforePlayerKilled(LivingEntity livingEntity, DamageSource source, float amount) {
 		if (livingEntity instanceof ServerPlayerEntity) {
-			return isDead() && !ServerPlayerEvents.CANCEL_DEATH.invoker().cancelDeath((ServerPlayerEntity) livingEntity, source, amount);
+			return isDead() && ServerPlayerEvents.ALLOW_DEATH.invoker().allowDeath((ServerPlayerEntity) livingEntity, source, amount);
 		}
 
 		return isDead();

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -48,7 +48,7 @@ abstract class LivingEntityMixin extends EntityMixin {
 
 	@Redirect(method = "damage", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;isDead()Z", ordinal = 1))
 	boolean beforePlayerKilled(LivingEntity livingEntity, DamageSource source, float amount) {
-		if (livingEntity instanceof PlayerEntity) {
+		if (livingEntity instanceof ServerPlayerEntity) {
 			return isDead() && !ServerPlayerEvents.CANCEL_DEATH.invoker().cancelDeath((ServerPlayerEntity) livingEntity, source, amount);
 		}
 

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -16,9 +16,6 @@
 
 package net.fabricmc.fabric.mixin.entity.event;
 
-import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -30,9 +27,12 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 
 import net.fabricmc.fabric.api.entity.event.v1.ServerEntityCombatEvents;
+import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
 
 @Mixin(LivingEntity.class)
 abstract class LivingEntityMixin extends EntityMixin {
@@ -48,8 +48,10 @@ abstract class LivingEntityMixin extends EntityMixin {
 
 	@Redirect(method = "damage", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;isDead()Z", ordinal = 1))
 	boolean beforePlayerKilled(LivingEntity livingEntity, DamageSource source, float amount) {
-		if (livingEntity instanceof PlayerEntity)
+		if (livingEntity instanceof PlayerEntity) {
 			return isDead() && ServerPlayerEvents.BEFORE_DEATH.invoker().beforeDeath((ServerPlayerEntity) livingEntity, source, amount);
+		}
+
 		return isDead();
 	}
 }

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -16,9 +16,14 @@
 
 package net.fabricmc.fabric.mixin.entity.event;
 
+import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
@@ -31,10 +36,20 @@ import net.fabricmc.fabric.api.entity.event.v1.ServerEntityCombatEvents;
 
 @Mixin(LivingEntity.class)
 abstract class LivingEntityMixin extends EntityMixin {
+	@Shadow
+	public abstract boolean isDead();
+
 	@Inject(method = "onDeath", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;onKilledOther(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/entity/LivingEntity;)V", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILEXCEPTION)
 	private void onEntityKilledOther(DamageSource source, CallbackInfo ci, Entity attacker) {
 		// FIXME: Cannot use shadowed fields from supermixins - needs a fix so people can use fabric api in a dev environment even though this is fine in this repo and prod.
 		//  A temporary fix is to just cast the mixin to LivingEntity and access the world field with a few ugly casts.
 		ServerEntityCombatEvents.AFTER_KILLED_OTHER_ENTITY.invoker().afterKilledOtherEntity((ServerWorld) ((LivingEntity) (Object) this).world, attacker, (LivingEntity) (Object) this);
+	}
+
+	@Redirect(method = "damage", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;isDead()Z", ordinal = 1))
+	boolean beforePlayerKilled(LivingEntity livingEntity, DamageSource source, float amount) {
+		if (livingEntity instanceof PlayerEntity)
+			return isDead() && ServerPlayerEvents.BEFORE_DEATH.invoker().beforeDeath((ServerPlayerEntity) livingEntity, source, amount);
+		return isDead();
 	}
 }

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -49,7 +49,7 @@ abstract class LivingEntityMixin extends EntityMixin {
 	@Redirect(method = "damage", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;isDead()Z", ordinal = 1))
 	boolean beforePlayerKilled(LivingEntity livingEntity, DamageSource source, float amount) {
 		if (livingEntity instanceof PlayerEntity) {
-			return isDead() && ServerPlayerEvents.BEFORE_DEATH.invoker().beforeDeath((ServerPlayerEntity) livingEntity, source, amount);
+			return isDead() && !ServerPlayerEvents.CANCEL_DEATH.invoker().cancelDeath((ServerPlayerEntity) livingEntity, source, amount);
 		}
 
 		return isDead();

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -27,7 +27,6 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -52,15 +52,15 @@ public final class EntityEventTests implements ModInitializer {
 			LOGGER.info("Respawned {}, [{}, {}]", oldPlayer.getGameProfile().getName(), oldPlayer.getServerWorld().getRegistryKey().getValue(), newPlayer.getServerWorld().getRegistryKey().getValue());
 		});
 
-		ServerPlayerEvents.CANCEL_DEATH.register((player, source, amount) -> {
+		ServerPlayerEvents.ALLOW_DEATH.register((player, source, amount) -> {
 			LOGGER.info("{} is going to die to {} damage from {} damage source", player.getGameProfile().getName(), amount, source.getName());
 
 			if (player.getStackInHand(Hand.MAIN_HAND).getItem() == Items.APPLE) {
 				player.setHealth(3.0f);
-				return true;
+				return false;
 			}
 
-			return false;
+			return true;
 		});
 	}
 }

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -52,15 +52,15 @@ public final class EntityEventTests implements ModInitializer {
 			LOGGER.info("Respawned {}, [{}, {}]", oldPlayer.getGameProfile().getName(), oldPlayer.getServerWorld().getRegistryKey().getValue(), newPlayer.getServerWorld().getRegistryKey().getValue());
 		});
 
-		ServerPlayerEvents.BEFORE_DEATH.register((player, source, amount) -> {
+		ServerPlayerEvents.CANCEL_DEATH.register((player, source, amount) -> {
 			LOGGER.info("{} is going to die to {} damage from {} damage source", player.getGameProfile().getName(), amount, source.getName());
 
 			if (player.getStackInHand(Hand.MAIN_HAND).getItem() == Items.APPLE) {
 				player.setHealth(3.0f);
-				return false;
+				return true;
 			}
 
-			return true;
+			return false;
 		});
 	}
 }

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -16,10 +16,11 @@
 
 package net.fabricmc.fabric.test.entity.event;
 
-import net.minecraft.item.Items;
-import net.minecraft.util.Hand;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import net.minecraft.item.Items;
+import net.minecraft.util.Hand;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.entity.event.v1.ServerEntityCombatEvents;
@@ -53,10 +54,12 @@ public final class EntityEventTests implements ModInitializer {
 
 		ServerPlayerEvents.BEFORE_DEATH.register((player, source, amount) -> {
 			LOGGER.info("{} is going to die to {} damage from {} damage source", player.getGameProfile().getName(), amount, source.getName());
+
 			if (player.getStackInHand(Hand.MAIN_HAND).getItem() == Items.APPLE) {
 				player.setHealth(3.0f);
 				return false;
 			}
+
 			return true;
 		});
 	}

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.test.entity.event;
 
+import net.minecraft.item.Items;
+import net.minecraft.util.Hand;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -47,6 +49,15 @@ public final class EntityEventTests implements ModInitializer {
 
 		ServerPlayerEvents.AFTER_RESPAWN.register((oldPlayer, newPlayer, alive) -> {
 			LOGGER.info("Respawned {}, [{}, {}]", oldPlayer.getGameProfile().getName(), oldPlayer.getServerWorld().getRegistryKey().getValue(), newPlayer.getServerWorld().getRegistryKey().getValue());
+		});
+
+		ServerPlayerEvents.BEFORE_DEATH.register((player, source, amount) -> {
+			LOGGER.info("{} is going to die to {} damage from {} damage source", player.getGameProfile().getName(), amount, source.getName());
+			if (player.getStackInHand(Hand.MAIN_HAND).getItem() == Items.APPLE) {
+				player.setHealth(3.0f);
+				return false;
+			}
+			return true;
 		});
 	}
 }


### PR DESCRIPTION
### PR Contents

This PR adds a new event, `ServerPlayerEvents.ALLOW_DEATH`. This is called when a player has just taken fatal damage. Mods can return `false` from this to cancel the death.

### Rationale

Mods may want to cancel a player's death in certain circumstances - [Gunpowder](https://github.com/Gunpowder-MC/Gunpowder/blob/c62a696eda68ca5648d78ed10779bf363efcb506/gunpowder-base/src/main/java/io/github/gunpowder/mixin/base/LivingEntityMixin_Base.java#L43) and [Haema](https://github.com/williambl/haema/blob/c7026d9ee18e9414b2a1e7eba8f033a68a2a44a8/src/main/java/com/williambl/haema/mixin/LivingEntityMixin.java#L46) are two mods which do.

Unfortunately, this requires a redirect mixin - however, this same redirect being needed for multiple mods (thus making them incompatible) suggests that it is appropriate for Fabric API.

CC: @martmists-gh