### PR TITLE
Make the client command registration match server commands with per world registration

### DIFF
--- a/fabric-command-api-v1/build.gradle
+++ b/fabric-command-api-v1/build.gradle
@@ -6,5 +6,6 @@ dependencies {
 }
 
 moduleDependencies(project, [
-		'fabric-api-base'
+		'fabric-api-base',
+		'fabric-networking-api-v1'
 ])


### PR DESCRIPTION
https://discord.com/channels/507304429255393322/507982478276034570/827246117867356250 for context.

Its really hard to make commands for server side or client side only. This pr switches to an event system that is very similar to the command API, but instead of passing a boolean for a dedicated server, it passes a boolean for a remote server (lan or dedicated). The dispatcher is reset each time the client joins a new world, but this is unavoidable with how brigadier is set up 