### PR TITLE
Add biome tag selector

### DIFF
--- a/fabric-biome-api-v1/build.gradle
+++ b/fabric-biome-api-v1/build.gradle
@@ -4,3 +4,9 @@ version = getSubprojectVersion(project, "3.1.11")
 minecraft {
     accessWidener = file("src/main/resources/fabric-biome-api-v1.accesswidener")
 }
+
+dependencies {
+	testmodImplementation project(path: ':fabric-api-base', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-resource-loader-v0', configuration: 'dev')
+	testmodImplementation project(path: ':fabric-tag-extensions-v0', configuration: 'dev')
+}

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeSelectors.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeSelectors.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableSet;
 
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.SpawnGroup;
+import net.minecraft.tag.Tag;
 import net.minecraft.util.registry.BuiltinRegistries;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.biome.Biome;
@@ -102,6 +103,15 @@ public final class BiomeSelectors {
 	 */
 	public static Predicate<BiomeSelectionContext> foundInTheEnd() {
 		return context -> context.getBiome().getCategory() == Biome.Category.THEEND;
+	}
+
+	/**
+	 * Returns a biome selector that will match all biomes in the given tag.
+	 *
+	 * @see net.fabricmc.fabric.api.tag.TagFactory#BIOME
+	 */
+	public static Predicate<BiomeSelectionContext> tag(Tag<Biome> tag) {
+		return context -> tag.contains(context.getBiome());
 	}
 
 	/**

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/modification/RegistryOpsMixin.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/modification/RegistryOpsMixin.java
@@ -37,20 +37,20 @@ import net.fabricmc.fabric.impl.biome.modification.BiomeModificationImpl;
  *     <li>{@link DynamicRegistryManager#create()} is used to create a dynamic registry manager with just
  *     entries from {@link net.minecraft.util.registry.BuiltinRegistries}</li>
  *     <li>Sometimes, Vanilla Minecraft will stop here, and use the {@link DynamicRegistryManager} as-is (examples: server.properties parsing, world creation screen).</li>
- *     <li>{@link RegistryOps#of(DynamicOps, ResourceManager, DynamicRegistryManager)} gets called with the manager, and a
+ *     <li>{@link RegistryOps#method_36574(DynamicOps, ResourceManager, DynamicRegistryManager)} gets called with the manager, and a
  *     resource manager that contains the loaded data packs. This will pull in all worldgen objects from datapacks into the
  *     dynamic registry manager.</li>
  *     <li>After the worldgen objects are pulled in from the datapacks, this mixin will call the biome modification callback.</li>
  *     <li>In most cases, Vanilla will stop here and now use the dynamic registy manager to instantiate a server.</li>
  *     <li>Sometimes, i.e. when using the "re-create world feature", and a datapack throws an error, Vanilla will sometimes
- *     repeat the {@link RegistryOps#of(DynamicOps, ResourceManager, DynamicRegistryManager)} call on the same
+ *     repeat the {@link RegistryOps#method_36574(DynamicOps, ResourceManager, DynamicRegistryManager)} call on the same
  *     dynamic registry manager. We guard against this using {@link net.fabricmc.fabric.impl.biome.modification.BiomeModificationTracker}.</li>
  * </ol>
  */
 @Mixin(RegistryOps.class)
 public class RegistryOpsMixin {
-	@Inject(method = "method_36575(Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/util/dynamic/RegistryOps$EntryLoader;Lnet/minecraft/util/registry/DynamicRegistryManager;)Lnet/minecraft/util/dynamic/RegistryOps;", at = @At("RETURN"))
-	private static <T> void afterCreation(DynamicOps<T> delegate, RegistryOps.EntryLoader entryLoader, DynamicRegistryManager impl, CallbackInfoReturnable<RegistryOps<T>> ci) {
+	@Inject(method = "method_36574", at = @At("RETURN"))
+	private static <T> void afterCreation(DynamicOps<T> dynamicOps, ResourceManager resourceManager, DynamicRegistryManager impl, CallbackInfoReturnable<RegistryOps<T>> cir) {
 		BiomeModificationImpl.INSTANCE.modifyBiomes((DynamicRegistryManager.Impl) impl);
 	}
 }

--- a/fabric-biome-api-v1/src/testmod/java/net/fabricmc/fabric/test/biome/FabricBiomeTest.java
+++ b/fabric-biome-api-v1/src/testmod/java/net/fabricmc/fabric/test/biome/FabricBiomeTest.java
@@ -50,6 +50,7 @@ import net.fabricmc.fabric.api.biome.v1.NetherBiomes;
 import net.fabricmc.fabric.api.biome.v1.OverworldBiomes;
 import net.fabricmc.fabric.api.biome.v1.OverworldClimate;
 import net.fabricmc.fabric.api.biome.v1.TheEndBiomes;
+import net.fabricmc.fabric.api.tag.TagFactory;
 import net.fabricmc.fabric.test.biome.mixin.DecoratorsAccessor;
 
 /**
@@ -121,7 +122,10 @@ public class FabricBiomeTest implements ModInitializer {
 							context.getGenerationSettings().addFeature(GenerationStep.Feature.TOP_LAYER_MODIFICATION,
 									BuiltinRegistries.CONFIGURED_FEATURE.getKey(COMMON_DESERT_WELL).get()
 							);
-						});
+						})
+				.add(ModificationPhase.ADDITIONS,
+						BiomeSelectors.tag(TagFactory.BIOME.create(new Identifier(MOD_ID, "tag_selector_test"))),
+						context -> context.getEffects().setSkyColor(0x770000));
 	}
 
 	// These are used for testing the spacing of custom end biomes.

--- a/fabric-biome-api-v1/src/testmod/resources/data/fabric-biome-api-v1-testmod/tags/biomes/tag_selector_test.json
+++ b/fabric-biome-api-v1/src/testmod/resources/data/fabric-biome-api-v1-testmod/tags/biomes/tag_selector_test.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:beach",
+    "minecraft:desert",
+    "minecraft:savanna",
+    "minecraft:badlands"
+  ]
+}


### PR DESCRIPTION
This PR adds a helper function into `BiomeSelectors` that accept a biome tag.
Also contains changes from #1571 for it to actually work.

<details>
<summary>A screenshot</summary>

![2021-08-18_11 40 55](https://user-images.githubusercontent.com/21150434/129838468-9c055d6e-d06e-4da9-8314-dde0f4b0dd28.png)

</details>