### PR TITLE
Add TooltipComponentCallback

### DIFF
--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipComponentCallback.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipComponentCallback.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.client.rendering.v1;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.client.gui.tooltip.TooltipComponent;
+import net.minecraft.item.Item;
+import net.minecraft.client.item.TooltipData;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+/**
+ * Allows registering a mapping from {@link TooltipData} to {@link TooltipComponent}.
+ * This allows custom tooltips for items: first, override {@link Item#getTooltipData} and return a custom {@code TooltipData}.
+ * Second, register a listener to this event and convert the data to your component implementation if it's an instance of your data class.
+ *
+ * <p>If nothing can handle some data and {@link TooltipComponent#of(TooltipData)} is called, an exception will be thrown!
+ * So make sure that you register a listener to the event.
+ */
+@Environment(EnvType.CLIENT)
+public interface TooltipComponentCallback {
+	Event<TooltipComponentCallback> EVENT = EventFactory.createArrayBacked(TooltipComponentCallback.class, listeners -> data -> {
+		for (TooltipComponentCallback listener : listeners) {
+			TooltipComponent component = listener.getComponent(data);
+
+			if (component != null) {
+				return component;
+			}
+		}
+
+		return null;
+	});
+
+	/**
+	 * Return the tooltip component for the passed data, or null if none is available.
+	 */
+	@Nullable
+	TooltipComponent getComponent(TooltipData data);
+}

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/impl/client/rendering/TooltipComponentCallbackImpl.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/impl/client/rendering/TooltipComponentCallbackImpl.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.rendering;
+
+import net.minecraft.client.gui.tooltip.BundleTooltipComponent;
+import net.minecraft.client.gui.tooltip.TooltipComponent;
+import net.minecraft.client.item.BundleTooltipData;
+import net.minecraft.client.item.TooltipData;
+
+import net.fabricmc.fabric.api.client.rendering.v1.TooltipComponentCallback;
+
+public class TooltipComponentCallbackImpl {
+	/**
+	 * Replaces {@link TooltipComponent#of(TooltipData)} through the power of ASM.
+	 */
+	public static TooltipComponent of(TooltipData data) {
+		// The vanilla case is handled by the listener registered below.
+		TooltipComponent component = TooltipComponentCallback.EVENT.invoker().getComponent(data);
+
+		if (component != null) {
+			return component;
+		} else {
+			throw new IllegalArgumentException("Unknown TooltipComponent");
+		}
+	}
+
+	static {
+		TooltipComponentCallback.EVENT.register(data -> {
+			if (data instanceof BundleTooltipData bundleData) {
+				return new BundleTooltipComponent(bundleData);
+			} else {
+				return null;
+			}
+		});
+	}
+}

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/impl/client/rendering/TooltipComponentMixinPlugin.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/impl/client/rendering/TooltipComponentMixinPlugin.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.rendering;
+
+import java.util.List;
+import java.util.Set;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import net.minecraft.client.item.TooltipData;
+
+import net.fabricmc.loader.api.FabricLoader;
+
+/**
+ * Used to replace the body of {@link net.minecraft.client.gui.tooltip.TooltipComponent#of(TooltipData)}
+ * by a call to {@link TooltipComponentCallbackImpl#of(TooltipData)}.
+ */
+public class TooltipComponentMixinPlugin implements IMixinConfigPlugin {
+	private static final String MIXIN_CLASS = "net.fabricmc.fabric.mixin.client.rendering.MixinTooltipComponent";
+	private static final String TARGET_METHOD_DESC = String.format(
+			"(L%s;)L%s;",
+			FabricLoader.getInstance().getMappingResolver().mapClassName("intermediary", "net.minecraft.class_5632"), // TooltipData
+			FabricLoader.getInstance().getMappingResolver().mapClassName("intermediary", "net.minecraft.class_5684") // TooltipComponent
+	).replace('.', '/');
+
+	@Override
+	public void onLoad(String mixinPackage) { }
+
+	@Override
+	public String getRefMapperConfig() {
+		return null;
+	}
+
+	@Override
+	public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+		return true;
+	}
+
+	@Override
+	public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) { }
+
+	@Override
+	public List<String> getMixins() {
+		return null;
+	}
+
+	@Override
+	public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+		if (!mixinClassName.equals(MIXIN_CLASS)) return;
+
+		MethodNode method = findOfMethod(targetClass);
+		method.instructions.clear();
+		method.visitIntInsn(Opcodes.ALOAD, 0);
+		method.visitMethodInsn(Opcodes.INVOKESTATIC, "net/fabricmc/fabric/impl/client/rendering/TooltipComponentCallbackImpl", "of", TARGET_METHOD_DESC, false);
+		method.visitInsn(Opcodes.ARETURN);
+	}
+
+	private static MethodNode findOfMethod(ClassNode node) {
+		return node.methods.stream()
+				.filter(methodNode -> methodNode.desc.equals(TARGET_METHOD_DESC))
+				.findFirst().get();
+	}
+
+	@Override
+	public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) { }
+}

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/mixin/client/rendering/MixinTooltipComponent.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/mixin/client/rendering/MixinTooltipComponent.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.rendering;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import net.minecraft.client.gui.tooltip.TooltipComponent;
+
+import net.fabricmc.fabric.impl.client.rendering.TooltipComponentMixinPlugin;
+
+/**
+ * Allows direct ASM modification through the corresponding {@link TooltipComponentMixinPlugin}.
+ */
+@Mixin(TooltipComponent.class)
+public interface MixinTooltipComponent {
+}

--- a/fabric-rendering-v1/src/main/resources/fabric-rendering-v1.mixins.json
+++ b/fabric-rendering-v1/src/main/resources/fabric-rendering-v1.mixins.json
@@ -13,9 +13,11 @@
     "EntityModelsMixin",
     "LivingEntityRendererAccessor",
     "MixinBlockEntityRenderers",
-    "MixinEntityRenderers"
+    "MixinEntityRenderers",
+    "MixinTooltipComponent"
   ],
   "injectors": {
     "defaultRequire": 1
-  }
+  },
+  "plugin": "net.fabricmc.fabric.impl.client.rendering.TooltipComponentMixinPlugin"
 }

--- a/fabric-rendering-v1/src/testmod/java/net/fabricmc/fabric/test/rendering/TooltipComponentTestInit.java
+++ b/fabric-rendering-v1/src/testmod/java/net/fabricmc/fabric/test/rendering/TooltipComponentTestInit.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.rendering;
+
+import java.util.Optional;
+
+import net.minecraft.client.item.TooltipData;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+import net.fabricmc.api.ModInitializer;
+
+public class TooltipComponentTestInit implements ModInitializer {
+	@Override
+	public void onInitialize() {
+		Registry.register(Registry.ITEM, new Identifier("fabric-rendering-v1-testmod", "custom_tooltip"), new CustomTooltipItem());
+	}
+
+	private static class CustomTooltipItem extends Item {
+		CustomTooltipItem() {
+			super(new Settings().group(ItemGroup.MISC));
+		}
+
+		@Override
+		public Optional<TooltipData> getTooltipData(ItemStack stack) {
+			return Optional.of(new Data(stack.getTranslationKey()));
+		}
+	}
+
+	public record Data(String string) implements TooltipData { }
+}

--- a/fabric-rendering-v1/src/testmod/java/net/fabricmc/fabric/test/rendering/client/TooltipComponentTests.java
+++ b/fabric-rendering-v1/src/testmod/java/net/fabricmc/fabric/test/rendering/client/TooltipComponentTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.rendering.client;
+
+import net.minecraft.client.gui.tooltip.TooltipComponent;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Style;
+import net.minecraft.util.Formatting;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.rendering.v1.TooltipComponentCallback;
+import net.fabricmc.fabric.test.rendering.TooltipComponentTestInit;
+
+public class TooltipComponentTests implements ClientModInitializer {
+	@Override
+	public void onInitializeClient() {
+		TooltipComponentCallback.EVENT.register(data -> {
+			if (data instanceof TooltipComponentTestInit.Data d) {
+				return TooltipComponent.of(new LiteralText(d.string()).setStyle(Style.EMPTY.withColor(Formatting.GREEN)).asOrderedText());
+			}
+
+			return null;
+		});
+	}
+}

--- a/fabric-rendering-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-rendering-v1/src/testmod/resources/fabric.mod.json
@@ -9,10 +9,14 @@
     "fabric-rendering-v1": "*"
   },
   "entrypoints": {
+    "main": [
+      "net.fabricmc.fabric.test.rendering.TooltipComponentTestInit"
+    ],
     "client": [
       "net.fabricmc.fabric.test.rendering.client.WorldRenderEventsTests",
       "net.fabricmc.fabric.test.rendering.client.ArmorRenderingTests",
-      "net.fabricmc.fabric.test.rendering.client.FeatureRendererTest"
+      "net.fabricmc.fabric.test.rendering.client.FeatureRendererTest",
+      "net.fabricmc.fabric.test.rendering.client.TooltipComponentTests"
     ]
   }
 }


### PR DESCRIPTION
Allows registering a custom mapping from `TooltipData` to `TooltipComponent`.

Unfortunately this is done by vanilla in the static `TooltipComponent#of` and mixin doesn't allow injecting into interface methods, even if they are static. So I used a mixin plugin to overwrite the method through ASM. This is the first time I use ASM, so it may not be optimal. Perhaps injecting right before the exception instead of throwing would be suitable as well, but then I'd have to learn how to do that. :smile: