### PR TITLE
Fix the issue of unloading dimensions v2

### DIFF
--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FailSoftMapCodec.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FailSoftMapCodec.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.dimension;
+
+import java.util.Map;
+import java.util.Objects;
+
+import com.google.common.collect.ImmutableMap;
+import com.mojang.datafixers.util.Pair;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.Lifecycle;
+import com.mojang.serialization.MapLike;
+import com.mojang.serialization.codecs.BaseMapCodec;
+import com.mojang.serialization.codecs.UnboundedMapCodec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.minecraft.util.registry.RegistryEntry;
+
+/**
+ * Has the same functionality as {@link UnboundedMapCodec}.
+ * But it will fail-soft when an entry cannot be deserialized or throw error during deserialization.
+ * When deserialization fails, it will also purge the wrong registry entries. See {@link RegistryPurge}
+ */
+public class FailSoftMapCodec<K, V> implements BaseMapCodec<K, V>, Codec<Map<K, V>> {
+	public static final Logger LOGGER = LoggerFactory.getLogger("FailSoftMapCodec");
+
+	private final Codec<K> keyCodec;
+	private final Codec<V> elementCodec;
+
+	public FailSoftMapCodec(final Codec<K> keyCodec, final Codec<V> elementCodec) {
+		this.keyCodec = keyCodec;
+		this.elementCodec = elementCodec;
+	}
+
+	@Override
+	public Codec<K> keyCodec() {
+		return keyCodec;
+	}
+
+	@Override
+	public Codec<V> elementCodec() {
+		return elementCodec;
+	}
+
+	@Override
+	public <T> DataResult<Pair<Map<K, V>, T>> decode(final DynamicOps<T> ops, final T input) {
+		return ops.getMap(input).setLifecycle(Lifecycle.stable()).flatMap(map -> decode(ops, map)).map(r -> Pair.of(r, input));
+	}
+
+	@Override
+	public <T> DataResult<T> encode(final Map<K, V> input, final DynamicOps<T> ops, final T prefix) {
+		return encode(input, ops, ops.mapBuilder()).build(prefix);
+	}
+
+	/**
+	 * In {@link BaseMapCodec#decode(DynamicOps, MapLike)}
+	 * The whole deserialization will fail if one element fails
+	 * `apply2stable` will return fail when any of the two elements is failed
+	 * In this implementation, if one deserialization fails, it will log and ignore
+	 * It also catches exceptions. Deserialization errors can also come from {@link RegistryEntry.Reference#value()}
+	 */
+	@Override
+	public <T> DataResult<Map<K, V>> decode(final DynamicOps<T> ops, final MapLike<T> input) {
+		final ImmutableMap.Builder<K, V> builder = ImmutableMap.builder();
+
+		input.entries().forEach(pair -> {
+			try {
+				final DataResult<K> k = keyCodec().parse(ops, pair.getFirst());
+				final DataResult<V> v = elementCodec().parse(ops, pair.getSecond());
+
+				k.get().ifRight(kPartialResult -> {
+					LOGGER.error("Failed to decode key {} from {}  {}", k, pair, kPartialResult);
+				});
+				v.get().ifRight(vPartialResult -> {
+					LOGGER.error("Failed to decode value {} from {}  {}", v, pair, vPartialResult);
+				});
+
+				if (k.get().left().isPresent() && v.get().left().isPresent()) {
+					builder.put(k.get().left().get(), v.get().left().get());
+				} else {
+					RegistryPurge.purgeInvalidEntriesFromDynamicOps(ops);
+				}
+			} catch (Throwable e) {
+				e.printStackTrace();
+				RegistryPurge.purgeInvalidEntriesFromDynamicOps(ops);
+			}
+		});
+
+		final Map<K, V> elements = builder.build();
+
+		return DataResult.success(elements);
+	}
+
+	@Override
+	public boolean equals(final Object o) {
+		if (this == o) {
+			return true;
+		}
+
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		final FailSoftMapCodec<?, ?> that = (FailSoftMapCodec<?, ?>) o;
+		return Objects.equals(keyCodec, that.keyCodec) && Objects.equals(elementCodec, that.elementCodec);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(keyCodec, elementCodec);
+	}
+
+	@Override
+	public String toString() {
+		return "FailSoftMapCodec[" + keyCodec + " -> " + elementCodec + ']';
+	}
+}

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/RegistryPurge.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/RegistryPurge.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.dimension;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.mojang.serialization.DynamicOps;
+
+import net.minecraft.util.dynamic.RegistryElementCodec;
+import net.minecraft.util.dynamic.RegistryOps;
+import net.minecraft.util.registry.DynamicRegistryManager;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.RegistryEntry;
+import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.util.registry.SimpleRegistry;
+
+import net.fabricmc.fabric.mixin.dimension.RegistryOpsAccessor;
+import net.fabricmc.fabric.mixin.dimension.SimpleRegistryAccessor;
+
+/**
+ * When it tries to deserialize a registry entry in {@link RegistryElementCodec#decode(DynamicOps, Object)},
+ * It will eventually call {@link SimpleRegistry#getOrCreateEntry(RegistryKey)}.
+ * When deserializing a dimension of an unloaded dimension mod or datapack,
+ * its deserialization will fail, but it will leave registry entries of its registry objects(custom biomes, noise settings...).
+ * These entries are invalid because the mods/datapacks providing the objects are not present.
+ * Then in {@link SimpleRegistry#freeze()} it will throw an exception.
+ * To avoid that, purge the invalid entries when deserialization fails.
+ */
+public class RegistryPurge {
+	public static final Logger LOGGER = LoggerFactory.getLogger("RegistryPurge");
+
+	public static <T> void purgeInvalidEntriesFromDynamicOps(DynamicOps<T> dynamicOps) {
+		if (dynamicOps instanceof RegistryOps<T> registryOps) {
+			DynamicRegistryManager manager = ((RegistryOpsAccessor) registryOps).fabric$getRegistryManager();
+			purgeInvalidEntriesFromRegistryManager(manager);
+		}
+	}
+
+	public static void purgeInvalidEntriesFromRegistryManager(DynamicRegistryManager manager) {
+		manager.streamAllRegistries().forEach(entry -> {
+			Registry<?> registry = entry.value();
+			purgeInvalidEntriesFromRegistry(registry);
+		});
+	}
+
+	public static void purgeInvalidEntriesFromRegistry(Registry<?> registry) {
+		if (registry instanceof SimpleRegistry) {
+			Map<RegistryKey<?>, RegistryEntry.Reference<?>> keyToEntry = ((SimpleRegistryAccessor) registry).fabric$getKeyToEntry();
+
+			keyToEntry.entrySet().removeIf(entry -> {
+				if (!entry.getValue().hasKeyAndValue()) {
+					LOGGER.error("Removed invalid registry entry {}", entry.getKey().getValue());
+					return true;
+				}
+
+				return false;
+			});
+		}
+	}
+}

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/dimension/MixinRegistryCodecs.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/dimension/MixinRegistryCodecs.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.dimension;
+
+import java.util.Map;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import com.mojang.serialization.Codec;
+
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.RegistryCodecs;
+import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.world.gen.GeneratorOptions;
+
+import net.fabricmc.fabric.impl.dimension.FailSoftMapCodec;
+
+@Mixin(RegistryCodecs.class)
+public class MixinRegistryCodecs {
+	/**
+	 * @author FabricMC
+	 * @reason make dimension deserialization fail soft
+	 * In MC 1.18.2, this is only used in the codec of {@link GeneratorOptions}
+	 */
+	@Overwrite
+	private static <T> Codec<Map<RegistryKey<T>, T>> registryMap(RegistryKey<? extends Registry<T>> registryRef, Codec<T> elementCodec) {
+		return new FailSoftMapCodec<>(
+				Identifier.CODEC.xmap(RegistryKey.createKeyFactory(registryRef), RegistryKey::getValue),
+				elementCodec
+		);
+	}
+}

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/dimension/RegistryOpsAccessor.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/dimension/RegistryOpsAccessor.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.dimension;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.util.dynamic.RegistryOps;
+import net.minecraft.util.registry.DynamicRegistryManager;
+
+@Mixin(RegistryOps.class)
+public interface RegistryOpsAccessor {
+	@Accessor("registryManager")
+	DynamicRegistryManager fabric$getRegistryManager();
+}

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/dimension/SimpleRegistryAccessor.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/dimension/SimpleRegistryAccessor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.dimension;
+
+import java.util.Map;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.util.registry.RegistryEntry;
+import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.util.registry.SimpleRegistry;
+
+@Mixin(SimpleRegistry.class)
+public interface SimpleRegistryAccessor {
+	@Accessor("keyToEntry")
+	Map<RegistryKey<?>, RegistryEntry.Reference<?>> fabric$getKeyToEntry();
+}

--- a/fabric-dimensions-v1/src/main/resources/fabric-dimensions-v1.mixins.json
+++ b/fabric-dimensions-v1/src/main/resources/fabric-dimensions-v1.mixins.json
@@ -4,8 +4,11 @@
   "compatibilityLevel": "JAVA_16",
   "mixins": [
     "EntityMixin",
+    "MixinRegistryCodecs",
+    "RegistryOpsAccessor",
+    "ServerBugfixMixin",
     "ServerPlayerEntityMixin",
-    "ServerBugfixMixin"
+    "SimpleRegistryAccessor"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Different to https://github.com/FabricMC/fabric/pull/2078  this PR use another way to fix this issue.
It makes dimension deserialization fail-soft and purge the invalid registry entries to prevent failing registry freeze.

As I tested, it can fix the issue of unloading dimension datapacks. But I didn't tested the DFU issue. It may still fail when DFU cannot recognize custom dimensions.
The old PR https://github.com/FabricMC/fabric/pull/2078 does not have any issue from DFU. This PR may have more potential issues than the old PR.

This PR maintains the (probably unwanted) vanilla behavior: if you have a simple dimension datapack that does not define its own things, then its dimension cannot be removed from the world.

The mod https://www.curseforge.com/minecraft/mc-mods/dimension-fix-some-forge-patches-ported is similar to this PR