### PR TITLE
Send block entity update packet along with regular block update packet

### DIFF
--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/MixinServerPlayerInteractionManager.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/MixinServerPlayerInteractionManager.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.fabric.mixin.event.interaction;
 
-import net.minecraft.network.packet.s2c.play.BlockEntityUpdateS2CPacket;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -28,6 +27,7 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.network.packet.s2c.play.BlockEntityUpdateS2CPacket;
 import net.minecraft.network.packet.s2c.play.BlockUpdateS2CPacket;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -62,12 +62,15 @@ public class MixinServerPlayerInteractionManager {
 		if (result != ActionResult.PASS) {
 			// The client might have broken the block on its side, so make sure to let it know.
 			this.player.networkHandler.sendPacket(new BlockUpdateS2CPacket(world, pos));
+
 			if (world.getBlockState(pos).hasBlockEntity()) {
 				BlockEntityUpdateS2CPacket updatePacket = world.getBlockEntity(pos).toUpdatePacket();
+
 				if (updatePacket != null) {
 					this.player.networkHandler.sendPacket(updatePacket);
 				}
 			}
+
 			info.cancel();
 		}
 	}

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/MixinServerPlayerInteractionManager.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/MixinServerPlayerInteractionManager.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.mixin.event.interaction;
 
+import net.minecraft.network.packet.s2c.play.BlockEntityUpdateS2CPacket;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -61,6 +62,12 @@ public class MixinServerPlayerInteractionManager {
 		if (result != ActionResult.PASS) {
 			// The client might have broken the block on its side, so make sure to let it know.
 			this.player.networkHandler.sendPacket(new BlockUpdateS2CPacket(world, pos));
+			if (world.getBlockState(pos).hasBlockEntity()) {
+				BlockEntityUpdateS2CPacket updatePacket = world.getBlockEntity(pos).toUpdatePacket();
+				if (updatePacket != null) {
+					this.player.networkHandler.sendPacket(updatePacket);
+				}
+			}
 			info.cancel();
 		}
 	}


### PR DESCRIPTION
Canceling a block break event on a block entity currently resets the block back to its data-less state. For example a steve head, blank sign and banners just disappear.