### PR TITLE
Make sure only render thread can call onGameJoin

### DIFF
--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPlayNetworkHandlerMixin.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPlayNetworkHandlerMixin.java
@@ -44,7 +44,7 @@ abstract class ClientPlayNetworkHandlerMixin {
 	@Final
 	private ClientCommandSource commandSource;
 
-	@Inject(method = "onGameJoin", at = @At("HEAD"))
+	@Inject(method = "onGameJoin", at = @At("RETURN"))
 	private void onGameJoin(GameJoinS2CPacket packet, CallbackInfo info) {
 		final CommandDispatcher<FabricClientCommandSource> dispatcher = new CommandDispatcher<>();
 		ClientCommandInternals.setActiveDispatcher(dispatcher);


### PR DESCRIPTION
Resolves #2288 
This is a temporary fix, the better fix would be the one haykam suggested. This works because on networking thread the call is terminated with an unchecked exception from `forceMainThread`.

I think this code means the event is currently triggered twice on load, on two threads, which is definitely not good in my opinion.