### PR TITLE
Use the correct information when throwing Exceptions for failed tests.

### DIFF
--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/FabricGameTestHelper.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/FabricGameTestHelper.java
@@ -102,8 +102,10 @@ public final class FabricGameTestHelper {
 	public static void invokeTestMethod(TestContext testContext, Method method, Object testObject) {
 		try {
 			method.invoke(testObject, testContext);
-		} catch (IllegalAccessException | InvocationTargetException e) {
-			throw new RuntimeException("Failed to invoke test method (%s) in (%s)".formatted(method.getName(), method.getDeclaringClass().getCanonicalName()), e);
+		} catch (IllegalAccessException e) {
+			throw new RuntimeException("Failed to invoke test method (%s) in (%s) because %s".formatted(method.getName(), method.getDeclaringClass().getCanonicalName(), e.getMessage()), e);
+		} catch(InvocationTargetException e) {
+			throw new RuntimeException(e.getCause().getMessage(), e.getCause());
 		}
 	}
 

--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/FabricGameTestHelper.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/FabricGameTestHelper.java
@@ -104,8 +104,12 @@ public final class FabricGameTestHelper {
 			method.invoke(testObject, testContext);
 		} catch (IllegalAccessException e) {
 			throw new RuntimeException("Failed to invoke test method (%s) in (%s) because %s".formatted(method.getName(), method.getDeclaringClass().getCanonicalName(), e.getMessage()), e);
-		} catch(InvocationTargetException e) {
-			throw new RuntimeException(e.getCause().getMessage(), e.getCause());
+		} catch (InvocationTargetException e) {
+			if (e.getCause() instanceof RuntimeException) {
+				throw (RuntimeException) e.getCause();
+			} else {
+				throw new RuntimeException(e.getCause());
+			}
 		}
 	}
 

--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/FabricGameTestHelper.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/FabricGameTestHelper.java
@@ -105,8 +105,8 @@ public final class FabricGameTestHelper {
 		} catch (IllegalAccessException e) {
 			throw new RuntimeException("Failed to invoke test method (%s) in (%s) because %s".formatted(method.getName(), method.getDeclaringClass().getCanonicalName(), e.getMessage()), e);
 		} catch (InvocationTargetException e) {
-			if (e.getCause() instanceof RuntimeException) {
-				throw (RuntimeException) e.getCause();
+			if (e.getCause() instanceof RuntimeException runtimeException) {
+				throw runtimeException;
 			} else {
 				throw new RuntimeException(e.getCause());
 			}


### PR DESCRIPTION
Currently when you fail a GameTest, you don't really get any useful information.
These tests:
```java
    @GameTest(template = "crafttweaker:empty")
    public void alwaysFail(GameTestHelper helper) {
        
        helper.fail("This will always fail because I told it to, this is useful information to know.");
    }

    @GameTest(template = "crafttweaker:empty")
    private void notAccessible(GameTestHelper helper) {
        
        helper.fail("I'm not accessible, since I'm private.");
    }
```

output:
```xml
        <testcase classname="crafttweaker:empty" name="jsonconvertertest.alwaysfail" time="0.082">
            <failure
                    message="Failed to invoke test method (alwaysFail) in (com.blamejared.crafttweaker.gametest.api.data.JsonConverterTest)"/>
        </testcase>
        <testcase classname="crafttweaker:empty" name="jsonconvertertest.notaccessible" time="0.09">
            <failure
                    message="Failed to invoke test method (notAccessible) in (com.blamejared.crafttweaker.gametest.api.data.JsonConverterTest)"/>
        </testcase>
```

Which doesn't really tell me anything about what is wrong with them.

This PR makes it that those tests produce:
```xml
        <testcase classname="crafttweaker:empty" name="jsonconvertertest.alwaysfail" time="0.111">
            <failure message="This will always fail because I told it to, this is useful information to know."/>
        </testcase>
        <testcase classname="crafttweaker:empty" name="jsonconvertertest.notaccessible" time="0.109">
            <failure
                    message="Failed to invoke test method (notAccessible) in (com.blamejared.crafttweaker.gametest.api.data.JsonConverterTest) because class net.fabricmc.fabric.impl.gametest.FabricGameTestHelper cannot access a member of class com.blamejared.crafttweaker.gametest.api.data.JsonConverterTest with modifiers &quot;private&quot;"/>
        </testcase>
```

Which I'm sure we can all agree is way more useful than before.

Something of note, I am *not* using `FabricGameTest` for my test classes.
Looking at the code, I believe if I was I would get the correct information, but as that interface says, it is optional.