### PR TITLE
Fix optional tag from TagKey datagen

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
@@ -346,7 +346,7 @@ public abstract class FabricTagProvider<T> extends AbstractTagProvider<T> {
 		 * @return the {@link FabricTagBuilder} instance
 		 */
 		public FabricTagBuilder<T> addOptionalTag(TagKey<T> tag) {
-			return addOptional(tag.id());
+			return addOptionalTag(tag.id());
 		}
 
 		/**


### PR DESCRIPTION
When tags are referenced in another tag's json, it is required to prefix them with `#`.

`FabricTagProvider.FabricTagBuilder#addOptionalTag(net.minecraft.util.Identifier)` uses the relevant vanilla code to do so; however,
`FabricTagProvider.FabricTagBuilder#addOptionalTag(net.minecraft.tag.TagKey<T>)` uses the logic for adding a non-tag id to a tag, causing the `#` to be missing from the generated jsons, and therefore tags that do not function as expected.

Other versions of the API may also be affected.