### PR TITLE
Fix off-by-one error in item group tooltip

### DIFF
--- a/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/impl/item/group/FabricCreativeGuiComponents.java
+++ b/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/impl/item/group/FabricCreativeGuiComponents.java
@@ -68,7 +68,8 @@ public class FabricCreativeGuiComponents {
 				this.drawTexture(matrixStack, this.x, this.y, u + (type == Type.NEXT ? 11 : 0), v, 11, 10);
 
 				if (this.hovered) {
-					gui.renderTooltip(matrixStack, new TranslatableText("fabric.gui.creativeTabPage", extensions.fabric_currentPage() + 1, ((ItemGroup.GROUPS.length - 12) / 9) + 2), mouseX, mouseY);
+					int pageCount = (int) Math.ceil((ItemGroup.GROUPS.length - COMMON_GROUPS.size()) / 9D);
+					gui.renderTooltip(matrixStack, new TranslatableText("fabric.gui.creativeTabPage", extensions.fabric_currentPage() + 1, pageCount), mouseX, mouseY);
 				}
 			}
 		}

--- a/fabric-item-groups-v0/src/testmod/java/net/fabricmc/fabric/test/item/group/ItemGroupTest.java
+++ b/fabric-item-groups-v0/src/testmod/java/net/fabricmc/fabric/test/item/group/ItemGroupTest.java
@@ -51,5 +51,11 @@ public class ItemGroupTest implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		TEST_ITEM = Registry.register(Registry.ITEM, new Identifier("fabric-item-groups-v0-testmod", "item_test_group"), new Item(new Item.Settings().group(ITEM_GROUP_2)));
+
+		// Exactly two pages of item groups
+		for (int i = 3; i < 10; i++) {
+			Item iconItem = Registry.ITEM.get(i);
+			FabricItemGroupBuilder.build(new Identifier("fabric-item-groups-v0-testmod", "test_group_" + i), () -> new ItemStack(iconItem));
+		}
 	}
 }


### PR DESCRIPTION
Tooltip when hovering over item group buttons is off by one if the amount of item groups is a multiple of 9 (= the last page is full).
<img width="966" alt="image" src="https://user-images.githubusercontent.com/13403842/159772858-e59433f0-7030-4a51-96f9-7031bc06d0ea.png">