### PR TITLE
Fixes double-invoking of the client start event

### DIFF
--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/client/MinecraftClientMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/client/MinecraftClientMixin.java
@@ -47,7 +47,7 @@ public abstract class MinecraftClientMixin {
 	}
 
 	// We inject after the thread field is set so `ThreadExecutor#getThread` will work
-	@Inject(at = @At(value = "FIELD", target = "Lnet/minecraft/client/MinecraftClient;thread:Ljava/lang/Thread;", shift = At.Shift.AFTER), method = "run")
+	@Inject(at = @At(value = "FIELD", target = "Lnet/minecraft/client/MinecraftClient;thread:Ljava/lang/Thread;", shift = At.Shift.AFTER, ordinal = 0), method = "run")
 	private void onStart(CallbackInfo ci) {
 		ClientLifecycleEvents.CLIENT_STARTED.invoker().onClientStarted((MinecraftClient) (Object) this);
 	}

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientLifecycleTests.java
@@ -23,15 +23,28 @@ import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 
 @Environment(EnvType.CLIENT)
 public final class ClientLifecycleTests implements ClientModInitializer {
+	private boolean startCalled;
+	private boolean stopCalled;
+
 	@Override
 	public void onInitializeClient() {
 		ClientLifecycleEvents.CLIENT_STARTED.register(client -> {
+			if (startCalled) {
+				throw new IllegalStateException("Start was already called!");
+			}
+
+			startCalled = true;
 			client.submitAndJoin(() -> { // This should fail if the client thread was not bound yet.
 				System.out.println("Started the client");
 			});
 		});
 
 		ClientLifecycleEvents.CLIENT_STOPPING.register(client -> {
+			if (stopCalled) {
+				throw new IllegalStateException("Stop was already called!");
+			}
+
+			stopCalled = true;
 			System.out.println("Client has started stopping!");
 		});
 	}


### PR DESCRIPTION
This is due to vanilla now calling thread.setPriority (thus accessing the field twice).