### PR TITLE
Structure API fixes [1.18]

### DIFF
--- a/fabric-structure-api-v1/src/main/java/net/fabricmc/fabric/impl/structure/FabricStructureImpl.java
+++ b/fabric-structure-api-v1/src/main/java/net/fabricmc/fabric/impl/structure/FabricStructureImpl.java
@@ -29,6 +29,9 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents;
 import net.fabricmc.fabric.mixin.structure.StructuresConfigAccessor;
 
 public class FabricStructureImpl implements ModInitializer {
+	//Keeps a map of structures to structure configs for purposes of initializing the flat chunk generator
+	public static final Map<StructureFeature<?>, StructureConfig> FLAT_STRUCTURE_TO_CONFIG_MAP = new HashMap<>();
+
 	//Keeps a map of structures to structure configs.
 	public static final Map<StructureFeature<?>, StructureConfig> STRUCTURE_TO_CONFIG_MAP = new HashMap<>();
 

--- a/fabric-structure-api-v1/src/main/java/net/fabricmc/fabric/mixin/structure/FlatChunkGeneratorConfigMixin.java
+++ b/fabric-structure-api-v1/src/main/java/net/fabricmc/fabric/mixin/structure/FlatChunkGeneratorConfigMixin.java
@@ -16,19 +16,21 @@
 
 package net.fabricmc.fabric.mixin.structure;
 
-import java.util.Map;
-
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.world.gen.chunk.FlatChunkGeneratorConfig;
-import net.minecraft.world.gen.feature.ConfiguredStructureFeature;
-import net.minecraft.world.gen.feature.StructureFeature;
+import net.minecraft.world.gen.chunk.StructuresConfig;
+
+import net.fabricmc.fabric.impl.structure.FabricStructureImpl;
 
 @Mixin(FlatChunkGeneratorConfig.class)
-public interface FlatChunkGeneratorConfigAccessor {
-	@Accessor("STRUCTURE_TO_FEATURES")
-	static Map<StructureFeature<?>, ConfiguredStructureFeature<?, ?>> getStructureToFeatures() {
-		throw new AssertionError("Untransformed accessor");
+public class FlatChunkGeneratorConfigMixin {
+	@Inject(method = "getDefaultConfig", at = @At(value = "RETURN"))
+	private static void createDefaultConfig(CallbackInfoReturnable<FlatChunkGeneratorConfig> cir) {
+		StructuresConfig structuresConfig = cir.getReturnValue().getStructuresConfig();
+		structuresConfig.getStructures().putAll(FabricStructureImpl.FLAT_STRUCTURE_TO_CONFIG_MAP);
 	}
 }

--- a/fabric-structure-api-v1/src/main/resources/fabric-structure-api-v1.mixins.json
+++ b/fabric-structure-api-v1/src/main/resources/fabric-structure-api-v1.mixins.json
@@ -4,7 +4,7 @@
   "compatibilityLevel": "JAVA_16",
   "mixins": [
     "ChunkSerializerMixin",
-    "FlatChunkGeneratorConfigAccessor",
+    "FlatChunkGeneratorConfigMixin",
     "StructureFeatureAccessor",
     "StructuresConfigAccessor"
   ],

--- a/fabric-structure-api-v1/src/testmod/java/net/fabricmc/fabric/test/structure/StructureTest.java
+++ b/fabric-structure-api-v1/src/testmod/java/net/fabricmc/fabric/test/structure/StructureTest.java
@@ -61,7 +61,7 @@ public class StructureTest {
 		FabricStructureBuilder.create(new Identifier("fabric", "test_structure"), STRUCTURE)
 				.step(GenerationStep.Feature.SURFACE_STRUCTURES)
 				.defaultConfig(32, 8, 12345)
-				.superflatFeature(CONFIGURED_STRUCTURE)
+				.enableSuperflat()
 				.adjustsSurface()
 				.register();
 		Registry.register(Registry.STRUCTURE_PIECE, new Identifier("fabric", "test_structure_piece"), PIECE);

--- a/fabric-structure-api-v1/src/testmod/java/net/fabricmc/fabric/test/structure/mixin/MixinConfiguredStructureFeatures.java
+++ b/fabric-structure-api-v1/src/testmod/java/net/fabricmc/fabric/test/structure/mixin/MixinConfiguredStructureFeatures.java
@@ -33,7 +33,7 @@ import net.fabricmc.fabric.test.structure.StructureTest;
 
 @Mixin(ConfiguredStructureFeatures.class)
 public class MixinConfiguredStructureFeatures {
-	@Inject(method = "method_38571", at = @At("TAIL"))
+	@Inject(method = "method_38570", at = @At("TAIL"))
 	private static void addStructuresToBiomes(BiConsumer<ConfiguredStructureFeature<?, ?>, RegistryKey<Biome>> consumer, CallbackInfo ci) {
 		consumer.accept(StructureTest.CONFIGURED_STRUCTURE, BiomeKeys.PLAINS);
 	}


### PR DESCRIPTION
These fixes allow the testmod to go ingame for the structure-api and the test structure will spawn correctly in a superflat world (which the changes relate to).

Structures are no longer linked to Biomes via an instance field  in the Biome class. Instead they are linked by registry keys. This means that standard biome structure start rules also apply to superflat worlds, and their biomes (default=PLAINS).

The superflat chunk generator now has its own StructuresConfig object, which only contains a hardcoded list of structures.
Changes the FabricStructureBuilder to allow adding structures to this default list.