### PR TITLE
Add id getter to ApiLookups and expose the BE in BlockApiCache

### DIFF
--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiCache.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiCache.java
@@ -75,6 +75,21 @@ public interface BlockApiCache<A, C> {
 	BlockEntity getBlockEntity();
 
 	/**
+	 * Return the lookup this cache is bound to.
+	 */
+	BlockApiLookup<A, C> getLookup();
+
+	/**
+	 * Return the world this cache is bound to.
+	 */
+	ServerWorld getWorld();
+
+	/**
+	 * Return the position this cache is bound to.
+	 */
+	BlockPos getPos();
+
+	/**
 	 * Create a new instance bound to the passed {@link ServerWorld} and position, and querying the same API as the passed lookup.
 	 */
 	static <A, C> BlockApiCache<A, C> create(BlockApiLookup<A, C> lookup, ServerWorld world, BlockPos pos) {

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiCache.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiCache.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 
@@ -63,6 +64,15 @@ public interface BlockApiCache<A, C> {
 	 */
 	@Nullable
 	A find(@Nullable BlockState state, C context);
+
+	/**
+	 * Return the block entity at the target position of this lookup.
+	 *
+	 * <p>This is the most efficient way to query the block entity at the target position repeatedly:
+	 * unless the block entity has been loaded or unloaded since the last query, the result will be cached.
+	 */
+	@Nullable
+	BlockEntity getBlockEntity();
 
 	/**
 	 * Create a new instance bound to the passed {@link ServerWorld} and position, and querying the same API as the passed lookup.

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiLookup.java
@@ -237,6 +237,11 @@ public interface BlockApiLookup<A, C> {
 	void registerFallback(BlockApiProvider<A, C> fallbackProvider);
 
 	/**
+	 * Return the identifier of this lookup.
+	 */
+	Identifier identifier();
+
+	/**
 	 * Return the API class of this lookup.
 	 */
 	Class<A> apiClass();

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiLookup.java
@@ -239,7 +239,7 @@ public interface BlockApiLookup<A, C> {
 	/**
 	 * Return the identifier of this lookup.
 	 */
-	Identifier getIdentifier();
+	Identifier getId();
 
 	/**
 	 * Return the API class of this lookup.

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiLookup.java
@@ -239,7 +239,7 @@ public interface BlockApiLookup<A, C> {
 	/**
 	 * Return the identifier of this lookup.
 	 */
-	Identifier identifier();
+	Identifier getIdentifier();
 
 	/**
 	 * Return the API class of this lookup.

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/entity/EntityApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/entity/EntityApiLookup.java
@@ -149,7 +149,7 @@ public interface EntityApiLookup<A, C> {
 	/**
 	 * Return the identifier of this lookup.
 	 */
-	Identifier getIdentifier();
+	Identifier getId();
 
 	/**
 	 * Returns the API class of this lookup.

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/entity/EntityApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/entity/EntityApiLookup.java
@@ -147,6 +147,11 @@ public interface EntityApiLookup<A, C> {
 	void registerFallback(EntityApiProvider<A, C> fallbackProvider);
 
 	/**
+	 * Return the identifier of this lookup.
+	 */
+	Identifier identifier();
+
+	/**
 	 * Returns the API class of this lookup.
 	 */
 	Class<A> apiClass();

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/entity/EntityApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/entity/EntityApiLookup.java
@@ -149,7 +149,7 @@ public interface EntityApiLookup<A, C> {
 	/**
 	 * Return the identifier of this lookup.
 	 */
-	Identifier identifier();
+	Identifier getIdentifier();
 
 	/**
 	 * Returns the API class of this lookup.

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
@@ -146,6 +146,11 @@ public interface ItemApiLookup<A, C> {
 	void registerFallback(ItemApiProvider<A, C> fallbackProvider);
 
 	/**
+	 * Return the identifier of this lookup.
+	 */
+	Identifier identifier();
+
+	/**
 	 * Return the API class of this lookup.
 	 */
 	Class<A> apiClass();

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
@@ -148,7 +148,7 @@ public interface ItemApiLookup<A, C> {
 	/**
 	 * Return the identifier of this lookup.
 	 */
-	Identifier identifier();
+	Identifier getIdentifier();
 
 	/**
 	 * Return the API class of this lookup.

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
@@ -148,7 +148,7 @@ public interface ItemApiLookup<A, C> {
 	/**
 	 * Return the identifier of this lookup.
 	 */
-	Identifier getIdentifier();
+	Identifier getId();
 
 	/**
 	 * Return the API class of this lookup.

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiCacheImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiCacheImpl.java
@@ -113,6 +113,21 @@ public final class BlockApiCacheImpl<A, C> implements BlockApiCache<A, C> {
 		return cachedBlockEntity;
 	}
 
+	@Override
+	public BlockApiLookupImpl<A, C> getLookup() {
+		return lookup;
+	}
+
+	@Override
+	public ServerWorld getWorld() {
+		return world;
+	}
+
+	@Override
+	public BlockPos getPos() {
+		return pos;
+	}
+
 	static {
 		ServerBlockEntityEvents.BLOCK_ENTITY_LOAD.register((blockEntity, world) -> {
 			((ServerWorldCache) world).fabric_invalidateCache(blockEntity.getPos());

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiCacheImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiCacheImpl.java
@@ -61,11 +61,8 @@ public final class BlockApiCacheImpl<A, C> implements BlockApiCache<A, C> {
 	@Nullable
 	@Override
 	public A find(@Nullable BlockState state, C context) {
-		// Get block entity
-		if (!blockEntityCacheValid) {
-			cachedBlockEntity = world.getBlockEntity(pos);
-			blockEntityCacheValid = true;
-		}
+		// Update block entity cache
+		getBlockEntity();
 
 		// Get block state
 		if (state == null) {
@@ -103,6 +100,17 @@ public final class BlockApiCacheImpl<A, C> implements BlockApiCache<A, C> {
 		}
 
 		return null;
+	}
+
+	@Override
+	@Nullable
+	public BlockEntity getBlockEntity() {
+		if (!blockEntityCacheValid) {
+			cachedBlockEntity = world.getBlockEntity(pos);
+			blockEntityCacheValid = true;
+		}
+
+		return cachedBlockEntity;
 	}
 
 	static {

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiLookupImpl.java
@@ -47,13 +47,15 @@ public final class BlockApiLookupImpl<A, C> implements BlockApiLookup<A, C> {
 		return (BlockApiLookup<A, C>) LOOKUPS.getLookup(lookupId, apiClass, contextClass);
 	}
 
+	private final Identifier identifier;
 	private final Class<A> apiClass;
 	private final Class<C> contextClass;
 	private final ApiProviderMap<Block, BlockApiProvider<A, C>> providerMap = ApiProviderMap.create();
 	private final List<BlockApiProvider<A, C>> fallbackProviders = new CopyOnWriteArrayList<>();
 
 	@SuppressWarnings("unchecked")
-	private BlockApiLookupImpl(Class<?> apiClass, Class<?> contextClass) {
+	private BlockApiLookupImpl(Identifier identifier, Class<?> apiClass, Class<?> contextClass) {
+		this.identifier = identifier;
 		this.apiClass = (Class<A>) apiClass;
 		this.contextClass = (Class<C>) contextClass;
 	}
@@ -172,6 +174,11 @@ public final class BlockApiLookupImpl<A, C> implements BlockApiLookup<A, C> {
 		Objects.requireNonNull(fallbackProvider, "BlockApiProvider may not be null.");
 
 		fallbackProviders.add(fallbackProvider);
+	}
+
+	@Override
+	public Identifier identifier() {
+		return identifier;
 	}
 
 	@Override

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiLookupImpl.java
@@ -177,7 +177,7 @@ public final class BlockApiLookupImpl<A, C> implements BlockApiLookup<A, C> {
 	}
 
 	@Override
-	public Identifier getIdentifier() {
+	public Identifier getId() {
 		return identifier;
 	}
 

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiLookupImpl.java
@@ -177,7 +177,7 @@ public final class BlockApiLookupImpl<A, C> implements BlockApiLookup<A, C> {
 	}
 
 	@Override
-	public Identifier identifier() {
+	public Identifier getIdentifier() {
 		return identifier;
 	}
 

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/custom/ApiLookupMapImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/custom/ApiLookupMapImpl.java
@@ -28,10 +28,10 @@ import net.fabricmc.fabric.api.lookup.v1.custom.ApiLookupMap;
 
 public final class ApiLookupMapImpl<L> implements ApiLookupMap<L> {
 	private final Map<Identifier, StoredLookup<L>> lookups = new HashMap<>();
-	private final LookupFactory<L> lookupFactory;
+	private final LookupConstructor<L> lookupConstructor;
 
-	public ApiLookupMapImpl(LookupFactory<L> lookupFactory) {
-		this.lookupFactory = lookupFactory;
+	public ApiLookupMapImpl(LookupConstructor<L> lookupConstructor) {
+		this.lookupConstructor = lookupConstructor;
 	}
 
 	@Override
@@ -40,7 +40,7 @@ public final class ApiLookupMapImpl<L> implements ApiLookupMap<L> {
 		Objects.requireNonNull(apiClass, "API class may not be null.");
 		Objects.requireNonNull(contextClass, "Context class may not be null.");
 
-		StoredLookup<L> storedLookup = lookups.computeIfAbsent(lookupId, id -> new StoredLookup<>(lookupFactory.get(apiClass, contextClass), apiClass, contextClass));
+		StoredLookup<L> storedLookup = lookups.computeIfAbsent(lookupId, id -> new StoredLookup<>(lookupConstructor.get(id, apiClass, contextClass), apiClass, contextClass));
 
 		if (storedLookup.apiClass == apiClass && storedLookup.contextClass == contextClass) {
 			return storedLookup.lookup;

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/entity/EntityApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/entity/EntityApiLookupImpl.java
@@ -156,7 +156,7 @@ public class EntityApiLookupImpl<A, C> implements EntityApiLookup<A, C> {
 	}
 
 	@Override
-	public Identifier getIdentifier() {
+	public Identifier getId() {
 		return identifier;
 	}
 

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/entity/EntityApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/entity/EntityApiLookupImpl.java
@@ -46,12 +46,14 @@ public class EntityApiLookupImpl<A, C> implements EntityApiLookup<A, C> {
 	private static final Map<Class<?>, Set<EntityType<?>>> REGISTERED_SELVES = new HashMap<>();
 	private static boolean checkEntityLookup = true;
 
+	private final Identifier identifier;
 	private final Class<A> apiClass;
 	private final Class<C> contextClass;
 	private final ApiProviderMap<EntityType<?>, EntityApiProvider<A, C>> providerMap = ApiProviderMap.create();
 	private final List<EntityApiProvider<A, C>> fallbackProviders = new CopyOnWriteArrayList<>();
 
-	private EntityApiLookupImpl(Class<A> apiClass, Class<C> contextClass) {
+	private EntityApiLookupImpl(Identifier identifier, Class<A> apiClass, Class<C> contextClass) {
+		this.identifier = identifier;
 		this.apiClass = apiClass;
 		this.contextClass = contextClass;
 	}
@@ -151,6 +153,11 @@ public class EntityApiLookupImpl<A, C> implements EntityApiLookup<A, C> {
 		Objects.requireNonNull(fallbackProvider, "EntityApiProvider may not be null.");
 
 		fallbackProviders.add(fallbackProvider);
+	}
+
+	@Override
+	public Identifier identifier() {
+		return identifier;
 	}
 
 	@Override

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/entity/EntityApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/entity/EntityApiLookupImpl.java
@@ -156,7 +156,7 @@ public class EntityApiLookupImpl<A, C> implements EntityApiLookup<A, C> {
 	}
 
 	@Override
-	public Identifier identifier() {
+	public Identifier getIdentifier() {
 		return identifier;
 	}
 

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
@@ -127,7 +127,7 @@ public class ItemApiLookupImpl<A, C> implements ItemApiLookup<A, C> {
 	}
 
 	@Override
-	public Identifier identifier() {
+	public Identifier getIdentifier() {
 		return identifier;
 	}
 

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
@@ -127,7 +127,7 @@ public class ItemApiLookupImpl<A, C> implements ItemApiLookup<A, C> {
 	}
 
 	@Override
-	public Identifier getIdentifier() {
+	public Identifier getId() {
 		return identifier;
 	}
 

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
@@ -43,13 +43,15 @@ public class ItemApiLookupImpl<A, C> implements ItemApiLookup<A, C> {
 		return (ItemApiLookup<A, C>) LOOKUPS.getLookup(lookupId, apiClass, contextClass);
 	}
 
+	private final Identifier identifier;
 	private final Class<A> apiClass;
 	private final Class<C> contextClass;
 	private final ApiProviderMap<Item, ItemApiProvider<A, C>> providerMap = ApiProviderMap.create();
 	private final List<ItemApiProvider<A, C>> fallbackProviders = new CopyOnWriteArrayList<>();
 
 	@SuppressWarnings("unchecked")
-	private ItemApiLookupImpl(Class<?> apiClass, Class<?> contextClass) {
+	private ItemApiLookupImpl(Identifier identifier, Class<?> apiClass, Class<?> contextClass) {
+		this.identifier = identifier;
 		this.apiClass = (Class<A>) apiClass;
 		this.contextClass = (Class<C>) contextClass;
 	}
@@ -122,6 +124,11 @@ public class ItemApiLookupImpl<A, C> implements ItemApiLookup<A, C> {
 		Objects.requireNonNull(fallbackProvider, "ItemApiProvider may not be null.");
 
 		fallbackProviders.add(fallbackProvider);
+	}
+
+	@Override
+	public Identifier identifier() {
+		return identifier;
 	}
 
 	@Override

--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/FabricApiLookupTest.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/FabricApiLookupTest.java
@@ -97,6 +97,10 @@ public class FabricApiLookupTest implements ModInitializer {
 			wrongInsertable.registerFallback((world, pos, state, be, nocontext) -> null);
 		}, "The registry should have prevented creation of another instance with different classes, but same id.");
 
+		if (!insertable2.identifier().equals(new Identifier("testmod:item_insertable"))) {
+			throw new AssertionError("Incorrect identifier was returned.");
+		}
+
 		if (insertable2.apiClass() != ItemInsertable.class) {
 			throw new AssertionError("Incorrect API class was returned.");
 		}

--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/FabricApiLookupTest.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/FabricApiLookupTest.java
@@ -97,7 +97,7 @@ public class FabricApiLookupTest implements ModInitializer {
 			wrongInsertable.registerFallback((world, pos, state, be, nocontext) -> null);
 		}, "The registry should have prevented creation of another instance with different classes, but same id.");
 
-		if (!insertable2.identifier().equals(new Identifier("testmod:item_insertable"))) {
+		if (!insertable2.getIdentifier().equals(new Identifier("testmod:item_insertable"))) {
 			throw new AssertionError("Incorrect identifier was returned.");
 		}
 

--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/FabricApiLookupTest.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/FabricApiLookupTest.java
@@ -97,7 +97,7 @@ public class FabricApiLookupTest implements ModInitializer {
 			wrongInsertable.registerFallback((world, pos, state, be, nocontext) -> null);
 		}, "The registry should have prevented creation of another instance with different classes, but same id.");
 
-		if (!insertable2.getIdentifier().equals(new Identifier("testmod:item_insertable"))) {
+		if (!insertable2.getId().equals(new Identifier("testmod:item_insertable"))) {
 			throw new AssertionError("Incorrect identifier was returned.");
 		}
 


### PR DESCRIPTION
Fixes #1838. I deprecated `LookupFactory` for removal because this is a very niche API (I couldn't find any use of it on github besides fabric's own uses), so hopefully we can remove it one day:tm:.

~~Will conflict with #1836, and will need updating to also add the identifier getter to `EntityApiLookup`. That's why it's still a draft.~~ Updated.