### PR TITLE
Handle teleporting within the same dimension better.

### DIFF
--- a/fabric-dimensions-v1/src/testmod/java/net/fabricmc/fabric/test/dimension/FabricDimensionTest.java
+++ b/fabric-dimensions-v1/src/testmod/java/net/fabricmc/fabric/test/dimension/FabricDimensionTest.java
@@ -92,6 +92,14 @@ public class FabricDimensionTest implements ModInitializer {
 
 		CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> dispatcher.register(literal("fabric_dimension_test")
 				.executes(FabricDimensionTest.this::swapTargeted)));
+
+		// Used to test https://github.com/FabricMC/fabric/issues/2239
+		CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> dispatcher.register(literal("fabric_dimension_test_desync")
+				.executes(FabricDimensionTest.this::testDesync)));
+
+		// Used to test https://github.com/FabricMC/fabric/issues/2238
+		CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> dispatcher.register(literal("fabric_dimension_test_entity")
+				.executes(FabricDimensionTest.this::testEntityTeleport)));
 	}
 
 	private int swapTargeted(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
@@ -114,6 +122,50 @@ public class FabricDimensionTest implements ModInitializer {
 					(float) Math.random() * 360 - 180, (float) Math.random() * 360 - 180);
 			FabricDimensions.teleport(player, getWorld(context, World.OVERWORLD), target);
 		}
+
+		return 1;
+	}
+
+	private int testDesync(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+		ServerPlayerEntity player = context.getSource().getPlayer();
+
+		if (player == null) {
+			context.getSource().sendFeedback(Text.literal("You must be a player to execute this command."), false);
+			return 1;
+		}
+
+		if (!context.getSource().getServer().isDedicated()) {
+			context.getSource().sendFeedback(Text.literal("This command can only be executed on dedicated servers."), false);
+			return 1;
+		}
+
+		TeleportTarget target = new TeleportTarget(player.getPos().add(5, 0, 0), player.getVelocity(), player.getYaw(), player.getPitch());
+		FabricDimensions.teleport(player, (ServerWorld) player.world, target);
+
+		return 1;
+	}
+
+	private int testEntityTeleport(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+		ServerPlayerEntity player = context.getSource().getPlayer();
+
+		if (player == null) {
+			context.getSource().sendFeedback(Text.literal("You must be a player to execute this command."), false);
+			return 1;
+		}
+
+		Entity entity = player.world
+				.getOtherEntities(player, player.getBoundingBox().expand(100, 100, 100))
+				.stream()
+				.findFirst()
+				.orElse(null);
+
+		if (entity == null) {
+			context.getSource().sendFeedback(Text.literal("No entities found."), false);
+			return 1;
+		}
+
+		TeleportTarget target = new TeleportTarget(player.getPos(), player.getVelocity(), player.getYaw(), player.getPitch());
+		FabricDimensions.teleport(entity, (ServerWorld) entity.world, target);
 
 		return 1;
 	}


### PR DESCRIPTION
Fixes #2239 and Fixes #2238

This API was mainly designed to teleport entities between diffrent dimensions, however I think it makes sense to handle the same dimension case better.