### PR TITLE
Fix handling of orphaned registry entries

### DIFF
--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/PersistentDynamicRegistryHandler.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/PersistentDynamicRegistryHandler.java
@@ -169,7 +169,7 @@ public class PersistentDynamicRegistryHandler {
 			for (String key : existingTag.getKeys()) {
 				if (!registryTag.contains(key)) {
 					LOGGER.debug("Saving orphaned registry entry: " + key);
-					registryTag.putInt(key, registryTag.getInt(key));
+					registryTag.putInt(key, existingTag.getInt(key));
 				}
 			}
 		}

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
@@ -224,7 +224,7 @@ public final class RegistrySyncManager {
 					for (String key : previousRegistryData.getKeys()) {
 						if (!registryTag.contains(key)) {
 							LOGGER.debug("Saving orphaned registry entry: " + key);
-							registryTag.putInt(key, registryTag.getInt(key));
+							registryTag.putInt(key, previousRegistryData.getInt(key));
 						}
 					}
 				}


### PR DESCRIPTION
Right now, Fabric API overwrites the IDs of any orphaned registry entries with 0. This is because the code tries to get the id from the registry tag, which it just checked that it doesn't have it.
This PR fixes this, restoring the intended behavior of the code.