### PR TITLE
Fix Indigo UV rotation

### DIFF
--- a/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
+++ b/fabric-renderer-api-v1/src/main/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
@@ -45,7 +45,7 @@ public interface MutableQuadView extends QuadView {
 	int BAKE_ROTATE_NONE = 0;
 
 	/**
-	 * Causes texture to appear rotated 90 deg. relative to nominal face.
+	 * Causes texture to appear rotated 90 deg. clockwise relative to nominal face.
 	 * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
 	 */
 	int BAKE_ROTATE_90 = 1;
@@ -57,7 +57,7 @@ public interface MutableQuadView extends QuadView {
 	int BAKE_ROTATE_180 = 2;
 
 	/**
-	 * Causes texture to appear rotated 270 deg. relative to nominal face.
+	 * Causes texture to appear rotated 270 deg. clockwise relative to nominal face.
 	 * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
 	 */
 	int BAKE_ROTATE_270 = 3;

--- a/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/helper/TextureHelper.java
+++ b/fabric-renderer-indigo/src/main/java/net/fabricmc/fabric/impl/client/indigo/renderer/helper/TextureHelper.java
@@ -91,7 +91,9 @@ public class TextureHelper {
 		}
 	}
 
-	private static final VertexModifier[] ROTATIONS = new VertexModifier[] { null, (q, i, t) -> q.sprite(i, t, q.spriteV(i, t), q.spriteU(i, t)), //90
+	private static final VertexModifier[] ROTATIONS = new VertexModifier[] {
+			null,
+			(q, i, t) -> q.sprite(i, t, q.spriteV(i, t), 1 - q.spriteU(i, t)), //90
 			(q, i, t) -> q.sprite(i, t, 1 - q.spriteU(i, t), 1 - q.spriteV(i, t)), //180
 			(q, i, t) -> q.sprite(i, t, 1 - q.spriteV(i, t), q.spriteU(i, t)) // 270
 	};


### PR DESCRIPTION
When using the `MutableQuadView.BAKE_ROTATE_90` flag, Indigo does a diagonal flip instead of a 90-degree rotation. Since the docs for the flags don't specify whether the rotations should be clockwise or counter-clockwise, I assumed the `BAKE_ROTATE_270` flag is working correctly and the rotations should be clockwise. This fix makes the `BAKE_ROTATE_90` flag apply a 90-degree clockwise rotation. The screenshots below are the results of using the relevant flags.


`BAKE_ROTATE_NONE`
![no-rotation](https://user-images.githubusercontent.com/5130165/148239532-3634c577-e22a-485b-8568-e6328db9dd3d.png)

`BAKE_ROTATE_90` (without fix)
![90-rotation-bug](https://user-images.githubusercontent.com/5130165/148239755-b9e6eabc-6cd4-4d81-be9b-81b13e7d1e3b.png)

`BAKE_ROTATE_90` (with fix)
![90-rotation-fix](https://user-images.githubusercontent.com/5130165/148239809-de46552b-858c-4400-b13d-9980ae17e772.png)
