### PR TITLE
Add all missing tags for SAVANNA, TAIGA, OVERWORLD and END

### DIFF
--- a/fabric-convention-tags-v1/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BiomeTagGenerator.java
+++ b/fabric-convention-tags-v1/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BiomeTagGenerator.java
@@ -48,6 +48,7 @@ public class BiomeTagGenerator extends FabricTagProvider.DynamicRegistryTagProvi
 				.add(BiomeKeys.SOUL_SAND_VALLEY)
 				.add(BiomeKeys.BASALT_DELTAS);
 		getOrCreateTagBuilder(ConventionalBiomeTags.IN_THE_END)
+				.addOptionalTag(BiomeTags.IS_END)
 				.add(BiomeKeys.END_BARRENS)
 				.add(BiomeKeys.END_MIDLANDS)
 				.add(BiomeKeys.END_HIGHLANDS)
@@ -55,6 +56,7 @@ public class BiomeTagGenerator extends FabricTagProvider.DynamicRegistryTagProvi
 				.add(BiomeKeys.SMALL_END_ISLANDS);
 		// We avoid the vanilla group tags here as mods may add to them without actually spawning them in the overworld
 		getOrCreateTagBuilder(ConventionalBiomeTags.IN_OVERWORLD)
+				.addOptionalTag(BiomeTags.IS_OVERWORLD)
 				.add(BiomeKeys.RIVER).add(BiomeKeys.FROZEN_RIVER)
 				.add(BiomeKeys.COLD_OCEAN).add(BiomeKeys.DEEP_COLD_OCEAN)
 				.add(BiomeKeys.DEEP_FROZEN_OCEAN).add(BiomeKeys.DEEP_OCEAN)
@@ -95,6 +97,7 @@ public class BiomeTagGenerator extends FabricTagProvider.DynamicRegistryTagProvi
 				.add(BiomeKeys.SUNFLOWER_PLAINS)
 				.add(BiomeKeys.PLAINS);
 		getOrCreateTagBuilder(ConventionalBiomeTags.SAVANNA)
+				.addOptionalTag(BiomeTags.IS_SAVANNA)
 				.add(BiomeKeys.SAVANNA_PLATEAU)
 				.add(BiomeKeys.WINDSWEPT_SAVANNA)
 				.add(BiomeKeys.SAVANNA);
@@ -160,6 +163,8 @@ public class BiomeTagGenerator extends FabricTagProvider.DynamicRegistryTagProvi
 		getOrCreateTagBuilder(ConventionalBiomeTags.CLIMATE_COLD)
 				.add(BiomeKeys.GROVE)
 				.add(BiomeKeys.JAGGED_PEAKS)
+				.add(BiomeKeys.TAIGA).add(BiomeKeys.SNOWY_TAIGA)
+				.add(BiomeKeys.OLD_GROWTH_SPRUCE_TAIGA).add(BiomeKeys.OLD_GROWTH_PINE_TAIGA)
 				.addOptionalTag(ConventionalBiomeTags.ICY);
 		getOrCreateTagBuilder(ConventionalBiomeTags.CLIMATE_TEMPERATE)
 				.add(BiomeKeys.FOREST)

--- a/fabric-convention-tags-v1/src/generated/resources/data/c/tags/worldgen/biome/climate_cold.json
+++ b/fabric-convention-tags-v1/src/generated/resources/data/c/tags/worldgen/biome/climate_cold.json
@@ -3,6 +3,10 @@
   "values": [
     "minecraft:grove",
     "minecraft:jagged_peaks",
+    "minecraft:taiga",
+    "minecraft:snowy_taiga",
+    "minecraft:old_growth_spruce_taiga",
+    "minecraft:old_growth_pine_taiga",
     {
       "id": "#c:icy",
       "required": false

--- a/fabric-convention-tags-v1/src/generated/resources/data/c/tags/worldgen/biome/in_overworld.json
+++ b/fabric-convention-tags-v1/src/generated/resources/data/c/tags/worldgen/biome/in_overworld.json
@@ -1,6 +1,10 @@
 {
   "replace": false,
   "values": [
+    {
+      "id": "#minecraft:is_overworld",
+      "required": false
+    },
     "minecraft:river",
     "minecraft:frozen_river",
     "minecraft:cold_ocean",

--- a/fabric-convention-tags-v1/src/generated/resources/data/c/tags/worldgen/biome/in_the_end.json
+++ b/fabric-convention-tags-v1/src/generated/resources/data/c/tags/worldgen/biome/in_the_end.json
@@ -1,6 +1,10 @@
 {
   "replace": false,
   "values": [
+    {
+      "id": "#minecraft:is_end",
+      "required": false
+    },
     "minecraft:end_barrens",
     "minecraft:end_midlands",
     "minecraft:end_highlands",

--- a/fabric-convention-tags-v1/src/generated/resources/data/c/tags/worldgen/biome/savanna.json
+++ b/fabric-convention-tags-v1/src/generated/resources/data/c/tags/worldgen/biome/savanna.json
@@ -1,6 +1,10 @@
 {
   "replace": false,
   "values": [
+    {
+      "id": "#minecraft:is_savanna",
+      "required": false
+    },
     "minecraft:savanna_plateau",
     "minecraft:windswept_savanna",
     "minecraft:savanna"


### PR DESCRIPTION
Fix #2244

- `c:is_savanna`

Fix #2243 

- `c:in_overworld`
- `c:in_the_end`

Fix #2242 

- `c:taiga` 
- `c:snowy_taiga`
- `c:old_growth_pine_taiga` 
- `c:old_growth_spruce_taiga`