### PR TITLE
Fix Block2ObjectMap not using TagKey

### DIFF
--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/FlammableBlockRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/FlammableBlockRegistry.java
@@ -18,7 +18,7 @@ package net.fabricmc.fabric.api.registry;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
-import net.minecraft.tag.Tag;
+import net.minecraft.tag.TagKey;
 
 import net.fabricmc.fabric.api.util.Block2ObjectMap;
 import net.fabricmc.fabric.impl.content.registry.FlammableBlockRegistryImpl;
@@ -36,7 +36,7 @@ public interface FlammableBlockRegistry extends Block2ObjectMap<FlammableBlockRe
 		this.add(block, new Entry(burn, spread));
 	}
 
-	default void add(Tag<Block> tag, int burn, int spread) {
+	default void add(TagKey<Block> tag, int burn, int spread) {
 		this.add(tag, new Entry(burn, spread));
 	}
 

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/util/Block2ObjectMap.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/util/Block2ObjectMap.java
@@ -17,20 +17,20 @@
 package net.fabricmc.fabric.api.util;
 
 import net.minecraft.block.Block;
-import net.minecraft.tag.Tag;
+import net.minecraft.tag.TagKey;
 
 public interface Block2ObjectMap<V> {
 	V get(Block block);
 
 	void add(Block block, V value);
 
-	void add(Tag<Block> tag, V value);
+	void add(TagKey<Block> tag, V value);
 
 	void remove(Block block);
 
-	void remove(Tag<Block> tag);
+	void remove(TagKey<Block> tag);
 
 	void clear(Block block);
 
-	void clear(Tag<Block> tag);
+	void clear(TagKey<Block> tag);
 }

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/FlammableBlockRegistryImpl.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/FlammableBlockRegistryImpl.java
@@ -24,8 +24,10 @@ import java.util.Map;
 import net.minecraft.block.Block;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.resource.ResourceType;
-import net.minecraft.tag.Tag;
+import net.minecraft.tag.TagKey;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.RegistryEntry;
 
 import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
@@ -39,7 +41,7 @@ public class FlammableBlockRegistryImpl implements FlammableBlockRegistry, Simpl
 	private static int idCounter = 0;
 
 	private final Map<Block, FlammableBlockRegistry.Entry> registeredEntriesBlock = new HashMap<>();
-	private final Map<Tag<Block>, FlammableBlockRegistry.Entry> registeredEntriesTag = new HashMap<>();
+	private final Map<TagKey<Block>, FlammableBlockRegistry.Entry> registeredEntriesTag = new HashMap<>();
 	private final Map<Block, FlammableBlockRegistry.Entry> computedEntries = new HashMap<>();
 	private final Identifier id;
 	private final Block key;
@@ -62,11 +64,11 @@ public class FlammableBlockRegistryImpl implements FlammableBlockRegistry, Simpl
 		computedEntries.clear();
 
 		// tags take precedence before blocks
-		for (Tag<Block> tag : registeredEntriesTag.keySet()) {
+		for (TagKey<Block> tag : registeredEntriesTag.keySet()) {
 			FlammableBlockRegistry.Entry entry = registeredEntriesTag.get(tag);
 
-			for (Block block : tag.values()) {
-				computedEntries.put(block, entry);
+			for (RegistryEntry<Block> block : Registry.BLOCK.iterateEntries(tag)) {
+				computedEntries.put(block.value(), entry);
 			}
 		}
 
@@ -108,7 +110,7 @@ public class FlammableBlockRegistryImpl implements FlammableBlockRegistry, Simpl
 	}
 
 	@Override
-	public void add(Tag<Block> tag, Entry value) {
+	public void add(TagKey<Block> tag, Entry value) {
 		registeredEntriesTag.put(tag, value);
 
 		if (tagsPresent) {
@@ -122,7 +124,7 @@ public class FlammableBlockRegistryImpl implements FlammableBlockRegistry, Simpl
 	}
 
 	@Override
-	public void remove(Tag<Block> tag) {
+	public void remove(TagKey<Block> tag) {
 		add(tag, REMOVED);
 	}
 
@@ -136,7 +138,7 @@ public class FlammableBlockRegistryImpl implements FlammableBlockRegistry, Simpl
 	}
 
 	@Override
-	public void clear(Tag<Block> tag) {
+	public void clear(TagKey<Block> tag) {
 		registeredEntriesTag.remove(tag);
 
 		if (tagsPresent) {


### PR DESCRIPTION
This is an API breaking change, however the API is effectively broken/useless anyway.

A quick search of the source seems to suggest this is all that was missed.