### PR TITLE
Restore contact of  InvalidateRenderStateCallback

### DIFF
--- a/fabric-rendering-v1/build.gradle
+++ b/fabric-rendering-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-rendering-v1"
-version = getSubprojectVersion(project, "1.8.1")
+version = getSubprojectVersion(project, "1.8.2")
 
 moduleDependencies(project, [
 		'fabric-api-base'

--- a/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/mixin/client/rendering/MixinWorldRenderer.java
+++ b/fabric-rendering-v1/src/main/java/net/fabricmc/fabric/mixin/client/rendering/MixinWorldRenderer.java
@@ -166,7 +166,7 @@ public abstract class MixinWorldRenderer {
 		WorldRenderEvents.END.invoker().onEnd(context);
 	}
 
-	@Inject(method = "reload", at = @At("HEAD"))
+	@Inject(method = "Lnet/minecraft/client/render/WorldRenderer;reload()V", at = @At("HEAD"))
 	private void onReload(CallbackInfo ci) {
 		InvalidateRenderStateCallback.EVENT.invoker().onInvalidate();
 	}


### PR DESCRIPTION
Per the spec, `InvalidateRenderStateCallback` should trigger:
```
 ... when the world renderer reloads, usually as result of changing resource pack
 or video configuration, or when the player types F3+A in the debug screen.
 ```

When `InvalidateRenderStateCallback` was made, there was only one `reload()` method in `WorldRenderer`. Sometime later (I didn't track down precisely when) another method was mapped to `reload()` that accepts a `ResourceManager` parameter and is only called on resource reload.  It comes first in the class, so now `InvalidateRenderStateCallback` does not trigger on F3+A.

This PR restores the original, intended behavior of `InvalidateRenderStateCallback` by making the mixin target fully qualified.