### PR TITLE
Load mod-provided data packs and DRM entries

### DIFF
--- a/fabric-biome-api-v1/src/testmod/java/net/fabricmc/fabric/test/biome/FabricBiomeTest.java
+++ b/fabric-biome-api-v1/src/testmod/java/net/fabricmc/fabric/test/biome/FabricBiomeTest.java
@@ -111,6 +111,14 @@ public class FabricBiomeTest implements ModInitializer {
 				.add(ModificationPhase.ADDITIONS,
 						BiomeSelectors.tag(TagKey.of(Registry.BIOME_KEY, new Identifier(MOD_ID, "tag_selector_test"))),
 						context -> context.getEffects().setSkyColor(0x770000));
+
+		// Make sure data packs can define dynamic registry contents
+		// See #2225, #2261
+		BiomeModifications.addFeature(
+				BiomeSelectors.foundInOverworld(),
+				GenerationStep.Feature.VEGETAL_DECORATION,
+				RegistryKey.of(Registry.PLACED_FEATURE_KEY, new Identifier(MOD_ID, "concrete_pile"))
+		);
 	}
 
 	// These are used for testing the spacing of custom end biomes.

--- a/fabric-biome-api-v1/src/testmod/resources/data/fabric-biome-api-v1-testmod/worldgen/placed_feature/concrete_pile.json
+++ b/fabric-biome-api-v1/src/testmod/resources/data/fabric-biome-api-v1-testmod/worldgen/placed_feature/concrete_pile.json
@@ -1,0 +1,26 @@
+{
+  "feature": {
+    "type": "minecraft:block_pile",
+    "config": {
+      "state_provider": {
+        "type": "minecraft:simple_state_provider",
+        "state": {
+          "Name": "minecraft:red_concrete"
+        }
+      }
+    }
+  },
+  "placement": [
+    {
+      "type": "minecraft:count",
+      "count": 2
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:heightmap",
+      "heightmap": "WORLD_SURFACE"
+    }
+  ]
+}

--- a/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/CreateWorldScreenMixin.java
+++ b/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/CreateWorldScreenMixin.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.JsonOps;
+import org.spongepowered.asm.mixin.Dynamic;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -51,9 +52,6 @@ import net.fabricmc.fabric.mixin.resource.loader.ResourcePackManagerAccessor;
 public class CreateWorldScreenMixin {
 	@Unique
 	private static DataPackSettings defaultDataPackSettings;
-
-	@Unique
-	private static ResourceManager loadingDataPackManager;
 
 	@Shadow
 	private ResourcePackManager packManager;
@@ -95,16 +93,10 @@ public class CreateWorldScreenMixin {
 		return defaultDataPackSettings;
 	}
 
-	@Inject(method = "method_41854", at = @At("HEAD"), remap = false)
-	private static void captureResourceManager(ResourceManager resourceManager, DataPackSettings dataPackSettings, CallbackInfoReturnable<Pair<?, ?>> cir) {
-		loadingDataPackManager = resourceManager;
-	}
-
 	@Redirect(method = "method_41854", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/registry/DynamicRegistryManager$Mutable;toImmutable()Lnet/minecraft/util/registry/DynamicRegistryManager$Immutable;"), remap = false)
-	private static DynamicRegistryManager.Immutable loadDynamicRegistry(DynamicRegistryManager.Mutable mutableRegistryManager) {
+	private static DynamicRegistryManager.Immutable loadDynamicRegistry(DynamicRegistryManager.Mutable mutableRegistryManager, ResourceManager dataPackManager) {
 		// This loads the dynamic registry from the data pack
-		RegistryOps.ofLoaded(JsonOps.INSTANCE, mutableRegistryManager, loadingDataPackManager);
-		loadingDataPackManager = null;
+		RegistryOps.ofLoaded(JsonOps.INSTANCE, mutableRegistryManager, dataPackManager);
 		return mutableRegistryManager.toImmutable();
 	}
 

--- a/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/CreateWorldScreenMixin.java
+++ b/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/CreateWorldScreenMixin.java
@@ -17,8 +17,6 @@
 package net.fabricmc.fabric.mixin.resource.loader.client;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 
 import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.JsonOps;
@@ -35,16 +33,13 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import net.minecraft.client.gui.screen.world.CreateWorldScreen;
 import net.minecraft.resource.DataPackSettings;
 import net.minecraft.resource.ResourceManager;
-import net.minecraft.resource.ResourcePack;
 import net.minecraft.resource.ResourcePackManager;
-import net.minecraft.resource.ResourcePackProfile;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.util.dynamic.RegistryOps;
 import net.minecraft.util.registry.DynamicRegistryManager;
 
-import net.fabricmc.fabric.impl.resource.loader.FabricModResourcePack;
-import net.fabricmc.fabric.impl.resource.loader.ModNioResourcePack;
 import net.fabricmc.fabric.impl.resource.loader.ModResourcePackCreator;
+import net.fabricmc.fabric.impl.resource.loader.ModResourcePackUtil;
 import net.fabricmc.fabric.mixin.resource.loader.ResourcePackManagerAccessor;
 
 @Mixin(CreateWorldScreen.class)
@@ -65,26 +60,7 @@ public class CreateWorldScreenMixin {
 
 	@Redirect(method = "create(Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/client/gui/screen/Screen;)V", at = @At(value = "FIELD", target = "Lnet/minecraft/resource/DataPackSettings;SAFE_MODE:Lnet/minecraft/resource/DataPackSettings;", ordinal = 0))
 	private static DataPackSettings replaceDefaultSettings() {
-		ModResourcePackCreator modResourcePackCreator = new ModResourcePackCreator(ResourceType.SERVER_DATA);
-		List<ResourcePackProfile> moddedResourcePacks = new ArrayList<>();
-		modResourcePackCreator.register(moddedResourcePacks::add);
-
-		List<String> enabled = new ArrayList<>(DataPackSettings.SAFE_MODE.getEnabled());
-		List<String> disabled = new ArrayList<>(DataPackSettings.SAFE_MODE.getDisabled());
-
-		// This ensures that any built-in registered data packs by mods which needs to be enabled by default are
-		// as the data pack screen automatically put any data pack as disabled except the Default data pack.
-		for (ResourcePackProfile profile : moddedResourcePacks) {
-			try (ResourcePack pack = profile.createResourcePack()) {
-				if (pack instanceof FabricModResourcePack || (pack instanceof ModNioResourcePack && ((ModNioResourcePack) pack).getActivationType().isEnabledByDefault())) {
-					enabled.add(profile.getName());
-				} else {
-					disabled.add(profile.getName());
-				}
-			}
-		}
-
-		return (defaultDataPackSettings = new DataPackSettings(enabled, disabled));
+		return (defaultDataPackSettings = ModResourcePackUtil.createDefaultDataPackSettings());
 	}
 
 	@ModifyArg(method = "create(Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/client/gui/screen/Screen;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/world/CreateWorldScreen;<init>(Lnet/minecraft/client/gui/screen/Screen;Lnet/minecraft/resource/DataPackSettings;Lnet/minecraft/client/gui/screen/world/MoreOptionsDialog;)V"), index = 1)

--- a/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/CreateWorldScreenMixin.java
+++ b/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/CreateWorldScreenMixin.java
@@ -87,8 +87,8 @@ public class CreateWorldScreenMixin {
 		return (defaultDataPackSettings = new DataPackSettings(enabled, disabled));
 	}
 
-	@ModifyArg(method = "create(Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/client/gui/screen/Screen;)V", at = @At(value = "NEW", target = "net/minecraft/client/gui/screen/world/CreateWorldScreen"), index = 1)
-	private static DataPackSettings useReplacedDefaultSettings() {
+	@ModifyArg(method = "create(Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/client/gui/screen/Screen;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/world/CreateWorldScreen;<init>(Lnet/minecraft/client/gui/screen/Screen;Lnet/minecraft/resource/DataPackSettings;Lnet/minecraft/client/gui/screen/world/MoreOptionsDialog;)V"), index = 1)
+	private static DataPackSettings useReplacedDefaultSettings(DataPackSettings dataPackSettings) {
 		return defaultDataPackSettings;
 	}
 

--- a/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/CreateWorldScreenMixin.java
+++ b/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/CreateWorldScreenMixin.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.JsonOps;
-import org.spongepowered.asm.mixin.Dynamic;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;

--- a/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/CreateWorldScreenMixin.java
+++ b/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/CreateWorldScreenMixin.java
@@ -21,27 +21,37 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.mojang.datafixers.util.Pair;
+import com.mojang.serialization.JsonOps;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.client.gui.screen.world.CreateWorldScreen;
 import net.minecraft.resource.DataPackSettings;
+import net.minecraft.resource.ResourceManager;
 import net.minecraft.resource.ResourcePack;
 import net.minecraft.resource.ResourcePackManager;
 import net.minecraft.resource.ResourcePackProfile;
 import net.minecraft.resource.ResourceType;
+import net.minecraft.util.dynamic.RegistryOps;
+import net.minecraft.util.registry.DynamicRegistryManager;
 
+import net.fabricmc.fabric.impl.resource.loader.FabricModResourcePack;
 import net.fabricmc.fabric.impl.resource.loader.ModNioResourcePack;
 import net.fabricmc.fabric.impl.resource.loader.ModResourcePackCreator;
 import net.fabricmc.fabric.mixin.resource.loader.ResourcePackManagerAccessor;
 
 @Mixin(CreateWorldScreen.class)
 public class CreateWorldScreenMixin {
+	@Unique
+	private static DataPackSettings defaultDataPackSettings;
+
 	@Shadow
 	private ResourcePackManager packManager;
 
@@ -53,35 +63,46 @@ public class CreateWorldScreenMixin {
 		return manager;
 	}
 
+	@Redirect(method = "create(Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/client/gui/screen/Screen;)V", at = @At(value = "FIELD", target = "Lnet/minecraft/resource/DataPackSettings;SAFE_MODE:Lnet/minecraft/resource/DataPackSettings;", ordinal = 0))
+	private static DataPackSettings replaceDefaultSettings() {
+		ModResourcePackCreator modResourcePackCreator = new ModResourcePackCreator(ResourceType.SERVER_DATA);
+		List<ResourcePackProfile> moddedResourcePacks = new ArrayList<>();
+		modResourcePackCreator.register(moddedResourcePacks::add);
+
+		List<String> enabled = new ArrayList<>(DataPackSettings.SAFE_MODE.getEnabled());
+		List<String> disabled = new ArrayList<>(DataPackSettings.SAFE_MODE.getDisabled());
+
+		// This ensures that any built-in registered data packs by mods which needs to be enabled by default are
+		// as the data pack screen automatically put any data pack as disabled except the Default data pack.
+		for (ResourcePackProfile profile : moddedResourcePacks) {
+			try (ResourcePack pack = profile.createResourcePack()) {
+				if (pack instanceof FabricModResourcePack || (pack instanceof ModNioResourcePack && ((ModNioResourcePack) pack).getActivationType().isEnabledByDefault())) {
+					enabled.add(profile.getName());
+				} else {
+					disabled.add(profile.getName());
+				}
+			}
+		}
+
+		return (defaultDataPackSettings = new DataPackSettings(enabled, disabled));
+	}
+
+	@ModifyArg(method = "create(Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/client/gui/screen/Screen;)V", at = @At(value = "NEW", target = "net/minecraft/client/gui/screen/world/CreateWorldScreen"), index = 1)
+	private static DataPackSettings useReplacedDefaultSettings() {
+		return defaultDataPackSettings;
+	}
+
+	@Redirect(method = "method_41854", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/registry/DynamicRegistryManager$Mutable;toImmutable()Lnet/minecraft/util/registry/DynamicRegistryManager$Immutable;"), remap = false)
+	private static DynamicRegistryManager.Immutable loadDynamicRegistry(DynamicRegistryManager.Mutable mutableRegistryManager, ResourceManager resourceManager) {
+		// This loads the dynamic registry from the data pack
+		RegistryOps.ofLoaded(JsonOps.INSTANCE, mutableRegistryManager, resourceManager);
+		return mutableRegistryManager.toImmutable();
+	}
+
 	@Inject(method = "getScannedPack",
 			at = @At(value = "INVOKE", target = "Lnet/minecraft/resource/ResourcePackManager;scanPacks()V", shift = At.Shift.BEFORE))
 	private void onScanPacks(CallbackInfoReturnable<Pair<File, ResourcePackManager>> cir) {
 		// Allow to display built-in data packs in the data pack selection screen at world creation.
 		((ResourcePackManagerAccessor) this.packManager).getProviders().add(new ModResourcePackCreator(ResourceType.SERVER_DATA));
-	}
-
-	@ModifyArg(method = "create",
-			at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/world/CreateWorldScreen;<init>(Lnet/minecraft/client/gui/screen/Screen;Lnet/minecraft/resource/DataPackSettings;Lnet/minecraft/client/gui/screen/world/MoreOptionsDialog;)V"), index = 1)
-	private static DataPackSettings onNew(DataPackSettings settings) {
-		ModResourcePackCreator modResourcePackCreator = new ModResourcePackCreator(ResourceType.SERVER_DATA);
-		List<ResourcePackProfile> moddedResourcePacks = new ArrayList<>();
-		modResourcePackCreator.register(moddedResourcePacks::add);
-
-		List<String> enabled = new ArrayList<>(settings.getEnabled());
-		List<String> disabled = new ArrayList<>(settings.getDisabled());
-
-		// This ensure that any built-in registered data packs by mods which needs to be enabled by default are
-		// as the data pack screen automatically put any data pack as disabled except the Default data pack.
-		for (ResourcePackProfile profile : moddedResourcePacks) {
-			ResourcePack pack = profile.createResourcePack();
-
-			if (pack instanceof ModNioResourcePack && ((ModNioResourcePack) pack).getActivationType().isEnabledByDefault()) {
-				enabled.add(profile.getName());
-			} else {
-				disabled.add(profile.getName());
-			}
-		}
-
-		return new DataPackSettings(enabled, disabled);
 	}
 }

--- a/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/CreateWorldScreenMixin.java
+++ b/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/CreateWorldScreenMixin.java
@@ -92,7 +92,7 @@ public class CreateWorldScreenMixin {
 		return defaultDataPackSettings;
 	}
 
-	@Redirect(method = "method_41854", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/registry/DynamicRegistryManager$Mutable;toImmutable()Lnet/minecraft/util/registry/DynamicRegistryManager$Immutable;"), remap = false)
+	@Redirect(method = "method_41854", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/registry/DynamicRegistryManager$Mutable;toImmutable()Lnet/minecraft/util/registry/DynamicRegistryManager$Immutable;"))
 	private static DynamicRegistryManager.Immutable loadDynamicRegistry(DynamicRegistryManager.Mutable mutableRegistryManager, ResourceManager dataPackManager) {
 		// This loads the dynamic registry from the data pack
 		RegistryOps.ofLoaded(JsonOps.INSTANCE, mutableRegistryManager, dataPackManager);

--- a/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/CreateWorldScreenMixin.java
+++ b/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/CreateWorldScreenMixin.java
@@ -52,6 +52,9 @@ public class CreateWorldScreenMixin {
 	@Unique
 	private static DataPackSettings defaultDataPackSettings;
 
+	@Unique
+	private static ResourceManager loadingDataPackManager;
+
 	@Shadow
 	private ResourcePackManager packManager;
 
@@ -92,10 +95,16 @@ public class CreateWorldScreenMixin {
 		return defaultDataPackSettings;
 	}
 
+	@Inject(method = "method_41854", at = @At("HEAD"), remap = false)
+	private static void captureResourceManager(ResourceManager resourceManager, DataPackSettings dataPackSettings, CallbackInfoReturnable<Pair<?, ?>> cir) {
+		loadingDataPackManager = resourceManager;
+	}
+
 	@Redirect(method = "method_41854", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/registry/DynamicRegistryManager$Mutable;toImmutable()Lnet/minecraft/util/registry/DynamicRegistryManager$Immutable;"), remap = false)
-	private static DynamicRegistryManager.Immutable loadDynamicRegistry(DynamicRegistryManager.Mutable mutableRegistryManager, ResourceManager resourceManager) {
+	private static DynamicRegistryManager.Immutable loadDynamicRegistry(DynamicRegistryManager.Mutable mutableRegistryManager) {
 		// This loads the dynamic registry from the data pack
-		RegistryOps.ofLoaded(JsonOps.INSTANCE, mutableRegistryManager, resourceManager);
+		RegistryOps.ofLoaded(JsonOps.INSTANCE, mutableRegistryManager, loadingDataPackManager);
+		loadingDataPackManager = null;
 		return mutableRegistryManager.toImmutable();
 	}
 

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/MainMixin.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/MainMixin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.resource.loader;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.resource.DataPackSettings;
+import net.minecraft.server.Main;
+
+import net.fabricmc.fabric.impl.resource.loader.ModResourcePackUtil;
+
+@Mixin(Main.class)
+public class MainMixin {
+	@Redirect(method = "main", at = @At(value = "FIELD", target = "Lnet/minecraft/resource/DataPackSettings;SAFE_MODE:Lnet/minecraft/resource/DataPackSettings;"))
+	private static DataPackSettings replaceDefaultDataPackSettings() {
+		return ModResourcePackUtil.createDefaultDataPackSettings();
+	}
+}

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/TestServerMixin.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/TestServerMixin.java
@@ -16,12 +16,18 @@
 
 package net.fabricmc.fabric.mixin.resource.loader;
 
+import java.util.function.Supplier;
+
+import com.mojang.serialization.JsonOps;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 import net.minecraft.resource.DataPackSettings;
+import net.minecraft.resource.ResourceManager;
 import net.minecraft.test.TestServer;
+import net.minecraft.util.dynamic.RegistryOps;
+import net.minecraft.util.registry.DynamicRegistryManager;
 
 import net.fabricmc.fabric.impl.resource.loader.ModResourcePackUtil;
 
@@ -30,5 +36,14 @@ public class TestServerMixin {
 	@Redirect(method = "create", at = @At(value = "FIELD", target = "Lnet/minecraft/resource/DataPackSettings;SAFE_MODE:Lnet/minecraft/resource/DataPackSettings;"))
 	private static DataPackSettings replaceDefaultDataPackSettings() {
 		return ModResourcePackUtil.createDefaultDataPackSettings();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Redirect(method = "method_40377", at = @At(value = "INVOKE", target = "Ljava/util/function/Supplier;get()Ljava/lang/Object;"))
+	private static <T> T loadRegistry(Supplier<T> unused, ResourceManager resourceManager) {
+		DynamicRegistryManager.Mutable mutableRegistryManager = DynamicRegistryManager.createAndLoad();
+		// This loads the dynamic registry manager
+		RegistryOps.ofLoaded(JsonOps.INSTANCE, mutableRegistryManager, resourceManager);
+		return (T) mutableRegistryManager.toImmutable();
 	}
 }

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/TestServerMixin.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/TestServerMixin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.resource.loader;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.resource.DataPackSettings;
+import net.minecraft.test.TestServer;
+
+import net.fabricmc.fabric.impl.resource.loader.ModResourcePackUtil;
+
+@Mixin(TestServer.class)
+public class TestServerMixin {
+	@Redirect(method = "create", at = @At(value = "FIELD", target = "Lnet/minecraft/resource/DataPackSettings;SAFE_MODE:Lnet/minecraft/resource/DataPackSettings;"))
+	private static DataPackSettings replaceDefaultDataPackSettings() {
+		return ModResourcePackUtil.createDefaultDataPackSettings();
+	}
+}

--- a/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
+++ b/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
@@ -3,16 +3,17 @@
   "package": "net.fabricmc.fabric.mixin.resource.loader",
   "compatibilityLevel": "JAVA_16",
   "mixins": [
-    "FileResourcePackProviderAccessor",
     "DefaultResourcePackMixin",
+    "FileResourcePackProviderAccessor",
     "KeyedResourceReloadListenerMixin",
     "LifecycledResourceManagerImplMixin",
+    "MainMixin",
     "MinecraftServerMixin",
     "NamespaceResourceManagerAccessor",
     "NamespaceResourceManagerMixin",
     "ReloadableResourceManagerImplMixin",
-    "ResourcePackManagerMixin",
     "ResourcePackManagerAccessor",
+    "ResourcePackManagerMixin",
     "SimpleResourceReloadMixin"
   ],
   "injectors": {

--- a/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
+++ b/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
@@ -14,7 +14,8 @@
     "ReloadableResourceManagerImplMixin",
     "ResourcePackManagerAccessor",
     "ResourcePackManagerMixin",
-    "SimpleResourceReloadMixin"
+    "SimpleResourceReloadMixin",
+    "TestServerMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Fixes #2225
Fixes #2259

There were 2 issues in the existing `CreateWorldScreenMixin` mixin, specifically with `create(MinecraftClient, Screen)` method:

- There were two references to `DataPackSettings#SAFE_MODE`. The first one was used to load the DRM, and the second one is passed to the constructor. Previously, only the second one was replaced to include Fabric-provided data packs.
- There were no attempts to load dynamic registry from the provided data packs.

This fixes both issues, plus a code change to try-with-resources `createResourcePack`.

The first issue also affected dedicated servers, and both for test servers, which should be fixed as well.

Biome API testmod now includes a test for adding a placed feature (pile of red concrete) defined in a data pack. Previously this caused a crash.