### PR TITLE
Message API: add clientside events

### DIFF
--- a/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/api/client/message/v1/ClientMessageEvents.java
+++ b/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/api/client/message/v1/ClientMessageEvents.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.client.message.v1;
+
+import net.minecraft.network.message.MessageSender;
+import net.minecraft.network.message.MessageType;
+import net.minecraft.text.Text;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+@Environment(EnvType.CLIENT)
+public final class ClientMessageEvents {
+	/**
+	 * An event triggered when the client receives a chat message sent by the player or
+	 * commands such as {@code /me}, {@code /msg}, {@code /say}, or {@code /teammsg}, including
+	 * ones executed using command block or sent from non-player entities.
+	 *
+	 * <p>This event will not be called if the message is blocked for some reason,
+	 * such as the message signature verification failing with "Only Show Secure Chat" option
+	 * enabled, or the sender being blocked via the social interactions screen.
+	 */
+	public static final Event<ChatMessage> CHAT_MESSAGE = EventFactory.createArrayBacked(ChatMessage.class, (handlers) -> (message, sender, type) -> {
+		for (ChatMessage handler : handlers) {
+			handler.onChatMessage(message, sender, type);
+		}
+	});
+
+	/**
+	 * An event triggered when the client receives a game message from the server. Game
+	 * messages include death messages, join/leave messages, and advancement messages.
+	 */
+	public static final Event<GameMessage> GAME_MESSAGE = EventFactory.createArrayBacked(GameMessage.class, (handlers) -> (message, type) -> {
+		for (GameMessage handler : handlers) {
+			handler.onGameMessage(message, type);
+		}
+	});
+
+	public interface ChatMessage {
+		/**
+		 * Called when the client receives a chat message sent by the player or
+		 * commands such as {@code /me}, {@code /msg}, {@code /say}, or {@code /teammsg}, including
+		 * ones executed using command block or as entities using {@code /execute}. To
+		 * distinguish the source of the message, compare the passed message type.
+		 *
+		 * <p>This will not be called if the message is blocked for some reason,
+		 * such as the message signature verification failing with "Only Show Secure Chat" option
+		 * enabled, or the sender being blocked via the social interactions screen.
+		 * @param message the received message
+		 * @param sender the sender; use methods in {@link ClientMessageHelper} to convert this
+		 * @param type the message type
+		 * @see ClientMessageHelper
+		 */
+		void onChatMessage(Text message, MessageSender sender, MessageType type);
+	}
+
+	public interface GameMessage {
+		/**
+		 * Called when the client receives a game message from the server. Game
+		 * messages include death messages, join/leave messages, and advancement messages.
+		 * @param message the received message
+		 * @param type the message type
+		 */
+		void onGameMessage(Text message, MessageType type);
+	}
+}

--- a/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/api/client/message/v1/ClientMessageHelper.java
+++ b/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/api/client/message/v1/ClientMessageHelper.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.client.message.v1;
+
+import java.util.Objects;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.PlayerListEntry;
+import net.minecraft.entity.Entity;
+import net.minecraft.network.message.MessageSender;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.mixin.client.message.ClientWorldAccessor;
+
+/**
+ * Clientside helper methods for use with {@link ClientMessageEvents}.
+ */
+@Environment(EnvType.CLIENT)
+public final class ClientMessageHelper {
+	/**
+	 * Converts provided {@code sender} to {@link Entity} using the clientside entity lookup.
+	 * This returns {@code null} if {@code sender} is {@code null} or if the entity is
+	 * missing, in another world, or unloaded on the client.
+	 * @param sender the message sender
+	 * @return the entity from the sender, or {@code null} if the entity does not exist on the client
+	 * @throws NullPointerException if the client is not in any world
+	 * @see #getSenderPlayer(MessageSender)
+	 */
+	@Nullable
+	public static Entity getSenderEntity(MessageSender sender) {
+		MinecraftClient client = MinecraftClient.getInstance();
+		Objects.requireNonNull(client.world, "Client is not in any world");
+		if (sender == null) return null;
+		return ((ClientWorldAccessor) client.world).getEntityLookup().get(sender.uuid());
+	}
+
+	/**
+	 * Converts provided {@code sender} to {@link PlayerListEntry}.
+	 * This returns {@code null} if {@code sender} is {@code null} or if the UUID
+	 * is not found in the player list. This works for all players currently playing regardless
+	 * of their current worlds.
+	 * @param sender the message sender
+	 * @return the player list entry from the sender, or {@code null} if the player does not exist on the client
+	 * @throws NullPointerException if the client is not in any world
+	 * @see #getSenderEntity(MessageSender)
+	 */
+	@Nullable
+	public static PlayerListEntry getSenderPlayer(MessageSender sender) {
+		MinecraftClient client = MinecraftClient.getInstance();
+		Objects.requireNonNull(client.player, "Client is not in any world");
+		if (sender == null) return null;
+		return client.player.networkHandler.getPlayerListEntry(sender.uuid());
+	}
+}

--- a/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/message/ClientWorldAccessor.java
+++ b/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/message/ClientWorldAccessor.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.message;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.entity.Entity;
+import net.minecraft.world.entity.EntityLookup;
+
+@Mixin(ClientWorld.class)
+public interface ClientWorldAccessor {
+	@Invoker("getEntityLookup")
+	EntityLookup<Entity> getEntityLookup();
+}

--- a/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/message/InGameHudMixin.java
+++ b/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/message/InGameHudMixin.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.message;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.ClientChatListener;
+import net.minecraft.client.gui.hud.InGameHud;
+import net.minecraft.client.render.item.ItemRenderer;
+
+import net.fabricmc.fabric.api.client.message.v1.ClientMessageEvents;
+
+@Mixin(InGameHud.class)
+public class InGameHudMixin {
+	@Shadow
+	@Final
+	@Mutable
+	private List<ClientChatListener> listeners;
+
+	@Inject(method = "<init>", at = @At("TAIL"))
+	private void addCustomChatListener(MinecraftClient client, ItemRenderer itemRenderer, CallbackInfo ci) {
+		List<ClientChatListener> listeners = new ArrayList<>(this.listeners);
+		listeners.add((type, message, sender) -> {
+			if (sender == null) {
+				ClientMessageEvents.GAME_MESSAGE.invoker().onGameMessage(message, type);
+			} else {
+				ClientMessageEvents.CHAT_MESSAGE.invoker().onChatMessage(message, sender, type);
+			}
+		});
+		this.listeners = listeners;
+	}
+}

--- a/fabric-message-api-v1/src/client/resources/fabric-message-api-v1.client.mixins.json
+++ b/fabric-message-api-v1/src/client/resources/fabric-message-api-v1.client.mixins.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "package": "net.fabricmc.fabric.mixin.client.message",
+  "compatibilityLevel": "JAVA_16",
+  "client": [
+    "ClientWorldAccessor",
+    "InGameHudMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1,
+    "maxShiftBy": 3
+  }
+}

--- a/fabric-message-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-message-api-v1/src/main/resources/fabric.mod.json
@@ -21,7 +21,11 @@
   },
   "description": "Adds message-related hooks.",
   "mixins": [
-    "fabric-message-api-v1.mixins.json"
+    "fabric-message-api-v1.mixins.json",
+    {
+      "config": "fabric-message-api-v1.client.mixins.json",
+      "environment": "client"
+    }
   ],
   "custom": {
     "fabric-api:module-lifecycle": "experimental"


### PR DESCRIPTION
WIP, untested.

This update will bring ~~three~~ two things:

- `ClientMessageEvents`. Like `ServerMessageEvents`, if the message is blocked by the client, it won't be handled. It uses a similar set of callbacks using the same parameter orders with the server-side ones, however command callback obviously does not exist, and `RegistryKey<MessageType> typeKey` is replaced with `MessageType type` due to technical reasons. (Those who need the key can lookup DRM.) Currently there is no Allow callback. This is implemented by adding a custom `ClientChatListener` to `InGameHud#listeners`.
- `ClientMessageHelper`. The event will receive `MessageSender`, but the client might want to resolve the otherwise-empty record; these methods provide UUID-to-entity/player list entry lookup.
- ~~`ServerChatEvents#MODIFY_SENDER_NAME` event. This can be used for coloring player names (note that custom message type might be better), pronouns mods, nicknames, etc. Since the name is not signed, we can modify this with no issue. This will use event phases like `ServerMessageDecoratorEvent`.~~ (postponed due to usability issues)