### PR TITLE
Restore printing the mod name in crash reports

### DIFF
--- a/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/mixin/crash/report/info/MixinCrashReport.java
+++ b/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/mixin/crash/report/info/MixinCrashReport.java
@@ -62,6 +62,8 @@ public abstract class MixinCrashReport {
 			modString.append('\n');
 			modString.append("\t".repeat(depth));
 			modString.append(mod.getMetadata().getId());
+			modString.append(": ");
+			modString.append(mod.getMetadata().getName());
 			modString.append(' ');
 			modString.append(mod.getMetadata().getVersion().getFriendlyString());
 


### PR DESCRIPTION
Looks like I unwillingly removed it in #2157, this readds it.

This is useful for those cases where mods decide to use 3 letter ids instead of the full mod name.

I have not tested how the new output looks like.