### PR TITLE
Add `fabric-registry-sync-v0` to all testmods runtime classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -226,6 +226,11 @@ subprojects {
 			testmodImplementation project(path: ':fabric-gametest-api-v1', configuration: 'namedElements')
 			testmodImplementation project(path: ':fabric-resource-loader-v0', configuration: 'namedElements')
 		}
+
+		// Make all testmods run with registry-sync-v0 as it is required to register new objects.
+		if (project.name != "fabric-registry-sync-v0") {
+			testmodRuntimeOnly project(path: ':fabric-registry-sync-v0', configuration: 'namedElements')
+		}
 	}
 
 	publishing {


### PR DESCRIPTION
Some testmod doesn't depend on `fabric-registry-sync-v0`, making it crashes if it registers new objects if you run it individually.
This PR will fix that for all modules by adding it into the runtime classpath. You need to explicitly use `testmodImplementation` if you want to access the API.