### PR TITLE
Fix AttackBlockCallback on the client not sending a packet to the server

### DIFF
--- a/fabric-events-interaction-v0/src/testmod/java/net/fabricmc/fabric/test/event/interaction/AttackBlockTests.java
+++ b/fabric-events-interaction-v0/src/testmod/java/net/fabricmc/fabric/test/event/interaction/AttackBlockTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.event.interaction;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import net.minecraft.block.Blocks;
+import net.minecraft.item.Items;
+import net.minecraft.util.ActionResult;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
+
+public class AttackBlockTests implements ModInitializer {
+	private static final Logger LOGGER = LogManager.getLogger();
+
+	@Override
+	public void onInitialize() {
+		AttackBlockCallback.EVENT.register((player, world, hand, pos, side) -> {
+			LOGGER.info("AttackBlockCallback: before chest/lava hook (client-side = %s)".formatted(world.isClient));
+			return ActionResult.PASS;
+		});
+		// If a chest is attacked and the player holds a lava bucket, delete it!
+		AttackBlockCallback.EVENT.register((player, world, hand, pos, side) -> {
+			if (!player.isSpectator() && world.canPlayerModifyAt(player, pos)) {
+				if (world.getBlockState(pos).isOf(Blocks.CHEST)) {
+					if (player.getStackInHand(hand).isOf(Items.LAVA_BUCKET)) {
+						world.setBlockState(pos, Blocks.AIR.getDefaultState());
+						return ActionResult.success(world.isClient);
+					}
+				}
+			}
+
+			return ActionResult.PASS;
+		});
+		AttackBlockCallback.EVENT.register((player, world, hand, pos, side) -> {
+			LOGGER.info("AttackBlockCallback: after chest/lava hook (client-side = %s)".formatted(world.isClient));
+			return ActionResult.PASS;
+		});
+	}
+}

--- a/fabric-events-interaction-v0/src/testmod/resources/fabric.mod.json
+++ b/fabric-events-interaction-v0/src/testmod/resources/fabric.mod.json
@@ -10,6 +10,7 @@
   },
   "entrypoints": {
     "main": [
+      "net.fabricmc.fabric.test.event.interaction.AttackBlockTests",
       "net.fabricmc.fabric.test.event.interaction.PlayerBreakBlockTests",
       "net.fabricmc.fabric.test.event.interaction.PlayerPickBlockTests"
     ]


### PR DESCRIPTION
Attacking a chest with a lava bucket (see testmod) fails without this mixin patch. I also removed all the useless cancels and returns after `ci.setReturnValue` in other methods.