### PR TITLE
Prevent SpriteFinder from returning Missing sprite for wrong atlas

### DIFF
--- a/fabric-renderer-api-v1/build.gradle
+++ b/fabric-renderer-api-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-renderer-api-v1"
-version = getSubprojectVersion(project, "0.4.3")
+version = getSubprojectVersion(project, "0.4.4")
 
 moduleDependencies(project, [
 		'fabric-api-base'

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/impl/renderer/SpriteFinderImpl.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/impl/renderer/SpriteFinderImpl.java
@@ -19,7 +19,6 @@ package net.fabricmc.fabric.impl.renderer;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.texture.MissingSprite;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.texture.SpriteAtlasTexture;
@@ -39,9 +38,11 @@ import net.fabricmc.fabric.api.renderer.v1.model.SpriteFinder;
  */
 public class SpriteFinderImpl implements SpriteFinder {
 	private final Node root;
+	private final SpriteAtlasTexture spriteAtlasTexture;
 
-	public SpriteFinderImpl(Map<Identifier, Sprite> sprites) {
+	public SpriteFinderImpl(Map<Identifier, Sprite> sprites, SpriteAtlasTexture spriteAtlasTexture) {
 		root = new Node(0.5f, 0.5f, 0.25f);
+		this.spriteAtlasTexture = spriteAtlasTexture;
 		sprites.values().forEach(root::add);
 	}
 
@@ -63,7 +64,7 @@ public class SpriteFinderImpl implements SpriteFinder {
 		return root.find(u, v);
 	}
 
-	private static class Node {
+	private class Node {
 		final float midU;
 		final float midV;
 		final float cellRadius;
@@ -75,7 +76,7 @@ public class SpriteFinderImpl implements SpriteFinder {
 		Node(float midU, float midV, float radius) {
 			this.midU = midU;
 			this.midV = midV;
-			this.cellRadius = radius;
+			cellRadius = radius;
 		}
 
 		static final float EPS = 0.00001f;
@@ -134,7 +135,7 @@ public class SpriteFinderImpl implements SpriteFinder {
 			} else if (quadrant instanceof Node) {
 				return ((Node) quadrant).find(u, v);
 			} else {
-				return MinecraftClient.getInstance().getSpriteAtlas(SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE).apply(MissingSprite.getMissingSpriteId());
+				return spriteAtlasTexture.getSprite(MissingSprite.getMissingSpriteId());
 			}
 		}
 	}

--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinSpriteAtlasTexture.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/mixin/renderer/client/MixinSpriteAtlasTexture.java
@@ -47,7 +47,7 @@ public class MixinSpriteAtlasTexture implements SpriteFinderImpl.SpriteFinderAcc
 		SpriteFinderImpl result = fabric_spriteFinder;
 
 		if (result == null) {
-			result = new SpriteFinderImpl(sprites);
+			result = new SpriteFinderImpl(sprites, (SpriteAtlasTexture) (Object) this);
 			fabric_spriteFinder = result;
 		}
 


### PR DESCRIPTION
SpriteFinder was originally designed for use with block/item rendering. Since then, Mojang has added new sprite atlas textures and each atlas has it's own "missing" sprite.  However, SpriteFinder still returns the block/item missing sprite in all cases.  This sprite will almost certainly not render correctly when used with other atlases, causing confusion. 

This will be only a cosmetic problem in most cases, but mods with atlas-specific mixins or logic can have more negative impacts.
 
This PR causes SpriteFinder to return the correct, atlas-specific missing Sprite.  

 