### PR TITLE
Added support for VillagerEntity task lists.

### DIFF
--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/ai/tasks/VillagerTaskProvider.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/ai/tasks/VillagerTaskProvider.java
@@ -1,0 +1,616 @@
+package net.fabricmc.fabric.api.object.builder.v1.ai.tasks;
+
+import com.google.common.collect.*;
+import com.mojang.datafixers.util.*;
+import net.minecraft.entity.ai.brain.task.*;
+import net.minecraft.entity.passive.*;
+import net.minecraft.village.*;
+//import org.jetbrains.annotations.*;
+
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
+/**
+ * Provides task lists for villager professions. Called when initializing a {@code VillagerEntity}'s {@link net.minecraft.entity.ai.brain.Brain Brain}. Must be registered with {@link VillagerTaskProviderRegistry#register(VillagerProfession, VillagerTaskProvider)} before it can be called.
+ * @see VillagerTaskListProvider Vanilla Source
+ * @see Task Task&lt;VillagerEntity&gt;
+ */
+@SuppressWarnings({"unused"})
+public final class VillagerTaskProvider {
+	public VillagerTaskProvider()
+	{
+		constantTaskMap = new EnumMap<>(TaskType.class);
+		randomTaskMap = new EnumMap<>(TaskType.class);
+	}
+	
+	private final EnumMap<TaskType, List<BiFunction<VillagerProfession, Float, Pair<Integer, ? extends Task<? super VillagerEntity>>>>> constantTaskMap;
+	private final EnumMap<TaskType, List<BiFunction<VillagerProfession, Float, Pair<Task<? super VillagerEntity>, Integer>>>> randomTaskMap;
+	
+	
+	/**
+	 * Adds a <b>Constant</b> task under the specified {@link TaskType} for any {@link VillagerProfession VillagerProfession} using this {@code VillagerTaskProvider}.
+	 * <p><i>Constant</i> tasks are priorities given to a {@code LivingEntity} which are constantly assessed, whereas <i>Random</i> tasks are selected during the {@code Entity's} lifetime.
+	 * <p>Example Usage: <blockquote><pre>addConstantTask(TaskType.CORE, (profession, f) -&gt; Pair.of(1, new VillagerTask(profession, f)));</pre></blockquote>
+	 * @see #addRandomTask(TaskType, BiFunction) addRandomTask
+	 * @see #addBaseConstantTask(TaskType, BiFunction) addBaseConstantTask
+	 * @apiNote {@code PLAY} tasks may only be modified in {@code base} tasks. All calls to this method with {@code TaskType.PLAY} will be redirected to {@link #addBaseConstantTask(TaskType, BiFunction) addBaseConstantTask}.
+	 * @implSpec {@code BiFunction}s must return a {@link Pair} containing the <b>Task</b> and its <b>Weight</b> (as used in a {@link net.minecraft.util.collection.WeightedList WeightedList}).
+	 * In addition, {@code PLAY} tasks must expect the {@code VillagerProfession} argument to be {@code NULL} when calculated.
+	 * @param taskType The {@code TaskType} of the specified task.
+	 * @param dynamicTask {@code BiFunction}, taking the {@code VillagerProfession} of the {@link VillagerEntity} executing the task and the <b>walk speed</b> of the villager as arguments.
+	 */
+	public VillagerTaskProvider addConstantTask(TaskType taskType, BiFunction<VillagerProfession, Float, Pair<Integer, ? extends Task<? super VillagerEntity>>> dynamicTask)
+	{
+		if (taskType == TaskType.PLAY) {
+			addBaseConstantTask(taskType, dynamicTask);
+			
+			return this;
+		}
+		
+		List<BiFunction<VillagerProfession, Float, Pair<Integer, ? extends Task<? super VillagerEntity>>>> list = constantTaskMap.get(taskType);
+		if (list == null)
+			list = new ArrayList<>();
+		
+		list.add(dynamicTask);
+		
+		constantTaskMap.put(taskType, list);
+		return this;
+	}
+	
+	/**
+	 * Adds a <b>Constant</b> task under the specified {@link TaskType} for any {@link VillagerProfession} using this {@code VillagerTaskProvider}.
+	 * <p><i>Constant</i> tasks are priorities given to a {@code LivingEntity} which are constantly assessed, whereas <i>Random</i> tasks are selected during the {@code Entity's} lifetime.
+	 * <p>Example Usage: <blockquote><pre>addConstantTasks(TaskType.CORE, (profession, f) -&gt; Pair.of(1, new VillagerTask(profession, f)));</pre></blockquote>
+	 * @see #addRandomTasks(TaskType, BiFunction[]) addRandomTasks
+	 * @see #addBaseConstantTasks(TaskType, BiFunction[]) addBaseConstantTasks
+	 * @apiNote {@code PLAY} tasks may only be modified in {@code base} tasks. All calls to this method with {@code TaskType.PLAY} will be redirected to {@link #addBaseConstantTasks(TaskType, BiFunction[]) addBaseConstantTasks}.
+	 * @implSpec {@code BiFunction}s must return a {@link Pair} containing the <b>Task</b> and its <b>Weight</b> (as used in a {@link net.minecraft.util.collection.WeightedList WeightedList}).
+	 * In addition, {@code PLAY} tasks must expect the {@code VillagerProfession} argument to be {@code NULL} when calculated.
+	 * @param taskType The {@code TaskType} of the specified task.
+	 * @param dynamicTasks {@code BiFunctions}, taking the {@code VillagerProfession} of the {@link VillagerEntity VillagerEntity} executing the task and the <b>walk speed</b> of the villager as arguments.
+	 */
+	@SafeVarargs
+	public final VillagerTaskProvider addConstantTasks(TaskType taskType, BiFunction<VillagerProfession, Float, Pair<Integer, ? extends Task<? super VillagerEntity>>>... dynamicTasks)
+	{
+		return addConstantTasks(taskType, toListCheckNull(dynamicTasks));
+	}
+	
+	/**
+	 * Adds a <b>Constant</b> task under the specified {@link TaskType} for any {@link VillagerProfession} using this {@code VillagerTaskProvider}.
+	 * <p><i>Constant</i> tasks are priorities given to a {@code LivingEntity} which are constantly assessed, whereas <i>Random</i> tasks are selected during the {@code Entity's} lifetime.
+	 * <p>Example Usage: 
+	 * <blockquote><pre>addConstantTasks(TaskType.CORE, (profession, f) -&gt; Pair.of(1, new VillagerTask(profession, f)));</pre></blockquote>
+	 * @see #addRandomTasks(TaskType, BiFunction[]) addRandomTasks
+	 * @see #addBaseConstantTasks(TaskType, BiFunction[]) addBaseConstantTasks
+	 * @apiNote {@code PLAY} tasks may only be modified in {@code base} tasks. All calls to this method with {@code TaskType.PLAY} will be redirected to {@link #addBaseConstantTasks(TaskType, BiFunction[]) addBaseConstantTasks}.
+	 * @implSpec {@code BiFunction}s must return a {@link Pair} containing the <b>Task</b> and its <b>Weight</b> (as used in a {@link net.minecraft.util.collection.WeightedList WeightedList}).
+	 * In addition, {@code PLAY} tasks must expect the {@code VillagerProfession} argument to be {@code NULL} when calculated.
+	 * @param taskType The {@code TaskType} of the specified task.
+	 * @param dynamicTasks A {@code List} of {@code BiFunctions}, taking the {@code VillagerProfession} of the {@link VillagerEntity VillagerEntity} executing the task and the <b>walk speed</b> of the villager as arguments.
+	 */
+	public final VillagerTaskProvider addConstantTasks(TaskType taskType, List<BiFunction<VillagerProfession, Float, Pair<Integer, ? extends Task<? super VillagerEntity>>>> dynamicTasks)
+	{
+		if (taskType == TaskType.PLAY) {
+			addBaseConstantTasks(taskType, dynamicTasks);
+			
+			return this;
+		}
+		
+		List<BiFunction<VillagerProfession, Float, Pair<Integer, ? extends Task<? super VillagerEntity>>>> list = constantTaskMap.get(taskType);
+		if (list == null)
+			list = new ArrayList<>();
+		
+		list.addAll(dynamicTasks);
+		
+		constantTaskMap.put(taskType, list);
+		return this;
+	}
+	
+	
+	/**
+	 * Adds a <b>Random</b> task under the specified {@link TaskType} for any {@link VillagerProfession VillagerProfession} using this {@code VillagerTaskProvider}.
+	 * <p><i>Random</i> tasks are randomly selected and executed during the Villager's lifetime, whereas <i>Constant</i> tasks are priorities that are always active.
+	 * <p>Example Usage:
+	 * <blockquote><pre>addRandomTask(TaskType.CORE, (profession, f) -&gt; Pair.of(new VillagerTask(profession, f), 1));</pre></blockquote>
+	 * @apiNote {@code PLAY} tasks may only be modified in {@code base} tasks. All calls to this method with {@code TaskType.PLAY} will be redirected to {@link #addBaseConstantTask(TaskType, BiFunction) addBaseConstantTask}.
+	 * @implNote {@code Task}s are added to a single {@code List} passed to the {@link RandomTask RandomTask} constructor.  If the {@code TaskType} does not include a {@code RandomTask} by default, one will be added.
+	 * @see #addConstantTask(TaskType, BiFunction) addConstantTask
+	 * @see #addBaseRandomTask(TaskType, BiFunction) addBaseRandomTask
+	 * @implSpec {@code BiFunction}s must return a {@link Pair} containing the <b>Task</b> and its <b>Weight</b> (as used in a {@link net.minecraft.util.collection.WeightedList WeightedList}).
+	 * In addition, {@code PLAY} tasks must expect the {@code VillagerProfession} argument to be {@code NULL} when calculated.
+	 * @param taskType The {@code TaskType} of the specified task.
+	 * @param dynamicTask {@code BiFunction}, taking the {@code VillagerProfession} of the {@link VillagerEntity} executing the task and the <b>walk speed</b> of the villager as arguments.
+	 */
+	public final VillagerTaskProvider addRandomTask(TaskType taskType, BiFunction<VillagerProfession, Float, Pair<Task<? super VillagerEntity>, Integer>> dynamicTask)
+	{
+		if (taskType == TaskType.PLAY) {
+			addBaseRandomTask(taskType, dynamicTask);
+			return this;
+		}
+		List<BiFunction<VillagerProfession, Float, Pair<Task<? super VillagerEntity>, Integer>>> list = randomTaskMap.get(taskType);
+		if (list == null)
+			list = new ArrayList<>();
+		
+		list.add(dynamicTask);
+		
+		randomTaskMap.put(taskType, list);
+		
+		return this;
+	}
+	
+	/**
+	 * Adds a <b>Random</b> task under the specified {@link TaskType} for any {@link VillagerProfession VillagerProfession} using this {@code VillagerTaskProvider}.
+	 * <p><i>Random</i> tasks are randomly selected and executed during the Villager's lifetime, whereas <i>Constant</i> tasks are priorities that are always active.
+	 * <p>Example Usage:
+	 * <blockquote><pre>addRandomTasks(TaskType.CORE, (profession, f) -&gt; Pair.of(new VillagerTask(profession, f), 1));</pre></blockquote>
+	 * @apiNote {@code PLAY} tasks may only be modified in {@code base} tasks. All calls to this method with {@code TaskType.PLAY} will be redirected to {@link #addBaseRandomTasks(TaskType, BiFunction[]) addBaseRandomTasks}.
+	 * @implNote {@code Task}s are added to a single {@code List} passed to the {@link RandomTask RandomTask} constructor.  If the {@code TaskType} does not include a {@code RandomTask} by default, one will be added.
+	 * @see #addConstantTasks(TaskType, BiFunction[]) addConstantTasks
+	 * @see #addBaseRandomTasks(TaskType, BiFunction[]) addBaseRandomTasks
+	 * @implSpec {@code BiFunction}s must return a {@link Pair} containing the <b>Task</b> and its <b>Weight</b> (as used in a {@link net.minecraft.util.collection.WeightedList WeightedList}).
+	 * In addition, {@code PLAY} tasks must expect the {@code VillagerProfession} argument to be {@code NULL} when calculated.
+	 * @param taskType The {@code TaskType} of the specified task.
+	 * @param dynamicTasks {@code BiFunctions}, taking the {@code VillagerProfession} of the {@link VillagerEntity} executing the task and the <b>walk speed</b> of the villager as arguments.
+	 */
+	@SafeVarargs
+	public final VillagerTaskProvider addRandomTasks(TaskType taskType, BiFunction<VillagerProfession, Float, Pair<Task<? super VillagerEntity>, Integer>>... dynamicTasks)
+	{
+		return addRandomTasks(taskType, toListCheckNull(dynamicTasks));
+	}
+	
+	/**
+	 * Adds a <b>Random</b> task under the specified {@link TaskType} for any {@link VillagerProfession VillagerProfession} using this {@code VillagerTaskProvider}.
+	 * <p><i>Random</i> tasks are randomly selected and executed during the Villager's lifetime, whereas <i>Constant</i> tasks are priorities that are always active.
+	 * <p>Example Usage:
+	 * <blockquote><pre>addRandomTasks(TaskType.CORE, (profession, f) -&gt; Pair.of(new VillagerTask(profession, f), 1));</pre></blockquote>
+	 * @apiNote {@code PLAY} tasks may only be modified in {@code base} tasks. All calls to this method with {@code TaskType.PLAY} will be redirected to {@link #addBaseRandomTasks(TaskType, BiFunction[]) addBaseRandomTasks}.
+	 * @implNote {@code Task}s are added to a single {@code List} passed to the {@link RandomTask RandomTask} constructor.  If the {@code TaskType} does not include a {@code RandomTask} by default, one will be added.
+	 * @see #addConstantTasks(TaskType, List) addConstantTasks
+	 * @see #addBaseRandomTasks(TaskType, List) addBaseRandomTasks
+	 * @implSpec {@code BiFunction}s must return a {@link Pair} containing the <b>Task</b> and its <b>Weight</b> (as used in a {@link net.minecraft.util.collection.WeightedList WeightedList}).
+	 * In addition, {@code PLAY} tasks must expect the {@code VillagerProfession} argument to be {@code NULL} when calculated.
+	 * @param taskType The {@code TaskType} of the specified task.
+	 * @param dynamicTasks A {@code List} of {@code BiFunctions}, taking the {@code VillagerProfession} of the {@link VillagerEntity} executing the task and the <b>walk speed</b> of the villager as arguments.
+	 */
+	public final VillagerTaskProvider addRandomTasks(TaskType taskType, List<BiFunction<VillagerProfession, Float, Pair<Task<? super VillagerEntity>, Integer>>> dynamicTasks)
+	{
+		if (taskType == TaskType.PLAY) {
+			addBaseRandomTasks(taskType, dynamicTasks);
+			
+			return this;
+		}
+		
+		List<BiFunction<VillagerProfession, Float, Pair<Task<? super VillagerEntity>, Integer>>> list = randomTaskMap.get(taskType);
+		if (list == null)
+			list = new ArrayList<>();
+		
+		list.addAll(dynamicTasks);
+		
+		randomTaskMap.put(taskType, list);
+		return this;
+	}
+	
+	
+	
+	
+	
+	
+	public List<Pair<Integer, ? extends Task<? super VillagerEntity>>> getConstantTasks(TaskType taskType, VillagerProfession villagerProfession, float f)
+	{
+		return applyToTasks(constantTaskMap.get(taskType), villagerProfession, f);
+	}
+	
+	public List<Pair<Task<? super VillagerEntity>, Integer>> getRandomTasks(TaskType type, VillagerProfession profession, float f)
+	{
+		return applyToTasks(randomTaskMap.get(type), profession, f);
+	}
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	private static final EnumMap<TaskType, List<BiFunction<VillagerProfession, Float, Pair<Integer, ? extends Task<? super VillagerEntity>>>>> baseConstantTaskMap;
+	private static final EnumMap<TaskType, List<BiFunction<VillagerProfession, Float, Pair<Task<? super VillagerEntity>, Integer>>>> baseRandomTaskMap;
+	
+	
+	/**
+	 * Adds a <b>Constant</b> task under the specified {@link TaskType} for <i>all</i> {@link VillagerEntity VillagerEntities}, regardless of {@link VillagerProfession}.
+	 * <p><i>Constant</i> tasks are priorities given to a {@code LivingEntity} which are constantly assessed, whereas <i>Random</i> tasks are selected during the {@code Entity's} lifetime.
+	 * <p>Example Usage: <blockquote><pre>addBaseConstantTask(TaskType.CORE, (profession, f) -&gt; Pair.of(1, new VillagerTask(profession, f)));</pre></blockquote>
+	 * @see #addBaseRandomTask(TaskType, BiFunction) addBaseRandomTask
+	 * @see #addConstantTask(TaskType, BiFunction) addConstantTask
+	 * @apiNote {@code PLAY} tasks may only be modified here.
+	 * @implSpec {@code BiFunction}s must return a {@link Pair} containing the <b>Task</b> and its <b>Weight</b> (as used in a {@link net.minecraft.util.collection.WeightedList WeightedList}).
+	 * In addition, {@code PLAY} tasks must expect the {@code VillagerProfession} argument to be {@code NULL} when calculated.
+	 * @param taskType The {@code TaskType} of the specified task.
+	 * @param dynamicTask {@code BiFunction}, taking the {@code VillagerProfession} of the {@link VillagerEntity} executing the task and the <b>walk speed</b> of the villager as arguments.
+	 */
+	public static void addBaseConstantTask(TaskType taskType, BiFunction<VillagerProfession, Float, Pair<Integer, ? extends Task<? super VillagerEntity>>> dynamicTask)
+	{
+		List<BiFunction<VillagerProfession, Float, Pair<Integer, ? extends Task<? super VillagerEntity>>>> list = baseConstantTaskMap.get(taskType);
+		if (list == null)
+			list = new ArrayList<>();
+		
+		list.add(dynamicTask);
+		
+		baseConstantTaskMap.put(taskType, list);
+	}
+	
+	
+	
+	
+	
+	/**
+	 * Adds a <b>Constant</b> task under the specified {@link TaskType} for <i>all</i> {@link VillagerEntity VillagerEntities}, regardless of {@link VillagerProfession}.
+	 * <p><i>Constant</i> tasks are priorities given to a {@code LivingEntity} which are constantly assessed, whereas <i>Random</i> tasks are selected during the {@code Entity's} lifetime.
+	 * <p>Example Usage: <blockquote><pre>addBaseConstantTasks(TaskType.CORE, (profession, f) -&gt; Pair.of(1, new VillagerTask(profession, f)));</pre></blockquote>
+	 * @see #addBaseRandomTasks(TaskType, BiFunction[]) addBaseRandomTasks
+	 * @see #addConstantTasks(TaskType, BiFunction[]) addConstantTasks
+	 * @apiNote {@code PLAY} tasks may only be modified here.
+	 * @implSpec {@code BiFunction}s must return a {@link Pair} containing the <b>Task</b> and its <b>Weight</b> (as used in a {@link net.minecraft.util.collection.WeightedList WeightedList}).
+	 * In addition, {@code PLAY} tasks must expect the {@code VillagerProfession} argument to be {@code NULL} when calculated.
+	 * @param taskType The {@code TaskType} of the specified task.
+	 * @param dynamicTasks {@code BiFunctions}, taking the {@code VillagerProfession} of the {@link VillagerEntity VillagerEntity} executing the task and the <b>walk speed</b> of the villager as arguments.
+	 */
+	@SafeVarargs
+	public static void addBaseConstantTasks(TaskType taskType, BiFunction<VillagerProfession, Float, Pair<Integer, ? extends Task<? super VillagerEntity>>>... dynamicTasks)
+	{
+		addBaseConstantTasks(taskType, toListCheckNull(dynamicTasks));
+	}
+	
+	/**
+	 * Adds a <b>Constant</b> task under the specified {@link TaskType} for <i>all</i> {@link VillagerEntity VillagerEntities}, regardless of {@link VillagerProfession}.
+	 * <p><i>Constant</i> tasks are priorities given to a {@code LivingEntity} which are constantly assessed, whereas <i>Random</i> tasks are selected during the {@code Entity's} lifetime.
+	 * <p>Example Usage: <blockquote><pre>addBaseConstantTask(TaskType.CORE, (profession, f) -&gt; Pair.of(1, new VillagerTask(profession, f)));</pre></blockquote>
+	 * @see #addBaseRandomTasks(TaskType, List) addBaseRandomTasks
+	 * @see #addConstantTasks(TaskType, List) addConstantTasks
+	 * @apiNote {@code PLAY} tasks may only be modified here.
+	 * @implSpec {@code BiFunction}s must return a {@link Pair} containing the <b>Task</b> and its <b>Weight</b> (as used in a {@link net.minecraft.util.collection.WeightedList WeightedList}).
+	 * In addition, {@code PLAY} tasks must expect the {@code VillagerProfession} argument to be {@code NULL} when calculated.
+	 * @param taskType The {@code TaskType} of the specified task.
+	 * @param dynamicTasks {@code BiFunction}, taking the {@code VillagerProfession} of the {@link VillagerEntity} executing the task and the <b>walk speed</b> of the villager as arguments.
+	 */
+	public static void addBaseConstantTasks(TaskType taskType, List<BiFunction<VillagerProfession, Float, Pair<Integer, ? extends Task<? super VillagerEntity>>>> dynamicTasks)
+	{
+		List<BiFunction<VillagerProfession, Float, Pair<Integer, ? extends Task<? super VillagerEntity>>>> list = baseConstantTaskMap.get(taskType);
+		if (list == null)
+			list = new ArrayList<>();
+		
+		list.addAll(dynamicTasks);
+		
+		baseConstantTaskMap.put(taskType, list);
+	}
+	
+	
+	/**
+	 * Adds a <b>Random</b> task under the specified {@link TaskType} for <i>all</i> {@link VillagerEntity VillagerEntities}, regardless of {@link VillagerProfession}.
+	 * <p><i>Random</i> tasks are randomly selected and executed during the Villager's lifetime, whereas <i>Constant</i> tasks are priorities that are always active.
+	 * <p>Example Usage:
+	 * <blockquote><pre>addBaseRandomTask(TaskType.CORE, (profession, f) -&gt; Pair.of(new VillagerTask(profession, f), 1));</pre></blockquote>
+	 * @apiNote {@code PLAY} tasks may only be modified here.
+	 * @implNote {@code Task}s are added to a single {@code List} passed to the {@link RandomTask RandomTask} constructor.  If the {@code TaskType} does not include a {@code RandomTask} by default, one will be added.
+	 * @see #addBaseConstantTask(TaskType, BiFunction) addBaseConstantTask
+	 * @see #addRandomTask(TaskType, BiFunction) addRandomTask
+	 * @implSpec {@code BiFunction}s must return a {@link Pair} containing the <b>Task</b> and its <b>Weight</b> (as used in a {@link net.minecraft.util.collection.WeightedList WeightedList}).
+	 * In addition, {@code PLAY} tasks must expect the {@code VillagerProfession} argument to be {@code NULL} when calculated.
+	 * @param taskType The {@code TaskType} of the specified task.
+	 * @param dynamicTask {@code BiFunction}, taking the {@code VillagerProfession} of the {@link VillagerEntity} executing the task and the <b>walk speed</b> of the villager as arguments.
+	 */
+	public static void addBaseRandomTask(TaskType taskType, BiFunction<VillagerProfession, Float, Pair<Task<? super VillagerEntity>, Integer>> dynamicTask)
+	{
+		List<BiFunction<VillagerProfession, Float, Pair<Task<? super VillagerEntity>, Integer>>> list = baseRandomTaskMap.get(taskType);
+		if (list == null)
+			list = new ArrayList<>();
+		
+		list.add(dynamicTask);
+		
+		baseRandomTaskMap.put(taskType, list);
+	}
+	
+	
+	
+	
+	
+	
+	
+	/**
+	 * Adds a <b>Random</b> task under the specified {@link TaskType} for <i>all</i> {@link VillagerEntity VillagerEntities}, regardless of {@link VillagerProfession}.
+	 * <p><i>Random</i> tasks are randomly selected and executed during the Villager's lifetime, whereas <i>Constant</i> tasks are priorities that are always active.
+	 * <p>Example Usage:
+	 * <blockquote><pre>addBaseRandomTasks(TaskType.CORE, (profession, f) -&gt; Pair.of(new VillagerTask(profession, f), 1));</pre></blockquote>
+	 * @apiNote {@code PLAY} tasks may only be modified here.
+	 * @implNote {@code Task}s are added to a single {@code List} passed to the {@link RandomTask RandomTask} constructor.  If the {@code TaskType} does not include a {@code RandomTask} by default, one will be added.
+	 * @see #addBaseConstantTasks(TaskType, BiFunction[]) addBaseConstantTasks
+	 * @see #addRandomTasks(TaskType, BiFunction[]) addRandomTask
+	 * @implSpec {@code BiFunction}s must return a {@link Pair} containing the <b>Task</b> and its <b>Weight</b> (as used in a {@link net.minecraft.util.collection.WeightedList WeightedList}).
+	 * @param taskType The {@code TaskType} of the specified task.
+	 * @param dynamicTasks {@code BiFunctions}, taking the {@code VillagerProfession} of the {@link VillagerEntity} executing the task and the <b>walk speed</b> of the villager as arguments.
+	 */
+	@SafeVarargs
+	public static void addBaseRandomTasks(TaskType taskType, BiFunction<VillagerProfession, Float, Pair<Task<? super VillagerEntity>, Integer>>... dynamicTasks)
+	{
+		addBaseRandomTasks(taskType, toListCheckNull(dynamicTasks));
+	}
+	
+	/**
+	 * Adds a <b>Random</b> task under the specified {@link TaskType} for <i>all</i> {@link VillagerEntity VillagerEntities}, regardless of {@link VillagerProfession}.
+	 * <p><i>Random</i> tasks are randomly selected and executed during the Villager's lifetime, whereas <i>Constant</i> tasks are priorities that are always active.
+	 * <p>Example Usage:
+	 * <blockquote><pre>addBaseRandomTasks(TaskType.CORE, (profession, f) -&gt; Pair.of(new VillagerTask(profession, f), 1));</pre></blockquote>
+	 * @apiNote {@code PLAY} tasks may only be modified here.
+	 * @implNote {@code Task}s are added to a single {@code List} passed to the {@link RandomTask RandomTask} constructor.  If the {@code TaskType} does not include a {@code RandomTask} by default, one will be added.
+	 * @see #addBaseConstantTasks(TaskType, BiFunction[]) addBaseConstantTasks
+	 * @see #addRandomTasks(TaskType, BiFunction[]) addRandomTask
+	 * @implSpec {@code BiFunction}s must return a {@link Pair} containing the <b>Task</b> and its <b>Weight</b> (as used in a {@link net.minecraft.util.collection.WeightedList WeightedList}).
+	 * @param taskType The {@code TaskType} of the specified task.
+	 * @param dynamicTasks {@code List} of {@code BiFunctions}, taking the {@code VillagerProfession} of the {@link VillagerEntity} executing the task and the <b>walk speed</b> of the villager as arguments.
+	 */
+	public static void addBaseRandomTasks(TaskType taskType, List<BiFunction<VillagerProfession, Float, Pair<Task<? super VillagerEntity>, Integer>>> dynamicTasks)
+	{
+		List<BiFunction<VillagerProfession, Float, Pair<Task<? super VillagerEntity>, Integer>>> list = baseRandomTaskMap.get(taskType);
+		if (list == null)
+			list = new ArrayList<>();
+		
+		list.addAll(dynamicTasks);
+		
+		baseRandomTaskMap.put(taskType, list);
+	}
+	
+	
+	static {
+		baseConstantTaskMap = new EnumMap<>(TaskType.class);
+		baseRandomTaskMap = new EnumMap<>(TaskType.class);
+	}
+	
+	
+	
+	
+	
+	
+	
+	public static List<Pair<Task<? super VillagerEntity>, Integer>> getBaseRandomTasks(TaskType taskType, /* @Nullable */ VillagerProfession profession, float f)
+	{
+		return applyToTasks(baseRandomTaskMap.get(taskType), profession, f);
+	}
+	
+	
+	public static List<Pair<Integer, ? extends Task<? super VillagerEntity>>> getBaseConstantTasks(TaskType taskType, /* @Nullable */ VillagerProfession profession, float f)
+	{
+		return applyToTasks(baseConstantTaskMap.get(taskType), profession, f);
+	}
+	
+	
+	
+	
+	
+	
+	public boolean hasRandomTasks(/* @NotNull */ TaskType taskType)
+	{
+		return randomTaskMap.containsKey(taskType);
+	}
+	
+	public boolean hasConstantTasks(/* @NotNull */ TaskType taskType)
+	{
+		return constantTaskMap.containsKey(taskType);
+	}
+	
+	public static boolean hasBaseConstantTasks(/* @NotNull */ TaskType taskType)
+	{
+		return baseConstantTaskMap.containsKey(taskType);
+	}
+	
+	public static boolean hasBaseRandomTasks(/* @NotNull */ TaskType taskType)
+	{
+		return baseRandomTaskMap.containsKey(taskType);
+	}
+	
+	public List<BiFunction<VillagerProfession, Float, Pair<Integer, ? extends Task<? super VillagerEntity>>>> getRawConstantTasks(TaskType taskType)
+	{
+		return constantTaskMap.get(taskType);
+	}
+	
+	public List<BiFunction<VillagerProfession, Float, Pair<Task<? super VillagerEntity>, Integer>>> getRawRandomTasks(TaskType taskType)
+	{
+		return randomTaskMap.get(taskType);
+	}
+	
+	public static List<BiFunction<VillagerProfession, Float, Pair<Integer, ? extends Task<? super VillagerEntity>>>> getRawBaseConstantTasks(TaskType taskType)
+	{
+		return baseConstantTaskMap.get(taskType);
+	}
+	
+	public static List<BiFunction<VillagerProfession, Float, Pair<Task<? super VillagerEntity>, Integer>>> getRawBaseRandomTasks(TaskType taskType)
+	{
+		return baseRandomTaskMap.get(taskType);
+	}
+	
+	
+	
+	
+	
+	
+	
+	
+	/*
+	 * Helper functions
+	 */
+	/* @NotNull */
+	private static <T> List<T> toListCheckNull(T[] arr)
+	{
+		if (arr == null)
+			return ImmutableList.of();
+		
+		return Arrays.asList(arr);
+	}
+	
+	private static <T> List<T> applyToTasks(List<BiFunction<VillagerProfession, Float, T>> l, final VillagerProfession p, final float f)
+	{
+		if (l == null)
+			return ImmutableList.of();
+		
+		return l.stream().map(el -> el.apply(p, f)).collect(Collectors.toList());
+	}
+	
+	private static <T> List<BiFunction<VillagerProfession, Float, T>> mapToBiFunction(final List<T> in)
+	{
+		final List<BiFunction<VillagerProfession, Float, T>> out = new ArrayList<>();
+		
+		for (final T t : in) {
+			if (t == null) {
+				continue;
+			}
+			
+			out.add((p, f) -> t);
+		}
+		
+		return out;
+	}
+	
+	private static <T> List<BiFunction<VillagerProfession, Float, T>> mapToBiFunction(final T[] in)
+	{
+		return mapToBiFunction(toListCheckNull(in));
+	}
+	
+	
+	/**
+	 * The type of {@code Task} being added.
+	 * @see TaskType#CORE
+	 * @see TaskType#WORK
+	 * @see TaskType#PLAY
+	 * @see TaskType#REST
+	 * @see TaskType#MEET
+	 * @see TaskType#IDLE
+	 * @see TaskType#PANIC
+	 * @see TaskType#PRERAID
+	 * @see TaskType#RAID
+	 * @see TaskType#HIDE
+	 */
+	public enum TaskType {
+		/**
+		 * {@code CORE} tasks are priorities given to the {@code VillagerEntity}.
+		 * <p>Includes tasks such as:
+		 * <ul>
+		 *     <li>{@link StayAboveWaterTask Stay above water},</li>
+		 *     <li>{@link OpenDoorsTask Open doors}, and</li>
+		 *     <li>{@link LookAroundTask Look around}.</li>
+		 * </ul>
+		 * @see VillagerTaskListProvider#createCoreTasks(VillagerProfession, float) Vanilla Code Source
+		 */
+		CORE,
+		
+		/**
+		 * {@code WORK} tasks are executed when a {@code VillagerProfession} is near its secondary worksite.
+		 * <p>Includes tasks such as:
+		 * <ul>
+		 *     <li>{@link FarmerVillagerTask Farmer breaking crops},</li>
+		 *     <li>{@link HoldTradeOffersTask Hold trade offers}, and</li>
+		 *     <li>{@link GoToNearbyPositionTask Go to jobsite}.</li>
+		 * </ul>
+		 * @see WorkerVillagerTask Implementation Framework (optional)
+		 * @see VillagerTaskListProvider#createWorkTasks(VillagerProfession, float) Vanilla Code Source
+		 */
+		WORK,
+		
+		/**
+		 * {@code REST} tasks are executed as nighttime begins.
+		 * <p>Includes tasks such as:
+		 * <ul>
+		 *     <li>{@link VillagerWalkTowardsTask Go home},</li>
+		 *     <li>{@link SleepTask Sleep}, and</li>
+		 *     <li>{@link WanderIndoorsTask Wander indoors}.</li>
+		 * </ul>
+		 * @see VillagerTaskListProvider#createRestTasks(VillagerProfession, float) Vanilla Code Source
+		 */
+		REST,
+		
+		/**
+		 * {@code MEET} tasks are executed at midday, when all villagers gather in the center of their village.
+		 * <p>Includes tasks such as:
+		 * <ul>
+		 *     <li>{@link FindInteractionTargetTask Interact with player},</li>
+		 *     <li>{@link GatherItemsVillagerTask Acquire food from {@code Farmer} Villagers}, and</li>
+		 *     <li>{@link VillagerWalkTowardsTask Walk to meeting point}.</li>
+		 * </ul>
+		 * @see VillagerTaskListProvider#createMeetTasks(VillagerProfession, float) Vanilla Code Source
+		 */
+		MEET,
+		
+		/**
+		 * {@code IDLE} tasks are executed to make Villagers seek out additional tasks.
+		 * <p>Includes tasks such as:
+		 * <ul>
+		 *     <li>{@link FindEntityTask Find entities nearby},</li>
+		 *     <li>{@link FindInteractionTargetTask Find interaction target}, and</li>
+		 *     <li>{@link JumpInBedTask Babies jumping in bed}.</li>
+		 * </ul>
+		 * @see VillagerTaskListProvider#createIdleTasks(VillagerProfession, float) Vanilla Code Source
+		 */
+		IDLE,
+		
+		/**
+		 * {@code PANIC} tasks are executed when a {@code VillagerEntity} is hurt.
+		 * <p>Includes tasks such as:
+		 * <ul>
+		 *     <li>{@code Escape from nearest hostile}, and</li>
+		 *     <li>{@code Escape from attacker}.</li>
+		 * </ul>
+		 * @see VillagerTaskListProvider#createPanicTasks(VillagerProfession, float) Vanilla Code Source
+		 */
+		PANIC,
+		
+		/**
+		 * {@code PRERAID} tasks are executed immediately before an {@link net.minecraft.entity.mob.IllagerEntity Illager} {@link net.minecraft.village.raid.Raid Raid}.
+		 * <p>Includes tasks such as:
+		 * <ul>
+		 *     <li>{@link RingBellTask Ring bell}, and</li>
+		 *     <li>{@link FindWalkTargetTask Run around}.</li>
+		 * </ul>
+		 * @see VillagerTaskListProvider#createPreRaidTasks(VillagerProfession, float) Vanilla Code Source
+		 */
+		PRERAID,
+		
+		/**
+		 * {@code Raid} tasks are generated during an {@link net.minecraft.entity.mob.IllagerEntity Illager} {@link net.minecraft.village.raid.Raid Raid}.
+		 * <p>Includes tasks such as:
+		 * <ul>
+		 *     <li>{@link HideInHomeDuringRaidTask Stay in home during raid},</li>
+		 *     <li>{@link SeekSkyAfterRaidWinTask Seek sky}, executed when {@code Raid} is complete, and</li>
+		 *     <li>{@link CelebrateRaidWinTask Celebrate raid win}, executed when {@code Raid} is complete.</li>
+		 * </ul>
+		 * @see VillagerTaskListProvider#createRaidTasks(VillagerProfession, float) Vanilla Code Source
+		 */
+		RAID,
+		
+		/**
+		 * {@code HIDE} tasks are executed immediately prior to and during an {@link net.minecraft.entity.mob.IllagerEntity Illager} {@link net.minecraft.village.raid.Raid Raid}.
+		 * <p>Includes tasks such as:
+		 * <ul>
+		 *     <li>{@link ForgetBellRingTask Forget ring bell task}, and</li>
+		 *     <li>{@link HideInHomeTask Hide inside home}.</li>
+		 * </ul>
+		 * @see VillagerTaskListProvider#createHideTasks(VillagerProfession, float) Vanilla Code Source
+		 */
+		HIDE,
+		
+		
+		/**
+		 * {@code PLAY} tasks are executed by "baby" Villagers.
+		 * <p>Includes tasks such as:
+		 * <ul>
+		 *     <li>{@link JumpInBedTask Jump in bed},</li>
+		 *     <li>{@link FindEntityTask Follow villagers and cats}, and</li>
+		 *     <li>{@link PlayWithVillagerBabiesTask Play with other "baby" Villagers}.</li>
+		 * </ul>
+		 * @see VillagerTaskListProvider#createPlayTasks(float) Vanilla Code Source
+		 * @apiNote {@code PLAY} tasks may only be added in the base tasks, due to the lack of a {@link VillagerProfession} to map to.
+		 */
+		PLAY
+	}
+}

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/ai/tasks/VillagerTaskProviderRegistry.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/ai/tasks/VillagerTaskProviderRegistry.java
@@ -1,0 +1,84 @@
+package net.fabricmc.fabric.api.object.builder.v1.ai.tasks;
+
+import com.google.common.collect.ImmutableMap;
+import com.mojang.datafixers.util.Pair;
+import net.minecraft.entity.ai.brain.task.Task;
+import net.minecraft.entity.passive.VillagerEntity;
+import net.minecraft.village.VillagerProfession;
+//import org.jetbrains.annotations.Contract;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+public final class VillagerTaskProviderRegistry {
+	private static final Map<VillagerProfession, VillagerTaskProvider> VILLAGER_TASK_PROVIDER_BUILDER = new HashMap<>();
+	
+	/**
+	 * Adds a {@link VillagerTaskProvider} to the registry, which will be called by the associated {@link VillagerProfession}.
+	 * @param executingProfession The {@code VillagerProfession} that will execute this {@code VillagerTaskProvider}.
+	 * @param taskListProvider The {@code VillagerTaskProvider} to register.
+	 */
+	public static void register(final VillagerProfession executingProfession, final VillagerTaskProvider taskListProvider)
+	{
+		assert(executingProfession != null || taskListProvider != null) : "Argument cannot be null.";
+		
+		final VillagerTaskProvider old = VILLAGER_TASK_PROVIDER_BUILDER.put(executingProfession, taskListProvider);
+		
+		// Protection in case multiple people try to modify the same Profession
+		if (old != null)
+			VILLAGER_TASK_PROVIDER_BUILDER.put(executingProfession, combineTaskLists(old, taskListProvider));
+	}
+	
+	/**
+	 * Implementation retrieval method. Do not invoke.
+	 */
+	public static ImmutableMap<VillagerProfession, VillagerTaskProvider> getCompletedMap()
+	{
+		return ImmutableMap.copyOf(VILLAGER_TASK_PROVIDER_BUILDER);
+	}
+	
+	
+	/**
+	 * Helper function for combining {@link VillagerTaskProvider VillagerTaskProviders}.
+	 * @param a The first {@code VillagerTaskProvider}.
+	 * @param b The second {@code VillagerTaskProvider}.
+	 * @return A {@code VillagerTaskProvider} containing all tasks from both {@code a} and {@code b}.
+	 */
+	/* @Contract("_, _ -> new") */
+	private static VillagerTaskProvider combineTaskLists(VillagerTaskProvider a, VillagerTaskProvider b)
+	{
+		final VillagerTaskProvider out = new VillagerTaskProvider();
+		
+		combineConstantTasks(out, a, b);
+		combineRandomTasks(out, a, b);
+		
+		return out;
+	}
+	
+	/* @Contract(mutates="param1") */
+	private static void combineConstantTasks(final VillagerTaskProvider out, final VillagerTaskProvider a, final VillagerTaskProvider b)
+	{
+		for (VillagerTaskProvider.TaskType taskType : VillagerTaskProvider.TaskType.values())
+		{
+			List<BiFunction<VillagerProfession, Float, Pair<Integer, ? extends Task<? super VillagerEntity>>>> l = new ArrayList<>();
+			l.addAll(a.getRawConstantTasks(taskType));
+			l.addAll(b.getRawConstantTasks(taskType));
+			out.addConstantTasks(taskType, l);
+		}
+	}
+	
+	/* @Contract(mutates="param1") */
+	private static void combineRandomTasks(final VillagerTaskProvider out, final VillagerTaskProvider a, final VillagerTaskProvider b)
+	{
+		for (VillagerTaskProvider.TaskType taskType : VillagerTaskProvider.TaskType.values())
+		{
+			List<BiFunction<VillagerProfession, Float, Pair<Task<? super VillagerEntity>, Integer>>> l = new ArrayList<>();
+			l.addAll(a.getRawRandomTasks(taskType));
+			l.addAll(b.getRawRandomTasks(taskType));
+			out.addRandomTasks(taskType, l);
+		}
+	}
+}

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/ai/tasks/WorkerVillagerTask.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/ai/tasks/WorkerVillagerTask.java
@@ -1,0 +1,295 @@
+package net.fabricmc.fabric.api.object.builder.v1.ai.tasks;
+
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import net.minecraft.entity.ai.brain.BlockPosLookTarget;
+import net.minecraft.entity.ai.brain.MemoryModuleState;
+import net.minecraft.entity.ai.brain.MemoryModuleType;
+import net.minecraft.entity.ai.brain.WalkTarget;
+import net.minecraft.entity.ai.brain.task.FarmerVillagerTask;
+import net.minecraft.entity.ai.brain.task.Task;
+import net.minecraft.entity.passive.VillagerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.village.VillagerProfession;
+import net.minecraft.world.GameRules;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+//import org.jetbrains.annotations.Contract;
+//import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * A framework for creating simple world-affecting {@code VillagerTask}s, including pre-made functions for scanning for targets, etc.
+ * @apiNote Tasks may also extend {@code Task<VillagerEntity>}.
+ * @see FarmerVillagerTask FarmerVillagerTask
+ * @see net.minecraft.entity.ai.brain.task.BoneMealTask BoneMealTask
+ * @see Task
+ * @see VillagerTaskProviderRegistry
+ */
+public abstract class WorkerVillagerTask extends Task<VillagerEntity> {
+    /* @Nullable */
+    protected BlockPos currentTarget;
+    protected long nextResponseTime;
+    protected int ticksRan;
+    
+    protected List<BlockPos> targetPositions = Lists.newArrayList();
+    
+    public WorkerVillagerTask() {
+        super(ImmutableMap.of(
+                MemoryModuleType.LOOK_TARGET, MemoryModuleState.VALUE_ABSENT,
+                MemoryModuleType.WALK_TARGET, MemoryModuleState.VALUE_ABSENT,
+                MemoryModuleType.SECONDARY_JOB_SITE, MemoryModuleState.VALUE_PRESENT));
+        LogManager.getLogger().log(Level.INFO, "Task initialized");
+    }
+    
+    @SuppressWarnings("unused")
+    public WorkerVillagerTask(ImmutableMap<MemoryModuleType<?>, MemoryModuleState> memoryMap)
+    {
+        super(memoryMap);
+    }
+    
+    /**
+     * Checks if the block at this position satisfies interaction requirements.<p>
+     * 
+     * Example: the Farmer {@link VillagerProfession} checks for one of two things:
+     * <ol>
+     *     <li>For harvesting: if the block is a crop and is mature,</li>
+     *      <li>For planting: if the targeted block is air and the block below it is farmland.</li>
+     * </ol>
+     * Thus, the Farmer's implementation of this method would be as follows:
+     * <blockquote><pre>protected boolean isSuitableTarget(BlockPos pos, ServerWorld world) {
+     *      BlockState blockState = world.getBlockState(pos);
+     *      Block block = blockState.getBlock();
+     *      Block block2 = world.getBlockState(pos.down()).getBlock();
+     *      return (block instanceof CropBlock) &amp;&amp; ((CropBlock)block).isMature(blockState)
+     *             || (blockState.isAir() &amp;&amp; block2 instanceof FarmlandBlock);
+     * }</pre></blockquote>
+     * 
+     * @param pos The position of the block in the world.
+     * @param world The serverworld in which the block exists.
+     * @return {@code true} if the block at that position satisfies the requirements to be interacted with.
+     */
+    /* @Contract(pure=true) */
+    protected abstract boolean isSuitableTarget(BlockPos pos, ServerWorld world);
+
+    /**
+     * The conditions for this task running, e.g. daylight level, villager age, profession, etc.<p>
+     * 
+     * Example:
+     * <pre>protected boolean checkRunConditions(ServerWorld serverWorld, VillagerEntity villagerEntity) {
+     *      return villagerEntity.getVillagerData().getProfession() == VillagerProfession.FARMER;
+     * }</pre>
+     * 
+     * @param serverWorld the current server world.
+     * @param villagerEntity the {@link VillagerEntity} currently attempting to execute this task.
+     * @return {@code true} if this task should run with the given environment.
+     */
+    /* @Contract(pure=true) */
+    protected abstract boolean checkRunConditions(ServerWorld serverWorld, VillagerEntity villagerEntity);
+    
+    /**
+     * If this task should run only if the {@code doMobGriefing} game-rule is enabled.<p>
+     * Generally necessary for any tasks that break blocks, but not required if they only modify {@code BlockState}s.<p>
+     * 
+     * Example: {@link FarmerVillagerTask} needs to break crops to harvest them, so its implementation would return {@code true}.<p>
+     * @return {@code true} or {@code false}.
+     */
+    /* @Contract(pure=true) */
+    protected abstract boolean doesMobGriefing();
+    
+    
+    /**
+     * The world action to be performed on the currently-targeted block position.
+     * <p>
+     * @param currentTarget The {@link BlockPos} of the currently-targeted block.
+     * @param serverWorld The {@link ServerWorld} the block is located in.
+     * @param villagerEntity The {@link VillagerEntity} acting upon this block.
+     * @param startTick The game tick that the task began.
+     */
+    /* @Contract(mutates="this, param2, param3") */
+    protected abstract void doWorldActions(BlockPos currentTarget, ServerWorld serverWorld, VillagerEntity villagerEntity, long startTick);
+    
+    
+    /**
+	 * @return The duration, in game ticks, that the task should run for.
+	 */
+    /* @Contract(pure=true) */
+    protected abstract int getDuration();
+    
+    
+    /**
+     * Checks if this task should be executed by the villager who randomly chose it.
+     * @apiNote Should avoid overriding this method, instead using {@link WorkerVillagerTask#checkRunConditions}.
+     * @see Task#shouldRun
+     * @param serverWorld The {@code ServerWorld} this task is being executed in.
+     * @param villagerEntity The {@code VillagerEntity} attempting to execute the task.
+     * @return {@code true} if this task should run.
+     * @implNote Implementations of this method should also set the current target via side-effect.
+     */
+    /* @Contract(mutates="this, param1") */
+    @Override
+    protected boolean shouldRun(ServerWorld serverWorld, VillagerEntity villagerEntity) {
+        if ((doesMobGriefing() && serverWorld.getGameRules().getBoolean(GameRules.DO_MOB_GRIEFING))
+                || !checkRunConditions(serverWorld, villagerEntity))
+            return false;
+        else {
+            setCurrentTarget(serverWorld, villagerEntity);
+            return this.currentTarget != null;
+        }
+    }
+    
+    /**
+	 * Clears all potential targets stored, scans for new potential targets, then selects one randomly as the current target.
+     * @apiNote Programs should not override this method, instead overriding {@link WorkerVillagerTask#chooseRandomTarget}.
+     * @param serverWorld The {@code ServerWorld} this task is being executed in.
+     * @param villagerEntity The {@code VillagerEntity} currently executing this task.
+     */
+    /* @Contract(mutates="this") */
+    protected void setCurrentTarget(ServerWorld serverWorld, VillagerEntity villagerEntity) {
+        this.targetPositions.clear();
+        
+        this.getTargetsInRange(serverWorld, villagerEntity);
+        
+        this.currentTarget = this.chooseRandomTarget(serverWorld);
+    }
+    
+    protected void getTargetsInRange(ServerWorld serverWorld, VillagerEntity villagerEntity)
+    {
+        BlockPos.Mutable mutable = new BlockPos.Mutable();
+        
+        for (int i = -1; i <= 1; ++i) {
+            for (int j = -1; j <= 1; ++j) {
+                for (int k = -1; k <= 1; ++k) 
+                {
+                    mutable.set(villagerEntity.getBlockPos(), i, j, k);
+                    
+                    if (this.isSuitableTarget(mutable, serverWorld)) 
+                        addPotentialTarget(mutable.toImmutable());
+                    
+                }
+            }
+        }
+    }
+    
+    /**
+     * The mechanism for saving potential {@link BlockPos} target positions.
+     * @implNote The only reason to override this method is to use an alternative storage method, as with {@link net.minecraft.entity.ai.brain.task.BoneMealTask BoneMealTask}.
+     * @param pos The potential target position.
+     */
+    protected void addPotentialTarget(BlockPos pos) {
+        this.targetPositions.add(pos);
+    }
+    
+    /**
+     * 
+     * @param world The server world being scanned.
+     * @return The {@link BlockPos} that should be chosen as a target.
+     */
+    /* @Contract(pure=true) */
+    /* @Nullable */
+    protected BlockPos chooseRandomTarget(ServerWorld world) {
+        if (this.targetPositions.isEmpty())
+            return null;
+        else
+            return this.targetPositions.get(world.getRandom().nextInt(this.targetPositions.size()));
+    }
+    
+    /**
+     * Called to execute the main task.
+     * @param serverWorld The world this task is being executed in.
+     * @param villagerEntity The {@link VillagerEntity} executing this task.
+     * @param startTick The game tick this task began on.
+     */
+    /* @Contract(mutates="this, param1, param2") */
+    @Override
+    protected void run(ServerWorld serverWorld, VillagerEntity villagerEntity, long startTick) {
+        if (startTick > this.nextResponseTime && this.currentTarget != null) {
+            addLookWalkTarget(villagerEntity, this.currentTarget);
+        }
+    }
+    
+    /**
+     * Called to finish up the current task.
+     * @param serverWorld The world this task is being executed in.
+	 * @param villagerEntity The {@link VillagerEntity} executing this task.
+	 * @param startTick The game tick this task began on.
+     */
+    /* @Contract(mutates="this, param1, param2") */
+    @Override
+    protected void finishRunning(ServerWorld serverWorld, VillagerEntity villagerEntity, long startTick) {
+        forgetLookWalkTarget(villagerEntity);
+        this.ticksRan = 0;
+        this.nextResponseTime = startTick + getEndDelay();
+    }
+    
+    /**
+     * Adds look/walk target to the {@link VillagerEntity}'s {@link net.minecraft.entity.ai.brain.Brain Brain}.
+     * @param villagerEntity The {@code VillagerEntity} to add the look/walk target to.
+     * @param target The target {@code BlockPos}.
+     */
+    /* @Contract(mutates="param1") */
+    protected void addLookWalkTarget(final VillagerEntity villagerEntity, final BlockPos target)
+    {
+        final BlockPosLookTarget lookTarget = new BlockPosLookTarget(target);
+        villagerEntity.getBrain().remember(MemoryModuleType.WALK_TARGET, (new WalkTarget(lookTarget, 0.5F, 1)));
+        villagerEntity.getBrain().remember(MemoryModuleType.LOOK_TARGET, (lookTarget));
+    }
+    
+    /**
+     * Makes the {@code VillagerEntity} forget its Look Target and Walk Target.
+     * @param villagerEntity The {@code VillagerEntity} that will forget its look/walk target.
+     */
+    /* @Contract(mutates="param") */
+    protected void forgetLookWalkTarget(VillagerEntity villagerEntity)
+    {
+        villagerEntity.getBrain().forget(MemoryModuleType.LOOK_TARGET);
+        villagerEntity.getBrain().forget(MemoryModuleType.WALK_TARGET);
+    }
+	
+	
+	/**
+     * Called to perform the task's main action.
+     * @implNote {@code currentTarget} should be set in {@link WorkerVillagerTask#shouldRun}, and implementations of this method should assume {@code currentTarget} has already been set. This is to prevent the task running when no suitable target is within range.
+     * @param serverWorld The world that this task is being executed in.
+     * @param villagerEntity The {@code VillagerEntity} executing this task.
+     * @param startTick The game tick the task was started on.
+     */
+	/* @Contract(mutates="this, param1, param2") */
+    @Override
+    protected void keepRunning(ServerWorld serverWorld, VillagerEntity villagerEntity, long startTick) {
+        if (this.currentTarget == null || this.currentTarget.isWithinDistance(villagerEntity.getPos(), 1.0D)) {
+            if (this.currentTarget != null && startTick > this.nextResponseTime) {
+                doWorldActions(currentTarget, serverWorld, villagerEntity, startTick);
+            }
+
+            ++this.ticksRan;
+        }
+    }
+    
+    /**
+     * 
+     * @return the number of game ticks before the next random target should be chosen.
+     */
+    /* @Contract(pure=true) */
+    protected long getEndDelay()
+    {
+        return 40L;
+    }
+    
+    
+    
+    
+    /* @Contract(pure=true) */
+    @Override
+    protected boolean shouldKeepRunning(ServerWorld serverWorld, VillagerEntity villagerEntity, long l) {
+        return this.ticksRan < getDuration();
+    }
+    
+    
+    
+    
+}
+

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/impl/object/builder/VillagerTaskProviderInternals.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/impl/object/builder/VillagerTaskProviderInternals.java
@@ -1,0 +1,116 @@
+package net.fabricmc.fabric.impl.object.builder;
+
+import com.google.common.collect.ImmutableList;
+import com.mojang.datafixers.util.Pair;
+import net.fabricmc.fabric.api.object.builder.v1.ai.tasks.*;
+import net.minecraft.entity.ai.brain.task.Task;
+import net.minecraft.entity.passive.VillagerEntity;
+import net.minecraft.village.VillagerProfession;
+//import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+
+import static net.fabricmc.fabric.api.object.builder.v1.ai.tasks.VillagerTaskProvider.TaskType.PLAY;
+
+
+public class VillagerTaskProviderInternals {
+	
+	private static final Map<VillagerProfession, VillagerTaskProvider> villagerTaskProviderMap;
+	
+	private static final VillagerTaskProvider defaultTaskProvider = new VillagerTaskProvider();
+	
+	private static VillagerTaskProvider getTaskProvider(VillagerProfession profession)
+	{
+		assert(profession != null);
+		
+		if (profession == VillagerProfession.NONE)
+			return defaultTaskProvider;
+		
+		final VillagerTaskProvider vtp = villagerTaskProviderMap.get(profession);
+		if (vtp == null)
+			return defaultTaskProvider;
+		else
+			return vtp;
+	}
+	
+	static {
+		villagerTaskProviderMap = VillagerTaskProviderRegistry.getCompletedMap();
+	}
+	
+	
+	
+	public static ImmutableList<Pair<Integer, ? extends Task<? super VillagerEntity>>> getConstantTasks(VillagerTaskProvider.TaskType taskType, /* @Nullable */ VillagerProfession profession, float f)
+	{
+		assert(!(profession == null && taskType != PLAY)); // The only hardcoding in this whole thing, because PLAY is an outlier.
+		
+		ImmutableList.Builder<Pair<Integer, ? extends Task<? super VillagerEntity>>> out = ImmutableList.builder();
+		
+		out.addAll(VillagerTaskProvider.getBaseConstantTasks(taskType, profession, f));
+		
+		if (profession != VillagerProfession.NONE && taskType != PLAY)
+			out.addAll(getTaskProvider(profession).getConstantTasks(taskType, profession, f));
+		
+		return out.build();
+	}
+	
+//	private static ImmutableList<Pair<Integer, ? extends Task<? super VillagerEntity>>> getVanillaTasks(VillagerTaskProvider.TaskType taskType, VillagerProfession p, float f)
+//	{
+//		switch (taskType)
+//		{
+//			case CORE:
+//				return VillagerTaskListProvider.createCoreTasks(p, f);
+//			case WORK:
+//				return VillagerTaskListProvider.createWorkTasks(p, f);
+//			case PLAY:
+//				return VillagerTaskListProvider.createPlayTasks(f);
+//			case MEET:
+//				return VillagerTaskListProvider.createMeetTasks(p, f);
+//			case IDLE:
+//				return VillagerTaskListProvider.createIdleTasks(p, f);
+//			case PANIC:
+//				return VillagerTaskListProvider.createPanicTasks(p, f);
+//			case PRERAID:
+//				return VillagerTaskListProvider.createPreRaidTasks(p, f);
+//			case RAID:
+//				return VillagerTaskListProvider.createRaidTasks(p, f);
+//			case HIDE:
+//				return VillagerTaskListProvider.createHideTasks(p, f);
+//			case REST:
+//				return VillagerTaskListProvider.createRestTasks(p, f);
+//			default:
+//				throw new AssertionError("Invalid VillagerTaskProvider.TaskType provided: " + taskType);
+//		}
+//	}
+	
+	
+	
+	// These are injected directly into the random task list, so there's no need to worry about switch cases.
+	public static ImmutableList<Pair<Task<? super VillagerEntity>, Integer>> getRandomTasks(VillagerTaskProvider.TaskType taskType, /* @Nullable */ VillagerProfession p, float f)
+	{
+		ImmutableList.Builder<Pair<Task<? super VillagerEntity>, Integer>> out = ImmutableList.builder();
+		out.addAll(VillagerTaskProvider.getBaseRandomTasks(taskType, p, f));
+		
+		if (taskType != PLAY) 
+			out.addAll(getTaskProvider(p).getRandomTasks(taskType, p, f));
+		
+		return out.build();
+	}
+	
+	
+	
+	
+	public static boolean hasCustomRandomTasks(VillagerTaskProvider.TaskType taskType, VillagerProfession villagerProfession)
+	{
+		return getTaskProvider(villagerProfession).hasRandomTasks(taskType) || VillagerTaskProvider.hasBaseRandomTasks(taskType);
+	}
+	
+	public static boolean hasCustomRandomTasks(VillagerTaskProvider.TaskType taskType)
+	{
+		return VillagerTaskProvider.hasBaseRandomTasks(taskType);
+	}
+	
+//	public static boolean baseHasRandomTasks(VillagerTaskProvider.TaskType taskType)
+//	{
+//		return VillagerTaskProvider.hasBaseRandomTasks(taskType);
+//	}
+}

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/VillagerTaskListProviderInjector.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/VillagerTaskListProviderInjector.java
@@ -1,0 +1,447 @@
+package net.fabricmc.fabric.mixin.object.builder;
+
+import com.google.common.collect.*;
+import com.mojang.datafixers.util.*;
+import net.fabricmc.fabric.api.object.builder.v1.ai.tasks.*;
+import net.fabricmc.fabric.impl.object.builder.*;
+import net.minecraft.entity.ai.brain.task.*;
+import net.minecraft.entity.passive.*;
+import net.minecraft.village.*;
+import org.spongepowered.asm.mixin.*;
+import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.callback.*;
+import org.spongepowered.asm.mixin.injection.invoke.arg.*;
+
+import java.util.*;
+
+@SuppressWarnings({"unchecked"})
+@Mixin(VillagerTaskListProvider.class)
+abstract class VillagerTaskListProviderInjector {
+	
+	private static final int RANDOM_TASK_WEIGHT = 3;
+	
+	/*
+	 * Possible issues in the future:
+	 * -"MixinTransformerError"/"Critical injection failure: Multi-argument modifier method..."
+	 * 		Cause: RandomTask constructor can take either (Map, List) or (List).
+	 * 			   Mojang likely changed which constructor is being used.
+	 * 		Fix: Change "RandomTask.<init>(Ljava/util/List;)V" to "(Ljava/util/Map;Ljava/util/List;)V", or vice versa.
+	 * 
+	 * 
+	 */
+	
+	
+	@Inject(method = "createCoreTasks", at = @At("RETURN"), cancellable=true)
+	private static void addCustomConstantCoreTasks(VillagerProfession profession, float f, CallbackInfoReturnable<ImmutableList<Pair<Integer, ? extends Task<? super VillagerEntity>>>> cir)
+	{
+		ImmutableList.Builder<Pair<Integer, ? extends Task<? super VillagerEntity>>> taskList = ImmutableList.builder();
+		taskList.addAll(cir.getReturnValue());
+		taskList.addAll(VillagerTaskProviderInternals.getConstantTasks(VillagerTaskProvider.TaskType.CORE, profession, f));
+		
+		//START ADD NEW RANDOM TASK
+		//	NOTE: This is to reuse the addCustomRandomTasks code.
+		//		If Mojang ever adds a "RandomTask" in this section, 
+		//			delete this block and uncomment the "@ModifyArgs" annotation below.
+		if (VillagerTaskProviderInternals.hasCustomRandomTasks(VillagerTaskProvider.TaskType.CORE, profession))
+		{
+			Args randomTasksDummyParam = new Args(new ImmutableList[] {ImmutableList.of()}) {
+				@Override
+				public <T> void set(final int index, final T value)
+				{
+					this.values[index] = value;
+				}
+				
+				@Override
+				public void setAll(final Object... values)
+				{
+					System.arraycopy(values, 0, this.values, 0, values.length);
+				}
+			};
+			
+			addCustomRandomCoreTasks(randomTasksDummyParam, profession, f);
+			ImmutableList<Pair<Task<? super VillagerEntity>, Integer>> randomTasks = randomTasksDummyParam.get(0);
+			if (!randomTasks.isEmpty())
+				taskList.add(Pair.of(RANDOM_TASK_WEIGHT, new RandomTask<>(randomTasks)));
+		}
+		//END ADD NEW RANDOM TASK
+		
+		cir.setReturnValue(taskList.build());
+	}
+	
+	//@ModifyArgs(method = "createCoreTasks", at = @At(value = "INVOKE", target = "net/minecraft/entity/ai/brain/task/RandomTask.<init>(Ljava/util/List;)V"))
+	private static void addCustomRandomCoreTasks(Args args, VillagerProfession profession, float f)
+	{
+		ImmutableList.Builder<Pair<Task<? super VillagerEntity>, Integer>> taskList = ImmutableList.builder();
+		
+		int listIndex = -1;
+		for (int i = 0; i < args.size(); i++) {
+			if (args.get(i) instanceof List<?>)
+				listIndex = i;
+		}
+		assert listIndex != -1 : "No List argument provided.";
+		taskList.addAll((List<Pair<Task<? super VillagerEntity>, Integer>>) args.get(listIndex));
+		
+		taskList.addAll(VillagerTaskProviderInternals.getRandomTasks(VillagerTaskProvider.TaskType.CORE, profession, f));
+
+		args.set(listIndex, taskList.build());
+	}
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	@Inject(method = "createWorkTasks", at = @At(value = "RETURN"), cancellable=true)
+	private static void addCustomConstantWorkTasks(VillagerProfession profession, float f, CallbackInfoReturnable<ImmutableList<Pair<Integer, ? extends Task<? super VillagerEntity>>>> cir)
+	{
+		ImmutableList.Builder<Pair<Integer, ? extends Task<? super VillagerEntity>>> taskList = ImmutableList.builder();
+		
+		taskList.addAll(cir.getReturnValue());
+		taskList.addAll(VillagerTaskProviderInternals.getConstantTasks(VillagerTaskProvider.TaskType.WORK, profession, f));
+		
+		cir.setReturnValue(taskList.build());
+	}
+	
+	@ModifyArgs(method = "createWorkTasks", at = @At(value = "INVOKE", target = "net/minecraft/entity/ai/brain/task/RandomTask.<init>(Ljava/util/List;)V"))
+	private static void addCustomRandomWorkTasks(Args args, VillagerProfession profession, float f)
+	{
+		ImmutableList.Builder<Pair<Task<? super VillagerEntity>, Integer>> taskList = ImmutableList.builder();
+		
+		int listIndex = -1;
+		for (int i = 0; i < args.size(); i++) {
+			if (args.get(i) instanceof List<?>)
+				listIndex = i;
+		}
+		assert listIndex != -1 : "No List argument provided.";
+		taskList.addAll((List<Pair<Task<? super VillagerEntity>, Integer>>) args.get(listIndex));
+		
+		taskList.addAll(VillagerTaskProviderInternals.getRandomTasks(VillagerTaskProvider.TaskType.WORK, profession, f));
+		
+		args.set(listIndex, taskList.build());
+	}
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	@Inject(method = "createPlayTasks", at = @At(value = "RETURN"), cancellable=true)
+	private static void addCustomConstantPlayTasks(float f, CallbackInfoReturnable<ImmutableList<Pair<Integer, ? extends Task<? super VillagerEntity>>>> cir)
+	{
+		ImmutableList.Builder<Pair<Integer, ? extends Task<? super VillagerEntity>>> taskList = ImmutableList.builder();
+		
+		taskList.addAll(cir.getReturnValue());
+		taskList.addAll(VillagerTaskProviderInternals.getConstantTasks(VillagerTaskProvider.TaskType.PLAY, null, f));
+		
+		cir.setReturnValue(taskList.build());
+	}
+	
+	@ModifyArgs(method = "createPlayTasks", at = @At(value = "INVOKE", target = "net/minecraft/entity/ai/brain/task/RandomTask.<init>(Ljava/util/Map;Ljava/util/List;)V"))
+	private static void addCustomRandomPlayTasks(Args args, float f)
+	{
+		ImmutableList.Builder<Pair<Task<? super VillagerEntity>, Integer>> taskList = ImmutableList.builder();
+		
+		int listIndex = -1;
+		for (int i = 0; i < args.size(); i++) {
+			if (args.get(i) instanceof List<?>)
+				listIndex = i;
+		}
+		assert listIndex != -1 : "No List argument provided.";
+		taskList.addAll((List<Pair<Task<? super VillagerEntity>, Integer>>) args.get(listIndex));
+		
+		taskList.addAll(VillagerTaskProviderInternals.getRandomTasks(VillagerTaskProvider.TaskType.PLAY, null, f));
+		
+		args.set(listIndex, taskList.build());
+	}
+	
+	
+	
+	@Inject(method = "createRestTasks", at = @At(value = "RETURN"), cancellable=true)
+	private static void addCustomConstantRestTasks(VillagerProfession profession, float f, CallbackInfoReturnable<ImmutableList<Pair<Integer, ? extends Task<? super VillagerEntity>>>> cir)
+	{
+		ImmutableList.Builder<Pair<Integer, ? extends Task<? super VillagerEntity>>> taskList = ImmutableList.builder();
+		
+		taskList.addAll(cir.getReturnValue());
+		taskList.addAll(VillagerTaskProviderInternals.getConstantTasks(VillagerTaskProvider.TaskType.REST, profession, f));
+		
+		cir.setReturnValue(taskList.build());
+	}
+	
+	
+	@ModifyArgs(method = "createRestTasks", at = @At(value = "INVOKE", target = "net/minecraft/entity/ai/brain/task/RandomTask.<init>(Ljava/util/Map;Ljava/util/List;)V"))
+	private static void addCustomRandomRestTasks(Args args, VillagerProfession profession, float f)
+	{
+		ImmutableList.Builder<Pair<Task<? super VillagerEntity>, Integer>> taskList = ImmutableList.builder();
+		
+		int listIndex = -1;
+		for (int i = 0; i < args.size(); i++) {
+			if (args.get(i) instanceof List<?>)
+				listIndex = i;
+		}
+		assert listIndex != -1 : "No List argument provided.";
+		taskList.addAll((List<Pair<Task<? super VillagerEntity>, Integer>>) args.get(listIndex));
+		
+		taskList.addAll(VillagerTaskProviderInternals.getRandomTasks(VillagerTaskProvider.TaskType.REST, profession, f));
+		
+		args.set(listIndex, taskList.build());
+	}
+	
+	
+	
+	
+	
+	
+	
+	
+	@Inject(method = "createMeetTasks", at = @At(value = "RETURN"), cancellable=true)
+	private static void addCustomConstantMeetTasks(VillagerProfession profession, float f, CallbackInfoReturnable<ImmutableList<Pair<Integer, ? extends Task<? super VillagerEntity>>>> cir)
+	{
+		ImmutableList.Builder<Pair<Integer, ? extends Task<? super VillagerEntity>>> taskList = ImmutableList.builder();
+		
+		taskList.addAll(cir.getReturnValue());
+		taskList.addAll(VillagerTaskProviderInternals.getConstantTasks(VillagerTaskProvider.TaskType.MEET, profession, f));
+		
+		cir.setReturnValue(taskList.build());
+	}
+	
+	@ModifyArgs(method = "createMeetTasks", at = @At(value = "INVOKE", target = "net/minecraft/entity/ai/brain/task/RandomTask.<init>(Ljava/util/List;)V"))
+	private static void addCustomRandomMeetTasks(Args args, VillagerProfession profession, float f)
+	{
+		ImmutableList.Builder<Pair<Task<? super VillagerEntity>, Integer>> taskList = ImmutableList.builder();
+		
+		int listIndex = -1;
+		for (int i = 0; i < args.size(); i++) {
+			if (args.get(i) instanceof List<?>)
+				listIndex = i;
+		}
+		assert listIndex != -1 : "No List argument provided.";
+		taskList.addAll((List<Pair<Task<? super VillagerEntity>, Integer>>) args.get(listIndex));
+		
+		taskList.addAll(VillagerTaskProviderInternals.getRandomTasks(VillagerTaskProvider.TaskType.MEET, profession, f));
+		
+		args.set(listIndex, taskList.build());
+	}
+	
+	
+	
+	
+	
+	
+	
+	@Inject(method = "createIdleTasks", at = @At(value = "RETURN"), cancellable=true)
+	private static void addCustomConstantIdleTasks(VillagerProfession profession, float f, CallbackInfoReturnable<ImmutableList<Pair<Integer, ? extends Task<? super VillagerEntity>>>> cir)
+	{
+		ImmutableList.Builder<Pair<Integer, ? extends Task<? super VillagerEntity>>> taskList = ImmutableList.builder();
+		
+		taskList.addAll(cir.getReturnValue());
+		taskList.addAll(VillagerTaskProviderInternals.getConstantTasks(VillagerTaskProvider.TaskType.IDLE, profession, f));
+		
+		cir.setReturnValue(taskList.build());
+	}
+	
+	@ModifyArgs(method = "createIdleTasks", at = @At(value = "INVOKE", target = "net/minecraft/entity/ai/brain/task/RandomTask.<init>(Ljava/util/List;)V"))
+	private static void addCustomRandomIdleTasks(Args args, VillagerProfession profession, float f)
+	{
+		ImmutableList.Builder<Pair<Task<? super VillagerEntity>, Integer>> taskList = ImmutableList.builder();
+		
+		int listIndex = -1;
+		for (int i = 0; i < args.size(); i++) {
+			if (args.get(i) instanceof List<?>)
+				listIndex = i;
+		}
+		assert listIndex != -1 : "No List argument provided.";
+		taskList.addAll((List<Pair<Task<? super VillagerEntity>, Integer>>) args.get(listIndex));
+		
+		taskList.addAll(VillagerTaskProviderInternals.getRandomTasks(VillagerTaskProvider.TaskType.IDLE, profession, f));
+		
+		args.set(listIndex, taskList.build());
+	}
+	
+	
+	
+	
+	
+	
+	
+	@Inject(method = "createPanicTasks", at = @At(value = "RETURN"), cancellable=true)
+	private static void addCustomConstantPanicTasks(VillagerProfession profession, float f, CallbackInfoReturnable<ImmutableList<Pair<Integer, ? extends Task<? super VillagerEntity>>>> cir)
+	{
+		ImmutableList.Builder<Pair<Integer, ? extends Task<? super VillagerEntity>>> taskList = ImmutableList.builder();
+		taskList.addAll(cir.getReturnValue());
+		taskList.addAll(VillagerTaskProviderInternals.getConstantTasks(VillagerTaskProvider.TaskType.PANIC, profession, f));
+		
+		//START ADD NEW RANDOM TASK
+		//	NOTE: This is to reuse the addCustomRandomTasks code.
+		//		If Mojang ever adds a "RandomTask" in the target method, 
+		//			delete this block and uncomment the "@ModifyArgs" annotation below.
+		if (VillagerTaskProviderInternals.hasCustomRandomTasks(VillagerTaskProvider.TaskType.PANIC, profession))
+		{
+			Args randomTasksDummyParam = new Args(new ImmutableList[] {ImmutableList.of()}) {
+				@Override
+				public <T> void set(final int index, final T value)
+				{
+					this.values[index] = value;
+				}
+				
+				@Override
+				public void setAll(final Object... values)
+				{ }
+			};
+			
+			addCustomRandomPanicTasks(randomTasksDummyParam, profession, f);
+			ImmutableList<Pair<Task<? super VillagerEntity>, Integer>> randomTasks = randomTasksDummyParam.get(0);
+			if (!randomTasks.isEmpty())
+				taskList.add(Pair.of(RANDOM_TASK_WEIGHT, new RandomTask<>(randomTasks)));
+		}
+		//END ADD NEW RANDOM TASK
+		
+		cir.setReturnValue(taskList.build());
+	}
+	
+	//@ModifyArgs(method = "createPanicTasks", at = @At(value = "INVOKE", target = "com/google/common/collect/ImmutableList.of (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;[Ljava/lang/Object;)Lcom/google/common/collect/ImmutableList"))
+	private static void addCustomRandomPanicTasks(Args args, VillagerProfession profession, float f)
+	{
+		ImmutableList.Builder<Pair<Task<? super VillagerEntity>, Integer>> taskList = ImmutableList.builder();
+		
+		int listIndex = -1;
+		for (int i = 0; i < args.size(); i++) {
+			if (args.get(i) instanceof List<?>)
+				listIndex = i;
+		}
+		assert listIndex != -1 : "No List argument provided.";
+		taskList.addAll((List<Pair<Task<? super VillagerEntity>, Integer>>) args.get(listIndex));
+		
+		taskList.addAll(VillagerTaskProviderInternals.getRandomTasks(VillagerTaskProvider.TaskType.PANIC, profession, f));
+		
+		args.set(listIndex, taskList.build());
+	}
+	
+	
+	
+	
+	
+	@Inject(method = "createPreRaidTasks", at = @At(value = "RETURN"), cancellable=true)
+	private static void addCustomConstantPreRaidTasks(VillagerProfession profession, float f, CallbackInfoReturnable<ImmutableList<Pair<Integer, ? extends Task<? super VillagerEntity>>>> cir)
+	{
+		ImmutableList.Builder<Pair<Integer, ? extends Task<? super VillagerEntity>>> taskList = ImmutableList.builder();
+		
+		taskList.addAll(cir.getReturnValue());
+		taskList.addAll(VillagerTaskProviderInternals.getConstantTasks(VillagerTaskProvider.TaskType.PRERAID, profession, f));
+		
+		cir.setReturnValue(taskList.build());
+	}
+	
+	@ModifyArgs(method = "createPreRaidTasks", at = @At(value = "INVOKE", target = "net/minecraft/entity/ai/brain/task/RandomTask.<init>(Ljava/util/List;)V"))
+	private static void addCustomRandomPreRaidTasks(Args args, VillagerProfession profession, float f)
+	{
+		ImmutableList.Builder<Pair<Task<? super VillagerEntity>, Integer>> taskList = ImmutableList.builder();
+		
+		int listIndex = -1;
+		for (int i = 0; i < args.size(); i++) {
+			if (args.get(i) instanceof List<?>)
+				listIndex = i;
+		}
+		assert listIndex != -1 : "No List argument provided.";
+		taskList.addAll((List<Pair<Task<? super VillagerEntity>, Integer>>) args.get(listIndex));
+		
+		taskList.addAll(VillagerTaskProviderInternals.getRandomTasks(VillagerTaskProvider.TaskType.PRERAID, profession, f));
+		
+		args.set(listIndex, taskList.build());
+	}
+	
+	
+	
+	@Inject(method = "createRaidTasks", at = @At(value = "RETURN"), cancellable=true)
+	private static void addCustomConstantRaidTasks(VillagerProfession profession, float f, CallbackInfoReturnable<ImmutableList<Pair<Integer, ? extends Task<? super VillagerEntity>>>> cir)
+	{
+		ImmutableList.Builder<Pair<Integer, ? extends Task<? super VillagerEntity>>> taskList = ImmutableList.builder();
+		
+		taskList.addAll(cir.getReturnValue());
+		taskList.addAll(VillagerTaskProviderInternals.getConstantTasks(VillagerTaskProvider.TaskType.RAID, profession, f));
+		
+		cir.setReturnValue(taskList.build());
+	}
+	
+	@ModifyArgs(method = "createRaidTasks", at = @At(value = "INVOKE", target = "net/minecraft/entity/ai/brain/task/RandomTask.<init>(Ljava/util/List;)V"))
+	private static void addCustomRandomRaidTasks(Args args, VillagerProfession profession, float f)
+	{
+		ImmutableList.Builder<Pair<Task<? super VillagerEntity>, Integer>> taskList = ImmutableList.builder();
+		
+		int listIndex = -1;
+		for (int i = 0; i < args.size(); i++) {
+			if (args.get(i) instanceof List<?>)
+				listIndex = i;
+		}
+		assert listIndex != -1 : "No List argument provided.";
+		taskList.addAll((List<Pair<Task<? super VillagerEntity>, Integer>>) args.get(listIndex));
+		
+		taskList.addAll(VillagerTaskProviderInternals.getRandomTasks(VillagerTaskProvider.TaskType.RAID, profession, f));
+		
+		args.set(listIndex, taskList.build());
+	}
+	
+	
+	
+	
+	
+	
+	
+	@Inject(method = "createHideTasks", at = @At("RETURN"), cancellable=true)
+	private static void addCustomConstantHideTasks(VillagerProfession profession, float f, CallbackInfoReturnable<ImmutableList<Pair<Integer, ? extends Task<? super VillagerEntity>>>> cir)
+	{
+		ImmutableList.Builder<Pair<Integer, ? extends Task<? super VillagerEntity>>> taskList = ImmutableList.builder();
+		taskList.addAll(cir.getReturnValue());
+		taskList.addAll(VillagerTaskProviderInternals.getConstantTasks(VillagerTaskProvider.TaskType.HIDE, profession, f));
+		
+		//START ADD NEW RANDOM TASK
+		//	NOTE: This is to reuse the addCustomRandomTasks code.
+		//		If Mojang ever adds a "RandomTask" in the target method, 
+		//			delete this block and uncomment the "@ModifyArgs" annotation below.
+		if (VillagerTaskProviderInternals.hasCustomRandomTasks(VillagerTaskProvider.TaskType.HIDE, profession))
+		{
+			Args randomTasksDummyParam = new Args(new ImmutableList[] {ImmutableList.of()}) {
+				@Override
+				public <T> void set(final int index, final T value)
+				{
+					this.values[index] = value;
+				}
+				
+				@Override
+				public void setAll(final Object... values)
+				{ }
+			};
+			
+			addCustomRandomHideTasks(randomTasksDummyParam, profession, f);
+			ImmutableList<Pair<Task<? super VillagerEntity>, Integer>> randomTasks = randomTasksDummyParam.get(0);
+			if (!randomTasks.isEmpty())
+				taskList.add(Pair.of(RANDOM_TASK_WEIGHT, new RandomTask<>(randomTasks)));
+		}
+		//END ADD NEW RANDOM TASK
+		
+		cir.setReturnValue(taskList.build());
+	}
+	
+	//@ModifyArgs(method = "createHideTasks", at = @At(value = "INVOKE", target = "com/google/common/collect/ImmutableList.of (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;[Ljava/lang/Object;)Lcom/google/common/collect/ImmutableList"))
+	private static void addCustomRandomHideTasks(Args args, VillagerProfession profession, float f)
+	{
+		ImmutableList.Builder<Pair<Task<? super VillagerEntity>, Integer>> taskList = ImmutableList.builder();
+		
+		int listIndex = -1;
+		for (int i = 0; i < args.size(); i++) {
+			if (args.get(i) instanceof List<?>)
+				listIndex = i;
+		}
+		assert listIndex != -1 : "No List argument provided.";
+		taskList.addAll((List<Pair<Task<? super VillagerEntity>, Integer>>) args.get(listIndex));
+		
+		taskList.addAll(VillagerTaskProviderInternals.getRandomTasks(VillagerTaskProvider.TaskType.HIDE, profession, f));
+		
+		args.set(listIndex, taskList.build());
+	}
+}

--- a/fabric-object-builder-api-v1/src/main/resources/fabric-object-builder-api-v1.accesswidener
+++ b/fabric-object-builder-api-v1/src/main/resources/fabric-object-builder-api-v1.accesswidener
@@ -1,3 +1,6 @@
 accessWidener	v1	named
 extendable  method    net/minecraft/block/AbstractBlock$Settings    <init>  (Lnet/minecraft/block/Material;Ljava/util/function/Function;)V
 extendable  method    net/minecraft/block/AbstractBlock$Settings    <init>  (Lnet/minecraft/block/Material;Lnet/minecraft/block/MaterialColor;)V
+
+accessible  class   net/minecraft/entity/ai/brain/task/CompositeTask$Order
+accessible  class   net/minecraft/entity/ai/brain/task/CompositeTask$RunMode

--- a/fabric-object-builder-api-v1/src/main/resources/fabric-object-builder-v1.mixins.json
+++ b/fabric-object-builder-api-v1/src/main/resources/fabric-object-builder-v1.mixins.json
@@ -11,7 +11,8 @@
     "MaterialBuilderAccessor",
     "MixinBlock",
     "PointOfInterestTypeAccessor",
-    "VillagerProfessionAccessor"
+    "VillagerProfessionAccessor",
+    "VillagerTaskListProviderInjector"
   ],
   "client": [
     "ModelPredicateProviderRegistryAccessor",


### PR DESCRIPTION
### Adds:

- `VillagerTaskProvider`: A handler for dynamically adding tasks to a villager's task-list based on their `VillagerProfession`.  Essentially extends the hardcoded `net.minecraft.entity.ai.brain.VillagerTaskListProvider` and makes it able to adapt based on profession.  Two types of tasks can be changed: constant (added to the main list) and random (added to the list passed to that task-list's RandomTask).  Task "category" is chosen based on an enum - each value corresponding to a different `create<X>Tasks` method in `VillagerTaskListProvider`.
- Base!`VillagerTaskProvider`: Allows modders to change the tasks of _every_ villager, regardless of profession.
- `VillagerTaskProviderRegistry`: Registers `VillagerTaskProvider`s, mapped to `VillagerProfession`.  If multiple task-lists are submitted for the same profession, the lists will be merged.
- `VillagerTaskProviderInternals`: Allows `VillagerTaskListProviderInjector` to retrieve entries from the `VillagerTaskProvider` registry at runtime.  The Profession-TaskProvider map is retrieved from `VillagerTaskProviderRegistry` during startup, converted to an `ImmutableMap`, and stored as a static property of this class.
- `WorkerVillagerTask`: A framework for creating simple world-altering `VillagerTask`s.  Includes handler methods for scanning the surrounding area, registering and selecting a random target, and adding a look/walk target.  Includes hooks for run conditions, executing world actions, duration, and other factors that need to be considered when implementing `Task<LivingEntity>`.  The framework is not required; it's just an easier way to implement `Task<LivingEntity>`.
- Extensive documentation for each of these.

### Future Maintenance:

- If a new method is added to `VillagerTaskListProvider`, three things will need to be added:
1. An `@Inject` mixin for that method's "Constant" method (inject into the main list),
2. A `@ModifyArgs` mixin for that method's "Random" tasks (inject into the list passed to `RandomTask`), or add a new `RandomTask` to that list if none is included by default (copy from the other methods of that kind and change the enum), and,
3. A new enum value for that category.

- Potential signature changes are documented in `VillagerTaskListProviderInjector`.

