### PR TITLE
Fix FuelRegistry not following vanilla checks for valid fuels

### DIFF
--- a/fabric-content-registries-v0/build.gradle
+++ b/fabric-content-registries-v0/build.gradle
@@ -1,5 +1,9 @@
 archivesBaseName = "fabric-content-registries-v0"
-version = getSubprojectVersion(project, "0.2.2")
+version = getSubprojectVersion(project, "0.2.3")
+
+loom {
+	accessWidener = file("src/main/resources/fabric-content-registries-v0.accesswidener")
+}
 
 moduleDependencies(project, [
 		'fabric-api-base',

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/FuelRegistryImpl.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/FuelRegistryImpl.java
@@ -117,9 +117,7 @@ public final class FuelRegistryImpl implements FuelRegistry {
 					map.remove(i);
 				}
 			} else {
-				for (Item i : tag.values()) {
-					map.put(i, time);
-				}
+				AbstractFurnaceBlockEntity.addFuel(map, tag, time);
 			}
 		}
 
@@ -129,7 +127,7 @@ public final class FuelRegistryImpl implements FuelRegistry {
 			if (time <= 0) {
 				map.remove(item.asItem());
 			} else {
-				map.put(item.asItem(), time);
+				AbstractFurnaceBlockEntity.addFuel(map, item, time);
 			}
 		}
 	}

--- a/fabric-content-registries-v0/src/main/resources/fabric-content-registries-v0.accesswidener
+++ b/fabric-content-registries-v0/src/main/resources/fabric-content-registries-v0.accesswidener
@@ -1,0 +1,4 @@
+accessWidener	v1	named
+
+accessible method net/minecraft/block/entity/AbstractFurnaceBlockEntity addFuel (Ljava/util/Map;Lnet/minecraft/tag/Tag;I)V
+accessible method net/minecraft/block/entity/AbstractFurnaceBlockEntity addFuel (Ljava/util/Map;Lnet/minecraft/item/ItemConvertible;I)V

--- a/fabric-content-registries-v0/src/main/resources/fabric.mod.json
+++ b/fabric-content-registries-v0/src/main/resources/fabric.mod.json
@@ -25,6 +25,7 @@
   "mixins": [
     "fabric-content-registries-v0.mixins.json"
   ],
+  "accessWidener" : "fabric-content-registries-v0.accesswidener",
   "custom": {
     "fabric-api:module-lifecycle": "stable"
   }


### PR DESCRIPTION
Closes #1476.

Unlike adding the fuel items directly, calling `AbstractFurnaceBlockEntity.addFuel` checks that the fuel is not excluded in `#minecraft:non_flammable_wood`. This makes Fabric API fuels match the vanilla behaviour, which is also configurable via data packs.

(I had to use an AW instead of an accessor due to SpongePowered/Mixin#399 - the two `addFuel` overloads broke the Mixin AP.)