### PR TITLE
Fix a ClassCastException being thrown when a data pack reload event is invoked

### DIFF
--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
@@ -31,7 +31,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-import net.minecraft.resource.ServerResourceManager;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.world.ServerWorld;
 

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
@@ -91,14 +91,14 @@ public abstract class MinecraftServerMixin {
 
 	@Inject(method = "reloadResources", at = @At("HEAD"))
 	private void startResourceReload(Collection<String> collection, CallbackInfoReturnable<CompletableFuture<Void>> cir) {
-		ServerLifecycleEvents.START_DATA_PACK_RELOAD.invoker().startDataPackReload((MinecraftServer) (Object) this, (ServerResourceManager) this.serverResourceManager.resourceManager());
+		ServerLifecycleEvents.START_DATA_PACK_RELOAD.invoker().startDataPackReload((MinecraftServer) (Object) this, this.serverResourceManager.managers());
 	}
 
 	@Inject(method = "reloadResources", at = @At("TAIL"))
 	private void endResourceReload(Collection<String> collection, CallbackInfoReturnable<CompletableFuture<Void>> cir) {
 		cir.getReturnValue().handleAsync((value, throwable) -> {
 			// Hook into fail
-			ServerLifecycleEvents.END_DATA_PACK_RELOAD.invoker().endDataPackReload((MinecraftServer) (Object) this, (ServerResourceManager) this.serverResourceManager.resourceManager(), throwable == null);
+			ServerLifecycleEvents.END_DATA_PACK_RELOAD.invoker().endDataPackReload((MinecraftServer) (Object) this, this.serverResourceManager.managers(), throwable == null);
 			return value;
 		}, (MinecraftServer) (Object) this);
 	}


### PR DESCRIPTION
This pull request fixes data pack reload events and the `/reload` command being broken:

![](https://user-images.githubusercontent.com/24855774/153929167-d7154563-7ed8-4fef-82ce-72f95370b720.png)

This change matches vanilla refactors to the `serverResourceManager` field. Except for with structures, resource manager accesses have been changed to use the `managers` record component instead:

```diff
  public ServerAdvancementLoader getAdvancementLoader() {
-  	return this.serverResourceManager.getServerAdvancementLoader();
+ 	return this.serverResourceManager.managers.getServerAdvancementLoader();
  }
```

This fix should in theory not affect mods expecting certain resources to be available from the manager, but further testing would be required.