### PR TITLE
Fix attribute modifiers inject limiting other mixins.

### DIFF
--- a/fabric-tool-attribute-api-v1/src/main/java/net/fabricmc/fabric/mixin/tool/attribute/MixinItemStack.java
+++ b/fabric-tool-attribute-api-v1/src/main/java/net/fabricmc/fabric/mixin/tool/attribute/MixinItemStack.java
@@ -78,10 +78,11 @@ public abstract class MixinItemStack implements ItemStackContext {
 	private void revokeTooltipAttributeEntityContext(PlayerEntity player, TooltipContext context, CallbackInfoReturnable<List<Text>> cir) {
 		contextEntity = null;
 	}
-	
+
 	@ModifyVariable(method = "getAttributeModifiers", at = @At(value = "RETURN", shift = At.Shift.BEFORE))
 	public Multimap<EntityAttribute, EntityAttributeModifier> modifyAttributeModifiersMap(Multimap<EntityAttribute, EntityAttributeModifier> multimap, EquipmentSlot slot) {
 		ItemStack stack = (ItemStack) (Object) this;
+
 		// Only perform our custom operations if the tool being operated on is dynamic.
 		if (stack.getItem() instanceof DynamicAttributeTool) {
 			// The Multimap passed in is not ordered, so we need to re-assemble the vanilla and modded attributes
@@ -95,6 +96,7 @@ public abstract class MixinItemStack implements ItemStackContext {
 			orderedAttributes.putAll(holder.getDynamicModifiers(slot, stack, contextEntity));
 			return orderedAttributes;
 		}
+
 		return multimap;
 	}
 

--- a/fabric-tool-attribute-api-v1/src/main/java/net/fabricmc/fabric/mixin/tool/attribute/MixinItemStack.java
+++ b/fabric-tool-attribute-api-v1/src/main/java/net/fabricmc/fabric/mixin/tool/attribute/MixinItemStack.java
@@ -25,8 +25,8 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.client.item.TooltipContext;
@@ -78,26 +78,24 @@ public abstract class MixinItemStack implements ItemStackContext {
 	private void revokeTooltipAttributeEntityContext(PlayerEntity player, TooltipContext context, CallbackInfoReturnable<List<Text>> cir) {
 		contextEntity = null;
 	}
-
-	@Inject(at = @At("RETURN"), method = "getAttributeModifiers", cancellable = true, locals = LocalCapture.CAPTURE_FAILEXCEPTION)
-	public void getAttributeModifiers(EquipmentSlot slot, CallbackInfoReturnable<Multimap<EntityAttribute, EntityAttributeModifier>> info, Multimap<EntityAttribute, EntityAttributeModifier> multimap) {
+	
+	@ModifyVariable(method = "getAttributeModifiers", at = @At(value = "RETURN", shift = At.Shift.BEFORE))
+	public Multimap<EntityAttribute, EntityAttributeModifier> modifyAttributeModifiersMap(Multimap<EntityAttribute, EntityAttributeModifier> multimap, EquipmentSlot slot) {
 		ItemStack stack = (ItemStack) (Object) this;
-
 		// Only perform our custom operations if the tool being operated on is dynamic.
 		if (stack.getItem() instanceof DynamicAttributeTool) {
 			// The Multimap passed in is not ordered, so we need to re-assemble the vanilla and modded attributes
 			// into a custom, ordered Multimap. If this step is not done, and both vanilla + modded attributes
 			// exist at once, the item tooltip attribute lines will randomly switch positions.
 			LinkedListMultimap<EntityAttribute, EntityAttributeModifier> orderedAttributes = LinkedListMultimap.create();
-
 			// First, add all vanilla attributes to our ordered Multimap.
 			orderedAttributes.putAll(multimap);
-
 			// Second, calculate the dynamic attributes, and add them at the end of our Multimap.
 			DynamicAttributeTool holder = (DynamicAttributeTool) stack.getItem();
 			orderedAttributes.putAll(holder.getDynamicModifiers(slot, stack, contextEntity));
-			info.setReturnValue(orderedAttributes);
+			return orderedAttributes;
 		}
+		return multimap;
 	}
 
 	@Override


### PR DESCRIPTION
Since the inject is cancelled, it always runs last, and other mixins aren't able to target the map *after* the inject has been applied.

This is the code output of trying to modify the map after the inject has been applied (in this case, there are 2 `ModifyVariable`s used to show how they chain):
```java
Multimap<Attribute, AttributeModifier> multimap = this.localvar$zli000$modifyMapTwo((Multimap)multimap, slot);
multimap = this.localvar$zlh000$modifyMapOne(multimap, slot);
CallbackInfoReturnable callbackInfo8 = new CallbackInfoReturnable("getAttributeModifiers", true, multimap);
this.handler$zga000$getAttributeModifiers(slot, callbackInfo8, multimap);
return callbackInfo8.isCancelled() ? (Multimap)callbackInfo8.getReturnValue() : multimap;
```
`modifyMapTwo` has a priority of `999` and `modifyMapOne` has a priority of `1001`, so regardless of what priority you use, you can't change the output of `getAttributeModifiers`.

My use-case is being able to nuke all attributes from an item, even if they are "default".

