### PR TITLE
Fix wrong mixin in client commands

### DIFF
--- a/fabric-command-api-v1/src/main/java/net/fabricmc/fabric/mixin/command/client/ClientPlayerEntityMixin.java
+++ b/fabric-command-api-v1/src/main/java/net/fabricmc/fabric/mixin/command/client/ClientPlayerEntityMixin.java
@@ -22,14 +22,15 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.text.Text;
 
 import net.fabricmc.fabric.impl.command.client.ClientCommandInternals;
 
 @Mixin(ClientPlayerEntity.class)
 abstract class ClientPlayerEntityMixin {
-	@Inject(method = "sendChatMessage", at = @At("HEAD"), cancellable = true)
-	private void onSendChatMessage(String message, CallbackInfo info) {
-		if (ClientCommandInternals.executeCommand(message)) {
+	@Inject(method = "method_44098", at = @At("HEAD"), cancellable = true)
+	private void onSendCommand(String command, Text preview, CallbackInfo info) {
+		if (ClientCommandInternals.executeCommand(command)) {
 			info.cancel();
 		}
 	}


### PR DESCRIPTION
Resolves #2215 

`ClientCommandInternals` was changed to take unprefixed command messages (same as `ClientPlayerEntity#sendCommand`). This has some user-visible (although minor) change; the profiler and the debug logs now log unprefixed command.

Tested, works.