### PR TITLE
Move biome modifications after datapacks loaded

### DIFF
--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/modification/RegistryOpsMixin.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/modification/RegistryOpsMixin.java
@@ -37,20 +37,20 @@ import net.fabricmc.fabric.impl.biome.modification.BiomeModificationImpl;
  *     <li>{@link DynamicRegistryManager#create()} is used to create a dynamic registry manager with just
  *     entries from {@link net.minecraft.util.registry.BuiltinRegistries}</li>
  *     <li>Sometimes, Vanilla Minecraft will stop here, and use the {@link DynamicRegistryManager} as-is (examples: server.properties parsing, world creation screen).</li>
- *     <li>{@link RegistryOps#of(DynamicOps, ResourceManager, DynamicRegistryManager)} gets called with the manager, and a
+ *     <li>{@link RegistryOps#method_36574(DynamicOps, ResourceManager, DynamicRegistryManager)} gets called with the manager, and a
  *     resource manager that contains the loaded data packs. This will pull in all worldgen objects from datapacks into the
  *     dynamic registry manager.</li>
  *     <li>After the worldgen objects are pulled in from the datapacks, this mixin will call the biome modification callback.</li>
  *     <li>In most cases, Vanilla will stop here and now use the dynamic registy manager to instantiate a server.</li>
  *     <li>Sometimes, i.e. when using the "re-create world feature", and a datapack throws an error, Vanilla will sometimes
- *     repeat the {@link RegistryOps#of(DynamicOps, ResourceManager, DynamicRegistryManager)} call on the same
+ *     repeat the {@link RegistryOps#method_36574(DynamicOps, ResourceManager, DynamicRegistryManager)} call on the same
  *     dynamic registry manager. We guard against this using {@link net.fabricmc.fabric.impl.biome.modification.BiomeModificationTracker}.</li>
  * </ol>
  */
 @Mixin(RegistryOps.class)
 public class RegistryOpsMixin {
-	@Inject(method = "method_36575(Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/util/dynamic/RegistryOps$EntryLoader;Lnet/minecraft/util/registry/DynamicRegistryManager;)Lnet/minecraft/util/dynamic/RegistryOps;", at = @At("RETURN"))
-	private static <T> void afterCreation(DynamicOps<T> delegate, RegistryOps.EntryLoader entryLoader, DynamicRegistryManager impl, CallbackInfoReturnable<RegistryOps<T>> ci) {
+	@Inject(method = "method_36574", at = @At("RETURN"))
+	private static <T> void afterCreation(DynamicOps<T> dynamicOps, ResourceManager resourceManager, DynamicRegistryManager impl, CallbackInfoReturnable<RegistryOps<T>> cir) {
 		BiomeModificationImpl.INSTANCE.modifyBiomes((DynamicRegistryManager.Impl) impl);
 	}
 }


### PR DESCRIPTION
This PR restores 1.16 behavior in which biomes would only be modified after datapacks loaded.
Now the behavior will actually match the javadocs.