### PR TITLE
Add resource source tracking

### DIFF
--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/FabricResource.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/FabricResource.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.resource;
+
+import org.slf4j.LoggerFactory;
+
+import net.minecraft.resource.ResourcePackSource;
+
+/**
+ * Extensions to {@link net.minecraft.resource.Resource}.
+ * Automatically implemented there as an injected interface.
+ */
+public interface FabricResource {
+	/**
+	 * Gets the resource pack source of this resource.
+	 * The source is used to separate vanilla/mod resources from user resources in Fabric API.
+	 *
+	 * <p>Custom {@link net.minecraft.resource.Resource} implementations should override this method.
+	 *
+	 * @return the resource pack source
+	 */
+	default ResourcePackSource getFabricPackSource() {
+		LoggerFactory.getLogger(FabricResource.class).error("Unknown Resource implementation {}, returning PACK_SOURCE_NONE as the source", getClass().getName());
+		return ResourcePackSource.PACK_SOURCE_NONE;
+	}
+}

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/FabricResourceImpl.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/FabricResourceImpl.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.resource.loader;
+
+import net.minecraft.resource.Resource;
+import net.minecraft.resource.ResourcePackSource;
+
+public interface FabricResourceImpl extends Resource {
+	void setFabricPackSource(ResourcePackSource packSource);
+}

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/GroupResourcePack.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/GroupResourcePack.java
@@ -130,7 +130,9 @@ public abstract class GroupResourcePack implements ResourcePack {
 		for (ModResourcePack pack : packs) {
 			if (pack.contains(manager.getType(), id)) {
 				InputStream metadataInputStream = pack.contains(manager.getType(), metadataId) ? manager.fabric$accessor_open(metadataId, pack) : null;
-				resources.add(new ResourceImpl(pack.getName(), id, manager.fabric$accessor_open(id, pack), metadataInputStream));
+				ResourceImpl resource = new ResourceImpl(pack.getName(), id, manager.fabric$accessor_open(id, pack), metadataInputStream);
+				((FabricResourceImpl) resource).setFabricPackSource(ModResourcePackCreator.RESOURCE_PACK_SOURCE);
+				resources.add(resource);
 			}
 		}
 	}

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ResourcePackSourceTracker.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ResourcePackSourceTracker.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.resource.loader;
+
+import java.util.WeakHashMap;
+
+import net.minecraft.resource.ResourcePack;
+import net.minecraft.resource.ResourcePackSource;
+
+/**
+ * Tracks the sources of resource pack profiles.
+ */
+public final class ResourcePackSourceTracker {
+	private static final WeakHashMap<ResourcePack, ResourcePackSource> SOURCES = new WeakHashMap<>();
+
+	/**
+	 * Gets the source of a pack.
+	 *
+	 * @param pack the resource pack
+	 * @return the source, or {@link ResourcePackSource#PACK_SOURCE_NONE} if not tracked
+	 */
+	public static ResourcePackSource getSource(ResourcePack pack) {
+		return SOURCES.getOrDefault(pack, ResourcePackSource.PACK_SOURCE_NONE);
+	}
+
+	/**
+	 * Sets the source of a pack.
+	 *
+	 * @param pack the resource pack
+	 * @param source the source
+	 */
+	public static void setSource(ResourcePack pack, ResourcePackSource source) {
+		SOURCES.put(pack, source);
+	}
+}

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/DefaultResourcePackResourceMixin.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/DefaultResourcePackResourceMixin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.resource.loader;
 
 import org.spongepowered.asm.mixin.Mixin;

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/DefaultResourcePackResourceMixin.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/DefaultResourcePackResourceMixin.java
@@ -1,0 +1,15 @@
+package net.fabricmc.fabric.mixin.resource.loader;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import net.minecraft.resource.ResourcePackSource;
+
+import net.fabricmc.fabric.api.resource.FabricResource;
+
+@Mixin(targets = "net/minecraft/resource/DefaultResourcePack$1")
+abstract class DefaultResourcePackResourceMixin implements FabricResource {
+	@Override
+	public ResourcePackSource getFabricPackSource() {
+		return ResourcePackSource.PACK_SOURCE_BUILTIN;
+	}
+}

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/ResourceImplMixin.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/ResourceImplMixin.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.resource.loader;
+
+import java.util.Objects;
+
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+import net.minecraft.resource.ResourceImpl;
+import net.minecraft.resource.ResourcePackSource;
+
+import net.fabricmc.fabric.impl.resource.loader.FabricResourceImpl;
+
+@Mixin(ResourceImpl.class)
+abstract class ResourceImplMixin implements FabricResourceImpl {
+	@Unique
+	private @Nullable ResourcePackSource fabric_packSource;
+
+	@Override
+	public ResourcePackSource getFabricPackSource() {
+		return Objects.requireNonNullElse(fabric_packSource, ResourcePackSource.PACK_SOURCE_NONE);
+	}
+
+	@Override
+	public void setFabricPackSource(ResourcePackSource packSource) {
+		this.fabric_packSource = packSource;
+	}
+}

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/ResourceMixin.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/ResourceMixin.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.resource.loader;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import net.minecraft.resource.Resource;
+
+import net.fabricmc.fabric.api.resource.FabricResource;
+
+// Even though the interface is injected, we must extend it here,
+// so it works outside of dev.
+@Mixin(Resource.class)
+interface ResourceMixin extends FabricResource {
+}

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/ResourcePackProfileMixin.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/ResourcePackProfileMixin.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.resource.loader;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.resource.ResourcePack;
+import net.minecraft.resource.ResourcePackProfile;
+import net.minecraft.resource.ResourcePackSource;
+
+import net.fabricmc.fabric.impl.resource.loader.ResourcePackSourceTracker;
+
+/**
+ * Implements resource pack source tracking.
+ */
+@Mixin(ResourcePackProfile.class)
+abstract class ResourcePackProfileMixin {
+	@Shadow
+	@Final
+	private ResourcePackSource source;
+
+	@Inject(method = "createResourcePack", at = @At("RETURN"))
+	private void onCreateResourcePack(CallbackInfoReturnable<ResourcePack> info) {
+		ResourcePackSourceTracker.setSource(info.getReturnValue(), source);
+	}
+}

--- a/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
+++ b/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
@@ -5,6 +5,7 @@
   "mixins": [
     "FileResourcePackProviderAccessor",
     "DefaultResourcePackMixin",
+    "DefaultResourcePackResourceMixin",
     "KeyedResourceReloadListenerMixin",
     "LifecycledResourceManagerImplMixin",
     "MinecraftServerMixin",

--- a/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
+++ b/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
@@ -11,9 +11,12 @@
     "NamespaceResourceManagerAccessor",
     "NamespaceResourceManagerMixin",
     "ReloadableResourceManagerImplMixin",
+    "ResourceImplMixin",
+    "ResourceMixin",
     "ResourcePackManagerMixin",
     "ResourcePackManagerAccessor",
     "ResourcePackProfileAccessor",
+    "ResourcePackProfileMixin",
     "SimpleResourceReloadMixin"
   ],
   "client": [

--- a/fabric-resource-loader-v0/src/main/resources/fabric.mod.json
+++ b/fabric-resource-loader-v0/src/main/resources/fabric.mod.json
@@ -23,6 +23,9 @@
     "fabric-resource-loader-v0.mixins.json"
   ],
   "custom": {
-    "fabric-api:module-lifecycle": "stable"
+    "fabric-api:module-lifecycle": "stable",
+    "loom:injected_interfaces": {
+      "net/minecraft/class_3298": ["net/fabricmc/fabric/api/resource/FabricResource"]
+    }
   }
 }


### PR DESCRIPTION
Adds `FabricResource` that contains `getFabricPackSource()` for determining where a resource comes from (vanilla, a mod or a user-provided resource pack). Note: requires changes if #1827 merged since the sources aren't constant anymore

## Why is this useful?

This is a prerequisite for loot table sources in #1241, where we can similarly determine where a loot table comes from. This can be used in Fabric API for de-hardcoding tools like shears in vanilla loot tables - we replace a loot table if its `LootTableSource` is `VANILLA`. This PR's source tracking is used as the base for that.