### PR TITLE
Make BlockApiLookup expose the API and context classes

### DIFF
--- a/fabric-api-lookup-api-v1/build.gradle
+++ b/fabric-api-lookup-api-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-api-lookup-api-v1"
-version = getSubprojectVersion(project, "1.0.0")
+version = getSubprojectVersion(project, "1.1.0")
 
 moduleDependencies(project, [
 	'fabric-api-base',

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiLookup.java
@@ -217,6 +217,16 @@ public interface BlockApiLookup<A, C> {
 	 */
 	void registerFallback(BlockApiProvider<A, C> fallbackProvider);
 
+	/**
+	 * Return the API class of this lookup.
+	 */
+	Class<A> apiClass();
+
+	/**
+	 * Return the context class of this lookup.
+	 */
+	Class<C> contextClass();
+
 	@FunctionalInterface
 	interface BlockApiProvider<A, C> {
 		/**

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiLookupImpl.java
@@ -48,12 +48,14 @@ public final class BlockApiLookupImpl<A, C> implements BlockApiLookup<A, C> {
 	}
 
 	private final Class<A> apiClass;
+	private final Class<C> contextClass;
 	private final ApiProviderMap<Block, BlockApiProvider<A, C>> providerMap = ApiProviderMap.create();
 	private final List<BlockApiProvider<A, C>> fallbackProviders = new CopyOnWriteArrayList<>();
 
 	@SuppressWarnings("unchecked")
 	private BlockApiLookupImpl(Class<?> apiClass, Class<?> contextClass) {
 		this.apiClass = (Class<A>) apiClass;
+		this.contextClass = (Class<C>) contextClass;
 	}
 
 	@Nullable
@@ -168,6 +170,16 @@ public final class BlockApiLookupImpl<A, C> implements BlockApiLookup<A, C> {
 		Objects.requireNonNull(fallbackProvider, "BlockApiProvider may not be null.");
 
 		fallbackProviders.add(fallbackProvider);
+	}
+
+	@Override
+	public Class<A> apiClass() {
+		return apiClass;
+	}
+
+	@Override
+	public Class<C> contextClass() {
+		return contextClass;
 	}
 
 	@Nullable

--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/FabricApiLookupTest.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/FabricApiLookupTest.java
@@ -82,6 +82,14 @@ public class FabricApiLookupTest implements ModInitializer {
 			BlockApiLookup<Void, Void> wrongInsertable = BlockApiLookup.get(new Identifier("testmod:item_insertable"), Void.class, Void.class);
 			wrongInsertable.registerFallback((world, pos, state, be, nocontext) -> null);
 		}, "The registry should have prevented creation of another instance with different classes, but same id.");
+
+		if (insertable2.apiClass() != ItemInsertable.class) {
+			throw new AssertionError("Incorrect API class was returned.");
+		}
+
+		if (insertable2.contextClass() != Direction.class) {
+			throw new AssertionError("Incorrect context class was returned.");
+		}
 	}
 
 	private static void testSelfRegistration() {


### PR DESCRIPTION
Closes #1464. I had a few minutes to write this, not high priority but at the same time very simple.