### PR TITLE
Fix #1772

### DIFF
--- a/fabric-key-binding-api-v1/src/main/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
+++ b/fabric-key-binding-api-v1/src/main/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
@@ -32,7 +32,7 @@ import net.fabricmc.fabric.mixin.client.keybinding.KeyBindingAccessor;
 public final class KeyBindingRegistryImpl {
 	private static final Logger LOGGER = LogManager.getLogger();
 
-	private static final List<KeyBinding> moddedKeyBindings = new ReferenceArrayList<>();
+	private static final List<KeyBinding> moddedKeyBindings = new ReferenceArrayList<>(); // ArrayList with identity based comparisons for contains/remove/indexOf etc., required for correctly handling duplicate keybinds
 
 	private KeyBindingRegistryImpl() {
 	}

--- a/fabric-key-binding-api-v1/src/main/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
+++ b/fabric-key-binding-api-v1/src/main/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
@@ -16,22 +16,21 @@
 
 package net.fabricmc.fabric.impl.client.keybinding;
 
+import com.google.common.collect.Lists;
+import it.unimi.dsi.fastutil.objects.ReferenceArrayList;
+import net.fabricmc.fabric.mixin.client.keybinding.KeyBindingAccessor;
+import net.minecraft.client.option.KeyBinding;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import com.google.common.collect.Lists;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import net.minecraft.client.option.KeyBinding;
-
-import net.fabricmc.fabric.mixin.client.keybinding.KeyBindingAccessor;
-
 public final class KeyBindingRegistryImpl {
 	private static final Logger LOGGER = LogManager.getLogger();
 
-	private static final List<KeyBinding> moddedKeyBindings = Lists.newArrayList();
+	private static final List<KeyBinding> moddedKeyBindings = new ReferenceArrayList<>();
 
 	private KeyBindingRegistryImpl() {
 	}

--- a/fabric-key-binding-api-v1/src/main/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
+++ b/fabric-key-binding-api-v1/src/main/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
@@ -16,16 +16,18 @@
 
 package net.fabricmc.fabric.impl.client.keybinding;
 
-import com.google.common.collect.Lists;
-import it.unimi.dsi.fastutil.objects.ReferenceArrayList;
-import net.fabricmc.fabric.mixin.client.keybinding.KeyBindingAccessor;
-import net.minecraft.client.option.KeyBinding;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import com.google.common.collect.Lists;
+import it.unimi.dsi.fastutil.objects.ReferenceArrayList;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import net.minecraft.client.option.KeyBinding;
+
+import net.fabricmc.fabric.mixin.client.keybinding.KeyBindingAccessor;
 
 public final class KeyBindingRegistryImpl {
 	private static final Logger LOGGER = LogManager.getLogger();

--- a/fabric-key-binding-api-v1/src/testmod/java/net/fabricmc/fabric/test/client/keybinding/KeyBindingsTest.java
+++ b/fabric-key-binding-api-v1/src/testmod/java/net/fabricmc/fabric/test/client/keybinding/KeyBindingsTest.java
@@ -47,6 +47,7 @@ public class KeyBindingsTest implements ClientModInitializer {
 			if (stickyBinding.isPressed()) {
 				client.player.sendMessage(new LiteralText("Sticky Key was pressed!"), false);
 			}
+
 			while (duplicateBinding.wasPressed()) {
 				client.player.sendMessage(new LiteralText("Duplicate Key was pressed!"), false);
 			}

--- a/fabric-key-binding-api-v1/src/testmod/java/net/fabricmc/fabric/test/client/keybinding/KeyBindingsTest.java
+++ b/fabric-key-binding-api-v1/src/testmod/java/net/fabricmc/fabric/test/client/keybinding/KeyBindingsTest.java
@@ -33,6 +33,7 @@ public class KeyBindingsTest implements ClientModInitializer {
 		KeyBinding binding1 = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.test_keybinding_1", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_P, "key.category.first.test"));
 		KeyBinding binding2 = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.test_keybinding_2", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_U, "key.category.second.test"));
 		KeyBinding stickyBinding = KeyBindingHelper.registerKeyBinding(new StickyKeyBinding("key.fabric-key-binding-api-v1-testmod.test_keybinding_sticky", GLFW.GLFW_KEY_R, "key.category.first.test", () -> true));
+		KeyBinding duplicateBinding = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.test_keybinding_duplicate", GLFW.GLFW_KEY_LEFT_SHIFT, "key.category.first.test"));
 
 		ClientTickEvents.END_CLIENT_TICK.register(client -> {
 			while (binding1.wasPressed()) {
@@ -45,6 +46,9 @@ public class KeyBindingsTest implements ClientModInitializer {
 
 			if (stickyBinding.isPressed()) {
 				client.player.sendMessage(new LiteralText("Sticky Key was pressed!"), false);
+			}
+			while (duplicateBinding.wasPressed()) {
+				client.player.sendMessage(new LiteralText("Duplicate Key was pressed!"), false);
 			}
 		});
 	}

--- a/fabric-key-binding-api-v1/src/testmod/resources/assets/fabric-keybindings-v1-testmod/lang/en_us.json
+++ b/fabric-key-binding-api-v1/src/testmod/resources/assets/fabric-keybindings-v1-testmod/lang/en_us.json
@@ -3,5 +3,6 @@
   "key.category.second.test": "Second Test Category",
   "key.fabric-key-binding-api-v1-testmod.test_keybinding_1": "Test 1",
   "key.fabric-key-binding-api-v1-testmod.test_keybinding_2": "Test 2",
-  "key.fabric-key-binding-api-v1-testmod.test_keybinding_sticky": "Sticky Test"
+  "key.fabric-key-binding-api-v1-testmod.test_keybinding_sticky": "Sticky Test",
+  "key.fabric-key-binding-api-v1-testmod.test_keybinding_duplicate": "Duplicate Test"
 }


### PR DESCRIPTION
This appears to fix #1772  by replacing an ArrayList with an ReferenceArrayList, this replicates the pre 1.17 behaviour of remove duplicate keys based on reference equality.