### PR TITLE
Fix missing structures causing chunks to reset on upgrade.

### DIFF
--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinChunkSerializer.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinChunkSerializer.java
@@ -1,0 +1,17 @@
+package net.fabricmc.fabric.mixin.registry.sync;
+
+import org.slf4j.Logger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.world.ChunkSerializer;
+
+@Mixin(ChunkSerializer.class)
+public class MixinChunkSerializer {
+	@Redirect(method = "readStructureReferences", at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;warn(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V"))
+	private static void log(Logger logger, String msg, Object identifier, Object chunkPos) {
+		// Drop to debug log level.
+		logger.debug(msg, identifier, chunkPos);
+	}
+}

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinChunkSerializer.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinChunkSerializer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.registry.sync;
 
 import org.slf4j.Logger;

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinStructuresToConfiguredStructuresFix.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MixinStructuresToConfiguredStructuresFix.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.registry.sync;
+
+import java.util.Locale;
+
+import com.mojang.datafixers.util.Pair;
+import com.mojang.serialization.Dynamic;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.datafixer.fix.StructuresToConfiguredStructuresFix;
+
+@Mixin(StructuresToConfiguredStructuresFix.class)
+public class MixinStructuresToConfiguredStructuresFix {
+	private static final Logger LOGGER = LoggerFactory.getLogger("MixinStructuresToConfiguredStructuresFix");
+
+	/**
+	 * Vanilla throws a IllegalStateException when there is no mapping for a structure to upgrade, this causes the chunk to reset and regenerate.
+	 * Now we just return the previous value, this can still cause a missing structure log warning, but it is a lot better than resetting the chunk.
+	 */
+	@Inject(method = "method_41022", at = @At(value = "INVOKE", target = "Ljava/lang/IllegalStateException;<init>(Ljava/lang/String;)V"), cancellable = true)
+	private void method_41022(Pair<Dynamic<?>, Dynamic<?>> pair, Dynamic<?> dynamic, CallbackInfoReturnable<Dynamic<?>> cir) {
+		String id = pair.getFirst().asString("UNKNOWN").toLowerCase(Locale.ROOT);
+		LOGGER.debug("Found unknown structure: {}", id);
+		cir.setReturnValue(pair.getSecond().createString(id));
+	}
+}

--- a/fabric-registry-sync-v0/src/main/resources/fabric-registry-sync-v0.mixins.json
+++ b/fabric-registry-sync-v0/src/main/resources/fabric-registry-sync-v0.mixins.json
@@ -7,13 +7,15 @@
     "AccessorLevelStorageSession",
     "AccessorRegistry",
     "MixinBootstrap",
+    "MixinChunkSerializer",
     "MixinDynamicRegistryManager",
     "MixinIdList",
     "MixinIdRegistry",
     "MixinLevelStorageSession",
     "MixinRegistry",
     "MixinMinecraftServer",
-    "MixinSimpleRegistry"
+    "MixinSimpleRegistry",
+    "MixinStructuresToConfiguredStructuresFix"
   ],
   "client": [
     "client.MixinBlockColorMap",


### PR DESCRIPTION
Reduce log level of "Found reference to unknown structure" log output, as it spams for every chunk load, causing confusion for players.