### PR TITLE
Fix type passed to data pack reload events.

### DIFF
--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerLifecycleEvents.java
@@ -16,7 +16,7 @@
 
 package net.fabricmc.fabric.api.event.lifecycle.v1;
 
-import net.minecraft.resource.ServerResourceManager;
+import net.minecraft.resource.LifecycledResourceManager;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.PlayerManager;
 
@@ -118,7 +118,7 @@ public final class ServerLifecycleEvents {
 
 	@FunctionalInterface
 	public interface StartDataPackReload {
-		void startDataPackReload(MinecraftServer server, ServerResourceManager serverResourceManager);
+		void startDataPackReload(MinecraftServer server, LifecycledResourceManager resourceManager);
 	}
 
 	@FunctionalInterface
@@ -129,9 +129,9 @@ public final class ServerLifecycleEvents {
 		 * <p>If the reload was not successful, the old data packs will be kept.
 		 *
 		 * @param server the server
-		 * @param serverResourceManager the server resource manager
+		 * @param resourceManager the resource manager
 		 * @param success if the reload was successful
 		 */
-		void endDataPackReload(MinecraftServer server, ServerResourceManager serverResourceManager, boolean success);
+		void endDataPackReload(MinecraftServer server, LifecycledResourceManager resourceManager, boolean success);
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
@@ -90,14 +90,14 @@ public abstract class MinecraftServerMixin {
 
 	@Inject(method = "reloadResources", at = @At("HEAD"))
 	private void startResourceReload(Collection<String> collection, CallbackInfoReturnable<CompletableFuture<Void>> cir) {
-		ServerLifecycleEvents.START_DATA_PACK_RELOAD.invoker().startDataPackReload((MinecraftServer) (Object) this, this.serverResourceManager.managers());
+		ServerLifecycleEvents.START_DATA_PACK_RELOAD.invoker().startDataPackReload((MinecraftServer) (Object) this, this.serverResourceManager.resourceManager());
 	}
 
 	@Inject(method = "reloadResources", at = @At("TAIL"))
 	private void endResourceReload(Collection<String> collection, CallbackInfoReturnable<CompletableFuture<Void>> cir) {
 		cir.getReturnValue().handleAsync((value, throwable) -> {
 			// Hook into fail
-			ServerLifecycleEvents.END_DATA_PACK_RELOAD.invoker().endDataPackReload((MinecraftServer) (Object) this, this.serverResourceManager.managers(), throwable == null);
+			ServerLifecycleEvents.END_DATA_PACK_RELOAD.invoker().endDataPackReload((MinecraftServer) (Object) this, this.serverResourceManager.resourceManager(), throwable == null);
 			return value;
 		}, (MinecraftServer) (Object) this);
 	}


### PR DESCRIPTION
This is a breaking API change, the API was effectively broken anyway so it makes sense to do this ASAP.