### PR TITLE
Datagen Additions

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
@@ -237,7 +237,7 @@ public abstract class FabricTagProvider<T> extends AbstractTagProvider<T> {
 		 * Add another tag to this tag.
 		 *
 		 * @return the {@link FabricTagBuilder} instance
-		 * @throws ClassCastException if tag is not {@link Tag.Identified identified}
+		 * @throws ClassCastException if tag is not {@linkplain Tag.Identified identified}
 		 */
 		public FabricTagBuilder<T> addTag(Tag<T> tag) {
 			parent.addTag((Tag.Identified<T>) tag);

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
@@ -237,6 +237,7 @@ public abstract class FabricTagProvider<T> extends AbstractTagProvider<T> {
 		 * Add another tag to this tag.
 		 *
 		 * @return the {@link FabricTagBuilder} instance
+		 * @throws ClassCastException if tag is not {@link Tag.Identified identified}
 		 */
 		public FabricTagBuilder<T> addTag(Tag<T> tag) {
 			parent.addTag((Tag.Identified<T>) tag);

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
@@ -140,6 +140,8 @@ public abstract class FabricTagProvider<T> extends AbstractTagProvider<T> {
 		 *
 		 * <p>The {@link ItemTagProvider} tag provider must be constructed with an associated {@link BlockTagProvider} tag provider to use this method.
 		 *
+		 * <p>Any block ids that do not exist in the item registry will be filtered out automatically.
+		 *
 		 * @param blockTag The block tag to copy from.
 		 * @param itemTag The item tag to copy to.
 		 */

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
@@ -146,7 +146,7 @@ public abstract class FabricTagProvider<T> extends AbstractTagProvider<T> {
 		public void copy(Tag.Identified<Block> blockTag, Tag.Identified<Item> itemTag) {
 			Tag.Builder blockTagBuilder = Objects.requireNonNull(this.blockTagBuilderProvider, "Pass Block tag provider via constructor to use copy").apply(blockTag);
 			Tag.Builder itemTagBuilder = this.getTagBuilder(itemTag);
-			blockTagBuilder.streamEntries().forEach(itemTagBuilder::add);
+			blockTagBuilder.streamEntries().filter((entry) -> entry.getEntry().canAdd(this.registry::containsId, (id) -> true)).forEach(itemTagBuilder::add);
 		}
 	}
 
@@ -230,6 +230,16 @@ public abstract class FabricTagProvider<T> extends AbstractTagProvider<T> {
 		@Override
 		public FabricTagBuilder<T> addTag(Tag.Identified<T> tag) {
 			parent.addTag(tag);
+			return this;
+		}
+
+		/**
+		 * Add another tag to this tag.
+		 *
+		 * @return the {@link FabricTagBuilder} instance
+		 */
+		public FabricTagBuilder<T> addTag(Tag<T> tag) {
+			parent.addTag((Tag.Identified<T>) tag);
 			return this;
 		}
 

--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.accesswidener
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.accesswidener
@@ -7,6 +7,8 @@ accessible  field   net/minecraft/data/server/AbstractTagProvider$ObjectBuilder 
 accessible  field   net/minecraft/data/server/AbstractTagProvider$ObjectBuilder registry    Lnet/minecraft/util/registry/Registry;
 accessible  field   net/minecraft/data/server/AbstractTagProvider$ObjectBuilder source  Ljava/lang/String;
 
+accessible  field   net/minecraft/data/server/AbstractTagProvider   tagBuilders Ljava/util/Map;
+
 accessible  field   net/minecraft/data/server/BlockLootTableGenerator   lootTables  Ljava/util/Map;
 
 transitive-accessible   method  net/minecraft/data/family/BlockFamilies register    (Lnet/minecraft/block/Block;)Lnet/minecraft/data/family/BlockFamily$Builder;
@@ -14,6 +16,12 @@ transitive-accessible   method  net/minecraft/data/family/BlockFamilies register
 transitive-accessible    method    net/minecraft/data/client/ItemModelGenerator    register    (Lnet/minecraft/item/Item;Lnet/minecraft/data/client/model/Model;)V
 transitive-accessible    method    net/minecraft/data/client/ItemModelGenerator    register    (Lnet/minecraft/item/Item;Lnet/minecraft/item/Item;Lnet/minecraft/data/client/model/Model;)V
 transitive-accessible    method    net/minecraft/data/client/ItemModelGenerator    register    (Lnet/minecraft/item/Item;Ljava/lang/String;Lnet/minecraft/data/client/model/Model;)V
+
+transitive-accessible   field   net/minecraft/data/client/model/BlockStateModelGenerator    blockStateCollector Ljava/util/function/Consumer;
+transitive-accessible   field   net/minecraft/data/client/model/BlockStateModelGenerator    modelCollector  Ljava/util/function/BiConsumer;
+
+transitive-accessible   method  net/minecraft/data/client/model/TextureKey  of  (Ljava/lang/String;)Lnet/minecraft/data/client/model/TextureKey;
+transitive-accessible   method  net/minecraft/data/client/model/TextureKey	of  (Ljava/lang/String;Lnet/minecraft/data/client/model/TextureKey;)Lnet/minecraft/data/client/model/TextureKey;
 
 transitive-accessible	method	net/minecraft/data/server/RecipesProvider	saveRecipe	(Lnet/minecraft/data/DataCache;Lcom/google/gson/JsonObject;Ljava/nio/file/Path;)V
 transitive-accessible	method	net/minecraft/data/server/RecipesProvider	saveRecipeAdvancement	(Lnet/minecraft/data/DataCache;Lcom/google/gson/JsonObject;Ljava/nio/file/Path;)V

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestContent.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestContent.java
@@ -33,18 +33,24 @@ public class DataGeneratorTestContent implements ModInitializer {
 	public static final String MOD_ID = "fabric-data-gen-api-v1-testmod";
 
 	public static Block SIMPLE_BLOCK;
+	public static Block BLOCK_WITHOUT_ITEM;
 
 	@Override
 	public void onInitialize() {
-		SIMPLE_BLOCK = createBlock("simple_block");
+		SIMPLE_BLOCK = createBlock("simple_block", true);
+		BLOCK_WITHOUT_ITEM = createBlock("block_without_item", false);
 	}
 
-	private static Block createBlock(String name) {
+	private static Block createBlock(String name, boolean hasItem) {
 		Identifier identifier = new Identifier(MOD_ID, name);
 		Block block = Registry.register(Registry.BLOCK, identifier, new Block(AbstractBlock.Settings.of(Material.STONE)));
-		Registry.register(Registry.ITEM, identifier, new BlockItem(block, new Item.Settings().group(ItemGroup.MISC)));
 
-		Objects.requireNonNull(block.asItem().getGroup());
+		if (hasItem) {
+			Registry.register(Registry.ITEM, identifier, new BlockItem(block, new Item.Settings().group(ItemGroup.MISC)));
+
+			Objects.requireNonNull(block.asItem().getGroup());
+		}
+
 		return block;
 	}
 }

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.test.datagen;
 
+import static net.fabricmc.fabric.test.datagen.DataGeneratorTestContent.BLOCK_WITHOUT_ITEM;
 import static net.fabricmc.fabric.test.datagen.DataGeneratorTestContent.MOD_ID;
 import static net.fabricmc.fabric.test.datagen.DataGeneratorTestContent.SIMPLE_BLOCK;
 
@@ -80,6 +81,7 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 		@Override
 		public void generateBlockStateModels(BlockStateModelGenerator blockStateModelGenerator) {
 			blockStateModelGenerator.registerSimpleCubeAll(SIMPLE_BLOCK);
+			blockStateModelGenerator.registerSimpleCubeAll(BLOCK_WITHOUT_ITEM);
 		}
 
 		@Override
@@ -96,7 +98,7 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 		@Override
 		protected void generateTags() {
 			getOrCreateTagBuilder(BlockTags.FIRE).add(SIMPLE_BLOCK);
-			getOrCreateTagBuilder(BlockTags.ANVIL).setReplace(true).add(SIMPLE_BLOCK);
+			getOrCreateTagBuilder(BlockTags.ANVIL).setReplace(true).add(SIMPLE_BLOCK, BLOCK_WITHOUT_ITEM);
 		}
 	}
 
@@ -139,6 +141,7 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 		@Override
 		protected void generateBlockLootTables() {
 			addDrop(SIMPLE_BLOCK);
+			addDrop(BLOCK_WITHOUT_ITEM, drops(SIMPLE_BLOCK));
 		}
 	}
 

--- a/fabric-data-generation-api-v1/template.accesswidener
+++ b/fabric-data-generation-api-v1/template.accesswidener
@@ -7,6 +7,8 @@ accessible  field   net/minecraft/data/server/AbstractTagProvider$ObjectBuilder 
 accessible  field   net/minecraft/data/server/AbstractTagProvider$ObjectBuilder registry    Lnet/minecraft/util/registry/Registry;
 accessible  field   net/minecraft/data/server/AbstractTagProvider$ObjectBuilder source  Ljava/lang/String;
 
+accessible  field   net/minecraft/data/server/AbstractTagProvider   tagBuilders Ljava/util/Map;
+
 accessible  field   net/minecraft/data/server/BlockLootTableGenerator   lootTables  Ljava/util/Map;
 
 transitive-accessible   method  net/minecraft/data/family/BlockFamilies register    (Lnet/minecraft/block/Block;)Lnet/minecraft/data/family/BlockFamily$Builder;
@@ -14,3 +16,9 @@ transitive-accessible   method  net/minecraft/data/family/BlockFamilies register
 transitive-accessible    method    net/minecraft/data/client/ItemModelGenerator    register    (Lnet/minecraft/item/Item;Lnet/minecraft/data/client/model/Model;)V
 transitive-accessible    method    net/minecraft/data/client/ItemModelGenerator    register    (Lnet/minecraft/item/Item;Lnet/minecraft/item/Item;Lnet/minecraft/data/client/model/Model;)V
 transitive-accessible    method    net/minecraft/data/client/ItemModelGenerator    register    (Lnet/minecraft/item/Item;Ljava/lang/String;Lnet/minecraft/data/client/model/Model;)V
+
+transitive-accessible   field   net/minecraft/data/client/model/BlockStateModelGenerator    blockStateCollector Ljava/util/function/Consumer;
+transitive-accessible   field   net/minecraft/data/client/model/BlockStateModelGenerator    modelCollector  Ljava/util/function/BiConsumer;
+
+transitive-accessible   method  net/minecraft/data/client/model/TextureKey  of  (Ljava/lang/String;)Lnet/minecraft/data/client/model/TextureKey;
+transitive-accessible   method  net/minecraft/data/client/model/TextureKey	of  (Ljava/lang/String;Lnet/minecraft/data/client/model/TextureKey;)Lnet/minecraft/data/client/model/TextureKey;


### PR DESCRIPTION
Adds TAWs for `BlockStateModelGenerator.blockStateCollector`, `BlockStateModelGenerator.modelCollector`, `TextureKey.of(String)`, and `TextureKey.of(String, TextureKey)`.
Adds method in `FabricTagBuilder` for adding a non-identified tag, which simply casts the tag to identified as it's highly unlikely that any tags will *not* be identified. Helps with adding old Tag fields from FAPI (like Tool Tags).
Makes `ItemTagProvider#copy` filter out any item entries that don't exist in the item registry.

(supersedes #1889 , this one contains just the additions from that)