### PR TITLE
Update Modrinth plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 	id "com.diffplug.spotless" version "6.5.1"
 	id "org.ajoberstar.grgit" version "3.1.0"
 	id "com.matthewprenger.cursegradle" version "1.4.0"
-	id "com.modrinth.minotaur" version "1.1.0"
+	id "com.modrinth.minotaur" version "2.4.3"
 	id "me.modmuss50.remotesign" version "0.3.0" apply false
 }
 
@@ -519,6 +519,7 @@ curseforge {
 
 if (signingEnabled) {
 	project.tasks.curseforge.dependsOn signRemapJar
+	project.tasks.modrinth.dependsOn signRemapJar
 	build.dependsOn signRemapJar
 }
 
@@ -545,22 +546,13 @@ task github(dependsOn: (signingEnabled ? signRemapJar : remapJar)) {
 	}
 }
 
-task modrinth(type: com.modrinth.minotaur.TaskModrinthUpload, dependsOn: (signingEnabled ? signRemapJar : remapJar)) {
-	onlyIf {
-		ENV.MODRINTH_TOKEN
-	}
-
-	token = ENV.MODRINTH_TOKEN
-	projectId = "P7dR8mSH"
-	versionNumber = version
+modrinth {
+	projectId = "fabric-api"
 	versionName = "[$project.minecraft_version] Fabric API $project.version"
-	releaseType = project.prerelease == "true" ? "beta" : "release"
+	versionType = project.prerelease == "true" ? "beta" : "release"
 	changelog = ENV.CHANGELOG ?: "No changelog provided"
 
 	uploadFile = signingEnabled ? signRemapJar.output : remapJar
-
-	addGameVersion(project.minecraft_version)
-	addLoader('fabric')
 }
 
 // A task to ensure that the version being released has not already been released.

--- a/build.gradle
+++ b/build.gradle
@@ -568,6 +568,6 @@ task checkVersion {
 }
 
 github.mustRunAfter checkVersion
-modrinth.mustRunAfter checkVersion
+project.tasks.modrinth.mustRunAfter checkVersion
 publish.mustRunAfter checkVersion
 project.tasks.curseforge.mustRunAfter checkVersion


### PR DESCRIPTION
Updates the Modrinth plugin from v1.1.0 to v2.1.1, re: [migration guide on the wiki](https://fabricmc.net/wiki/tutorial:minotaur#updating_from_minotaur_1x_to_2x)

[Minotaur's changelog is here](https://github.com/modrinth/minotaur/compare/v1.1.0...v2.1.1) if you're curious, main changes were moving to an extension and the removal of `addLoader` and `addGameVersion`.

Game version, loader, project version, and token are automatically detected. You may have to bump the Minotaur version too if Loom makes breaking changes to the way that Minotaur [finds the Minecraft dependency](https://github.com/modrinth/minotaur/blob/3f4f065ba8d041497a9e26268acd64858c736ff8/src/main/java/com/modrinth/minotaur/compat/FabricLoomCompatibility.java#L11-L18), but I saw that pinning specific versions was preferred rather than using the latest version like Modrinth recommends.

Tested to work well [on staging](https://staging.modrinth.com/mod/freeeedom/version/0.48.0+local-update-minotaur).

