### PR TITLE
Make `crash-report-info` print mods in a tree form

### DIFF
--- a/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/mixin/crash/report/info/MixinCrashReport.java
+++ b/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/mixin/crash/report/info/MixinCrashReport.java
@@ -16,8 +16,8 @@
 
 package net.fabricmc.fabric.mixin.crash.report.info;
 
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.Comparator;
+import java.util.TreeSet;
 import java.util.function.Supplier;
 
 import org.spongepowered.asm.mixin.Mixin;
@@ -39,22 +39,35 @@ public abstract class MixinCrashReport {
 	@Inject(at = @At("RETURN"), method = "<init>")
 	private void fillSystemDetails(CallbackInfo info) {
 		addSection("Fabric Mods", () -> {
-			Map<String, String> mods = new TreeMap<>();
+			TreeSet<ModContainer> topLevelMods = new TreeSet<>(Comparator.comparing(mod -> mod.getMetadata().getId()));
 
 			for (ModContainer container : FabricLoader.getInstance().getAllMods()) {
-				mods.put(container.getMetadata().getId(), container.getMetadata().getName() + " " + container.getMetadata().getVersion().getFriendlyString());
+				if (container.getContainingMod().isEmpty()) {
+					topLevelMods.add(container);
+				}
 			}
 
 			StringBuilder modString = new StringBuilder();
 
-			for (String id : mods.keySet()) {
-				modString.append("\n\t\t");
-				modString.append(id);
-				modString.append(": ");
-				modString.append(mods.get(id));
-			}
+			appendMods(modString, 2, topLevelMods);
 
 			return modString.toString();
 		});
+	}
+
+	private static void appendMods(StringBuilder modString, int depth, TreeSet<ModContainer> mods) {
+		for (ModContainer mod: mods) {
+			modString.append('\n');
+			modString.append("\t".repeat(depth));
+			modString.append(mod.getMetadata().getId());
+			modString.append(": ");
+			modString.append(mod.getMetadata().getVersion().getFriendlyString());
+
+			if (!mod.getContainedMods().isEmpty()) {
+				TreeSet<ModContainer> childMods = new TreeSet<>(Comparator.comparing(m -> m.getMetadata().getId()));
+				childMods.addAll(mod.getContainedMods());
+				appendMods(modString, depth + 1, childMods);
+			}
+		}
 	}
 }

--- a/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/mixin/crash/report/info/MixinCrashReport.java
+++ b/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/mixin/crash/report/info/MixinCrashReport.java
@@ -16,8 +16,8 @@
 
 package net.fabricmc.fabric.mixin.crash.report.info;
 
+import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.TreeSet;
 import java.util.function.Supplier;
 
 import org.spongepowered.asm.mixin.Mixin;
@@ -39,7 +39,7 @@ public abstract class MixinCrashReport {
 	@Inject(at = @At("RETURN"), method = "<init>")
 	private void fillSystemDetails(CallbackInfo info) {
 		addSection("Fabric Mods", () -> {
-			TreeSet<ModContainer> topLevelMods = new TreeSet<>(Comparator.comparing(mod -> mod.getMetadata().getId()));
+			ArrayList<ModContainer> topLevelMods = new ArrayList<>();
 
 			for (ModContainer container : FabricLoader.getInstance().getAllMods()) {
 				if (container.getContainingMod().isEmpty()) {
@@ -55,7 +55,9 @@ public abstract class MixinCrashReport {
 		});
 	}
 
-	private static void appendMods(StringBuilder modString, int depth, TreeSet<ModContainer> mods) {
+	private static void appendMods(StringBuilder modString, int depth, ArrayList<ModContainer> mods) {
+		mods.sort(Comparator.comparing(mod -> mod.getMetadata().getId()));
+
 		for (ModContainer mod: mods) {
 			modString.append('\n');
 			modString.append("\t".repeat(depth));
@@ -64,8 +66,7 @@ public abstract class MixinCrashReport {
 			modString.append(mod.getMetadata().getVersion().getFriendlyString());
 
 			if (!mod.getContainedMods().isEmpty()) {
-				TreeSet<ModContainer> childMods = new TreeSet<>(Comparator.comparing(m -> m.getMetadata().getId()));
-				childMods.addAll(mod.getContainedMods());
+				ArrayList<ModContainer> childMods = new ArrayList<>(mod.getContainedMods());
 				appendMods(modString, depth + 1, childMods);
 			}
 		}

--- a/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/mixin/crash/report/info/MixinCrashReport.java
+++ b/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/mixin/crash/report/info/MixinCrashReport.java
@@ -58,11 +58,11 @@ public abstract class MixinCrashReport {
 	private static void appendMods(StringBuilder modString, int depth, ArrayList<ModContainer> mods) {
 		mods.sort(Comparator.comparing(mod -> mod.getMetadata().getId()));
 
-		for (ModContainer mod: mods) {
+		for (ModContainer mod : mods) {
 			modString.append('\n');
 			modString.append("\t".repeat(depth));
 			modString.append(mod.getMetadata().getId());
-			modString.append(": ");
+			modString.append(' ');
 			modString.append(mod.getMetadata().getVersion().getFriendlyString());
 
 			if (!mod.getContainedMods().isEmpty()) {

--- a/fabric-crash-report-info-v1/src/main/resources/fabric.mod.json
+++ b/fabric-crash-report-info-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.4.0"
+    "fabricloader": ">=0.13.0"
   },
   "description": "Adds Fabric-related debug info to crash reports.",
   "mixins": [


### PR DESCRIPTION
Supersedes #1462. Resolves #1422.

This PR makes mods be shown in a tree view in crash reports. The main purpose of this issue/PR was to prevent mods called `fabric-something` to be confused within fabric API modules (and therefore considered as not the cause).

Uses the containing/container mod API from Fabric loader 0.13+.

Supports mods contained by contained mods, with any depth.

<details>
<summary>Example result</summary>

```
	Fabric Mods: 
		canvas: 1.0.2282
			blue_endless_jankson: 1.2.1
			cloth-config: 6.1.48
				cloth-basic-math: 0.6.0
			fabric-api-base: 0.4.1+b4f4f6cdc8
			fabric-key-binding-api-v1: 1.0.8+c8aba2f3c8
			fabric-lifecycle-events-v1: 1.4.10+c15ca335c8
			fabric-resource-loader-v0: 0.4.11+3ac43d95c8
			io_vram_bitraster: 1.5.53
			io_vram_dtklib: 1.0.3
			io_vram_special-circumstances: 1.10.7
			json-model-extensions: 1.22.243
				frex: 6.0.236
					io_vram_bitkit: 1.0.1
			org_anarres_jcpp: 1.4.14
		carpet: 1.4.56
		dynamicfps: 1.2.1
		fabric: 0.45.0+1.18
			fabric-api-lookup-api-v1: 1.5.0+17be577f65
			fabric-biome-api-v1: 6.0.1+ded849a965
			fabric-blockrenderlayer-v1: 1.1.9+3ac43d9565
			fabric-command-api-v1: 1.1.6+3ac43d9565
			fabric-commands-v0: 0.2.5+b4f4f6cd65
			fabric-containers-v0: 0.1.18+d154e2c665
			fabric-content-registries-v0: 0.4.5+6f53a73d65
			fabric-dimensions-v1: 2.1.7+43d2957165
			fabric-entity-events-v1: 1.4.5+6b21378a65
			fabric-events-interaction-v0: 0.4.16+bfa23f1765
			fabric-events-lifecycle-v0: 0.2.6+b4f4f6cd65
			fabric-game-rule-api-v1: 1.0.10+3ac43d9565
			fabric-item-api-v1: 1.3.0+691a79b565
			fabric-item-groups-v0: 0.3.3+3ac43d9565
			fabric-keybindings-v0: 0.2.6+b4f4f6cd65
			fabric-loot-tables-v1: 1.0.8+3ac43d9565
			fabric-mining-level-api-v1: 1.0.3+3ac43d9565
			fabric-mining-levels-v0: 0.1.7+b4f4f6cd65
			fabric-models-v0: 0.3.3+3ac43d9565
			fabric-networking-api-v1: 1.0.18+3ac43d9565
			fabric-networking-v0: 0.3.5+b4f4f6cd65
			fabric-object-builder-api-v1: 1.11.0+3b82842e65
			fabric-object-builders-v0: 0.7.8+3ac43d9565
			fabric-particles-v1: 0.2.9+526dc1ac65
			fabric-registry-sync-v0: 0.8.6+533be9ba65
			fabric-renderer-api-v1: 0.4.9+3ac43d9565
			fabric-renderer-indigo: 0.4.12+3ac43d9565
			fabric-renderer-registries-v1: 3.2.7+b4f4f6cd65
			fabric-rendering-data-attachment-v1: 0.3.4+7242e9d765
			fabric-rendering-fluids-v1: 0.1.18+3ac43d9565
			fabric-rendering-v0: 1.1.9+b4f4f6cd65
			fabric-rendering-v1: 1.10.3+6b21378a65
			fabric-screen-api-v1: 1.0.7+3ac43d9565
			fabric-screen-handler-api-v1: 1.1.11+3ac43d9565
			fabric-structure-api-v1: 2.0.8+295197a765
			fabric-tag-extensions-v0: 1.2.5+3ac43d9565
			fabric-textures-v0: 1.0.9+3ac43d9565
			fabric-tool-attribute-api-v1: 1.3.4+7de09f5565
			fabric-transfer-api-v1: 1.5.6+b4f4f6cd65
		fabric-crash-report-info-v1: 0.1.11+nogit
		fabricloader: 0.13.3
		fastopenlinksandfolders: 1.0.1
		forgetmechunk: 1.18.X-1.0.3
		java: 17
		lazydfu: 0.1.1
		lithium: 0.7.7
		minecraft: 1.18.1
		phosphor: 0.8.1
```

</details>