### PR TITLE
Fix Screen API ButtonList in 1.17

### DIFF
--- a/fabric-screen-api-v1/src/main/java/net/fabricmc/fabric/impl/client/screen/ButtonList.java
+++ b/fabric-screen-api-v1/src/main/java/net/fabricmc/fabric/impl/client/screen/ButtonList.java
@@ -65,11 +65,13 @@ public final class ButtonList extends AbstractList<ClickableWidget> {
 	public void add(int index, ClickableWidget element) {
 		// ensure no duplicates
 		final int duplicateIndex = drawables.indexOf(element);
+
 		if (duplicateIndex >= 0) {
 			drawables.remove(element);
 			selectables.remove(element);
 			children.remove(element);
-			if (duplicateIndex <= translateIndex(drawables, index, true)) { 
+
+			if (duplicateIndex <= translateIndex(drawables, index, true)) {
 				index--;
 			}
 		}
@@ -113,7 +115,10 @@ public final class ButtonList extends AbstractList<ClickableWidget> {
 
 		for (int i = 0, max = list.size(); i < max; i++) {
 			if (list.get(i) instanceof ClickableWidget) {
-				if (remaining == 0) return i;
+				if (remaining == 0) {
+					return i;
+				}
+
 				remaining--;
 			}
 		}

--- a/fabric-screen-api-v1/src/main/java/net/fabricmc/fabric/mixin/screen/ScreenMixin.java
+++ b/fabric-screen-api-v1/src/main/java/net/fabricmc/fabric/mixin/screen/ScreenMixin.java
@@ -28,6 +28,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.client.gui.Selectable;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.Drawable;
 import net.minecraft.client.gui.Element;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.ClickableWidget;
@@ -44,10 +45,13 @@ import net.fabricmc.fabric.impl.client.screen.ScreenExtensions;
 abstract class ScreenMixin implements ScreenExtensions {
 	@Shadow
 	@Final
-	protected List<Selectable> field_33815;
+	protected List<Selectable> selectables;
 	@Shadow
 	@Final
 	protected List<Element> children;
+	@Shadow
+	@Final
+	protected List<Drawable> drawables;
 
 	@Unique
 	private ButtonList fabricButtons;
@@ -137,7 +141,7 @@ abstract class ScreenMixin implements ScreenExtensions {
 	public List<ClickableWidget> fabric_getButtons() {
 		// Lazy init to make the list access safe after Screen#init
 		if (this.fabricButtons == null) {
-			this.fabricButtons = new ButtonList(this.field_33815, this.children);
+			this.fabricButtons = new ButtonList(this.drawables, this.selectables, this.children);
 		}
 
 		return this.fabricButtons;


### PR DESCRIPTION
`ButtonList` now properly handles `drawables`, `selectables` and `children`.

Closes https://github.com/FabricMC/fabric/issues/1473