### PR TITLE
Make biome & dimension api stable. And change useage around @Deprecated (for 1.17/1.16)

### DIFF
--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModification.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModification.java
@@ -27,11 +27,8 @@ import net.minecraft.util.Identifier;
 import net.fabricmc.fabric.impl.biome.modification.BiomeModificationImpl;
 
 /**
- * <b>Experimental feature</b>, may be removed or changed without further notice.
- *
  * @see BiomeModifications
  */
-@Deprecated
 public class BiomeModification {
 	private final Identifier id;
 

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModificationContext.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModificationContext.java
@@ -45,10 +45,7 @@ import net.fabricmc.fabric.impl.biome.modification.BuiltInRegistryKeys;
 
 /**
  * Allows {@link Biome} properties to be modified.
- *
- * <p><b>Experimental feature</b>, may be removed or changed without further notice.
  */
-@Deprecated
 public interface BiomeModificationContext {
 	/**
 	 * @see Biome#getDepth()

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModifications.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModifications.java
@@ -36,10 +36,7 @@ import net.minecraft.world.gen.feature.ConfiguredStructureFeature;
  *
  * <p>Any modifications made to biomes will not be available for use in server.properties (as of 1.16.1),
  * or the demo level.
- *
- * <p><b>Experimental feature</b>, may be removed or changed without further notice.
  */
-@Deprecated
 public final class BiomeModifications {
 	/**
 	 * Convenience method to add a feature to one or more biomes.

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeSelectionContext.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeSelectionContext.java
@@ -33,9 +33,7 @@ import net.fabricmc.fabric.impl.biome.modification.BuiltInRegistryKeys;
 /**
  * Context given to a biome selector for deciding whether it applies to a biome or not.
  *
- * <p><b>Experimental feature</b>, may be removed or changed without further notice.
  */
-@Deprecated
 public interface BiomeSelectionContext {
 	RegistryKey<Biome> getBiomeKey();
 

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeSelectionContext.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeSelectionContext.java
@@ -32,7 +32,6 @@ import net.fabricmc.fabric.impl.biome.modification.BuiltInRegistryKeys;
 
 /**
  * Context given to a biome selector for deciding whether it applies to a biome or not.
- *
  */
 public interface BiomeSelectionContext {
 	RegistryKey<Biome> getBiomeKey();

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeSelectors.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeSelectors.java
@@ -38,9 +38,7 @@ import net.fabricmc.fabric.mixin.biome.VanillaLayeredBiomeSourceAccessor;
 /**
  * Provides several convenient biome selectors that can be used with {@link BiomeModifications}.
  *
- * <p><b>Experimental feature</b>, may be removed or changed without further notice.
  */
-@Deprecated
 public final class BiomeSelectors {
 	private BiomeSelectors() {
 	}

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeSelectors.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeSelectors.java
@@ -37,7 +37,6 @@ import net.fabricmc.fabric.mixin.biome.VanillaLayeredBiomeSourceAccessor;
 
 /**
  * Provides several convenient biome selectors that can be used with {@link BiomeModifications}.
- *
  */
 public final class BiomeSelectors {
 	private BiomeSelectors() {

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/ModificationPhase.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/ModificationPhase.java
@@ -27,7 +27,6 @@ package net.fabricmc.fabric.api.biome.v1;
  *     <li>Replacements (removal + add) in biomes</li>
  *     <li>Generic post-processing of biomes</li>
  * </ol>
- *
  */
 public enum ModificationPhase {
 	/**

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/ModificationPhase.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/ModificationPhase.java
@@ -28,9 +28,7 @@ package net.fabricmc.fabric.api.biome.v1;
  *     <li>Generic post-processing of biomes</li>
  * </ol>
  *
- * <p><b>Experimental feature</b>, may be removed or changed without further notice.
  */
-@Deprecated
 public enum ModificationPhase {
 	/**
 	 * The appropriate phase for enriching biomes by adding to them without relying on

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/NetherBiomes.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/NetherBiomes.java
@@ -23,7 +23,6 @@ import net.fabricmc.fabric.impl.biome.InternalBiomeData;
 
 /**
  * API that exposes the internals of Minecraft's nether biome code.
- *
  */
 public final class NetherBiomes {
 	private NetherBiomes() {

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/NetherBiomes.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/NetherBiomes.java
@@ -24,9 +24,7 @@ import net.fabricmc.fabric.impl.biome.InternalBiomeData;
 /**
  * API that exposes the internals of Minecraft's nether biome code.
  *
- * <p><b>Experimental feature</b>, may be removed or changed without further notice.
  */
-@Deprecated
 public final class NetherBiomes {
 	private NetherBiomes() {
 	}

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/OverworldBiomes.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/OverworldBiomes.java
@@ -24,9 +24,7 @@ import net.fabricmc.fabric.impl.biome.InternalBiomeData;
 /**
  * API that exposes some internals of the minecraft default biome source for the overworld.
  *
- * <p><b>Experimental feature</b>, may be removed or changed without further notice.
  */
-@Deprecated
 public final class OverworldBiomes {
 	private OverworldBiomes() {
 	}

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/OverworldBiomes.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/OverworldBiomes.java
@@ -23,7 +23,6 @@ import net.fabricmc.fabric.impl.biome.InternalBiomeData;
 
 /**
  * API that exposes some internals of the minecraft default biome source for the overworld.
- *
  */
 public final class OverworldBiomes {
 	private OverworldBiomes() {

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/OverworldClimate.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/OverworldClimate.java
@@ -18,7 +18,6 @@ package net.fabricmc.fabric.api.biome.v1;
 
 /**
  * Represents the climates of biomes on the overworld continents.
- *
  */
 public enum OverworldClimate {
 	/**

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/OverworldClimate.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/OverworldClimate.java
@@ -19,9 +19,7 @@ package net.fabricmc.fabric.api.biome.v1;
 /**
  * Represents the climates of biomes on the overworld continents.
  *
- * <p><b>Experimental feature</b>, may be removed or changed without further notice.
  */
-@Deprecated
 public enum OverworldClimate {
 	/**
 	 * Includes Snowy Tundra (with a weight of 3) and Snowy Taiga (with a weight of 1).

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
@@ -24,7 +24,6 @@ import net.fabricmc.fabric.impl.biome.InternalBiomeData;
 
 /**
  * API that exposes some internals of the minecraft default biome source for The End.
- *
  */
 public final class TheEndBiomes {
 	private TheEndBiomes() { }

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
@@ -25,11 +25,7 @@ import net.fabricmc.fabric.impl.biome.InternalBiomeData;
 /**
  * API that exposes some internals of the minecraft default biome source for The End.
  *
- * @deprecated Experimental feature, may be removed or changed without further notice.
- * Because of the volatility of world generation in Minecraft 1.16, this API is marked experimental
- * since it is likely to change in future Minecraft versions.
  */
-@Deprecated
 public final class TheEndBiomes {
 	private TheEndBiomes() { }
 

--- a/fabric-biome-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-biome-api-v1/src/main/resources/fabric.mod.json
@@ -25,6 +25,6 @@
   ],
   "accessWidener" : "fabric-biome-api-v1.accesswidener",
   "custom": {
-    "fabric-api:module-lifecycle": "experimental"
+    "fabric-api:module-lifecycle": "stable"
   }
 }

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/v1/FabricDimensions.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/v1/FabricDimensions.java
@@ -27,7 +27,6 @@ import net.fabricmc.fabric.impl.dimension.FabricDimensionInternals;
 
 /**
  * This class consists exclusively of static methods that operate on world dimensions.
- *
  */
 public final class FabricDimensions {
 	private FabricDimensions() {

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/v1/FabricDimensions.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/v1/FabricDimensions.java
@@ -28,9 +28,7 @@ import net.fabricmc.fabric.impl.dimension.FabricDimensionInternals;
 /**
  * This class consists exclusively of static methods that operate on world dimensions.
  *
- * @deprecated Experimental feature, may be removed or changed without further notice due to potential changes to Dimensions in subsequent versions.
  */
-@Deprecated
 public final class FabricDimensions {
 	private FabricDimensions() {
 		throw new AssertionError();

--- a/fabric-dimensions-v1/src/main/resources/fabric.mod.json
+++ b/fabric-dimensions-v1/src/main/resources/fabric.mod.json
@@ -24,6 +24,6 @@
     "fabric-dimensions-v1.mixins.json"
   ],
   "custom": {
-    "fabric-api:module-lifecycle": "experimental"
+    "fabric-api:module-lifecycle": "stable"
   }
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRenderHandler.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRenderHandler.java
@@ -37,11 +37,10 @@ import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
  * Defines how {@linkplain FluidVariant fluid variants} of a given Fluid should be displayed to clients.
  * Register with {@link FluidVariantRendering#register}.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 @Environment(EnvType.CLIENT)
 public interface FluidVariantRenderHandler {
 	/**

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRendering.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRendering.java
@@ -41,11 +41,10 @@ import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 /**
  * Client-side display of fluid variants.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 @Environment(EnvType.CLIENT)
 public class FluidVariantRendering {
 	private static final ApiProviderMap<Fluid, FluidVariantRenderHandler> HANDLERS = ApiProviderMap.create();

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/context/ContainerItemContext.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/context/ContainerItemContext.java
@@ -82,11 +82,10 @@ import net.fabricmc.fabric.impl.transfer.context.SingleSlotContainerItemContext;
  *     In the water bucket example, this function can be used to combine steps 1, 2 and 3.</li>
  * </ul>
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public interface ContainerItemContext {
 	/**
 	 * Return a context for the passed player's hand. This is recommended for item use interactions.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/CauldronFluidContent.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/CauldronFluidContent.java
@@ -48,11 +48,10 @@ import net.fabricmc.fabric.impl.transfer.fluid.CauldronStorage;
  *     <li>{@code amountPerLevel} defines how much fluid (in droplets) there is in one level of the cauldron.</li>
  * </ul>
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public final class CauldronFluidContent {
 	/**
 	 * Block of the cauldron.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidConstants.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidConstants.java
@@ -24,11 +24,10 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>If you don't know how much droplets you should pick for a specific resource that has a block form,
  * the convention is to use 81000 droplets for what is worth one block of that resource.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public final class FluidConstants {
 	public static final long BUCKET = 81000;
 	public static final long BOTTLE = 27000;

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidStorage.java
@@ -46,11 +46,10 @@ import net.fabricmc.fabric.mixin.transfer.BucketItemAccessor;
 /**
  * Access to {@link Storage Storage&lt;FluidVariant&gt;} instances.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public final class FluidStorage {
 	/**
 	 * Sided block access to fluid variant storages.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariant.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariant.java
@@ -38,11 +38,10 @@ import net.fabricmc.fabric.impl.transfer.fluid.FluidVariantImpl;
  * <p><b>Fluid variants must always be compared with {@link #equals}, never by reference!</b>
  * {@link #hashCode} is guaranteed to be correct and constant time independently of the size of the NBT.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 @ApiStatus.NonExtendable
 public interface FluidVariant extends TransferVariant<Fluid> {
 	/**

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/base/EmptyItemFluidStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/base/EmptyItemFluidStorage.java
@@ -56,11 +56,10 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
  * and it is inefficient to have one storage registered per fluid
  * so Fabric API has a storage that accepts any fluid with a corresponding full bucket).
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public final class EmptyItemFluidStorage implements InsertionOnlyStorage<FluidVariant> {
 	private final ContainerItemContext context;
 	private final Item emptyItem;

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/base/FullItemFluidStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/base/FullItemFluidStorage.java
@@ -38,11 +38,10 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
  *
  * <p>This is used similarly to {@link EmptyItemFluidStorage}.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public final class FullItemFluidStorage implements ExtractionOnlyStorage<FluidVariant>, SingleSlotStorage<FluidVariant> {
 	private final ContainerItemContext context;
 	private final Item fullItem;

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/InventoryStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/InventoryStorage.java
@@ -45,11 +45,10 @@ import net.fabricmc.fabric.impl.transfer.item.InventoryStorageImpl;
  * <p><b>Important note:</b> This wrapper assumes that the inventory owns its slots.
  * If the inventory does not own its slots, for example because it delegates to another inventory, this wrapper should not be used!
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 @ApiStatus.NonExtendable
 public interface InventoryStorage extends Storage<ItemVariant> {
 	/**

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/ItemStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/ItemStorage.java
@@ -40,11 +40,10 @@ import net.fabricmc.fabric.mixin.transfer.DoubleInventoryAccessor;
 /**
  * Access to {@link Storage Storage&lt;ItemVariant&gt;} instances.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public final class ItemStorage {
 	/**
 	 * Sided block access to item variant storages.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/ItemVariant.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/ItemVariant.java
@@ -34,11 +34,10 @@ import net.fabricmc.fabric.api.transfer.v1.storage.TransferVariant;
  *
  * <p>Do not implement, use the static {@code of(...)} functions instead.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 @ApiStatus.NonExtendable
 public interface ItemVariant extends TransferVariant<Item> {
 	/**

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/PlayerInventoryStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/PlayerInventoryStorage.java
@@ -38,11 +38,10 @@ import net.fabricmc.fabric.impl.transfer.item.CursorSlotWrapper;
  * For simple insertions, {@link #offer} or {@link #offerOrDrop} is recommended.
  * {@link #getSlots} can also be used and combined with {@link CombinedStorage} to retrieve a wrapper around a specific range of slots.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 @ApiStatus.NonExtendable
 // TODO: Consider explicitly syncing stacks by sending a ScreenHandlerSlotUpdateS2CPacket if that proves to be necessary.
 // TODO: Vanilla doesn't seem to be doing it reliably, so we ignore it for now.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleStackStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleStackStorage.java
@@ -36,11 +36,10 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.base.SnapshotParticipant;
  * {@link #supportsInsertion} and/or {@link #supportsExtraction}.
  * {@link #getCapacity(ItemVariant)} can be overridden to change the maximum capacity depending on the item variant.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public abstract class SingleStackStorage extends SnapshotParticipant<ItemStack> implements SingleSlotStorage<ItemVariant> {
 	/**
 	 * Return the stack of this storage. It will be modified directly sometimes to avoid needless copies.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/Storage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/Storage.java
@@ -62,11 +62,10 @@ import net.fabricmc.fabric.impl.transfer.TransferApiImpl;
  * @param <T> The type of the stored resources.
  * @see Transaction
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public interface Storage<T> {
 	/**
 	 * Return an empty storage.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StoragePreconditions.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StoragePreconditions.java
@@ -24,11 +24,10 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>In particular, {@link #notNegative} or {@link #notBlankNotNegative} can be used by implementations of
  * {@link Storage#insert} and {@link Storage#extract} to fail-fast if the arguments are invalid.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public class StoragePreconditions {
 	/**
 	 * Ensure that the passed transfer variant is not blank.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StorageUtil.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StorageUtil.java
@@ -35,11 +35,10 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
  * <p>Note that the functions that take a predicate iterate over the entire inventory in the worst case.
  * If the resource is known, there will generally be a more performance efficient way.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public final class StorageUtil {
 	/**
 	 * Move resources between two storages, matching the passed filter, and return the amount that was successfully transferred.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StorageView.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StorageView.java
@@ -27,11 +27,10 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
  *
  * @param <T> The type of the stored resource.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public interface StorageView<T> {
 	/**
 	 * Try to extract a resource from this view.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/TransferVariant.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/TransferVariant.java
@@ -35,11 +35,10 @@ import net.minecraft.network.PacketByteBuf;
  *
  * @param <O> The type of the immutable object instance, for example {@code Item} or {@code Fluid}.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public interface TransferVariant<O> {
 	/**
 	 * Return true if this variant is blank, and false otherwise.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/BlankVariantView.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/BlankVariantView.java
@@ -26,11 +26,10 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
  * A transfer variant storage view that contains a blank variant all the time (it's always empty), but may have a nonzero capacity.
  * This can be used to give capacity hints even if the storage is empty.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public class BlankVariantView<T extends TransferVariant<?>> implements StorageView<T> {
 	private final T blankVariant;
 	private final long capacity;

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/CombinedStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/CombinedStorage.java
@@ -36,11 +36,10 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
  * @param <T> The type of the stored resources.
  * @param <S> The class of every part. {@code ? extends Storage<T>} can be used if the parts are of different types.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public class CombinedStorage<T, S extends Storage<T>> implements Storage<T> {
 	public List<S> parts;
 

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/ExtractionOnlyStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/ExtractionOnlyStorage.java
@@ -24,11 +24,10 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 /**
  * A {@link Storage} that supports extraction, and not insertion.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public interface ExtractionOnlyStorage<T> extends Storage<T> {
 	@Override
 	default boolean supportsInsertion() {

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/FilteringStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/FilteringStorage.java
@@ -36,11 +36,10 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
  *
  * @param <T> The type of the stored resources.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public abstract class FilteringStorage<T> implements Storage<T> {
 	protected final Supplier<Storage<T>> backingStorage;
 

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/InsertionOnlyStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/InsertionOnlyStorage.java
@@ -24,11 +24,10 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 /**
  * A {@link Storage} that supports insertion, and not extraction.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public interface InsertionOnlyStorage<T> extends Storage<T> {
 	@Override
 	default boolean supportsExtraction() {

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/ResourceAmount.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/ResourceAmount.java
@@ -22,10 +22,9 @@ import org.jetbrains.annotations.ApiStatus;
  * An immutable object storing both a resource and an amount, provided for convenience.
  * @param <T> The type of the stored resource.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public record ResourceAmount<T> (T resource, long amount) {
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/SingleSlotStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/SingleSlotStorage.java
@@ -30,11 +30,10 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
  *
  * @param <T> The type of the stored resource.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public interface SingleSlotStorage<T> extends Storage<T>, StorageView<T> {
 	@Override
 	default Iterator<StorageView<T>> iterator(TransactionContext transaction) {

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/SingleVariantItemStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/SingleVariantItemStorage.java
@@ -47,11 +47,10 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
  *
  * @param <T> The type of the stored transfer variant.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public abstract class SingleVariantItemStorage<T extends TransferVariant<?>> implements SingleSlotStorage<T> {
 	/**
 	 * Reference to the context.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/SingleVariantStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/SingleVariantStorage.java
@@ -32,11 +32,10 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.base.SnapshotParticipant;
  * If one of these two functions is overridden to always return false, implementors may also wish to override
  * {@link #supportsInsertion} and/or {@link #supportsExtraction}.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public abstract class SingleVariantStorage<T extends TransferVariant<?>> extends SnapshotParticipant<ResourceAmount<T>> implements SingleSlotStorage<T> {
 	public T variant = getBlankVariant();
 	public long amount = 0;

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/SingleViewIterator.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/SingleViewIterator.java
@@ -34,11 +34,10 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
  *
  * @param <T> The type of the stored resource.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public final class SingleViewIterator<T> implements Iterator<StorageView<T>>, Transaction.CloseCallback {
 	/**
 	 * Create a new iterator for the passed storage view, tied to the passed transaction.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/transaction/Transaction.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/transaction/Transaction.java
@@ -74,11 +74,10 @@ import net.fabricmc.fabric.impl.transfer.transaction.TransactionManagerImpl;
  * and attempts to use it on another thread will throw an exception.
  * Consequently, transactions can be concurrent across multiple threads, as long as they don't share any state.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 @ApiStatus.NonExtendable
 public interface Transaction extends AutoCloseable, TransactionContext {
 	/**

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/transaction/TransactionContext.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/transaction/TransactionContext.java
@@ -22,11 +22,10 @@ import org.jetbrains.annotations.ApiStatus;
  * A subset of a {@link Transaction} that lets participants properly take part in transactions, manage their state,
  * or open nested transactions, but does not allow them to close the transaction they are passed.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 @ApiStatus.NonExtendable
 public interface TransactionContext {
 	/**

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/transaction/base/SnapshotParticipant.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/transaction/base/SnapshotParticipant.java
@@ -41,11 +41,10 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
  *
  * @param <T> The objects that this participant uses to save its state snapshots.
  *
- * @deprecated Experimental feature, we reserve the right to remove or change it without further notice.
+ * <b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Deprecated
 public abstract class SnapshotParticipant<T> implements Transaction.CloseCallback, Transaction.OuterCloseCallback {
 	private final List<T> snapshots = new ArrayList<>();
 


### PR DESCRIPTION
Remove the usage of @Deprecated for other experimental modules. This idea clealy hasnt worked out quite how we had first imagined.

Going forward the @Deprecated should be used for experimental/volatile APIs that are highly likely to change (Such as APIs developed in snapshots). And the jetbrains `@ApiStatus.Experimental` annoation should be used for everything else. We cannot tell the future so the apis should only be consdiered stable for the branch's target mc version.

I'm happy to discuss any other ideas people may have. Once accpeted I will make a similar PR for 1.18 but keeping the biome api experimental.