### PR TITLE
A few datagen fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -375,7 +375,6 @@ sourceSets {
 // These modules are not included in the fat jar, maven will resolve them via the pom.
 def devOnlyModules = [
 		"fabric-gametest-api-v1",
-		"fabric-data-generation-api-v1"
 ]
 
 dependencies {

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricBlockLootTableProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricBlockLootTableProvider.java
@@ -16,12 +16,14 @@
 
 package net.fabricmc.fabric.api.datagen.v1.provider;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
 
 import com.google.common.collect.Sets;
 
+import net.minecraft.block.Block;
 import net.minecraft.data.server.BlockLootTableGenerator;
 import net.minecraft.loot.LootTable;
 import net.minecraft.loot.LootTables;
@@ -39,6 +41,7 @@ import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
  */
 public abstract class FabricBlockLootTableProvider extends BlockLootTableGenerator implements FabricLootTableProvider {
 	protected final FabricDataGenerator dataGenerator;
+	private final Set<Identifier> excludedFromStrictValidation = new HashSet<>();
 
 	protected FabricBlockLootTableProvider(FabricDataGenerator dataGenerator) {
 		this.dataGenerator = dataGenerator;
@@ -50,6 +53,13 @@ public abstract class FabricBlockLootTableProvider extends BlockLootTableGenerat
 	 * <p>Use the range of {@link BlockLootTableGenerator#addDrop} methods to generate block drops.
 	 */
 	protected abstract void generateBlockLootTables();
+
+	/**
+	 * Disable strict validation for the passed block.
+	 */
+	public void excludeFromStrictValidation(Block block) {
+		excludedFromStrictValidation.add(Registry.BLOCK.getId(block));
+	}
 
 	@Override
 	public LootContextType getLootContextType() {
@@ -85,6 +95,8 @@ public abstract class FabricBlockLootTableProvider extends BlockLootTableGenerat
 					}
 				}
 			}
+
+			missing.removeAll(excludedFromStrictValidation);
 
 			if (!missing.isEmpty()) {
 				throw new IllegalStateException("Missing loot table(s) for %s".formatted(missing));

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/ModelProviderMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/ModelProviderMixin.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.mixin.datagen;
 
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -55,6 +56,9 @@ public class ModelProviderMixin {
 	@Unique
 	private static ThreadLocal<DataGenerator> dataGeneratorThreadLocal = new ThreadLocal<>();
 
+	@Unique
+	private static ThreadLocal<Map<Block, BlockStateSupplier>> blockStateMapThreadLocal = new ThreadLocal<>();
+
 	@Redirect(method = "run", at = @At(value = "INVOKE", target = "Lnet/minecraft/data/client/BlockStateModelGenerator;register()V"))
 	private void registerBlockStateModels(BlockStateModelGenerator instance) {
 		if (((Object) this) instanceof FabricModelProvider fabricModelProvider) {
@@ -75,14 +79,16 @@ public class ModelProviderMixin {
 		}
 	}
 
-	@Inject(method = "run", at = @At("HEAD"))
-	private void runHead(DataCache cache, CallbackInfo ci) {
+	@Inject(method = "run", at = @At(value = "INVOKE_ASSIGN", target = "com/google/common/collect/Maps.newHashMap()Ljava/util/HashMap;"), locals = LocalCapture.CAPTURE_FAILHARD)
+	private void runHead(DataCache cache, CallbackInfo ci, Path path, Map<Block, BlockStateSupplier> map) {
 		dataGeneratorThreadLocal.set(generator);
+		blockStateMapThreadLocal.set(map);
 	}
 
 	@Inject(method = "run", at = @At("TAIL"))
 	private void runTail(DataCache cache, CallbackInfo ci) {
 		dataGeneratorThreadLocal.remove();
+		blockStateMapThreadLocal.remove();
 	}
 
 	@Inject(method = "method_25738", at = @At("HEAD"), cancellable = true)
@@ -103,7 +109,8 @@ public class ModelProviderMixin {
 	@Inject(method = "method_25741", at = @At(value = "INVOKE", target = "Lnet/minecraft/data/client/ModelIds;getItemModelId(Lnet/minecraft/item/Item;)Lnet/minecraft/util/Identifier;"), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD)
 	private static void filterItemsForProcessingMod(Set<Item> set, Map<Identifier, Supplier<JsonElement>> map, Block block, CallbackInfo ci, Item item) {
 		if (dataGeneratorThreadLocal.get() instanceof FabricDataGenerator dataGenerator) {
-			if (!dataGenerator.isStrictValidationEnabled()) {
+			// Only generate the item model if the block state json was registered
+			if (!blockStateMapThreadLocal.get().containsKey(block)) {
 				ci.cancel();
 				return;
 			}

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestContent.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestContent.java
@@ -34,11 +34,13 @@ public class DataGeneratorTestContent implements ModInitializer {
 
 	public static Block SIMPLE_BLOCK;
 	public static Block BLOCK_WITHOUT_ITEM;
+	public static Block BLOCK_WITHOUT_LOOT_TABLE;
 
 	@Override
 	public void onInitialize() {
 		SIMPLE_BLOCK = createBlock("simple_block", true);
 		BLOCK_WITHOUT_ITEM = createBlock("block_without_item", false);
+		BLOCK_WITHOUT_LOOT_TABLE = createBlock("block_without_loot_table", false);
 	}
 
 	private static Block createBlock(String name, boolean hasItem) {

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.test.datagen;
 
 import static net.fabricmc.fabric.test.datagen.DataGeneratorTestContent.BLOCK_WITHOUT_ITEM;
+import static net.fabricmc.fabric.test.datagen.DataGeneratorTestContent.BLOCK_WITHOUT_LOOT_TABLE;
 import static net.fabricmc.fabric.test.datagen.DataGeneratorTestContent.MOD_ID;
 import static net.fabricmc.fabric.test.datagen.DataGeneratorTestContent.SIMPLE_BLOCK;
 
@@ -130,6 +131,7 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 		public void generateBlockStateModels(BlockStateModelGenerator blockStateModelGenerator) {
 			blockStateModelGenerator.registerSimpleCubeAll(SIMPLE_BLOCK);
 			blockStateModelGenerator.registerSimpleCubeAll(BLOCK_WITHOUT_ITEM);
+			blockStateModelGenerator.registerSimpleCubeAll(BLOCK_WITHOUT_LOOT_TABLE);
 		}
 
 		@Override
@@ -221,6 +223,8 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 		protected void generateBlockLootTables() {
 			addDrop(SIMPLE_BLOCK);
 			addDrop(BLOCK_WITHOUT_ITEM, drops(SIMPLE_BLOCK));
+
+			excludeFromStrictValidation(BLOCK_WITHOUT_LOOT_TABLE);
 		}
 	}
 


### PR DESCRIPTION
1. Closes #2228.
2. Closes #2241.
3. Fixes #2240. Item models are now always automatically generated, but only for blocks whose blockstate jsons are generated. Calling `excludeFromSimpleItemModelGeneration(block)` on the `BlockStateModelGenerator` will opt out of this behavior (regular vanilla datagen feature). **Might require a major version bump since it's a breaking change for mods relying on the previous (wrong) behavior.**

Testing I did, for each commit respectively:
1. I just checked that the jar was indeed included in the built fatjar.
2. Expanded the testmod to check this, work as expected.
3. I tested various combinations of strictness, not registering some blocks, and explicitly disabling the item models with `excludeFromSimpleItemModelGeneration`, everything works as expected now.