### PR TITLE
Add two more sleep events

### DIFF
--- a/fabric-entity-events-v1/build.gradle
+++ b/fabric-entity-events-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-entity-events-v1"
-version = getSubprojectVersion(project, "1.2.3")
+version = getSubprojectVersion(project, "1.3.0")
 
 moduleDependencies(project, [
 		'fabric-api-base'

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
@@ -39,7 +39,8 @@ import net.fabricmc.fabric.api.event.EventFactory;
  * {@link #ALLOW_NEARBY_MONSTERS}, {@link #ALLOW_SETTING_SPAWN} and {@link #ALLOW_SLEEPING}
  *
  * <p><b>Note:</b> Only the {@link #ALLOW_BED} event applies to non-player entities.</li>
- * <li>Modifiers: {@link #MODIFY_SLEEPING_DIRECTION}</li>
+ * <li>Modifiers: {@link #MODIFY_SLEEPING_DIRECTION}, {@link #SET_BED_OCCUPATION_STATE}
+ * and {@link #MODIFY_WAKE_UP_POSITION}</li>
  * </ol>
  *
  * <p>Sleep events are useful for making custom bed blocks that do not extend {@link net.minecraft.block.BedBlock}.

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
@@ -55,7 +55,7 @@ public final class EntitySleepEvents {
 	 * if they match your use case! This helps with mod compatibility.
 	 *
 	 * <p>If this event returns a {@link net.minecraft.entity.player.PlayerEntity.SleepFailureReason}, it is used
-	 * as the return value of {@link PlayerEntity#trySleep(BlockPos)} and sleeping fails. A null return value
+	 * as the return value of {@link PlayerEntity#trySleep(BlockPos)} and sleeping fails. A {@code null} return value
 	 * means that the player will start sleeping.
 	 *
 	 * <p>When this event is called, all vanilla sleeping checks have already succeeded, i.e. this event
@@ -96,7 +96,7 @@ public final class EntitySleepEvents {
 	 * An event that is called to check whether a block is valid for sleeping.
 	 *
 	 * <p>Used for checking whether the block at the current sleeping position is a valid bed block.
-	 * If false, the player wakes up.
+	 * If {@code false}, the player wakes up.
 	 *
 	 * <p>This event is only checked <i>during</i> sleeping, so an entity can
 	 * {@linkplain LivingEntity#sleep(BlockPos) start sleeping} on any block, but will immediately
@@ -235,7 +235,7 @@ public final class EntitySleepEvents {
 		 *
 		 * @param player      the sleeping player
 		 * @param sleepingPos the future {@linkplain LivingEntity#getSleepingPosition() sleeping position} of the entity
-		 * @return null if the player can sleep, or a failure reason if they cannot
+		 * @return {@code null} if the player can sleep, or a failure reason if they cannot
 		 * @see PlayerEntity#trySleep(BlockPos)
 		 */
 		@Nullable
@@ -274,7 +274,7 @@ public final class EntitySleepEvents {
 		 * @param entity        the sleeping entity
 		 * @param sleepingPos   the position of the block
 		 * @param state         the block state to check
-		 * @param vanillaResult true if vanilla allows the block, false otherwise
+		 * @param vanillaResult {@code true} if vanilla allows the block, {@code false} otherwise
 		 * @return {@link ActionResult#SUCCESS} if the bed is valid, {@link ActionResult#FAIL} if it's not,
 		 *         {@link ActionResult#PASS} to fall back to other callbacks
 		 */
@@ -290,7 +290,7 @@ public final class EntitySleepEvents {
 		 *
 		 * @param player        the sleeping player
 		 * @param sleepingPos   the (possibly still unset) {@linkplain LivingEntity#getSleepingPosition() sleeping position} of the player
-		 * @param vanillaResult true if vanilla allows the time, false otherwise
+		 * @param vanillaResult {@code true} if vanilla allows the time, {@code false} otherwise
 		 * @return {@link ActionResult#SUCCESS} if the time is valid, {@link ActionResult#FAIL} if it's not,
 		 *         {@link ActionResult#PASS} to fall back to other callbacks
 		 */
@@ -306,7 +306,7 @@ public final class EntitySleepEvents {
 		 *
 		 * @param player        the sleeping player
 		 * @param sleepingPos   the (possibly still unset) {@linkplain LivingEntity#getSleepingPosition() sleeping position} of the player
-		 * @param vanillaResult true if vanilla's monster check succeeded, false otherwise
+		 * @param vanillaResult {@code true} if vanilla's monster check succeeded (there were no monsters), {@code false} otherwise
 		 * @return {@link ActionResult#SUCCESS} to allow sleeping, {@link ActionResult#FAIL} to prevent sleeping,
 		 *         {@link ActionResult#PASS} to fall back to other callbacks
 		 */
@@ -319,7 +319,7 @@ public final class EntitySleepEvents {
 		 * Checks whether a sleeping player counts into skipping the current day and resetting the time to 0.
 		 *
 		 * @param player        the sleeping player
-		 * @return true if allowed, false otherwise
+		 * @return {@code true} if allowed, {@code false} otherwise
 		 */
 		boolean allowResettingTime(PlayerEntity player);
 	}
@@ -332,7 +332,7 @@ public final class EntitySleepEvents {
 		 *
 		 * @param entity            the sleeping entity
 		 * @param sleepingPos       the position of the block slept on
-		 * @param sleepingDirection the old sleeping direction, or null if not determined by vanilla or previous callbacks
+		 * @param sleepingDirection the old sleeping direction, or {@code null} if not determined by vanilla or previous callbacks
 		 * @return the new sleeping direction
 		 */
 		@Nullable
@@ -346,7 +346,7 @@ public final class EntitySleepEvents {
 		 *
 		 * @param player      the sleeping player
 		 * @param sleepingPos the sleeping position
-		 * @return true if allowed, false otherwise
+		 * @return {@code true} if allowed, {@code false} otherwise
 		 */
 		boolean allowSettingSpawn(PlayerEntity player, BlockPos sleepingPos);
 	}
@@ -359,8 +359,8 @@ public final class EntitySleepEvents {
 		 * @param entity      the sleeping entity
 		 * @param sleepingPos the sleeping position
 		 * @param bedState    the block state of the bed
-		 * @param occupied    true if occupied, false if free
-		 * @return true if the occupation state was modified, false to fall back to other callbacks
+		 * @param occupied    {@code true} if occupied, {@code false} if free
+		 * @return {@code true} if the occupation state was successfully modified, {@code false} to fall back to other callbacks
 		 */
 		boolean setBedOccupationState(LivingEntity entity, BlockPos sleepingPos, BlockState bedState, boolean occupied);
 	}
@@ -373,7 +373,7 @@ public final class EntitySleepEvents {
 		 * @param entity      the sleeping entity
 		 * @param sleepingPos the position of the block slept on
 		 * @param bedState    the block slept on
-		 * @param wakeUpPos   the old wake up position, or null if not determined by vanilla or previous callbacks
+		 * @param wakeUpPos   the old wake-up position, or {@code null} if not determined by vanilla or previous callbacks
 		 * @return the new wake-up position
 		 */
 		@Nullable

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/EntitySleepEvents.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.api.entity.event.v1;
 
 import org.jetbrains.annotations.Nullable;
 
+import net.minecraft.block.BedBlock;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -196,6 +197,22 @@ public final class EntitySleepEvents {
 		return true;
 	});
 
+	/**
+	 * An event that sets the occupation state of a bed.
+	 *
+	 * <p>Note that this is <b>not</b> needed for blocks using {@link net.minecraft.block.BedBlock},
+	 * which are handled automatically.
+	 */
+	public static final Event<SetBedOccupationState> SET_BED_OCCUPATION_STATE = EventFactory.createArrayBacked(SetBedOccupationState.class, callbacks -> (entity, sleepingPos, bedState, occupied) -> {
+		for (SetBedOccupationState callback : callbacks) {
+			if (callback.setBedOccupationState(entity, sleepingPos, bedState, occupied)) {
+				return true;
+			}
+		}
+
+		return false;
+	});
+
 	@FunctionalInterface
 	public interface AllowSleeping {
 		/**
@@ -317,6 +334,20 @@ public final class EntitySleepEvents {
 		 * @return true if allowed, false otherwise
 		 */
 		boolean allowSettingSpawn(PlayerEntity player, BlockPos sleepingPos);
+	}
+
+	@FunctionalInterface
+	public interface SetBedOccupationState {
+		/**
+		 * Sets the occupation state of a bed block.
+		 *
+		 * @param entity      the sleeping entity
+		 * @param sleepingPos the sleeping position
+		 * @param bedState    the block state of the bed
+		 * @param occupied    true if occupied, false if free
+		 * @return true if the occupation state was modified, false to fall back to other callbacks
+		 */
+		boolean setBedOccupationState(LivingEntity entity, BlockPos sleepingPos, BlockState bedState, boolean occupied);
 	}
 
 	private EntitySleepEvents() {

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.mixin.entity.event;
 import java.util.Optional;
 
 import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Dynamic;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -88,7 +89,7 @@ abstract class LivingEntityMixin {
 		}
 	}
 
-	// Synthetic lambda body for Optional.map in isSleepingInBed
+	@Dynamic("method_18405: Synthetic lambda body for Optional.map in isSleepingInBed")
 	@Inject(method = "method_18405", at = @At("RETURN"), cancellable = true)
 	private void onIsSleepingInBed(BlockPos sleepingPos, CallbackInfoReturnable<Boolean> info) {
 		BlockState bedState = ((LivingEntity) (Object) this).world.getBlockState(sleepingPos);
@@ -106,9 +107,9 @@ abstract class LivingEntityMixin {
 		}
 	}
 
-	// method_18404: Synthetic lambda body for Optional.ifPresent in wakeUp
 	// This is needed 1) so that the vanilla logic in wakeUp runs for modded beds and 2) for the injector below.
 	// The injector is shared because method_18404 and sleep share much of the structure here.
+	@Dynamic("method_18404: Synthetic lambda body for Optional.ifPresent in wakeUp")
 	@ModifyVariable(method = {"method_18404", "sleep"}, at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/world/World;getBlockState(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/block/BlockState;"))
 	private BlockState modifyBedForOccupiedState(BlockState state, BlockPos sleepingPos) {
 		ActionResult result = EntitySleepEvents.ALLOW_BED.invoker().allowBed((LivingEntity) (Object) this, sleepingPos, state, state.getBlock() instanceof BedBlock);
@@ -117,8 +118,8 @@ abstract class LivingEntityMixin {
 		return result.isAccepted() ? Blocks.RED_BED.getDefaultState() : state;
 	}
 
-	// method_18404: Synthetic lambda body for Optional.ifPresent in wakeUp
 	// The injector is shared because method_18404 and sleep share much of the structure here.
+	@Dynamic("method_18404: Synthetic lambda body for Optional.ifPresent in wakeUp")
 	@Redirect(method = {"method_18404", "sleep"}, at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;I)Z"))
 	private boolean setOccupiedState(World world, BlockPos pos, BlockState state, int flags) {
 		// This might have been replaced by a red bed above, so we get it again.
@@ -138,7 +139,7 @@ abstract class LivingEntityMixin {
 		}
 	}
 
-	// Synthetic lambda body for Optional.ifPresent in wakeUp
+	@Dynamic("method_18404: Synthetic lambda body for Optional.ifPresent in wakeUp")
 	@Redirect(method = "method_18404", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BedBlock;findWakeUpPosition(Lnet/minecraft/entity/EntityType;Lnet/minecraft/world/CollisionView;Lnet/minecraft/util/math/BlockPos;F)Ljava/util/Optional;"))
 	private Optional<Vec3d> modifyWakeUpPosition(EntityType<?> type, CollisionView world, BlockPos pos, float yaw) {
 		Optional<Vec3d> original = Optional.empty();

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
 import net.minecraft.block.Material;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
@@ -95,6 +96,11 @@ public final class EntityEventTests implements ModInitializer {
 
 		EntitySleepEvents.START_SLEEPING.register((entity, sleepingPos) -> {
 			LOGGER.info("Entity {} sleeping at {}", entity, sleepingPos);
+			BlockState bedState = entity.world.getBlockState(sleepingPos);
+
+			if (bedState.isOf(TEST_BED) && !bedState.get(TestBedBlock.OCCUPIED)) {
+				throw new AssertionError("An entity is sleeping in test bed but the bed is not occupied");
+			}
 		});
 
 		EntitySleepEvents.STOP_SLEEPING.register((entity, sleepingPos) -> {

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -36,6 +36,7 @@ import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.registry.Registry;
 
 import net.fabricmc.api.ModInitializer;
@@ -98,8 +99,12 @@ public final class EntityEventTests implements ModInitializer {
 			LOGGER.info("Entity {} sleeping at {}", entity, sleepingPos);
 			BlockState bedState = entity.world.getBlockState(sleepingPos);
 
-			if (bedState.isOf(TEST_BED) && !bedState.get(TestBedBlock.OCCUPIED)) {
-				throw new AssertionError("An entity is sleeping in test bed but the bed is not occupied");
+			if (bedState.isOf(TEST_BED)) {
+				boolean shouldBeOccupied = !entity.getStackInHand(Hand.MAIN_HAND).isOf(Items.ORANGE_WOOL);
+
+				if (bedState.get(TestBedBlock.OCCUPIED) != shouldBeOccupied) {
+					throw new AssertionError("Test bed should " + (!shouldBeOccupied ? "not " : "") + "be occupied");
+				}
 			}
 		});
 
@@ -147,6 +152,20 @@ public final class EntityEventTests implements ModInitializer {
 			return !player.getStackInHand(Hand.MAIN_HAND).isOf(Items.BLACK_WOOL);
 		});
 
+		EntitySleepEvents.SET_BED_OCCUPATION_STATE.register((entity, sleepingPos, bedState, occupied) -> {
+			// Don't set occupied state if holding orange wool
+			return entity.getStackInHand(Hand.MAIN_HAND).isOf(Items.ORANGE_WOOL);
+		});
+
+		EntitySleepEvents.MODIFY_WAKE_UP_POSITION.register((entity, sleepingPos, bedState, wakeUpPos) -> {
+			// If holding cyan wool, wake up 10 blocks above the bed
+			if (entity.getStackInHand(Hand.MAIN_HAND).isOf(Items.CYAN_WOOL)) {
+				return Vec3d.ofCenter(sleepingPos).add(0, 10, 0);
+			}
+
+			return wakeUpPos;
+		});
+
 		CommandRegistrationCallback.EVENT.register((dispatcher, dedicated) -> {
 			dispatcher.register(CommandManager.literal("addsleeptestwools").executes(context -> {
 				addSleepWools(context.getSource().getPlayer());
@@ -163,6 +182,8 @@ public final class EntityEventTests implements ModInitializer {
 		inventory.offerOrDrop(createNamedItem(Items.RED_WOOL, "Detect nearby monsters"));
 		inventory.offerOrDrop(createNamedItem(Items.WHITE_WOOL, "Don't set spawn"));
 		inventory.offerOrDrop(createNamedItem(Items.BLACK_WOOL, "Don't reset time"));
+		inventory.offerOrDrop(createNamedItem(Items.ORANGE_WOOL, "Don't set occupied state"));
+		inventory.offerOrDrop(createNamedItem(Items.CYAN_WOOL, "Wake up high above"));
 	}
 
 	private static ItemStack createNamedItem(Item item, String name) {

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/TestBedBlock.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/TestBedBlock.java
@@ -24,6 +24,7 @@ import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.Properties;
 import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
@@ -48,7 +49,12 @@ public class TestBedBlock extends Block {
 
 	@Override
 	public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit) {
-		if (!state.get(OCCUPIED) && world.getDimension().isBedWorking()) {
+		if (state.get(OCCUPIED)) {
+			player.sendMessage(new TranslatableText("block.minecraft.bed.occupied"), true);
+			return ActionResult.CONSUME;
+		}
+
+		if (world.getDimension().isBedWorking()) {
 			if (!world.isClient) {
 				player.trySleep(pos).ifLeft(sleepFailureReason -> {
 					Text message = sleepFailureReason.toText();


### PR DESCRIPTION
These are the last things I found when porting Adorn's sofas over to sleep events.

- **This PR de-hardcodes the usual wake up code path from bed blocks to any block matching `ALLOW_BED`.** The two events below are needed for it to work correctly.
  - The code handles player positioning/rotation and occupied marking for you, and it would be a pain to reimplement this in mods.
- `SET_BED_OCCUPATION_STATE` event: this marks the bed as occupied or unoccupied
  - This is needed if the block uses some other method instead of the `BedBlock.OCCUPIED` property
  - The vanilla check is also de-hardcoded from `instance BedBlock` to `BlockState.contains(BedBlock.OCCUPIED)`
- `MODIFY_WAKE_UP_POSITION` event: self-explanatory
  - Works like `MODIFY_SLEEPING_DIRECTION`, so modifies an existing value or provides a new value
  - Needed for blocks where `BedBlock.findWakeUpPosition` doesn't work