### PR TITLE
Transfer API: Work around vanilla capturing ItemStack references

### DIFF
--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleStackStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleStackStorage.java
@@ -115,6 +115,7 @@ public abstract class SingleStackStorage extends SnapshotParticipant<ItemStack> 
 
 			if (insertedAmount > 0) {
 				updateSnapshots(transaction);
+				currentStack = getStack();
 
 				if (currentStack.isEmpty()) {
 					currentStack = insertedVariant.toStack(insertedAmount);
@@ -142,6 +143,7 @@ public abstract class SingleStackStorage extends SnapshotParticipant<ItemStack> 
 
 			if (extracted > 0) {
 				this.updateSnapshots(transaction);
+				currentStack = getStack();
 				currentStack.decrement(extracted);
 				setStack(currentStack);
 			}
@@ -154,7 +156,9 @@ public abstract class SingleStackStorage extends SnapshotParticipant<ItemStack> 
 
 	@Override
 	protected final ItemStack createSnapshot() {
-		return getStack().copy();
+		ItemStack original = getStack();
+		setStack(original.copy());
+		return original;
 	}
 
 	@Override

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/InventorySlotWrapper.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/InventorySlotWrapper.java
@@ -34,6 +34,7 @@ class InventorySlotWrapper extends SingleStackStorage {
 	 */
 	private final InventoryStorageImpl storage;
 	final int slot;
+	private ItemStack lastReleasedSnapshot = null;
 
 	InventorySlotWrapper(InventoryStorageImpl storage, int slot) {
 		this.storage = storage;
@@ -65,5 +66,26 @@ class InventorySlotWrapper extends SingleStackStorage {
 	public void updateSnapshots(TransactionContext transaction) {
 		storage.markDirtyParticipant.updateSnapshots(transaction);
 		super.updateSnapshots(transaction);
+	}
+
+	@Override
+	protected void releaseSnapshot(ItemStack snapshot) {
+		lastReleasedSnapshot = snapshot;
+	}
+
+	@Override
+	protected void onFinalCommit() {
+		// Try to apply the change to the original stack
+		ItemStack original = lastReleasedSnapshot;
+		ItemStack currentStack = getStack();
+
+		if (!original.isEmpty() && !currentStack.isEmpty() && ItemStack.canCombine(original, currentStack)) {
+			// None is empty and the contents match: just update the amount and reuse the original stack.
+			original.setCount(currentStack.getCount());
+			setStack(original);
+		} else {
+			// Otherwise assume everything was taken from original so empty it.
+			original.setCount(0);
+		}
 	}
 }


### PR DESCRIPTION
Ensure that Inventory wrappers will try to mutate the backing stack as much as possible. In many cases, MC code captures a reference to the ItemStack so we want to edit that stack directly and not a copy whenever we can. Obviously this can't be perfect, but we try to cover as many cases as possible.

This is the kind of change that makes me happy I wrote tests. :smile: