### PR TITLE
Confusing code paths in Keybinding API

### DIFF
--- a/fabric-key-binding-api-v1/src/main/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingHelper.java
+++ b/fabric-key-binding-api-v1/src/main/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingHelper.java
@@ -47,6 +47,16 @@ public final class KeyBindingHelper {
 	}
 
 	/**
+	 * Returns if the given keybind has been registered
+	 *
+	 * @param keyBinding the keybinding
+	 * @return if the keybind has been registered
+	 */
+	public static boolean keybindingExists(KeyBinding keyBinding) {
+		return KeyBindingRegistryImpl.doesKeybindingExist(keyBinding);
+	}
+
+	/**
 	 * Returns the configured KeyCode bound to the KeyBinding from the player's settings.
 	 *
 	 * @param keyBinding the keybinding

--- a/fabric-key-binding-api-v1/src/main/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
+++ b/fabric-key-binding-api-v1/src/main/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
@@ -62,7 +62,7 @@ public final class KeyBindingRegistryImpl {
 			if (existingKeyBindings == binding) {
 				throw new IllegalArgumentException("Key binding already registered!");
 			} else if (existingKeyBindings.getTranslationKey().equals(binding.getTranslationKey())) {
-				throw new IllegalArgumentException("Attempted to register two key bindings with equal ID: " + binding.getTranslationKey() + "!");
+				throw new IllegalStateException("Attempted to register two key bindings with equal ID: " + binding.getTranslationKey() + "!");
 			}
 		}
 

--- a/fabric-key-binding-api-v1/src/main/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
+++ b/fabric-key-binding-api-v1/src/main/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
@@ -60,9 +60,9 @@ public final class KeyBindingRegistryImpl {
 	public static KeyBinding registerKeyBinding(KeyBinding binding) {
 		for (KeyBinding existingKeyBindings : moddedKeyBindings) {
 			if (existingKeyBindings == binding) {
-				throw null;
+				throw new IllegalArgumentException("Key binding already registered!");
 			} else if (existingKeyBindings.getTranslationKey().equals(binding.getTranslationKey())) {
-				throw new RuntimeException("Attempted to register two key bindings with equal ID: " + binding.getTranslationKey() + "!");
+				throw new IllegalArgumentException("Attempted to register two key bindings with equal ID: " + binding.getTranslationKey() + "!");
 			}
 		}
 
@@ -70,7 +70,12 @@ public final class KeyBindingRegistryImpl {
 			addCategory(binding.getCategory());
 		}
 
-		return moddedKeyBindings.add(binding) ? binding : null;
+		moddedKeyBindings.add(binding);
+		return binding;
+	}
+
+	public static boolean doesKeybindingExist(KeyBinding binding) {
+		return moddedKeyBindings.stream().anyMatch(key -> key.getTranslationKey().equals(binding.getTranslationKey()));
 	}
 
 	/**


### PR DESCRIPTION
Keybinding registry's exceptions and returns have been overcomplicated and confused.
**What's Changed?**
```java
if (existingKeyBindings == binding) {
	throw null;
}
``` 
throwing null is not a shorthand but a de-reference of null, causing a `NullPointerException` as a result. This abstracts the exception making. It has been replaced with an `IllegalArgumentException` with a suitable description.
```java
... if (existingKeyBindings.getTranslationKey().equals(binding.getTranslationKey())) {
	throw new RuntimeException("...");
}
``` 
Throwing a `RuntimeException` is very bad because it makes catching fabric specific exceptions difficult. It has instead been replaced with `IllegalArgumentException`. This makes more sense because... it's an illegal argument. You can't register two keybindings with an equal ID.
```java
return moddedKeyBindings.add(binding) ? binding : null;
```
this is completely useless. `add()` always returns true.