### PR TITLE
Generate a changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,10 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     container:
-      image: openjdk:16-jdk-buster
+      image: adoptopenjdk:16-jdk
       options: --user root
     steps:
+      - run: apt update && apt install git -y && git --version
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,17 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     container:
-      image: openjdk:16-jdk
+      image: openjdk:16-jdk-buster
       options: --user root
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: FabricMC/fabric-action-scripts@v1
+        id: changelog
+        with:
+          context: changelog
+          workflow_id: release.yml
       - uses: gradle/wrapper-validation-action@v1
       - run: ./gradlew checkVersion build publish curseforge github modrinth --stacktrace
         env:
@@ -17,3 +24,4 @@ jobs:
           CURSEFORGE_API_KEY: ${{ secrets.CURSEFORGE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GH_API_KEY }}
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+          CHANGELOG: ${{ steps.changelog.outputs.changelog }}

--- a/build.gradle
+++ b/build.gradle
@@ -345,7 +345,7 @@ curseforge {
 
 	project {
 		id = "306612"
-		changelog = changelog = ENV.CHANGELOG ?: "No changelog provided"
+		changelog = ENV.CHANGELOG ?: "No changelog provided"
 		releaseType = Globals.preRelease ? "beta" : "release"
 		addGameVersion "1.17.1"
 		addGameVersion "Fabric"
@@ -378,7 +378,7 @@ task github(dependsOn: remapMavenJar) {
 
 		def releaseBuilder = new GHReleaseBuilder(repository, version as String)
 		releaseBuilder.name("[$Globals.mcVersion] Fabric API $Globals.baseVersion")
-		releaseBuilder.body(changelog = ENV.CHANGELOG ?: "No changelog provided")
+		releaseBuilder.body(ENV.CHANGELOG ?: "No changelog provided")
 		releaseBuilder.commitish(getBranch())
 		releaseBuilder.prerelease(Globals.preRelease)
 

--- a/build.gradle
+++ b/build.gradle
@@ -345,7 +345,7 @@ curseforge {
 
 	project {
 		id = "306612"
-		changelog = "A changelog can be found at https://github.com/FabricMC/fabric/commits"
+		changelog = changelog = ENV.CHANGELOG ?: "No changelog provided"
 		releaseType = Globals.preRelease ? "beta" : "release"
 		addGameVersion "1.17.1"
 		addGameVersion "Fabric"
@@ -378,7 +378,7 @@ task github(dependsOn: remapMavenJar) {
 
 		def releaseBuilder = new GHReleaseBuilder(repository, version as String)
 		releaseBuilder.name("[$Globals.mcVersion] Fabric API $Globals.baseVersion")
-		releaseBuilder.body("A changelog can be found at https://github.com/FabricMC/fabric/commits")
+		releaseBuilder.body(changelog = ENV.CHANGELOG ?: "No changelog provided")
 		releaseBuilder.commitish(getBranch())
 		releaseBuilder.prerelease(Globals.preRelease)
 
@@ -397,6 +397,7 @@ task modrinth(type: com.modrinth.minotaur.TaskModrinthUpload, dependsOn: remapMa
 	versionNumber = version
 	versionName = "[$Globals.mcVersion] Fabric API $Globals.baseVersion"
 	releaseType = Globals.preRelease ? "beta" : "release"
+	changelog = ENV.CHANGELOG ?: "No changelog provided"
 
 	uploadFile = file("${project.buildDir}/libs/${archivesBaseName}-${version}.jar")
 


### PR DESCRIPTION
This makes a simple changelog based off the commit messages. See https://github.com/FabricMC/fabric-action-scripts/blob/main/src/changelog.ts for the code behind it.

I have tested this in my own mod here: https://github.com/TechReborn/TechReborn/releases/tag/5.0.4-beta%2Bbuild.83

Should also be quite useful for other mods/projects as there is no reason why anyone cannot use it.