### PR TITLE
Allow adding vanilla tags to FabricTagBuilder

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
@@ -28,12 +28,18 @@ import net.minecraft.data.server.AbstractTagProvider;
 import net.minecraft.entity.EntityType;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.item.Item;
+import net.minecraft.tag.BlockTags;
+import net.minecraft.tag.EntityTypeTags;
+import net.minecraft.tag.FluidTags;
+import net.minecraft.tag.GameEventTags;
+import net.minecraft.tag.ItemTags;
 import net.minecraft.tag.Tag;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.event.GameEvent;
 
 import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
+import net.fabricmc.fabric.impl.datagen.FabricTagEntry;
 
 /**
  * Implement this class (or one of the inner classes) to generate a tag list.
@@ -225,11 +231,21 @@ public abstract class FabricTagProvider<T> extends AbstractTagProvider<T> {
 		/**
 		 * Add another tag to this tag.
 		 *
+		 * <p><b>Note:</b> any vanilla tags can be added to the builder,
+		 * but other tags can only be added if it has a builder registered in the same provider.
+		 *
+		 * <p>Use {@link #forceAddTag(Tag.Identified)} to force add any tag.
+		 *
 		 * @return the {@link FabricTagBuilder} instance
+		 * @see BlockTags
+		 * @see EntityTypeTags
+		 * @see FluidTags
+		 * @see GameEventTags
+		 * @see ItemTags
 		 */
 		@Override
 		public FabricTagBuilder<T> addTag(Tag.Identified<T> tag) {
-			parent.addTag(tag);
+			builder.add(new FabricTagEntry<>(registry, tag.getId(), false), source);
 			return this;
 		}
 
@@ -241,6 +257,19 @@ public abstract class FabricTagProvider<T> extends AbstractTagProvider<T> {
 		@Override
 		public FabricTagBuilder<T> addOptionalTag(Identifier id) {
 			parent.addOptionalTag(id);
+			return this;
+		}
+
+		/**
+		 * Add another tag to this tag, ignoring any warning.
+		 *
+		 * <p><b>Note:</b> only use this method if you sure that the tag will be always available at runtime.
+		 * If not, use {@link #addOptionalTag(Identifier)} instead.
+		 *
+		 * @return the {@link FabricTagBuilder} instance
+		 */
+		public FabricTagBuilder<T> forceAddTag(Tag.Identified<T> tag) {
+			builder.add(new FabricTagEntry<>(registry, tag.getId(), true), source);
 			return this;
 		}
 	}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricTagEntry.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricTagEntry.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.datagen;
+
+import java.util.function.Predicate;
+
+import net.minecraft.tag.RequiredTagListRegistry;
+import net.minecraft.tag.Tag;
+import net.minecraft.tag.TagGroup;
+import net.minecraft.tag.TagManager;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+public class FabricTagEntry<T> extends Tag.TagEntry {
+	private static final TagManager TAG_MANAGER = RequiredTagListRegistry.createBuiltinTagManager();
+
+	private final Registry<T> registry;
+	private final Identifier id;
+	private final boolean allowNonVanilla;
+
+	public FabricTagEntry(Registry<T> registry, Identifier id, boolean allowNonVanilla) {
+		super(id);
+
+		this.registry = registry;
+		this.id = id;
+		this.allowNonVanilla = allowNonVanilla;
+	}
+
+	@Override
+	public boolean canAdd(Predicate<Identifier> existenceTest, Predicate<Identifier> duplicationTest) {
+		if (allowNonVanilla) {
+			return true;
+		}
+
+		TagGroup<T> tagGroup = TAG_MANAGER.getOrCreateTagGroup(registry.getKey());
+		return tagGroup.contains(id) || super.canAdd(existenceTest, duplicationTest);
+	}
+}

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
@@ -97,6 +97,7 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 		protected void generateTags() {
 			getOrCreateTagBuilder(BlockTags.FIRE).add(SIMPLE_BLOCK);
 			getOrCreateTagBuilder(BlockTags.ANVIL).setReplace(true).add(SIMPLE_BLOCK);
+			getOrCreateTagBuilder(BlockTags.ACACIA_LOGS).addTag(BlockTags.ANIMALS_SPAWNABLE_ON);
 		}
 	}
 


### PR DESCRIPTION
Also add `forceAddTag` that always add the tag regardless if it present or not.

Closes #1908