### PR TITLE
Build script fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,4 +28,4 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: Maven Local
-          path: ~/.m2/repository
+          path: /root/.m2/repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,3 +25,7 @@ jobs:
         with:
           name: Artifacts
           path: ./*/build/libs/
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Maven Local
+          path: ~/.m2/repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Release
 on: [workflow_dispatch] # Manual trigger
+
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-20.04
@@ -23,6 +27,6 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
           CURSEFORGE_API_KEY: ${{ secrets.CURSEFORGE_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GH_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
           CHANGELOG: ${{ steps.changelog.outputs.changelog }}

--- a/build.gradle
+++ b/build.gradle
@@ -339,7 +339,7 @@ curseforge {
 	project {
 		id = "306612"
 		changelog = ENV.CHANGELOG ?: "No changelog provided"
-		releaseType = project.prerelease ? "beta" : "release"
+		releaseType = project.prerelease as Boolean ? "beta" : "release"
 		addGameVersion "1.18-Snapshot"
 		addGameVersion "Fabric"
 
@@ -389,7 +389,7 @@ task modrinth(type: com.modrinth.minotaur.TaskModrinthUpload, dependsOn: remapMa
 	projectId = "P7dR8mSH"
 	versionNumber = version
 	versionName = "[$project.minecraft_version] Fabric API $project.version"
-	releaseType = project.prerelease ? "beta" : "release"
+	releaseType = project.prerelease as Boolean ? "beta" : "release"
 	changelog = ENV.CHANGELOG ?: "No changelog provided"
 
 	uploadFile = remapJar

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 	id "eclipse"
 	id "idea"
 	id "maven-publish"
-	id "fabric-loom" version "0.10.55" apply false
+	id "fabric-loom" version "0.10.60" apply false
 	id "org.cadixdev.licenser" version "0.6.1"
 	id "org.ajoberstar.grgit" version "3.1.0"
 	id "com.matthewprenger.cursegradle" version "1.4.0"
@@ -241,10 +241,6 @@ subprojects {
 		genSourcesWithFernFlower.enabled = false
 		genSourcesWithCfr.enabled = false
 		unpickJar.enabled = false
-
-		// Work around a loom bug causing empty jars to be pushed to maven local.
-		publishMavenJavaPublicationToMavenLocal.dependsOn rootProject.tasks.getByName("remapAllJars")
-		publishMavenJavaPublicationToMavenLocal.dependsOn rootProject.tasks.getByName("remapAllSources")
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -132,9 +132,8 @@ allprojects {
 		include "**/*.java"
 	}
 
-	task sourcesJar(type: Jar, dependsOn: classes) {
-		archiveClassifier = "sources"
-		from sourceSets.main.allSource
+	java {
+		withSourcesJar()
 	}
 
 	checkstyle {


### PR DESCRIPTION
- Fixes source jar publishing
- Publishes maven local to github actions
- No longer use a PAT to release (I do hope this works 🤞)
- Fix prerelease option not working as intended.

Waiting on https://github.com/FabricMC/fabric-loom/pull/543 somewhat.