### PR TITLE
Add sleeping events

### DIFF
--- a/fabric-entity-events-v1/build.gradle
+++ b/fabric-entity-events-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-entity-events-v1"
-version = getSubprojectVersion(project, "1.1.0")
+version = getSubprojectVersion(project, "1.2.0")
 
 moduleDependencies(project, [
 		'fabric-api-base'
@@ -7,4 +7,6 @@ moduleDependencies(project, [
 
 dependencies {
 	testmodImplementation project(path: ':fabric-command-api-v1', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-networking-api-v1', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-registry-sync-v0', configuration: 'dev')
 }

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
@@ -99,7 +99,7 @@ public final class EntitySleepEvents {
 		/**
 		 * Called when an entity wakes up.
 		 *
-		 * @param entity      the sleeping entity
+		 * @param entity the sleeping entity
 		 */
 		void onWakeUp(LivingEntity entity);
 	}

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
@@ -72,15 +72,17 @@ public final class EntitySleepEvents {
 	 * <p>This is useful for custom bed blocks that need to determine the sleeping direction themselves.
 	 */
 	public static final Event<ModifySleepingDirection> MODIFY_SLEEPING_DIRECTION = EventFactory.createArrayBacked(ModifySleepingDirection.class, callbacks -> (entity, sleepingPos, sleepingDirection) -> {
+		@Nullable Direction direction = sleepingDirection;
+
 		for (ModifySleepingDirection callback : callbacks) {
-			Optional<Direction> result = callback.modifySleepDirection(entity, sleepingPos, sleepingDirection);
+			Optional<Direction> result = callback.modifySleepDirection(entity, sleepingPos, direction);
 
 			if (result.isPresent()) {
-				return result;
+				direction = result.get();
 			}
 		}
 
-		return Optional.empty();
+		return Optional.ofNullable(direction);
 	});
 
 	@FunctionalInterface
@@ -124,8 +126,6 @@ public final class EntitySleepEvents {
 	public interface ModifySleepingDirection {
 		/**
 		 * Modifies or provides a sleeping direction for a block.
-		 *
-		 * <p>A present return value cancels further callbacks.
 		 *
 		 * @param entity            the sleeping entity
 		 * @param sleepingPos       the position of the block slept on

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
@@ -16,8 +16,6 @@
 
 package net.fabricmc.fabric.api.entity.event.v1;
 
-import java.util.Optional;
-
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.BlockState;
@@ -72,17 +70,11 @@ public final class EntitySleepEvents {
 	 * <p>This is useful for custom bed blocks that need to determine the sleeping direction themselves.
 	 */
 	public static final Event<ModifySleepingDirection> MODIFY_SLEEPING_DIRECTION = EventFactory.createArrayBacked(ModifySleepingDirection.class, callbacks -> (entity, sleepingPos, sleepingDirection) -> {
-		@Nullable Direction direction = sleepingDirection;
-
 		for (ModifySleepingDirection callback : callbacks) {
-			Optional<Direction> result = callback.modifySleepDirection(entity, sleepingPos, direction);
-
-			if (result.isPresent()) {
-				direction = result.get();
-			}
+			sleepingDirection = callback.modifySleepDirection(entity, sleepingPos, sleepingDirection);
 		}
 
-		return Optional.ofNullable(direction);
+		return sleepingDirection;
 	});
 
 	@FunctionalInterface
@@ -130,9 +122,10 @@ public final class EntitySleepEvents {
 		 * @param entity            the sleeping entity
 		 * @param sleepingPos       the position of the block slept on
 		 * @param sleepingDirection the old sleeping direction, or null if not determined by vanilla logic
-		 * @return a new direction, or {@link Optional#empty()} to fall back to other callbacks
+		 * @return the new sleeping direction
 		 */
-		Optional<Direction> modifySleepDirection(LivingEntity entity, BlockPos sleepingPos, @Nullable Direction sleepingDirection);
+		@Nullable
+		Direction modifySleepDirection(LivingEntity entity, BlockPos sleepingPos, @Nullable Direction sleepingDirection);
 	}
 
 	private EntitySleepEvents() {

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
@@ -33,7 +33,7 @@ import net.fabricmc.fabric.api.event.EventFactory;
  */
 public final class EntitySleepEvents {
 	/**
-	 * An event that checks whether a player can sleep in a bed-like block.
+	 * An event that checks whether a player can start to sleep in a bed-like block.
 	 *
 	 * @see PlayerEntity#trySleep(BlockPos)
 	 */
@@ -77,7 +77,7 @@ public final class EntitySleepEvents {
 	 */
 	public static final Event<AllowBed> ALLOW_BED = EventFactory.createArrayBacked(AllowBed.class, callbacks -> (entity, sleepingPos, state) -> {
 		for (AllowBed callback : callbacks) {
-			ActionResult result = callback.isValidBed(entity, sleepingPos, state);
+			ActionResult result = callback.allowBed(entity, sleepingPos, state);
 
 			if (result != ActionResult.PASS) {
 				return result;
@@ -85,6 +85,51 @@ public final class EntitySleepEvents {
 		}
 
 		return ActionResult.PASS;
+	});
+
+	/**
+	 * An event that checks whether the current time of day is valid for sleeping.
+	 */
+	public static final Event<AllowSleepTime> ALLOW_SLEEP_TIME = EventFactory.createArrayBacked(AllowSleepTime.class, callbacks -> (player, sleepingPos, vanillaResult) -> {
+		for (AllowSleepTime callback : callbacks) {
+			ActionResult result = callback.allowSleepTime(player, sleepingPos, vanillaResult);
+
+			if (result != ActionResult.PASS) {
+				return result;
+			}
+		}
+
+		return ActionResult.PASS;
+	});
+
+	/**
+	 * An event that checks whether players can sleep when monsters are nearby.
+	 *
+	 * <p>This event can also be used to force a failing result, meaning it can do custom monster checks.
+	 */
+	public static final Event<AllowNearbyMonsters> ALLOW_NEARBY_MONSTERS = EventFactory.createArrayBacked(AllowNearbyMonsters.class, callbacks -> (player, sleepingPos, vanillaResult) -> {
+		for (AllowNearbyMonsters callback : callbacks) {
+			ActionResult result = callback.allowNearbyMonsters(player, sleepingPos, vanillaResult);
+
+			if (result != ActionResult.PASS) {
+				return result;
+			}
+		}
+
+		return ActionResult.PASS;
+	});
+
+	/**
+	 * An event that checks whether a sleeping player counts into skipping the current day and resetting the time to 0.
+	 */
+	public static final Event<AllowResettingTime> ALLOW_RESETTING_TIME = EventFactory.createArrayBacked(AllowResettingTime.class, callbacks -> player -> {
+		for (AllowResettingTime callback : callbacks) {
+			if (!callback.allowResettingTime(player)) {
+				return false;
+			}
+		}
+
+		return true;
 	});
 
 	/**
@@ -161,7 +206,50 @@ public final class EntitySleepEvents {
 		 * @return {@link ActionResult#SUCCESS} if the bed is valid, {@link ActionResult#FAIL} if it's not,
 		 *         {@link ActionResult#PASS} to fall back to other callbacks
 		 */
-		ActionResult isValidBed(LivingEntity entity, BlockPos sleepingPos, BlockState state);
+		ActionResult allowBed(LivingEntity entity, BlockPos sleepingPos, BlockState state);
+	}
+
+	@FunctionalInterface
+	public interface AllowSleepTime {
+		/**
+		 * Checks whether the current time of day is valid for sleeping.
+		 *
+		 * <p>Non-{@linkplain ActionResult#PASS passing} return values cancel further callbacks.
+		 *
+		 * @param player        the sleeping player
+		 * @param sleepingPos   the (possibly still unset) {@linkplain LivingEntity#getSleepingPosition() sleeping position} of the player
+		 * @param vanillaResult true if vanilla allows the time, false otherwise
+		 * @return {@link ActionResult#SUCCESS} if the time is valid, {@link ActionResult#FAIL} if it's not,
+		 *         {@link ActionResult#PASS} to fall back to other callbacks
+		 */
+		ActionResult allowSleepTime(PlayerEntity player, BlockPos sleepingPos, boolean vanillaResult);
+	}
+
+	@FunctionalInterface
+	public interface AllowNearbyMonsters {
+		/**
+		 * Checks whether a player can sleep when monsters are nearby.
+		 *
+		 * <p>Non-{@linkplain ActionResult#PASS passing} return values cancel further callbacks.
+		 *
+		 * @param player        the sleeping player
+		 * @param sleepingPos   the (possibly still unset) {@linkplain LivingEntity#getSleepingPosition() sleeping position} of the player
+		 * @param vanillaResult true if vanilla's monster check succeeded, false otherwise
+		 * @return {@link ActionResult#SUCCESS} to allow sleeping, {@link ActionResult#FAIL} to prevent sleeping,
+		 *         {@link ActionResult#PASS} to fall back to other callbacks
+		 */
+		ActionResult allowNearbyMonsters(PlayerEntity player, BlockPos sleepingPos, boolean vanillaResult);
+	}
+
+	@FunctionalInterface
+	public interface AllowResettingTime {
+		/**
+		 * Checks whether a sleeping player counts into skipping the current day and resetting the time to 0.
+		 *
+		 * @param player        the sleeping player
+		 * @return true if allowed, false otherwise
+		 */
+		boolean allowResettingTime(PlayerEntity player);
 	}
 
 	@FunctionalInterface

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
@@ -75,8 +75,8 @@ public final class EntitySleepEvents {
 	 *
 	 * @see LivingEntity#isSleepingInBed()
 	 */
-	public static final Event<VerifyBed> VERIFY_BED = EventFactory.createArrayBacked(VerifyBed.class, callbacks -> (entity, sleepingPos, state) -> {
-		for (VerifyBed callback : callbacks) {
+	public static final Event<AllowBed> ALLOW_BED = EventFactory.createArrayBacked(AllowBed.class, callbacks -> (entity, sleepingPos, state) -> {
+		for (AllowBed callback : callbacks) {
 			ActionResult result = callback.isValidBed(entity, sleepingPos, state);
 
 			if (result != ActionResult.PASS) {
@@ -149,7 +149,7 @@ public final class EntitySleepEvents {
 	}
 
 	@FunctionalInterface
-	public interface VerifyBed {
+	public interface AllowBed {
 		/**
 		 * Checks whether a block is a valid bed for the entity.
 		 *

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.entity.event.v1;
+
+import java.util.Optional;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+/**
+ * Events about the sleep of {@linkplain LivingEntity living entities}.
+ */
+public final class EntitySleepEvents {
+	/**
+	 * An event that is called when an entity starts to sleep.
+	 */
+	public static final Event<StartSleeping> START_SLEEPING = EventFactory.createArrayBacked(StartSleeping.class, callbacks -> (entity, sleepingPos) -> {
+		for (StartSleeping callback : callbacks) {
+			callback.onSleep(entity, sleepingPos);
+		}
+	});
+
+	/**
+	 * An event that is called when an entity wakes up.
+	 */
+	public static final Event<WakeUp> WAKE_UP = EventFactory.createArrayBacked(WakeUp.class, callbacks -> (entity) -> {
+		for (WakeUp callback : callbacks) {
+			callback.onWakeUp(entity);
+		}
+	});
+
+	/**
+	 * An event that is called to check whether a block is valid for sleeping.
+	 */
+	public static final Event<IsValidBed> IS_VALID_BED = EventFactory.createArrayBacked(IsValidBed.class, callbacks -> (entity, sleepingPos, state) -> {
+		for (IsValidBed callback : callbacks) {
+			ActionResult result = callback.isValidBed(entity, sleepingPos, state);
+
+			if (result != ActionResult.PASS) {
+				return result;
+			}
+		}
+
+		return ActionResult.PASS;
+	});
+
+	/**
+	 * An event that can be used to provide the entity's sleep direction if missing.
+	 *
+	 * <p>This is useful for custom bed blocks that need to determine the sleeping direction themselves.
+	 */
+	public static final Event<ModifySleepingDirection> MODIFY_SLEEPING_DIRECTION = EventFactory.createArrayBacked(ModifySleepingDirection.class, callbacks -> (entity, sleepingPos, sleepingDirection) -> {
+		for (ModifySleepingDirection callback : callbacks) {
+			Optional<Direction> result = callback.modifySleepDirection(entity, sleepingPos, sleepingDirection);
+
+			if (result.isPresent()) {
+				return result;
+			}
+		}
+
+		return Optional.empty();
+	});
+
+	@FunctionalInterface
+	public interface StartSleeping {
+		/**
+		 * Called when an entity starts to sleep.
+		 *
+		 * @param entity      the sleeping entity
+		 * @param sleepingPos the {@linkplain LivingEntity#getSleepingPosition() sleeping position} of the entity
+		 */
+		void onSleep(LivingEntity entity, BlockPos sleepingPos);
+	}
+
+	@FunctionalInterface
+	public interface WakeUp {
+		/**
+		 * Called when an entity wakes up.
+		 *
+		 * @param entity      the sleeping entity
+		 */
+		void onWakeUp(LivingEntity entity);
+	}
+
+	@FunctionalInterface
+	public interface IsValidBed {
+		/**
+		 * Checks whether a block is a valid bed for the entity.
+		 *
+		 * <p>Non-{@linkplain ActionResult#PASS passing} return values cancel further callbacks.
+		 *
+		 * @param entity      the sleeping entity
+		 * @param sleepingPos the position of the block
+		 * @param state       the block state to check
+		 * @return {@link ActionResult#SUCCESS} if the bed is valid, {@link ActionResult#FAIL} if it's not,
+		 *         {@link ActionResult#PASS} to fall back to other callbacks
+		 */
+		ActionResult isValidBed(LivingEntity entity, BlockPos sleepingPos, BlockState state);
+	}
+
+	@FunctionalInterface
+	public interface ModifySleepingDirection {
+		/**
+		 * Modifies or provides a sleeping direction for a block.
+		 *
+		 * <p>A present return value cancels further callbacks.
+		 *
+		 * @param entity            the sleeping entity
+		 * @param sleepingPos       the position of the block slept on
+		 * @param sleepingDirection the old sleeping direction, or null if not determined by vanilla logic
+		 * @return a new direction, or {@link Optional#empty()} to fall back to other callbacks
+		 */
+		Optional<Direction> modifySleepDirection(LivingEntity entity, BlockPos sleepingPos, @Nullable Direction sleepingDirection);
+	}
+
+	private EntitySleepEvents() {
+	}
+}

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
@@ -69,9 +69,14 @@ public final class EntitySleepEvents {
 
 	/**
 	 * An event that is called to check whether a block is valid for sleeping.
+	 *
+	 * <p>Used for checking whether the block at the current sleeping position is a valid bed block.
+	 * If false, the player wakes up.
+	 *
+	 * @see LivingEntity#isSleepingInBed()
 	 */
-	public static final Event<IsValidBed> IS_VALID_BED = EventFactory.createArrayBacked(IsValidBed.class, callbacks -> (entity, sleepingPos, state) -> {
-		for (IsValidBed callback : callbacks) {
+	public static final Event<VerifyBed> VERIFY_BED = EventFactory.createArrayBacked(VerifyBed.class, callbacks -> (entity, sleepingPos, state) -> {
+		for (VerifyBed callback : callbacks) {
 			ActionResult result = callback.isValidBed(entity, sleepingPos, state);
 
 			if (result != ActionResult.PASS) {
@@ -144,7 +149,7 @@ public final class EntitySleepEvents {
 	}
 
 	@FunctionalInterface
-	public interface IsValidBed {
+	public interface VerifyBed {
 		/**
 		 * Checks whether a block is a valid bed for the entity.
 		 *

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
@@ -89,6 +89,9 @@ public final class EntitySleepEvents {
 
 	/**
 	 * An event that checks whether the current time of day is valid for sleeping.
+	 *
+	 * <p>Note that if sleeping during day time is allowed, the game will still reset the time to 0 if the usual
+	 * conditions are met, unless forbidden with {@link #ALLOW_RESETTING_TIME}.
 	 */
 	public static final Event<AllowSleepTime> ALLOW_SLEEP_TIME = EventFactory.createArrayBacked(AllowSleepTime.class, callbacks -> (player, sleepingPos, vanillaResult) -> {
 		for (AllowSleepTime callback : callbacks) {

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -84,7 +84,7 @@ abstract class LivingEntityMixin extends EntityMixin {
 		if (getSleepingPosition().isPresent()) {
 			BlockPos sleepingPos = getSleepingPosition().get();
 			BlockState bedState = world.getBlockState(sleepingPos);
-			ActionResult result = EntitySleepEvents.VERIFY_BED.invoker().isValidBed((LivingEntity) (Object) this, sleepingPos, bedState);
+			ActionResult result = EntitySleepEvents.ALLOW_BED.invoker().isValidBed((LivingEntity) (Object) this, sleepingPos, bedState);
 
 			if (result != ActionResult.PASS) {
 				info.setReturnValue(result.isAccepted());

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -16,20 +16,29 @@
 
 package net.fabricmc.fabric.mixin.entity.event;
 
+import java.util.Optional;
+
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
+import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
 
+import net.fabricmc.fabric.api.entity.event.v1.EntitySleepEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerEntityCombatEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
 
@@ -37,6 +46,9 @@ import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
 abstract class LivingEntityMixin extends EntityMixin {
 	@Shadow
 	public abstract boolean isDead();
+
+	@Shadow
+	public abstract Optional<BlockPos> getSleepingPosition();
 
 	@Inject(method = "onDeath", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;onKilledOther(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/entity/LivingEntity;)V", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILEXCEPTION)
 	private void onEntityKilledOther(DamageSource source, CallbackInfo ci, Entity attacker) {
@@ -52,5 +64,39 @@ abstract class LivingEntityMixin extends EntityMixin {
 		}
 
 		return isDead();
+	}
+
+	@Inject(method = "sleep", at = @At("RETURN"))
+	private void onSleep(BlockPos pos, CallbackInfo info) {
+		EntitySleepEvents.START_SLEEPING.invoker().onSleep((LivingEntity) (Object) this, pos);
+	}
+
+	@Inject(method = "wakeUp", at = @At("RETURN"), locals = LocalCapture.CAPTURE_FAILHARD)
+	private void onWakeUp(CallbackInfo info) {
+		EntitySleepEvents.WAKE_UP.invoker().onWakeUp((LivingEntity) (Object) this);
+	}
+
+	@Inject(method = "isSleepingInBed", at = @At("RETURN"), cancellable = true)
+	private void onIsSleepingInBed(CallbackInfoReturnable<Boolean> info) {
+		if (getSleepingPosition().isPresent()) {
+			BlockPos sleepingPos = getSleepingPosition().get();
+			BlockState bedState = world.getBlockState(sleepingPos);
+			ActionResult result = EntitySleepEvents.IS_VALID_BED.invoker().isValidBed((LivingEntity) (Object) this, sleepingPos, bedState);
+
+			if (result != ActionResult.PASS) {
+				info.setReturnValue(result.isAccepted());
+			}
+		}
+	}
+
+	@Inject(method = "getSleepingDirection", at = @At("RETURN"), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD)
+	private void onGetSleepingDirection(CallbackInfoReturnable<Direction> info, @Nullable BlockPos sleepingPos) {
+		if (sleepingPos != null) {
+			Optional<Direction> newDirection = EntitySleepEvents.MODIFY_SLEEPING_DIRECTION.invoker().modifySleepDirection((LivingEntity) (Object) this, sleepingPos, info.getReturnValue());
+
+			if (newDirection.isPresent()) {
+				info.setReturnValue(newDirection.get());
+			}
+		}
 	}
 }

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -71,9 +71,12 @@ abstract class LivingEntityMixin extends EntityMixin {
 		EntitySleepEvents.START_SLEEPING.invoker().onSleep((LivingEntity) (Object) this, pos);
 	}
 
-	@Inject(method = "wakeUp", at = @At("RETURN"), locals = LocalCapture.CAPTURE_FAILHARD)
+	@Inject(method = "wakeUp", at = @At("HEAD"))
 	private void onWakeUp(CallbackInfo info) {
-		EntitySleepEvents.WAKE_UP.invoker().onWakeUp((LivingEntity) (Object) this);
+		// If actually asleep - this method is often called "just to be sure"...
+		if (getSleepingPosition().isPresent()) {
+			EntitySleepEvents.WAKE_UP.invoker().onWakeUp((LivingEntity) (Object) this);
+		}
 	}
 
 	@Inject(method = "isSleepingInBed", at = @At("RETURN"), cancellable = true)

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -84,7 +84,7 @@ abstract class LivingEntityMixin extends EntityMixin {
 		if (getSleepingPosition().isPresent()) {
 			BlockPos sleepingPos = getSleepingPosition().get();
 			BlockState bedState = world.getBlockState(sleepingPos);
-			ActionResult result = EntitySleepEvents.IS_VALID_BED.invoker().isValidBed((LivingEntity) (Object) this, sleepingPos, bedState);
+			ActionResult result = EntitySleepEvents.VERIFY_BED.invoker().isValidBed((LivingEntity) (Object) this, sleepingPos, bedState);
 
 			if (result != ActionResult.PASS) {
 				info.setReturnValue(result.isAccepted());

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -73,16 +73,19 @@ abstract class LivingEntityMixin extends EntityMixin {
 
 	@Inject(method = "wakeUp", at = @At("HEAD"))
 	private void onWakeUp(CallbackInfo info) {
+		BlockPos sleepingPos = getSleepingPosition().orElse(null);
+
 		// If actually asleep - this method is often called with data loading, syncing etc. "just to be sure"
-		if (getSleepingPosition().isPresent()) {
-			EntitySleepEvents.STOP_SLEEPING.invoker().onStopSleeping((LivingEntity) (Object) this, getSleepingPosition().get());
+		if (sleepingPos != null) {
+			EntitySleepEvents.STOP_SLEEPING.invoker().onStopSleeping((LivingEntity) (Object) this, sleepingPos);
 		}
 	}
 
 	@Inject(method = "isSleepingInBed", at = @At("RETURN"), cancellable = true)
 	private void onIsSleepingInBed(CallbackInfoReturnable<Boolean> info) {
-		if (getSleepingPosition().isPresent()) {
-			BlockPos sleepingPos = getSleepingPosition().get();
+		BlockPos sleepingPos = getSleepingPosition().orElse(null);
+
+		if (sleepingPos != null) {
 			BlockState bedState = world.getBlockState(sleepingPos);
 			ActionResult result = EntitySleepEvents.ALLOW_BED.invoker().allowBed((LivingEntity) (Object) this, sleepingPos, bedState, info.getReturnValueZ());
 

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -95,11 +95,7 @@ abstract class LivingEntityMixin extends EntityMixin {
 	@Inject(method = "getSleepingDirection", at = @At("RETURN"), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD)
 	private void onGetSleepingDirection(CallbackInfoReturnable<Direction> info, @Nullable BlockPos sleepingPos) {
 		if (sleepingPos != null) {
-			Optional<Direction> newDirection = EntitySleepEvents.MODIFY_SLEEPING_DIRECTION.invoker().modifySleepDirection((LivingEntity) (Object) this, sleepingPos, info.getReturnValue());
-
-			if (newDirection.isPresent()) {
-				info.setReturnValue(newDirection.get());
-			}
+			info.setReturnValue(EntitySleepEvents.MODIFY_SLEEPING_DIRECTION.invoker().modifySleepDirection((LivingEntity) (Object) this, sleepingPos, info.getReturnValue()));
 		}
 	}
 }

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -84,7 +84,7 @@ abstract class LivingEntityMixin extends EntityMixin {
 		if (getSleepingPosition().isPresent()) {
 			BlockPos sleepingPos = getSleepingPosition().get();
 			BlockState bedState = world.getBlockState(sleepingPos);
-			ActionResult result = EntitySleepEvents.ALLOW_BED.invoker().allowBed((LivingEntity) (Object) this, sleepingPos, bedState);
+			ActionResult result = EntitySleepEvents.ALLOW_BED.invoker().allowBed((LivingEntity) (Object) this, sleepingPos, bedState, info.getReturnValueZ());
 
 			if (result != ActionResult.PASS) {
 				info.setReturnValue(result.isAccepted());

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -84,7 +84,7 @@ abstract class LivingEntityMixin extends EntityMixin {
 		if (getSleepingPosition().isPresent()) {
 			BlockPos sleepingPos = getSleepingPosition().get();
 			BlockState bedState = world.getBlockState(sleepingPos);
-			ActionResult result = EntitySleepEvents.ALLOW_BED.invoker().isValidBed((LivingEntity) (Object) this, sleepingPos, bedState);
+			ActionResult result = EntitySleepEvents.ALLOW_BED.invoker().allowBed((LivingEntity) (Object) this, sleepingPos, bedState);
 
 			if (result != ActionResult.PASS) {
 				info.setReturnValue(result.isAccepted());

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -68,14 +68,14 @@ abstract class LivingEntityMixin extends EntityMixin {
 
 	@Inject(method = "sleep", at = @At("RETURN"))
 	private void onSleep(BlockPos pos, CallbackInfo info) {
-		EntitySleepEvents.START_SLEEPING.invoker().onSleep((LivingEntity) (Object) this, pos);
+		EntitySleepEvents.START_SLEEPING.invoker().onStartSleeping((LivingEntity) (Object) this, pos);
 	}
 
 	@Inject(method = "wakeUp", at = @At("HEAD"))
 	private void onWakeUp(CallbackInfo info) {
-		// If actually asleep - this method is often called "just to be sure"...
+		// If actually asleep - this method is often called with data loading, syncing etc. "just to be sure"
 		if (getSleepingPosition().isPresent()) {
-			EntitySleepEvents.WAKE_UP.invoker().onWakeUp((LivingEntity) (Object) this);
+			EntitySleepEvents.STOP_SLEEPING.invoker().onStopSleeping((LivingEntity) (Object) this, getSleepingPosition().get());
 		}
 	}
 

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/PlayerEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/PlayerEntityMixin.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.fabricmc.fabric.mixin.entity.event;
+
+import com.mojang.datafixers.util.Either;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.Unit;
+import net.minecraft.util.math.BlockPos;
+
+import net.fabricmc.fabric.api.entity.event.v1.EntitySleepEvents;
+
+@Mixin(PlayerEntity.class)
+abstract class PlayerEntityMixin {
+	@Inject(method = "trySleep", at = @At("HEAD"), cancellable = true)
+	private void onTrySleep(BlockPos pos, CallbackInfoReturnable<Either<PlayerEntity.SleepFailureReason, Unit>> info) {
+		PlayerEntity.SleepFailureReason failureReason = EntitySleepEvents.ALLOW_SLEEPING.invoker().allowSleep((PlayerEntity) (Object) this, pos);
+
+		if (failureReason != null) {
+			info.setReturnValue(Either.left(failureReason));
+		}
+	}
+}

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/ServerPlayerEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/ServerPlayerEntityMixin.java
@@ -16,8 +16,6 @@
 
 package net.fabricmc.fabric.mixin.entity.event;
 
-import java.util.Optional;
-
 import com.mojang.datafixers.util.Either;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
@@ -85,8 +83,7 @@ abstract class ServerPlayerEntityMixin extends LivingEntityMixin {
 	@Redirect(method = "trySleep", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;get(Lnet/minecraft/state/property/Property;)Ljava/lang/Comparable;"))
 	private Comparable<?> redirectSleepDirection(BlockState state, Property<?> property, BlockPos pos) {
 		Direction initial = state.getBlock() instanceof BedBlock ? (Direction) state.get(property) : null;
-		Optional<Direction> result = EntitySleepEvents.MODIFY_SLEEPING_DIRECTION.invoker().modifySleepDirection((LivingEntity) (Object) this, pos, initial);
-		return result.orElse(initial);
+		return EntitySleepEvents.MODIFY_SLEEPING_DIRECTION.invoker().modifySleepDirection((LivingEntity) (Object) this, pos, initial);
 	}
 
 	@Inject(method = "trySleep", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;get(Lnet/minecraft/state/property/Property;)Ljava/lang/Comparable;", shift = At.Shift.BY, by = 3), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD)

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/ServerPlayerEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/ServerPlayerEntityMixin.java
@@ -39,6 +39,8 @@ import net.minecraft.state.property.Property;
 import net.minecraft.util.Unit;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.world.World;
 
 import net.fabricmc.fabric.api.entity.event.v1.EntitySleepEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerEntityCombatEvents;
@@ -91,6 +93,13 @@ abstract class ServerPlayerEntityMixin extends LivingEntityMixin {
 		// This checks the result from the event call above.
 		if (sleepingDirection == null) {
 			info.setReturnValue(Either.left(PlayerEntity.SleepFailureReason.NOT_POSSIBLE_HERE));
+		}
+	}
+
+	@Redirect(method = "trySleep", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayerEntity;setSpawnPoint(Lnet/minecraft/util/registry/RegistryKey;Lnet/minecraft/util/math/BlockPos;FZZ)V"))
+	private void onSetSpawnPoint(ServerPlayerEntity player, RegistryKey<World> dimension, BlockPos pos, float angle, boolean spawnPointSet, boolean sendMessage) {
+		if (EntitySleepEvents.ALLOW_SETTING_SPAWN.invoker().allowSettingSpawn(player, pos)) {
+			player.setSpawnPoint(dimension, pos, angle, spawnPointSet, sendMessage);
 		}
 	}
 }

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/ServerPlayerEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/ServerPlayerEntityMixin.java
@@ -16,17 +16,33 @@
 
 package net.fabricmc.fabric.mixin.entity.event;
 
+import java.util.Optional;
+
+import com.mojang.datafixers.util.Either;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
+import net.minecraft.block.BedBlock;
+import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.state.property.Property;
+import net.minecraft.util.Unit;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
 
+import net.fabricmc.fabric.api.entity.event.v1.EntitySleepEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerEntityCombatEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerEntityWorldChangeEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
@@ -64,5 +80,20 @@ abstract class ServerPlayerEntityMixin extends LivingEntityMixin {
 	@Inject(method = "copyFrom", at = @At("TAIL"))
 	private void onCopyFrom(ServerPlayerEntity oldPlayer, boolean alive, CallbackInfo ci) {
 		ServerPlayerEvents.COPY_FROM.invoker().copyFromPlayer(oldPlayer, (ServerPlayerEntity) (Object) this, alive);
+	}
+
+	@Redirect(method = "trySleep", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;get(Lnet/minecraft/state/property/Property;)Ljava/lang/Comparable;"))
+	private Comparable<?> redirectSleepDirection(BlockState state, Property<?> property, BlockPos pos) {
+		Direction initial = state.getBlock() instanceof BedBlock ? (Direction) state.get(property) : null;
+		Optional<Direction> result = EntitySleepEvents.MODIFY_SLEEPING_DIRECTION.invoker().modifySleepDirection((LivingEntity) (Object) this, pos, initial);
+		return result.orElse(initial);
+	}
+
+	@Inject(method = "trySleep", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;get(Lnet/minecraft/state/property/Property;)Ljava/lang/Comparable;", shift = At.Shift.BY, by = 3), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD)
+	private void onTrySleep(BlockPos pos, CallbackInfoReturnable<Either<PlayerEntity.SleepFailureReason, Unit>> info, @Nullable Direction sleepingDirection) {
+		// This checks the result from the event call above.
+		if (sleepingDirection == null) {
+			info.setReturnValue(Either.left(PlayerEntity.SleepFailureReason.NOT_POSSIBLE_HERE));
+		}
 	}
 }

--- a/fabric-entity-events-v1/src/main/resources/fabric-entity-events-v1.mixins.json
+++ b/fabric-entity-events-v1/src/main/resources/fabric-entity-events-v1.mixins.json
@@ -5,6 +5,7 @@
   "mixins": [
     "EntityMixin",
     "LivingEntityMixin",
+    "PlayerEntityMixin",
     "PlayerManagerMixin",
     "ServerPlayerEntityMixin",
     "TeleportCommandMixin"

--- a/fabric-entity-events-v1/src/main/resources/fabric-entity-events-v1.mixins.json
+++ b/fabric-entity-events-v1/src/main/resources/fabric-entity-events-v1.mixins.json
@@ -10,6 +10,7 @@
     "TeleportCommandMixin"
   ],
   "injectors": {
-    "defaultRequire": 1
+    "defaultRequire": 1,
+    "maxShiftBy": 3
   }
 }

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -97,11 +97,11 @@ public final class EntityEventTests implements ModInitializer {
 			LOGGER.info("Entity {} sleeping at {}", entity, sleepingPos);
 		});
 
-		EntitySleepEvents.WAKE_UP.register(entity -> {
-			LOGGER.info("Entity {} woke up", entity);
+		EntitySleepEvents.STOP_SLEEPING.register((entity, sleepingPos) -> {
+			LOGGER.info("Entity {} woke up at {}", entity, sleepingPos);
 		});
 
-		EntitySleepEvents.ALLOW_BED.register((entity, sleepingPos, state) -> {
+		EntitySleepEvents.ALLOW_BED.register((entity, sleepingPos, state, vanillaResult) -> {
 			return state.isOf(TEST_BED) ? ActionResult.SUCCESS : ActionResult.PASS;
 		});
 

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -88,7 +88,7 @@ public final class EntityEventTests implements ModInitializer {
 			LOGGER.info("Entity {} woke up", entity);
 		});
 
-		EntitySleepEvents.VERIFY_BED.register((entity, sleepingPos, state) -> {
+		EntitySleepEvents.ALLOW_BED.register((entity, sleepingPos, state) -> {
 			return state.isOf(TEST_BED) ? ActionResult.SUCCESS : ActionResult.PASS;
 		});
 

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -88,7 +88,7 @@ public final class EntityEventTests implements ModInitializer {
 			LOGGER.info("Entity {} woke up", entity);
 		});
 
-		EntitySleepEvents.IS_VALID_BED.register((entity, sleepingPos, state) -> {
+		EntitySleepEvents.VERIFY_BED.register((entity, sleepingPos, state) -> {
 			return state.isOf(TEST_BED) ? ActionResult.SUCCESS : ActionResult.PASS;
 		});
 

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/TestBedBlock.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/TestBedBlock.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.entity.event;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.ShapeContext;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.state.StateManager;
+import net.minecraft.state.property.BooleanProperty;
+import net.minecraft.state.property.Properties;
+import net.minecraft.text.Text;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.World;
+
+public class TestBedBlock extends Block {
+	private static final VoxelShape SHAPE = createCuboidShape(0, 0, 0, 16, 8, 16);
+	public static final BooleanProperty OCCUPIED = Properties.OCCUPIED;
+
+	public TestBedBlock(Settings settings) {
+		super(settings);
+		setDefaultState(getDefaultState().with(OCCUPIED, false));
+	}
+
+	@Override
+	public VoxelShape getCollisionShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+		return SHAPE;
+	}
+
+	@Override
+	public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit) {
+		if (!state.get(OCCUPIED) && world.getDimension().isBedWorking()) {
+			if (!world.isClient) {
+				player.trySleep(pos).ifLeft(sleepFailureReason -> {
+					Text message = sleepFailureReason.toText();
+
+					if (message != null) {
+						player.sendMessage(message, true);
+					}
+				});
+			}
+
+			return ActionResult.CONSUME;
+		}
+
+		return ActionResult.PASS;
+	}
+
+	@Override
+	protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
+		builder.add(OCCUPIED);
+	}
+}

--- a/fabric-entity-events-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-entity-events-v1/src/testmod/resources/fabric.mod.json
@@ -7,7 +7,8 @@
   "license": "Apache-2.0",
   "depends": {
     "fabric-entity-events-v1": "*",
-    "fabric-command-api-v1":"*"
+    "fabric-command-api-v1": "*",
+    "fabric-registry-sync-v0": "*"
   },
   "entrypoints": {
     "main": [


### PR DESCRIPTION
Added 9 entity events related to sleep:
- starting to sleep
- waking up
- checking if a block is a valid bed for an entity (useful for custom beds)
- modifying the sleeping direction (useful for custom beds)
- only for players:
  - an "allow sleep time" event
  - an "allow setting spawn" event
  - an "allow sleeping" event (as in, allow to start sleeping)
  - an "allow nearby monsters" event that can also be used to do custom monster checks (to force a failed monster check)
  - an "allow resetting time" event (whether the player counts towards the minimum for skipping the night)