### PR TITLE
Add datagen support for dynamic registry tags

### DIFF
--- a/fabric-data-generation-api-v1/build.gradle
+++ b/fabric-data-generation-api-v1/build.gradle
@@ -7,6 +7,10 @@ moduleDependencies(project, [
 		'fabric-networking-api-v1'
 ])
 
+dependencies {
+	testmodImplementation project(path: ':fabric-tag-extensions-v0', configuration: 'namedElements')
+}
+
 sourceSets {
 	testmod {
 		resources {

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
@@ -210,7 +210,7 @@ public abstract class FabricTagProvider<T> extends AbstractTagProvider<T> {
 	/**
 	 * An extension to {@link net.minecraft.data.server.AbstractTagProvider.ObjectBuilder} that provides additional functionality.
 	 */
-	public class FabricTagBuilder<T> extends ObjectBuilder<T> {
+	public final class FabricTagBuilder<T> extends ObjectBuilder<T> {
 		private final AbstractTagProvider.ObjectBuilder<T> parent;
 
 		private FabricTagBuilder(ObjectBuilder<T> parent) {
@@ -319,7 +319,7 @@ public abstract class FabricTagProvider<T> extends AbstractTagProvider<T> {
 		 *
 		 * @return the {@link FabricTagBuilder} instance
 		 */
-		public final FabricTagBuilder<T> add(Identifier... ids) {
+		public FabricTagBuilder<T> add(Identifier... ids) {
 			for (Identifier id : ids) {
 				add(id);
 			}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
@@ -189,7 +189,7 @@ public abstract class FabricTagProvider<T> extends AbstractTagProvider<T> {
 	}
 
 	/**
-	 * Extend this class to create a dynamic registry tags.
+	 * Extend this class to create dynamic registry tags.
 	 */
 	public abstract static class DynamicRegistryTagProvider<T> extends FabricTagProvider<T> {
 		/**
@@ -210,10 +210,10 @@ public abstract class FabricTagProvider<T> extends AbstractTagProvider<T> {
 	/**
 	 * An extension to {@link net.minecraft.data.server.AbstractTagProvider.ObjectBuilder} that provides additional functionality.
 	 */
-	public class FabricTagBuilder<O> extends ObjectBuilder<O> {
-		private final AbstractTagProvider.ObjectBuilder<O> parent;
+	public class FabricTagBuilder<T> extends ObjectBuilder<T> {
+		private final AbstractTagProvider.ObjectBuilder<T> parent;
 
-		private FabricTagBuilder(ObjectBuilder<O> parent) {
+		private FabricTagBuilder(ObjectBuilder<T> parent) {
 			super(parent.builder, parent.registry, parent.source);
 			this.parent = parent;
 		}
@@ -225,7 +225,7 @@ public abstract class FabricTagProvider<T> extends AbstractTagProvider<T> {
 		 *
 		 * @return the {@link FabricTagBuilder} instance
 		 */
-		public FabricTagBuilder<O> setReplace(boolean replace) {
+		public FabricTagBuilder<T> setReplace(boolean replace) {
 			((net.fabricmc.fabric.impl.datagen.FabricTagBuilder) builder).fabric_setReplace(replace);
 			return this;
 		}
@@ -238,7 +238,7 @@ public abstract class FabricTagProvider<T> extends AbstractTagProvider<T> {
 		 * @see #add(Identifier)
 		 */
 		@Override
-		public FabricTagBuilder<O> add(O element) {
+		public FabricTagBuilder<T> add(T element) {
 			assertStaticRegistry();
 			parent.add(element);
 			return this;
@@ -249,9 +249,18 @@ public abstract class FabricTagProvider<T> extends AbstractTagProvider<T> {
 		 *
 		 * @return the {@link FabricTagBuilder} instance
 		 */
-		public FabricTagBuilder<O> add(Identifier id) {
+		public FabricTagBuilder<T> add(Identifier id) {
 			builder.add(id, source);
 			return this;
+		}
+
+		/**
+		 * Add a single element to the tag.
+		 *
+		 * @return the {@link FabricTagBuilder} instance
+		 */
+		public FabricTagBuilder<T> add(RegistryKey<? extends T> registryKey) {
+			return add(registryKey.getValue());
 		}
 
 		/**
@@ -260,7 +269,7 @@ public abstract class FabricTagProvider<T> extends AbstractTagProvider<T> {
 		 * @return the {@link FabricTagBuilder} instance
 		 */
 		@Override
-		public FabricTagBuilder<O> addOptional(Identifier id) {
+		public FabricTagBuilder<T> addOptional(Identifier id) {
 			parent.addOptional(id);
 			return this;
 		}
@@ -271,7 +280,7 @@ public abstract class FabricTagProvider<T> extends AbstractTagProvider<T> {
 		 * @return the {@link FabricTagBuilder} instance
 		 */
 		@Override
-		public FabricTagBuilder<O> addTag(Tag.Identified<O> tag) {
+		public FabricTagBuilder<T> addTag(Tag.Identified<T> tag) {
 			parent.addTag(tag);
 			return this;
 		}
@@ -282,7 +291,7 @@ public abstract class FabricTagProvider<T> extends AbstractTagProvider<T> {
 		 * @return the {@link FabricTagBuilder} instance
 		 */
 		@Override
-		public FabricTagBuilder<O> addOptionalTag(Identifier id) {
+		public FabricTagBuilder<T> addOptionalTag(Identifier id) {
 			parent.addOptionalTag(id);
 			return this;
 		}
@@ -295,10 +304,10 @@ public abstract class FabricTagProvider<T> extends AbstractTagProvider<T> {
 		 */
 		@SafeVarargs
 		@Override
-		public final FabricTagBuilder<O> add(O... elements) {
+		public final FabricTagBuilder<T> add(T... elements) {
 			assertStaticRegistry();
 
-			for (O element : elements) {
+			for (T element : elements) {
 				add(element);
 			}
 
@@ -310,9 +319,23 @@ public abstract class FabricTagProvider<T> extends AbstractTagProvider<T> {
 		 *
 		 * @return the {@link FabricTagBuilder} instance
 		 */
-		public FabricTagBuilder<O> add(Identifier... ids) {
+		public final FabricTagBuilder<T> add(Identifier... ids) {
 			for (Identifier id : ids) {
 				add(id);
+			}
+
+			return this;
+		}
+
+		/**
+		 * Add multiple elements to this tag.
+		 *
+		 * @return the {@link FabricTagBuilder} instance
+		 */
+		@SafeVarargs
+		public final FabricTagBuilder<T> add(RegistryKey<? extends T>... registryKeys) {
+			for (RegistryKey<? extends T> registryKey : registryKeys) {
+				add(registryKey);
 			}
 
 			return this;

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGenHelper.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGenHelper.java
@@ -22,13 +22,21 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
 
+import com.mojang.serialization.Lifecycle;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
+import net.minecraft.data.server.AbstractTagProvider;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.util.registry.SimpleRegistry;
+
 import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider.DynamicRegistryTagProvider;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
 
@@ -62,6 +70,21 @@ public final class FabricDataGenHelper {
 	 */
 	private static final String ENTRYPOINT_KEY = "fabric-datagen";
 
+	/**
+	 * A fake registry instance to be used for {@link DynamicRegistryTagProvider}.
+	 *
+	 * <p>In {@link AbstractTagProvider#run}, it checks for whether the registry has all the elements added to the builder.
+	 * This would be fine for static registry, but there won't be any instance dynamic registry available.
+	 * Therefore, this simply return true for all {@link Registry#containsId} call.
+	 */
+	@SuppressWarnings("rawtypes")
+	private static final Registry FAKE_DYNAMIC_REGISTRY = new SimpleRegistry<>(RegistryKey.ofRegistry(new Identifier("fabric:fake_dynamic_registry")), Lifecycle.experimental()) {
+		@Override
+		public boolean containsId(Identifier id) {
+			return true;
+		}
+	};
+
 	private FabricDataGenHelper() {
 	}
 
@@ -88,5 +111,10 @@ public final class FabricDataGenHelper {
 			entrypointContainer.getEntrypoint().onInitializeDataGenerator(dataGenerator);
 			dataGenerator.run();
 		}
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> Registry<T> getFakeDynamicRegistry() {
+		return FAKE_DYNAMIC_REGISTRY;
 	}
 }

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DynamicRegistryManagerAccessor.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DynamicRegistryManagerAccessor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.datagen;
+
+import java.util.Map;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.util.registry.DynamicRegistryManager;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.RegistryKey;
+
+@Mixin(DynamicRegistryManager.class)
+public interface DynamicRegistryManagerAccessor {
+	@Accessor("INFOS")
+	static Map<RegistryKey<? extends Registry<?>>, ?> getInfos() {
+		throw new AssertionError();
+	}
+}

--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.accesswidener
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.accesswidener
@@ -3,6 +3,7 @@ accessWidener	v2	named
 accessible  field   net/minecraft/data/server/RecipesProvider   root    Lnet/minecraft/data/DataGenerator;
 
 extendable  method  net/minecraft/data/server/AbstractTagProvider$ObjectBuilder <init>  (Lnet/minecraft/tag/Tag$Builder;Lnet/minecraft/util/registry/Registry;Ljava/lang/String;)V
+extendable  method  net/minecraft/data/server/AbstractTagProvider$ObjectBuilder add     ([Ljava/lang/Object;)Lnet/minecraft/data/server/AbstractTagProvider$ObjectBuilder;
 accessible  field   net/minecraft/data/server/AbstractTagProvider$ObjectBuilder builder Lnet/minecraft/tag/Tag$Builder;
 accessible  field   net/minecraft/data/server/AbstractTagProvider$ObjectBuilder registry    Lnet/minecraft/util/registry/Registry;
 accessible  field   net/minecraft/data/server/AbstractTagProvider$ObjectBuilder source  Ljava/lang/String;

--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_16",
   "mixins": [
     "BlockStateDefinitionProviderMixin",
+    "DynamicRegistryManagerAccessor",
     "TagBuilderMixin"
   ],
   "client": [

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
@@ -73,6 +73,7 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 				protected void generateTags() {
 				}
 			};
+			throw new AssertionError("Using FabricTagProvider with built-in registry didn't throw an exception!");
 		} catch (IllegalArgumentException e) {
 			// no-op
 		}
@@ -83,6 +84,7 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 				protected void generateTags() {
 				}
 			};
+			throw new AssertionError("Using DynamicRegistryTagProvider with static registry didn't throw an exception!");
 		} catch (IllegalArgumentException e) {
 			// no-op
 		}
@@ -151,6 +153,7 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 
 			try {
 				builder.add(BuiltinBiomes.PLAINS);
+				throw new AssertionError("Adding built-in entry to dynamic registry tag builder didn't throw an exception!");
 			} catch (UnsupportedOperationException e) {
 				// no-op
 			}

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
@@ -146,8 +146,8 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 		@Override
 		protected void generateTags() {
 			FabricTagBuilder<Biome> builder = getOrCreateTagBuilder(TagFactory.BIOME.create(new Identifier(MOD_ID, "biome_tag_test")))
-					.add(BiomeKeys.BADLANDS.getValue())
-					.add(BiomeKeys.BASALT_DELTAS.getValue());
+					.add(BiomeKeys.BADLANDS, BiomeKeys.BAMBOO_JUNGLE)
+					.add(BiomeKeys.BASALT_DELTAS);
 
 			try {
 				builder.add(BuiltinBiomes.PLAINS);

--- a/fabric-data-generation-api-v1/template.accesswidener
+++ b/fabric-data-generation-api-v1/template.accesswidener
@@ -3,6 +3,7 @@ accessWidener	v2	named
 accessible  field   net/minecraft/data/server/RecipesProvider   root    Lnet/minecraft/data/DataGenerator;
 
 extendable  method  net/minecraft/data/server/AbstractTagProvider$ObjectBuilder <init>  (Lnet/minecraft/tag/Tag$Builder;Lnet/minecraft/util/registry/Registry;Ljava/lang/String;)V
+extendable  method  net/minecraft/data/server/AbstractTagProvider$ObjectBuilder add     ([Ljava/lang/Object;)Lnet/minecraft/data/server/AbstractTagProvider$ObjectBuilder;
 accessible  field   net/minecraft/data/server/AbstractTagProvider$ObjectBuilder builder Lnet/minecraft/tag/Tag$Builder;
 accessible  field   net/minecraft/data/server/AbstractTagProvider$ObjectBuilder registry    Lnet/minecraft/util/registry/Registry;
 accessible  field   net/minecraft/data/server/AbstractTagProvider$ObjectBuilder source  Ljava/lang/String;


### PR DESCRIPTION
Some dynamic registries have a default registry in `BuiltinRegistries`, making it (somewhat) possible to use it in `FabricTagProvider` ctor. This is not the case for dimension type though, it doesn't have a default static registry.

There are two ways to make a support for dynamic registry tag datagen:
- Make our own `DataProvider` and copy all methods from `AbstractTagProvider` to it, besides the registry checking bit.
- Use a fake registry that always returns `true` on `Registry#containsId` calls, practically skipping the registry check.

I decided to go with the second option.

This PR:
- Adds `FabricTagProvider.DynamicRegistryTagProvider` that accepts a `RegistryKey` instead of `Registry`. It checks for whether the registry is dynamic and throws an exception if not.
- Throws an exception if someone use regular `FabricTagProvider` ctor with a registry from `BuiltinRegistries`.
- Adds `add` methods in `FabricTagBuilder` that accepts `Identifier` instead of registry object. This is the only way to add non-optional entries to dynamic registry tags.
- Throws an exception if someone call `add` with a default registry object on a dynamic registry tag provider.
