### PR TITLE
Support Loader 0.13's multiple mod root paths, optimize ModNioResourcePack

### DIFF
--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModResourcePackUtil.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModResourcePackUtil.java
@@ -17,8 +17,6 @@
 package net.fabricmc.fabric.impl.resource.loader;
 
 import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
 
 import com.google.common.base.Charsets;
@@ -54,21 +52,9 @@ public final class ModResourcePackUtil {
 				continue;
 			}
 
-			Path path = container.getRootPath();
+			ModResourcePack pack = ModNioResourcePack.create(getName(container.getMetadata()), container, null, type, ResourcePackActivationType.ALWAYS_ENABLED);
 
-			if (subPath != null) {
-				Path childPath = path.resolve(subPath.replace("/", path.getFileSystem().getSeparator())).toAbsolutePath().normalize();
-
-				if (!childPath.startsWith(path) || !Files.exists(childPath)) {
-					continue;
-				}
-
-				path = childPath;
-			}
-
-			ModResourcePack pack = new ModNioResourcePack(container.getMetadata(), path, type, null, ResourcePackActivationType.ALWAYS_ENABLED);
-
-			if (!pack.getNamespaces(type).isEmpty()) {
+			if (pack != null) {
 				packs.add(pack);
 			}
 		}

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ResourceManagerHelperImpl.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ResourceManagerHelperImpl.java
@@ -16,8 +16,6 @@
 
 package net.fabricmc.fabric.impl.resource.loader;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -67,30 +65,18 @@ public class ResourceManagerHelperImpl implements ResourceManagerHelper {
 	 * @see ResourceManagerHelper#registerBuiltinResourcePack(Identifier, String, ModContainer, boolean)
 	 */
 	public static boolean registerBuiltinResourcePack(Identifier id, String subPath, ModContainer container, ResourcePackActivationType activationType) {
-		String separator = container.getRootPath().getFileSystem().getSeparator();
-		subPath = subPath.replace("/", separator);
+		String name = id.getNamespace() + "/" + id.getPath();
+		ModNioResourcePack resourcePack = ModNioResourcePack.create(name, container, subPath, ResourceType.CLIENT_RESOURCES, activationType);
+		ModNioResourcePack dataPack = ModNioResourcePack.create(name, container, subPath, ResourceType.SERVER_DATA, activationType);
+		if (resourcePack == null && dataPack == null) return false;
 
-		Path resourcePackPath = container.getRootPath().resolve(subPath).toAbsolutePath().normalize();
-
-		if (!Files.exists(resourcePackPath)) {
-			return false;
+		if (resourcePack != null) {
+			builtinResourcePacks.add(new Pair<>(name, resourcePack));
 		}
 
-		String name = id.getNamespace() + "/" + id.getPath();
-
-		builtinResourcePacks.add(new Pair<>(name, new ModNioResourcePack(container.getMetadata(), resourcePackPath, ResourceType.CLIENT_RESOURCES, null, activationType) {
-			@Override
-			public String getName() {
-				return name; // Built-in resource pack provided by a mod, the name is overriden.
-			}
-		}));
-
-		builtinResourcePacks.add(new Pair<>(name, new ModNioResourcePack(container.getMetadata(), resourcePackPath, ResourceType.SERVER_DATA, null, activationType) {
-			@Override
-			public String getName() {
-				return name; // Built-in resource pack provided by a mod, the name is overriden.
-			}
-		}));
+		if (dataPack != null) {
+			builtinResourcePacks.add(new Pair<>(name, dataPack));
+		}
 
 		return true;
 	}

--- a/fabric-resource-loader-v0/src/main/resources/fabric.mod.json
+++ b/fabric-resource-loader-v0/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.4.0"
+    "fabricloader": ">=0.13.0"
   },
   "description": "Asset and data resource loading.",
   "mixins": [

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx2560M
 version=0.46.4
 minecraft_version=1.18.1
 yarn_version=+build.7
-loader_version=0.12.12
+loader_version=0.13.0
 
 prerelease=false
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.12.12",
+    "fabricloader": ">=0.13.0",
     "java": ">=17",
     "minecraft": "1.18.1"
   },


### PR DESCRIPTION
See https://github.com/FabricMC/fabric-loader/pull/585 which is a prerequisite

This also optimizes ModNioResourcePack through early namespace based filtering and removal of streams. The hot path should now only do file system accesses if the namespace is known to be present.

The way namespaces are cached limits hot reloading in dev slightly, it won't react to any namespaces changes without restarting the game. This is however a really obscure scenario and thus not a real problem.