### PR TITLE
Fix the issue of uninstalling a dimension mod or datapack

### DIFF
--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/dimension/LevelStorageBugfixMixin.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/dimension/LevelStorageBugfixMixin.java
@@ -34,15 +34,17 @@ import net.minecraft.world.level.storage.LevelStorage;
 /**
  * After removing a dimension mod or a dimension datapack, Minecraft may fail to enter
  * the world, because it fails to deserialize the chunk generator of the custom dimensions in file {@code level.dat}
- * This mixin will remove the custom dimensions from the nbt tag, so the deserializer and DFU cannot see custom dimensions and won't cause errors.
+ * This mixin will remove the custom dimensions from the nbt tag, so the deserializer and DFU cannot see custom
+ * dimensions and won't cause errors.
  * The custom dimensions will be re-added later.
  *
- * <p>This Mixin changes a vanilla behavior that is deemed as a bug (MC-197860). In vanilla, the custom dimension is not removed after uninstalling the dimension datapack.
+ * <p>This Mixin changes a vanilla behavior that is deemed as a bug (MC-197860). In vanilla, the custom dimension
+ * is not removed after uninstalling the dimension datapack.
  * This makes custom dimensions non-removable. Most players don't want this behavior.
  * With this Mixin, custom dimensions will be removed when its datapack is removed.
  */
 @Mixin(LevelStorage.class)
-public class LevelStorageMixin {
+public class LevelStorageBugfixMixin {
 	@SuppressWarnings("unchecked")
 	@Inject(method = "readGeneratorProperties", at = @At("HEAD"))
 	private static <T> void onReadGeneratorProperties(
@@ -51,11 +53,9 @@ public class LevelStorageMixin {
 	) {
 		NbtElement nbtTag = ((Dynamic<NbtElement>) nbt).getValue();
 
-		if (nbtTag instanceof NbtCompound compoundTag) {
-			NbtCompound worldGenSettings = ((NbtCompound) nbtTag).getCompound("WorldGenSettings");
+		NbtCompound worldGenSettings = ((NbtCompound) nbtTag).getCompound("WorldGenSettings");
 
-			removeNonVanillaDimensionsFromWorldGenSettingsTag(worldGenSettings);
-		}
+		removeNonVanillaDimensionsFromWorldGenSettingsTag(worldGenSettings);
 	}
 
 	/**

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/dimension/LevelStorageMixin.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/dimension/LevelStorageMixin.java
@@ -16,6 +16,11 @@
 
 package net.fabricmc.fabric.mixin.dimension;
 
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import com.mojang.datafixers.DataFixer;
 import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Dynamic;
@@ -26,19 +31,13 @@ import net.minecraft.nbt.NbtElement;
 import net.minecraft.world.gen.GeneratorOptions;
 import net.minecraft.world.level.storage.LevelStorage;
 
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
 /**
  * After removing a dimension mod or a dimension datapack, Minecraft may fail to enter
  * the world, because it fails to deserialize the chunk generator of the custom dimensions in file {@code level.dat}
  * This mixin will remove the custom dimensions from the nbt tag, so the deserializer and DFU cannot see custom dimensions and won't cause errors.
  * The custom dimensions will be re-added later.
- * <p>
- * This Mixin changes a vanilla behavior that is deemed as a bug (MC-197860). In vanilla, the custom dimension is not removed after uninstalling the dimension datapack.
+ *
+ * <p>This Mixin changes a vanilla behavior that is deemed as a bug (MC-197860). In vanilla, the custom dimension is not removed after uninstalling the dimension datapack.
  * This makes custom dimensions non-removable. Most players don't want this behavior.
  * With this Mixin, custom dimensions will be removed when its datapack is removed.
  */
@@ -71,6 +70,7 @@ public class LevelStorageMixin {
 
 		if (dimensions.getSize() > vanillaDimensionIds.length) {
 			NbtCompound newDimensions = new NbtCompound();
+
 			for (String dimId : vanillaDimensionIds) {
 				if (dimensions.contains(dimId)) {
 					newDimensions.put(dimId, dimensions.getCompound(dimId));

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/dimension/LevelStorageMixin.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/dimension/LevelStorageMixin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.dimension;
 
 import com.mojang.datafixers.DataFixer;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/dimension/LevelStorageMixin.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/dimension/LevelStorageMixin.java
@@ -1,0 +1,67 @@
+package net.fabricmc.fabric.mixin.dimension;
+
+import com.mojang.datafixers.DataFixer;
+import com.mojang.datafixers.util.Pair;
+import com.mojang.serialization.Dynamic;
+import com.mojang.serialization.Lifecycle;
+
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.world.gen.GeneratorOptions;
+import net.minecraft.world.level.storage.LevelStorage;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * After removing a dimension mod or a dimension datapack, Minecraft may fail to enter
+ * the world, because it fails to deserialize the chunk generator of the custom dimensions in file {@code level.dat}
+ * This mixin will remove the custom dimensions from the nbt tag, so the deserializer and DFU cannot see custom dimensions and won't cause errors.
+ * The custom dimensions will be re-added later.
+ * <p>
+ * This Mixin changes a vanilla behavior that is deemed as a bug (MC-197860). In vanilla, the custom dimension is not removed after uninstalling the dimension datapack.
+ * This makes custom dimensions non-removable. Most players don't want this behavior.
+ * With this Mixin, custom dimensions will be removed when its datapack is removed.
+ */
+@Mixin(LevelStorage.class)
+public class LevelStorageMixin {
+	@SuppressWarnings("unchecked")
+	@Inject(method = "readGeneratorProperties", at = @At("HEAD"))
+	private static <T> void onReadGeneratorProperties(
+			Dynamic<T> nbt, DataFixer dataFixer, int version,
+			CallbackInfoReturnable<Pair<GeneratorOptions, Lifecycle>> cir
+	) {
+		NbtElement nbtTag = ((Dynamic<NbtElement>) nbt).getValue();
+
+		if (nbtTag instanceof NbtCompound compoundTag) {
+			NbtCompound worldGenSettings = ((NbtCompound) nbtTag).getCompound("WorldGenSettings");
+
+			removeNonVanillaDimensionsFromWorldGenSettingsTag(worldGenSettings);
+		}
+	}
+
+	/**
+	 * Removes all non-vanilla dimensions from the tag. The custom dimensions will be re-added later from the datapacks.
+	 */
+	@Unique
+	private static void removeNonVanillaDimensionsFromWorldGenSettingsTag(NbtCompound worldGenSettings) {
+		String[] vanillaDimensionIds =
+				new String[]{"minecraft:overworld", "minecraft:the_nether", "minecraft:the_end"};
+
+		NbtCompound dimensions = worldGenSettings.getCompound("dimensions");
+
+		if (dimensions.getSize() > vanillaDimensionIds.length) {
+			NbtCompound newDimensions = new NbtCompound();
+			for (String dimId : vanillaDimensionIds) {
+				if (dimensions.contains(dimId)) {
+					newDimensions.put(dimId, dimensions.getCompound(dimId));
+				}
+			}
+
+			worldGenSettings.put("dimensions", newDimensions);
+		}
+	}
+}

--- a/fabric-dimensions-v1/src/main/resources/fabric-dimensions-v1.mixins.json
+++ b/fabric-dimensions-v1/src/main/resources/fabric-dimensions-v1.mixins.json
@@ -4,8 +4,9 @@
   "compatibilityLevel": "JAVA_16",
   "mixins": [
     "EntityMixin",
-    "ServerPlayerEntityMixin",
-    "ServerBugfixMixin"
+    "LevelStorageMixin",
+    "ServerBugfixMixin",
+    "ServerPlayerEntityMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/fabric-dimensions-v1/src/main/resources/fabric-dimensions-v1.mixins.json
+++ b/fabric-dimensions-v1/src/main/resources/fabric-dimensions-v1.mixins.json
@@ -4,7 +4,7 @@
   "compatibilityLevel": "JAVA_16",
   "mixins": [
     "EntityMixin",
-    "LevelStorageMixin",
+    "LevelStorageBugfixMixin",
     "ServerBugfixMixin",
     "ServerPlayerEntityMixin"
   ],


### PR DESCRIPTION
Minecraft stores custom dimension chunk generators in `level.dat`. To deserialize the chunk generator, it reads the registries (biome registry, chunk generator codec registry, etc.). After uninstalling a dimension mod or a dimension datapack, it fails to deserialize the custom dimensions. And Minecraft cannot load the world. (In 1.18.2, clicking the "Safe mode" button has no effect.)

This is important because uninstalling a dimension mod should be an allowed operation. Forge already contains the fix to this issue. It's easy to fix this issue by removing non-vanilla dimensions from the NBT tag before feeding into DFU and the deserializer. The custom dimensions will be re-added later.

In vanilla, if you have a simple dimension datapack that does define its own thing (for example, it only has a dimension with simple superfalt generation, and does not have any biome or noise settings), then after uninstalling that datapack, the dimension still exists. Vanilla does not give a way to remove custom dimensions. I think this is a wrong behavior. Almost no player want this behavior. After uninstalling a dimension datapack or a dimension mod, its dimension should vanish. This Mixin changes that behavior: it will make the dimensions of uninstalled datapacks vanish normally.
