### PR TITLE
Fix end return spawn location issue.

### DIFF
--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/dimension/ServerPlayerEntityMixin.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/dimension/ServerPlayerEntityMixin.java
@@ -65,6 +65,6 @@ public class ServerPlayerEntityMixin {
 			return null;
 		}
 
-		return World.END;
+		return World.OVERWORLD;
 	}
 }


### PR DESCRIPTION
## Fix for a serious issue:

When you return from the end, you'll spawn at world-spawn even if you have a valid spawnpoint.

probably it was a typo.
