### PR TITLE
Add Transaction#getCurrentUnsafe and fix mixin fields

### DIFF
--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/transaction/Transaction.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/transaction/Transaction.java
@@ -105,6 +105,23 @@ public interface Transaction extends AutoCloseable, TransactionContext {
 	}
 
 	/**
+	 * Retrieve the currently open transaction, or null if there is none.
+	 *
+	 * <p><b>Usage of this function is strongly discouraged</b>, this is why it is deprecated and contains {@code unsafe} in its name.
+	 * The transaction may be aborted unbeknownst to you and anything you think that you have committed might be undone.
+	 * Only use it if you have no way to pass the transaction down the stack, for example if you are implementing compat with a simulation-based API,
+	 * and you know what you are doing, for example because you opened the outer transaction.
+	 *
+	 * @throws IllegalStateException If called from a close or outer close callback.
+	 * @deprecated Only use if you absolutely need it, there is almost always a better way.
+	 */
+	@Deprecated
+	@Nullable
+	static TransactionContext getCurrentUnsafe() {
+		return TransactionManagerImpl.MANAGERS.get().getCurrentUnsafe();
+	}
+
+	/**
 	 * Close the current transaction, rolling back all the changes that happened during this transaction and
 	 * the transactions opened with {@link #openNested} from this transaction.
 	 *

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/transaction/TransactionManagerImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/transaction/TransactionManagerImpl.java
@@ -50,7 +50,7 @@ public class TransactionManagerImpl {
 		} else if (stack.get(currentDepth).isOpen) {
 			return stack.get(currentDepth);
 		} else {
-			throw new IllegalStateException("May not call getCurrentTransaction() from a close callback.");
+			throw new IllegalStateException("May not call getCurrentUnsafe() from a close callback.");
 		}
 	}
 

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/transaction/TransactionManagerImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/transaction/TransactionManagerImpl.java
@@ -18,6 +18,9 @@ package net.fabricmc.fabric.impl.transfer.transaction;
 
 import java.util.ArrayList;
 
+import org.jetbrains.annotations.Nullable;
+
+import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 
 public class TransactionManagerImpl {
@@ -38,6 +41,17 @@ public class TransactionManagerImpl {
 		}
 
 		return open();
+	}
+
+	@Nullable
+	public TransactionContext getCurrentUnsafe() {
+		if (currentDepth == -1) {
+			return null;
+		} else if (stack.get(currentDepth).isOpen) {
+			return stack.get(currentDepth);
+		} else {
+			throw new IllegalStateException("May not call getCurrentTransaction() from a close callback.");
+		}
 	}
 
 	/**

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/mixin/transfer/FluidMixin.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/mixin/transfer/FluidMixin.java
@@ -31,10 +31,10 @@ import net.fabricmc.fabric.impl.transfer.fluid.FluidVariantCache;
 @SuppressWarnings("unused")
 public class FluidMixin implements FluidVariantCache {
 	@SuppressWarnings("ConstantConditions")
-	private final FluidVariant cachedFluidVariant = new FluidVariantImpl((Fluid) (Object) this, null);
+	private final FluidVariant fabric_cachedFluidVariant = new FluidVariantImpl((Fluid) (Object) this, null);
 
 	@Override
 	public FluidVariant fabric_getCachedFluidVariant() {
-		return cachedFluidVariant;
+		return fabric_cachedFluidVariant;
 	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/mixin/transfer/ItemMixin.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/mixin/transfer/ItemMixin.java
@@ -17,7 +17,6 @@
 package net.fabricmc.fabric.mixin.transfer;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 
 import net.minecraft.item.Item;
 
@@ -30,11 +29,11 @@ import net.fabricmc.fabric.impl.transfer.item.ItemVariantImpl;
  */
 @Mixin(Item.class)
 public class ItemMixin implements ItemVariantCache {
-	@Unique
-	private final ItemVariant cachedItemVariant = new ItemVariantImpl((Item) (Object) this, null);
+	@SuppressWarnings("ConstantConditions")
+	private final ItemVariant fabric_cachedItemVariant = new ItemVariantImpl((Item) (Object) this, null);
 
 	@Override
 	public ItemVariant fabric_getCachedItemVariant() {
-		return cachedItemVariant;
+		return fabric_cachedItemVariant;
 	}
 }


### PR DESCRIPTION
`Transaction#getCurrentUnsafe` makes my life a bit easier when implementing support for AE2. It will also be useful for LBA should it attempt to have compatibility.

Adding a `fabric_` prefix will prevent conflicts with older versions of FastTransferLib that used to contain the exact same `ItemMixin` (with a `cachedItemVariant` field). `@Unique` only prevents conflicts with the mixin target, so it is effectively useless in 99% of the cases.