### PR TITLE
Another wave of transfer API improvements

### DIFF
--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRenderHandler.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRenderHandler.java
@@ -60,20 +60,34 @@ public interface FluidVariantRenderHandler {
 	}
 
 	/**
-	 * Return the sprite that should be used to render the passed fluid variant, for use in baked models, (block) entity renderers, or user interfaces.
+	 * Return an array of size at least 2 containing the sprites that should be used to render the passed fluid variant,
+	 * for use in baked models, (block) entity renderers, or user interfaces.
+	 * The first sprite in the array is the still sprite, and the second is the flowing sprite.
 	 *
-	 * <p>Null may be returned if the fluid variant should not be rendered.
+	 * <p>Null may be returned if the fluid variant should not be rendered, but if an array is returned it must have at least two entries and
+	 * they may not be null.
 	 */
 	@Nullable
-	default Sprite getSprite(FluidVariant fluidVariant) {
+	default Sprite[] getSprites(FluidVariant fluidVariant) {
 		// Use the fluid render handler by default.
 		FluidRenderHandler fluidRenderHandler = FluidRenderHandlerRegistry.INSTANCE.get(fluidVariant.getFluid());
 
 		if (fluidRenderHandler != null) {
-			return fluidRenderHandler.getFluidSprites(null, null, fluidVariant.getFluid().getDefaultState())[0];
+			return fluidRenderHandler.getFluidSprites(null, null, fluidVariant.getFluid().getDefaultState());
 		} else {
 			return null;
 		}
+	}
+
+	/**
+	 * @deprecated Use and implement {@linkplain #getSprites(FluidVariant) the other more general overload}.
+	 * This one will be removed in a future iteration of the API.
+	 */
+	@Deprecated(forRemoval = true)
+	@Nullable
+	default Sprite getSprite(FluidVariant fluidVariant) {
+		Sprite[] sprites = getSprites(fluidVariant);
+		return sprites != null ? sprites[0] : null;
 	}
 
 	/**

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRendering.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRendering.java
@@ -27,10 +27,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.fluid.Fluid;
-import net.minecraft.fluid.Fluids;
 import net.minecraft.text.LiteralText;
-import net.minecraft.text.MutableText;
-import net.minecraft.text.Style;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.math.BlockPos;
@@ -53,22 +50,6 @@ import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 public class FluidVariantRendering {
 	private static final ApiProviderMap<Fluid, FluidVariantRenderHandler> HANDLERS = ApiProviderMap.create();
 	private static final FluidVariantRenderHandler DEFAULT_HANDLER = new FluidVariantRenderHandler() { };
-
-	static {
-		// Add colored names for vanilla fluids!
-		register(Fluids.WATER, new FluidVariantRenderHandler() {
-			@Override
-			public Text getName(FluidVariant fluidVariant) {
-				return ((MutableText) FluidVariantRenderHandler.super.getName(fluidVariant)).setStyle(Style.EMPTY.withColor(Formatting.BLUE));
-			}
-		});
-		register(Fluids.LAVA, new FluidVariantRenderHandler() {
-			@Override
-			public Text getName(FluidVariant fluidVariant) {
-				return ((MutableText) FluidVariantRenderHandler.super.getName(fluidVariant)).setStyle(Style.EMPTY.withColor(Formatting.RED));
-			}
-		});
-	}
 
 	/**
 	 * Register a render handler for the passed fluid.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRendering.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRendering.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.api.transfer.v1.client.fluid;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -26,7 +27,10 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.fluid.Fluid;
+import net.minecraft.fluid.Fluids;
 import net.minecraft.text.LiteralText;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Style;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.math.BlockPos;
@@ -49,6 +53,22 @@ import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 public class FluidVariantRendering {
 	private static final ApiProviderMap<Fluid, FluidVariantRenderHandler> HANDLERS = ApiProviderMap.create();
 	private static final FluidVariantRenderHandler DEFAULT_HANDLER = new FluidVariantRenderHandler() { };
+
+	static {
+		// Add colored names for vanilla fluids!
+		register(Fluids.WATER, new FluidVariantRenderHandler() {
+			@Override
+			public Text getName(FluidVariant fluidVariant) {
+				return ((MutableText) FluidVariantRenderHandler.super.getName(fluidVariant)).setStyle(Style.EMPTY.withColor(Formatting.BLUE));
+			}
+		});
+		register(Fluids.LAVA, new FluidVariantRenderHandler() {
+			@Override
+			public Text getName(FluidVariant fluidVariant) {
+				return ((MutableText) FluidVariantRenderHandler.super.getName(fluidVariant)).setStyle(Style.EMPTY.withColor(Formatting.RED));
+			}
+		});
+	}
 
 	/**
 	 * Register a render handler for the passed fluid.
@@ -116,12 +136,24 @@ public class FluidVariantRendering {
 	}
 
 	/**
-	 * Return the sprite that should be used to render the passed fluid variant, or null if it's not available.
+	 * Return the still and the flowing sprite that should be used to render the passed fluid variant, or null if they are not available.
+	 * The sprites should be rendered using the color returned by {@link #getColor}.
+	 *
+	 * @see FluidVariantRenderHandler#getSprites
+	 */
+	@Nullable
+	public static Sprite[] getSprites(FluidVariant fluidVariant) {
+		return getHandlerOrDefault(fluidVariant.getFluid()).getSprites(fluidVariant);
+	}
+
+	/**
+	 * Return the still sprite that should be used to render the passed fluid variant, or null if it's not available.
 	 * The sprite should be rendered using the color returned by {@link #getColor}.
 	 */
 	@Nullable
 	public static Sprite getSprite(FluidVariant fluidVariant) {
-		return getHandlerOrDefault(fluidVariant.getFluid()).getSprite(fluidVariant);
+		Sprite[] sprites = getSprites(fluidVariant);
+		return sprites != null ? Objects.requireNonNull(sprites[0]) : null;
 	}
 
 	/**

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/context/ContainerItemContext.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/context/ContainerItemContext.java
@@ -134,7 +134,7 @@ public interface ContainerItemContext {
 	 * for example to simulate how much fluid could be extracted from the variant and amount.
 	 */
 	static ContainerItemContext withInitial(ItemVariant initialVariant, long initialAmount) {
-		StoragePreconditions.notBlankNotNegative(initialVariant, initialAmount);
+		StoragePreconditions.notNegative(initialAmount);
 		return new InitialContentsContainerItemContext(initialVariant, initialAmount);
 	}
 

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidStorage.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.api.transfer.v1.fluid;
 
+import com.google.common.base.Preconditions;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
@@ -128,6 +129,12 @@ public final class FluidStorage {
 	}
 
 	static {
+		// Ensure that the lookup is only queried on the server side.
+		FluidStorage.SIDED.registerFallback((world, pos, state, blockEntity, context) -> {
+			Preconditions.checkArgument(!world.isClient(), "Sided fluid storage may only be queried for a server world.");
+			return null;
+		});
+
 		// Initialize vanilla cauldron wrappers
 		CauldronFluidContent.getForFluid(Fluids.WATER);
 

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/ItemStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/ItemStorage.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.api.transfer.v1.item;
 
 import java.util.List;
 
+import com.google.common.base.Preconditions;
 import org.jetbrains.annotations.ApiStatus;
 
 import net.minecraft.block.Blocks;
@@ -79,6 +80,12 @@ public final class ItemStorage {
 	}
 
 	static {
+		// Ensure that the lookup is only queried on the server side.
+		ItemStorage.SIDED.registerFallback((world, pos, state, blockEntity, context) -> {
+			Preconditions.checkArgument(!world.isClient(), "Sided item storage may only be queried for a server world.");
+			return null;
+		});
+
 		// Composter support.
 		ItemStorage.SIDED.registerForBlocks((world, pos, state, blockEntity, direction) -> ComposterWrapper.get(world, pos, direction), Blocks.COMPOSTER);
 

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StorageView.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StorageView.java
@@ -40,7 +40,10 @@ public interface StorageView<T> {
 	long extract(T resource, long maxAmount, TransactionContext transaction);
 
 	/**
-	 * @return {@code true} if the {@link #getResource} contained in this storage view is blank, or {@code false} otherwise.
+	 * Return {@code true} if the {@link #getResource} contained in this storage view is blank, or {@code false} otherwise.
+	 *
+	 * <p>This function is mostly useful when dealing with storages of arbitrary types.
+	 * For transfer variant storages, this should always be equivalent to {@code getResource().isBlank()}.
 	 */
 	boolean isResourceBlank();
 

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/PlayerInventoryStorageImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/PlayerInventoryStorageImpl.java
@@ -26,6 +26,7 @@ import net.minecraft.util.Hand;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.fabricmc.fabric.api.transfer.v1.item.PlayerInventoryStorage;
 import net.fabricmc.fabric.api.transfer.v1.storage.StoragePreconditions;
+import net.fabricmc.fabric.api.transfer.v1.storage.StorageUtil;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleSlotStorage;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.fabricmc.fabric.api.transfer.v1.transaction.base.SnapshotParticipant;
@@ -63,18 +64,8 @@ class PlayerInventoryStorageImpl extends InventoryStorageImpl implements PlayerI
 			}
 		}
 
-		// Otherwise insert into the main slots, first iteration tries to stack, second iteration inserts into empty slots.
-		for (int iteration = 0; iteration < 2; iteration++) {
-			boolean allowEmptySlots = iteration == 1;
-
-			for (SingleSlotStorage<ItemVariant> slot : mainSlots) {
-				if (!slot.isResourceBlank() || allowEmptySlots) {
-					amount -= slot.insert(resource, amount, tx);
-				}
-
-				if (amount == 0) return initialAmount;
-			}
-		}
+		// Otherwise insert into the main slots, stacking first.
+		amount -= StorageUtil.insertStacking(mainSlots, resource, amount, tx);
 
 		return initialAmount - amount;
 	}

--- a/fabric-transfer-api-v1/src/testmod/java/net/fabricmc/fabric/test/transfer/unittests/FluidItemTests.java
+++ b/fabric-transfer-api-v1/src/testmod/java/net/fabricmc/fabric/test/transfer/unittests/FluidItemTests.java
@@ -48,6 +48,9 @@ class FluidItemTests {
 		testFluidItemApi();
 		testWaterPotion();
 		testSimpleContentsQuery();
+
+		// Ensure this doesn't throw an error due to the empty stack.
+		assertEquals(null, ContainerItemContext.withInitial(ItemStack.EMPTY).find(FluidStorage.ITEM));
 	}
 
 	private static void testFluidItemApi() {


### PR DESCRIPTION
- ~~Add a water and lava `FluidVariantRenderHandler` to have cool-looking blue and red names (respectively).~~ People don't want it so it will go into my mods instead.
- [x] Remove the notBlank check for `ContainerItemContext.withInitial` as it forced users to add a check themselves.
- [x] Clarify that `isResourceBlank()` is equivalent to `getResource().isBlank()` for transfer variants.
- [x] Add a few `FilteringStorage` static methods to wrap an existing storage, while blocking insertion or extraction entirely.
- [x] Deprecate for removal the fluid variant rendering methods that return a single sprite, and replace them with methods that return a `Sprite[]`. This will provide a standard way to retrieve a flowing fluid sprite for pipes, e.g. for use in pipes.
- [x] Add `insertStacking` to `StorageUtil`.
- [x] Add a fallback to the sided storages that throws an exception if the world is not a server world to guard against incorrect API usage (client worlds are not allowed).

(most of #1760).