### PR TITLE
Backport fixes to resource loader and biome API

### DIFF
--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/BiomeSourceAccess.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/BiomeSourceAccess.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.biome;
+
+public interface BiomeSourceAccess {
+	boolean fabric_shouldModifyBiomeEntries();
+
+	void fabric_setModifyBiomeEntries(boolean modifyBiomeEntries);
+}

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/NetherBiomeData.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/NetherBiomeData.java
@@ -16,18 +16,26 @@
 
 package net.fabricmc.fabric.impl.biome;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
+import com.mojang.datafixers.util.Pair;
+import com.mojang.logging.LogUtils;
 import org.jetbrains.annotations.ApiStatus;
+import org.slf4j.Logger;
 
-import net.minecraft.util.registry.RegistryEntry;
 import net.minecraft.util.registry.BuiltinRegistries;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.RegistryEntry;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.source.BiomeSource;
 import net.minecraft.world.biome.source.MultiNoiseBiomeSource;
 import net.minecraft.world.biome.source.util.MultiNoiseUtil;
 
@@ -41,6 +49,8 @@ public final class NetherBiomeData {
 	private static final Set<RegistryKey<Biome>> NETHER_BIOMES = new HashSet<>();
 
 	private static final Map<RegistryKey<Biome>, MultiNoiseUtil.NoiseHypercube> NETHER_BIOME_NOISE_POINTS = new HashMap<>();
+
+	private static final Logger LOGGER = LogUtils.getLogger();
 
 	private NetherBiomeData() {
 	}
@@ -65,10 +75,41 @@ public final class NetherBiomeData {
 			}
 		}
 
-		return NETHER_BIOMES.contains(biome);
+		return NETHER_BIOMES.contains(biome) || NETHER_BIOME_NOISE_POINTS.containsKey(biome);
 	}
 
 	private static void clearBiomeSourceCache() {
 		NETHER_BIOMES.clear(); // Clear cached biome source data
+	}
+
+	private static MultiNoiseUtil.Entries<RegistryEntry<Biome>> withModdedBiomeEntries(MultiNoiseUtil.Entries<RegistryEntry<Biome>> entries, Registry<Biome> biomeRegistry) {
+		if (NETHER_BIOME_NOISE_POINTS.isEmpty()) {
+			return entries;
+		}
+
+		List<Pair<MultiNoiseUtil.NoiseHypercube, RegistryEntry<Biome>>> entryList = new ArrayList<>(entries.getEntries());
+
+		for (Map.Entry<RegistryKey<Biome>, MultiNoiseUtil.NoiseHypercube> entry : NETHER_BIOME_NOISE_POINTS.entrySet()) {
+			if (biomeRegistry.contains(entry.getKey())) {
+				entryList.add(Pair.of(entry.getValue(), biomeRegistry.entryOf(entry.getKey())));
+			} else {
+				LOGGER.warn("Nether biome {} not loaded", entry.getKey().getValue());
+			}
+		}
+
+		return new MultiNoiseUtil.Entries<>(entryList);
+	}
+
+	public static void modifyBiomeSource(Registry<Biome> biomeRegistry, BiomeSource biomeSource) {
+		if (biomeSource instanceof MultiNoiseBiomeSource multiNoiseBiomeSource) {
+			if (((BiomeSourceAccess) multiNoiseBiomeSource).fabric_shouldModifyBiomeEntries() && multiNoiseBiomeSource.matchesInstance(MultiNoiseBiomeSource.Preset.NETHER)) {
+				multiNoiseBiomeSource.biomeEntries = NetherBiomeData.withModdedBiomeEntries(
+						MultiNoiseBiomeSource.Preset.NETHER.biomeSourceFunction.apply(biomeRegistry),
+						biomeRegistry
+				);
+				multiNoiseBiomeSource.biomes = multiNoiseBiomeSource.biomeEntries.getEntries().stream().map(Pair::getSecond).collect(Collectors.toSet());
+				((BiomeSourceAccess) multiNoiseBiomeSource).fabric_setModifyBiomeEntries(false);
+			}
+		}
 	}
 }

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/WeightedPicker.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/WeightedPicker.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 
 import com.google.common.base.Preconditions;
 
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.noise.PerlinNoiseSampler;
 
 /**
@@ -51,7 +52,7 @@ public final class WeightedPicker<T> {
 	}
 
 	public T pickFromNoise(PerlinNoiseSampler sampler, double x, double y, double z) {
-		double target = Math.abs(sampler.sample(x, y, z)) * getCurrentWeightTotal();
+		double target = MathHelper.clamp(Math.abs(sampler.sample(x, y, z)), 0, 1) * getCurrentWeightTotal();
 
 		return search(target).entry();
 	}

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/MixinBiomeSource.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/MixinBiomeSource.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.biome;
+
+import java.util.Set;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.util.registry.RegistryEntry;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.source.BiomeSource;
+
+@Mixin(BiomeSource.class)
+public class MixinBiomeSource {
+	// Not marked as @Final due to AW
+	@Shadow
+	public Set<RegistryEntry<Biome>> biomes;
+
+	@Inject(method = "getBiomes", at = @At("HEAD"))
+	private void getBiomes(CallbackInfoReturnable<Set<RegistryEntry<Biome>>> cir) {
+		fabric_modifyBiomeSet(biomes);
+	}
+
+	protected void fabric_modifyBiomeSet(Set<RegistryEntry<Biome>> biomes) {
+	}
+}

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/MixinMinecraftServer.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/MixinMinecraftServer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.biome;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.WorldGenerationProgressListener;
+import net.minecraft.util.registry.DynamicRegistryManager;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.world.SaveProperties;
+
+import net.fabricmc.fabric.impl.biome.NetherBiomeData;
+
+@Mixin(MinecraftServer.class)
+public class MixinMinecraftServer {
+	@Shadow
+	@Final
+	protected SaveProperties saveProperties;
+
+	@Shadow
+	@Final
+	private DynamicRegistryManager.Immutable registryManager;
+
+	@Inject(method = "createWorlds", at = @At("HEAD"))
+	private void addNetherBiomes(WorldGenerationProgressListener worldGenerationProgressListener, CallbackInfo ci) {
+		this.saveProperties.getGeneratorOptions().getDimensions().forEach(dimensionOptions -> NetherBiomeData.modifyBiomeSource(this.registryManager.get(Registry.BIOME_KEY), dimensionOptions.getChunkGenerator().getBiomeSource()));
+	}
+}

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/MixinMultiNoiseBiomeSource.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/MixinMultiNoiseBiomeSource.java
@@ -16,39 +16,25 @@
 
 package net.fabricmc.fabric.mixin.biome;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import com.mojang.datafixers.util.Pair;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.Unique;
 
-import net.minecraft.util.registry.Registry;
-import net.minecraft.util.registry.RegistryEntry;
-import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.source.MultiNoiseBiomeSource;
-import net.minecraft.world.biome.source.util.MultiNoiseUtil;
 
-import net.fabricmc.fabric.impl.biome.NetherBiomeData;
+import net.fabricmc.fabric.impl.biome.BiomeSourceAccess;
 
-/**
- * This Mixin is responsible for adding mod-biomes to the NETHER preset in the MultiNoiseBiomeSource.
- */
-@Mixin(MultiNoiseBiomeSource.Preset.class)
-public class MixinMultiNoiseBiomeSource {
-	// NOTE: This is a lambda-function in the NETHER preset field initializer
-	@Inject(method = "method_31088", at = @At("RETURN"), cancellable = true)
-	private static void appendNetherBiomes(Registry<Biome> registry, CallbackInfoReturnable<MultiNoiseUtil.Entries<RegistryEntry<Biome>>> cri) {
-		MultiNoiseUtil.Entries<RegistryEntry<Biome>> biomes = cri.getReturnValue();
-		List<Pair<MultiNoiseUtil.NoiseHypercube, RegistryEntry<Biome>>> entries = new ArrayList<>(biomes.getEntries());
+@Mixin(MultiNoiseBiomeSource.class)
+public class MixinMultiNoiseBiomeSource implements BiomeSourceAccess {
+	@Unique
+	private boolean modifyBiomeEntries = true;
 
-		// add fabric biome noise point data to list && BiomeSource biome list
-		NetherBiomeData.getNetherBiomeNoisePoints().forEach((biomeKey, noisePoint) -> {
-			entries.add(Pair.of(noisePoint, registry.entryOf(biomeKey)));
-		});
+	@Override
+	public void fabric_setModifyBiomeEntries(boolean modifyBiomeEntries) {
+		this.modifyBiomeEntries = modifyBiomeEntries;
+	}
 
-		cri.setReturnValue(new MultiNoiseUtil.Entries<>(entries));
+	@Override
+	public boolean fabric_shouldModifyBiomeEntries() {
+		return this.modifyBiomeEntries;
 	}
 }

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/MixinTheEndBiomeSource.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/MixinTheEndBiomeSource.java
@@ -16,6 +16,10 @@
 
 package net.fabricmc.fabric.mixin.biome;
 
+import java.util.Set;
+import java.util.function.Supplier;
+
+import com.google.common.base.Suppliers;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -32,17 +36,28 @@ import net.minecraft.world.biome.source.util.MultiNoiseUtil;
 import net.fabricmc.fabric.impl.biome.TheEndBiomeData;
 
 @Mixin(TheEndBiomeSource.class)
-public class MixinTheEndBiomeSource {
+public class MixinTheEndBiomeSource extends MixinBiomeSource {
 	@Unique
-	private TheEndBiomeData.Overrides overrides;
+	private Supplier<TheEndBiomeData.Overrides> overrides;
+
+	@Unique
+	private boolean biomeSetModified = false;
 
 	@Inject(method = "<init>", at = @At("RETURN"))
 	private void init(Registry<Biome> biomeRegistry, long seed, CallbackInfo ci) {
-		overrides = TheEndBiomeData.createOverrides(biomeRegistry, seed);
+		overrides = Suppliers.memoize(() -> TheEndBiomeData.createOverrides(biomeRegistry, seed));
 	}
 
 	@Inject(method = "getBiome", at = @At("RETURN"), cancellable = true)
 	private void getWeightedEndBiome(int biomeX, int biomeY, int biomeZ, MultiNoiseUtil.MultiNoiseSampler multiNoiseSampler, CallbackInfoReturnable<RegistryEntry<Biome>> cir) {
-		cir.setReturnValue(overrides.pick(biomeX, biomeY, biomeZ, cir.getReturnValue()));
+		cir.setReturnValue(overrides.get().pick(biomeX, biomeY, biomeZ, cir.getReturnValue()));
+	}
+
+	@Override
+	protected void fabric_modifyBiomeSet(Set<RegistryEntry<Biome>> biomes) {
+		if (!biomeSetModified) {
+			biomeSetModified = true;
+			biomes.addAll(overrides.get().customBiomes);
+		}
 	}
 }

--- a/fabric-biome-api-v1/src/main/resources/fabric-biome-api-v1.accesswidener
+++ b/fabric-biome-api-v1/src/main/resources/fabric-biome-api-v1.accesswidener
@@ -4,8 +4,14 @@ accessible  class   net/minecraft/world/biome/Biome$Weather
 # Rebuilding biome source feature lists
 accessible method net/minecraft/world/biome/source/BiomeSource method_39525 (Ljava/util/List;Z)Ljava/util/List;
 accessible field net/minecraft/world/biome/source/BiomeSource biomes Ljava/util/Set;
+mutable field net/minecraft/world/biome/source/BiomeSource biomes Ljava/util/Set;
 accessible field net/minecraft/world/biome/source/BiomeSource indexedFeaturesSupplier Ljava/util/function/Supplier;
 mutable field net/minecraft/world/biome/source/BiomeSource indexedFeaturesSupplier Ljava/util/function/Supplier;
+
+# Nether biomes
+accessible field net/minecraft/world/biome/source/MultiNoiseBiomeSource$Preset biomeSourceFunction Ljava/util/function/Function;
+accessible field net/minecraft/world/biome/source/MultiNoiseBiomeSource biomeEntries Lnet/minecraft/world/biome/source/util/MultiNoiseUtil$Entries;
+mutable field net/minecraft/world/biome/source/MultiNoiseBiomeSource biomeEntries Lnet/minecraft/world/biome/source/util/MultiNoiseUtil$Entries;
 
 # Top-Level Biome Fields Access
 accessible field net/minecraft/world/biome/Biome weather Lnet/minecraft/world/biome/Biome$Weather;

--- a/fabric-biome-api-v1/src/main/resources/fabric-biome-api-v1.mixins.json
+++ b/fabric-biome-api-v1/src/main/resources/fabric-biome-api-v1.mixins.json
@@ -3,10 +3,12 @@
   "package": "net.fabricmc.fabric.mixin.biome",
   "compatibilityLevel": "JAVA_16",
   "mixins": [
-    "modification.DynamicRegistryManagerImplMixin",
-    "modification.MinecraftServerMixin",
+    "MixinBiomeSource",
+    "MixinMinecraftServer",
     "MixinMultiNoiseBiomeSource",
-    "MixinTheEndBiomeSource"
+    "MixinTheEndBiomeSource",
+    "modification.DynamicRegistryManagerImplMixin",
+    "modification.MinecraftServerMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/fabric-biome-api-v1/src/testmod/java/net/fabricmc/fabric/test/biome/FabricBiomeTest.java
+++ b/fabric-biome-api-v1/src/testmod/java/net/fabricmc/fabric/test/biome/FabricBiomeTest.java
@@ -75,7 +75,7 @@ public class FabricBiomeTest implements ModInitializer {
 		Registry.register(BuiltinRegistries.BIOME, TEST_CRIMSON_FOREST.getValue(), TheNetherBiomeCreator.createCrimsonForest());
 
 		NetherBiomes.addNetherBiome(BiomeKeys.PLAINS, MultiNoiseUtil.createNoiseHypercube(0.0F, 0.5F, 0.0F, 0.0F, 0.0f, 0, 0.1F));
-		NetherBiomes.addNetherBiome(TEST_CRIMSON_FOREST, MultiNoiseUtil.createNoiseHypercube(0.0F, 0.0F, 0.0f, 0.35F, 0.0f, 0.35F, 0.2F));
+		NetherBiomes.addNetherBiome(TEST_CRIMSON_FOREST, MultiNoiseUtil.createNoiseHypercube(0.0F, -0.15F, 0.0f, 0.0F, 0.0f, 0.0F, 0.2F));
 
 		Registry.register(BuiltinRegistries.BIOME, CUSTOM_PLAINS.getValue(), OverworldBiomeCreator.createPlains(false, false, false));
 
@@ -85,9 +85,10 @@ public class FabricBiomeTest implements ModInitializer {
 
 		// TESTING HINT: to get to the end:
 		// /execute in minecraft:the_end run tp @s 0 90 0
+		TheEndBiomes.addHighlandsBiome(BiomeKeys.PLAINS, 5.0);
 		TheEndBiomes.addHighlandsBiome(TEST_END_HIGHLANDS, 5.0);
-		TheEndBiomes.addMidlandsBiome(TEST_END_HIGHLANDS, TEST_END_MIDLANDS, 1.0);
-		TheEndBiomes.addBarrensBiome(TEST_END_HIGHLANDS, TEST_END_BARRRENS, 1.0);
+		TheEndBiomes.addMidlandsBiome(TEST_END_HIGHLANDS, TEST_END_MIDLANDS, 10.0);
+		TheEndBiomes.addBarrensBiome(TEST_END_HIGHLANDS, TEST_END_BARRRENS, 10.0);
 
 		ConfiguredFeature<?, ?> COMMON_DESERT_WELL = new ConfiguredFeature<>(Feature.DESERT_WELL, DefaultFeatureConfig.INSTANCE);
 		Registry.register(BuiltinRegistries.CONFIGURED_FEATURE, new Identifier(MOD_ID, "fab_desert_well"), COMMON_DESERT_WELL);
@@ -111,13 +112,30 @@ public class FabricBiomeTest implements ModInitializer {
 				.add(ModificationPhase.ADDITIONS,
 						BiomeSelectors.tag(TagKey.of(Registry.BIOME_KEY, new Identifier(MOD_ID, "tag_selector_test"))),
 						context -> context.getEffects().setSkyColor(0x770000));
+
+		// Make sure data packs can define dynamic registry contents
+		// See #2225, #2261
+		BiomeModifications.addFeature(
+				BiomeSelectors.foundInOverworld(),
+				GenerationStep.Feature.VEGETAL_DECORATION,
+				RegistryKey.of(Registry.PLACED_FEATURE_KEY, new Identifier(MOD_ID, "concrete_pile"))
+		);
+
+		// Make sure data packs can define biomes
+		NetherBiomes.addNetherBiome(
+				RegistryKey.of(Registry.BIOME_KEY, new Identifier(MOD_ID, "example_biome")),
+				MultiNoiseUtil.createNoiseHypercube(1.0f, 0.0f, 0.0f, 0.0f, 0.2f, 0.5f, 0.3f)
+		);
+		TheEndBiomes.addHighlandsBiome(
+				RegistryKey.of(Registry.BIOME_KEY, new Identifier(MOD_ID, "example_biome")),
+				10.0
+		);
 	}
 
 	// These are used for testing the spacing of custom end biomes.
 	private static Biome createEndHighlands() {
 		GenerationSettings.Builder builder = new GenerationSettings.Builder()
-				.feature(GenerationStep.Feature.SURFACE_STRUCTURES, EndPlacedFeatures.END_GATEWAY_RETURN)
-				.feature(GenerationStep.Feature.VEGETAL_DECORATION, EndPlacedFeatures.CHORUS_PLANT);
+				.feature(GenerationStep.Feature.SURFACE_STRUCTURES, EndPlacedFeatures.END_GATEWAY_RETURN);
 		return composeEndSpawnSettings(builder);
 	}
 
@@ -133,7 +151,7 @@ public class FabricBiomeTest implements ModInitializer {
 
 	private static Biome composeEndSpawnSettings(GenerationSettings.Builder builder) {
 		SpawnSettings.Builder builder2 = new SpawnSettings.Builder();
-		DefaultBiomeFeatures.addEndMobs(builder2);
+		DefaultBiomeFeatures.addPlainsMobs(builder2);
 		return (new Biome.Builder()).precipitation(Biome.Precipitation.NONE).category(Biome.Category.THEEND).temperature(0.5F).downfall(0.5F).effects((new BiomeEffects.Builder()).waterColor(4159204).waterFogColor(329011).fogColor(10518688).skyColor(0).moodSound(BiomeMoodSound.CAVE).build()).spawnSettings(builder2.build()).generationSettings(builder.build()).build();
 	}
 }

--- a/fabric-biome-api-v1/src/testmod/java/net/fabricmc/fabric/test/biome/FabricBiomeTest.java
+++ b/fabric-biome-api-v1/src/testmod/java/net/fabricmc/fabric/test/biome/FabricBiomeTest.java
@@ -18,12 +18,12 @@ package net.fabricmc.fabric.test.biome;
 
 import java.util.List;
 
-import net.minecraft.tag.TagKey;
-import net.minecraft.util.registry.RegistryEntry;
 import net.minecraft.sound.BiomeMoodSound;
+import net.minecraft.tag.TagKey;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.BuiltinRegistries;
 import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.RegistryEntry;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.BiomeEffects;

--- a/fabric-biome-api-v1/src/testmod/resources/data/fabric-biome-api-v1-testmod/worldgen/biome/example_biome.json
+++ b/fabric-biome-api-v1/src/testmod/resources/data/fabric-biome-api-v1-testmod/worldgen/biome/example_biome.json
@@ -1,0 +1,16 @@
+{
+  "temperature": 0.8,
+  "downfall": 0.4,
+  "precipitation": "rain",
+  "category": "plains",
+  "effects": {
+    "sky_color": 7907327,
+    "fog_color": 12638463,
+    "water_color": 4159204,
+    "water_fog_color": 329011
+  },
+  "spawners": {},
+  "spawn_costs": {},
+  "carvers": {},
+  "features": []
+}

--- a/fabric-biome-api-v1/src/testmod/resources/data/fabric-biome-api-v1-testmod/worldgen/placed_feature/concrete_pile.json
+++ b/fabric-biome-api-v1/src/testmod/resources/data/fabric-biome-api-v1-testmod/worldgen/placed_feature/concrete_pile.json
@@ -1,0 +1,26 @@
+{
+  "feature": {
+    "type": "minecraft:block_pile",
+    "config": {
+      "state_provider": {
+        "type": "minecraft:simple_state_provider",
+        "state": {
+          "Name": "minecraft:red_concrete"
+        }
+      }
+    }
+  },
+  "placement": [
+    {
+      "type": "minecraft:count",
+      "count": 2
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:heightmap",
+      "heightmap": "WORLD_SURFACE"
+    }
+  ]
+}

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/MainMixin.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/MainMixin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.resource.loader;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.resource.DataPackSettings;
+import net.minecraft.server.Main;
+
+import net.fabricmc.fabric.impl.resource.loader.ModResourcePackUtil;
+
+@Mixin(Main.class)
+public class MainMixin {
+	@Redirect(method = "method_40372", at = @At(value = "FIELD", target = "Lnet/minecraft/resource/DataPackSettings;SAFE_MODE:Lnet/minecraft/resource/DataPackSettings;"))
+	private static DataPackSettings replaceDefaultDataPackSettings() {
+		return ModResourcePackUtil.createDefaultDataPackSettings();
+	}
+}

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/TestServerMixin.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/TestServerMixin.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.resource.loader;
+
+import java.util.function.Supplier;
+
+import com.mojang.serialization.JsonOps;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.resource.DataPackSettings;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.test.TestServer;
+import net.minecraft.util.dynamic.RegistryOps;
+import net.minecraft.util.registry.DynamicRegistryManager;
+
+import net.fabricmc.fabric.impl.resource.loader.ModResourcePackUtil;
+
+@Mixin(TestServer.class)
+public class TestServerMixin {
+	@Inject(method = "method_40379", at = @At("RETURN"), cancellable = true)
+	private static void replaceDefaultDataPackSettings(CallbackInfoReturnable<DataPackSettings> cir) {
+		cir.setReturnValue(ModResourcePackUtil.createDefaultDataPackSettings());
+	}
+
+	@Redirect(method = "method_40377", at = @At(value = "INVOKE", target = "Ljava/util/function/Supplier;get()Ljava/lang/Object;"))
+	@SuppressWarnings("unchecked")
+	private static <T> T loadRegistry(Supplier<T> instance, ResourceManager resourceManager) {
+		DynamicRegistryManager.Mutable dynamicRegistryManager = DynamicRegistryManager.createAndLoad();
+		RegistryOps.ofLoaded(JsonOps.INSTANCE, dynamicRegistryManager, resourceManager);
+		return (T) dynamicRegistryManager.toImmutable();
+	}
+}

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/client/CreateWorldScreenMixin.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/client/CreateWorldScreenMixin.java
@@ -17,8 +17,7 @@
 package net.fabricmc.fabric.mixin.resource.loader.client;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.function.Supplier;
 
 import com.mojang.datafixers.util.Pair;
 import org.spongepowered.asm.mixin.Mixin;
@@ -26,17 +25,17 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.client.gui.screen.world.CreateWorldScreen;
 import net.minecraft.resource.DataPackSettings;
-import net.minecraft.resource.ResourcePack;
 import net.minecraft.resource.ResourcePackManager;
-import net.minecraft.resource.ResourcePackProfile;
 import net.minecraft.resource.ResourceType;
+import net.minecraft.util.registry.DynamicRegistryManager;
 
-import net.fabricmc.fabric.impl.resource.loader.ModNioResourcePack;
 import net.fabricmc.fabric.impl.resource.loader.ModResourcePackCreator;
+import net.fabricmc.fabric.impl.resource.loader.ModResourcePackUtil;
 import net.fabricmc.fabric.mixin.resource.loader.ResourcePackManagerAccessor;
 
 @Mixin(CreateWorldScreen.class)
@@ -52,25 +51,14 @@ public class CreateWorldScreenMixin {
 
 	@ModifyArg(method = "create", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/world/CreateWorldScreen;<init>(Lnet/minecraft/client/gui/screen/Screen;Lnet/minecraft/resource/DataPackSettings;Lnet/minecraft/client/gui/screen/world/MoreOptionsDialog;)V"), index = 1)
 	private static DataPackSettings onNew(DataPackSettings settings) {
-		ModResourcePackCreator modResourcePackCreator = new ModResourcePackCreator(ResourceType.SERVER_DATA);
-		List<ResourcePackProfile> moddedResourcePacks = new ArrayList<>();
-		modResourcePackCreator.register(moddedResourcePacks::add);
+		return ModResourcePackUtil.createDefaultDataPackSettings();
+	}
 
-		List<String> enabled = new ArrayList<>(settings.getEnabled());
-		List<String> disabled = new ArrayList<>(settings.getDisabled());
-
-		// This ensure that any built-in registered data packs by mods which needs to be enabled by default are
-		// as the data pack screen automatically put any data pack as disabled except the Default data pack.
-		for (ResourcePackProfile profile : moddedResourcePacks) {
-			ResourcePack pack = profile.createResourcePack();
-
-			if (pack instanceof ModNioResourcePack && ((ModNioResourcePack) pack).getActivationType().isEnabledByDefault()) {
-				enabled.add(profile.getName());
-			} else {
-				disabled.add(profile.getName());
-			}
-		}
-
-		return new DataPackSettings(enabled, disabled);
+	@Redirect(method = "create(Lnet/minecraft/client/gui/screen/Screen;)Lnet/minecraft/client/gui/screen/world/CreateWorldScreen;", at = @At(value = "INVOKE", target = "Ljava/util/function/Supplier;get()Ljava/lang/Object;"))
+	@SuppressWarnings("unchecked")
+	private static <T> T loadDynamicRegistry(Supplier<T> instance) {
+		DynamicRegistryManager.Mutable dynamicRegistryManager = DynamicRegistryManager.createAndLoad();
+		ModResourcePackUtil.loadDynamicRegistry(dynamicRegistryManager);
+		return (T) dynamicRegistryManager.toImmutable();
 	}
 }

--- a/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
+++ b/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
@@ -3,21 +3,23 @@
   "package": "net.fabricmc.fabric.mixin.resource.loader",
   "compatibilityLevel": "JAVA_16",
   "mixins": [
-    "FileResourcePackProviderAccessor",
     "DefaultResourcePackMixin",
     "DefaultResourcePackResourceMixin",
+    "FileResourcePackProviderAccessor",
     "KeyedResourceReloadListenerMixin",
     "LifecycledResourceManagerImplMixin",
+    "MainMixin",
     "MinecraftServerMixin",
     "NamespaceResourceManagerAccessor",
     "NamespaceResourceManagerMixin",
     "ReloadableResourceManagerImplMixin",
     "ResourceImplMixin",
     "ResourceMixin",
-    "ResourcePackManagerMixin",
     "ResourcePackManagerAccessor",
+    "ResourcePackManagerMixin",
     "ResourcePackProfileMixin",
-    "SimpleResourceReloadMixin"
+    "SimpleResourceReloadMixin",
+    "TestServerMixin"
   ],
   "client": [
     "client.ClientBuiltinResourcePackProviderMixin",


### PR DESCRIPTION
Backport of #2261 and #2282 to 1.18.2
Fixes #2334

This backports the following changes:

- Mod-provided data packs and their DRM entries now always load. Note that such mod might produce "experimental world generation" warning. This is expected as the mods use the vanilla data pack system and it is not feasible to hide this without changing the behavior for vanilla data packs.
- End biomes are loaded lazily to allow data pack DRM entries to be used.
- Nether biomes are modified just before `ServerWorld` gets created to allow data pack DRM entries to be used. There aren't many other injection points which allow this sort of stuff, because `MultiNoiseBiomeSource` gets created too early.
- @deirn's fix: Fixes biome set not being modified for End biomes.
- `TheEndBiomeData` no longer assumes identity of `RegistryEntry`. See #2310 for solutions. This includes custom `Hash.Strategy` for them (used for fastutil hashmaps/hashsets) which we might want to expose in Registry Sync.
- Clamps the perlin noise value in `WeightedPicker` to fix a crash. As noted in #2127 perlin noises can in rare cases go outside `0 <= n < 1` range. Clamping should not mess up worldgen because it's very rare from my understanding, and weird generation is better than a crash.
- Testmod changes.

The following changes made in 1.19 branch are inapplicable to 1.18.2 thus not backported:
- Crash involving missing seed during custom end biome generation.
- Off-by-one error with custom end midlands/barrens.
- Attaching perlin noise sampler to multi noise sampler.