### PR TITLE
Add some more TAWs to the Datagen Module

### DIFF
--- a/fabric-data-generation-api-v1/build.gradle
+++ b/fabric-data-generation-api-v1/build.gradle
@@ -59,7 +59,7 @@ import java.util.zip.ZipFile
 
 task generateAccessWidener() {
 	doLast {
-		File inputJar = loom.namedMinecraftProvider.parentMinecraftProvider.mergedJar.toFile()
+		File inputJar = loom.namedMinecraftProvider.parentMinecraftProvider.commonJar.toFile()
 		String accessWidener = file("template.accesswidener").text + "\n"
 
 		visitMethods(inputJar, "net/minecraft/data/server/RecipeProvider.class") { name, desc, owner ->
@@ -78,6 +78,10 @@ task generateAccessWidener() {
 		}
 
 		visitMethods(inputJar, "net/minecraft/data/server/BlockLootTableGenerator.class") { name, desc, owner ->
+			accessWidener += "transitive-accessible\tmethod\t${owner}\t${name}\t${desc}\n"
+		}
+
+		visitMethods(inputJar, "net/minecraft/data/client/ItemModelGenerator.class") { name, desc, owner ->
 			accessWidener += "transitive-accessible\tmethod\t${owner}\t${name}\t${desc}\n"
 		}
 

--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.accesswidener
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.accesswidener
@@ -23,17 +23,20 @@ accessible  field   net/minecraft/data/DataGenerator$PathResolver directoryName 
 
 transitive-accessible   method  net/minecraft/data/family/BlockFamilies register    (Lnet/minecraft/block/Block;)Lnet/minecraft/data/family/BlockFamily$Builder;
 
-transitive-accessible    method    net/minecraft/data/client/ItemModelGenerator    register    (Lnet/minecraft/item/Item;Lnet/minecraft/data/client/Model;)V
-transitive-accessible    method    net/minecraft/data/client/ItemModelGenerator    register    (Lnet/minecraft/item/Item;Lnet/minecraft/item/Item;Lnet/minecraft/data/client/Model;)V
-transitive-accessible    method    net/minecraft/data/client/ItemModelGenerator    register    (Lnet/minecraft/item/Item;Ljava/lang/String;Lnet/minecraft/data/client/Model;)V
-
 transitive-accessible   field   net/minecraft/data/client/BlockStateModelGenerator    blockStateCollector Ljava/util/function/Consumer;
 transitive-accessible   field   net/minecraft/data/client/BlockStateModelGenerator    modelCollector  Ljava/util/function/BiConsumer;
 
-transitive-accessible   method  net/minecraft/data/client/TextureKey  of  (Ljava/lang/String;)Lnet/minecraft/data/client/TextureKey;
+transitive-accessible   method  net/minecraft/data/client/TextureKey	of  (Ljava/lang/String;)Lnet/minecraft/data/client/TextureKey;
 transitive-accessible   method  net/minecraft/data/client/TextureKey	of  (Ljava/lang/String;Lnet/minecraft/data/client/TextureKey;)Lnet/minecraft/data/client/TextureKey;
 
-transitive-extendable method net/minecraft/data/server/AbstractTagProvider$ObjectBuilder add ([Lnet/minecraft/util/registry/RegistryKey;)Lnet/minecraft/data/server/AbstractTagProvider$ObjectBuilder;
+transitive-extendable   method  net/minecraft/data/server/AbstractTagProvider$ObjectBuilder add ([Lnet/minecraft/util/registry/RegistryKey;)Lnet/minecraft/data/server/AbstractTagProvider$ObjectBuilder;
+
+transitive-accessible   method  net/minecraft/data/client/TexturedModel makeFactory (Ljava/util/function/Function;Lnet/minecraft/data/client/Model;)Lnet/minecraft/data/client/TexturedModel$Factory;
+
+transitive-accessible   class net/minecraft/data/client/BlockStateModelGenerator$TintType
+transitive-accessible   class net/minecraft/data/client/BlockStateModelGenerator$BlockTexturePool
+transitive-accessible   class net/minecraft/data/client/BlockStateModelGenerator$LogTexturePool
+transitive-accessible   class net/minecraft/data/client/BlockStateModelGenerator$BuiltinModelPool
 
 transitive-accessible	method	net/minecraft/data/server/RecipeProvider	saveRecipe	(Lnet/minecraft/data/DataWriter;Lcom/google/gson/JsonObject;Ljava/nio/file/Path;)V
 transitive-accessible	method	net/minecraft/data/server/RecipeProvider	saveRecipeAdvancement	(Lnet/minecraft/data/DataWriter;Lcom/google/gson/JsonObject;Ljava/nio/file/Path;)V
@@ -243,3 +246,8 @@ transitive-accessible	method	net/minecraft/data/server/BlockLootTableGenerator	c
 transitive-accessible	method	net/minecraft/data/server/BlockLootTableGenerator	addVinePlantDrop	(Lnet/minecraft/block/Block;Lnet/minecraft/block/Block;)V
 transitive-accessible	method	net/minecraft/data/server/BlockLootTableGenerator	addDrop	(Lnet/minecraft/block/Block;Ljava/util/function/Function;)V
 transitive-accessible	method	net/minecraft/data/server/BlockLootTableGenerator	addDrop	(Lnet/minecraft/block/Block;Lnet/minecraft/loot/LootTable$Builder;)V
+transitive-accessible	method	net/minecraft/data/client/ItemModelGenerator	register	(Lnet/minecraft/item/Item;Lnet/minecraft/data/client/Model;)V
+transitive-accessible	method	net/minecraft/data/client/ItemModelGenerator	register	(Lnet/minecraft/item/Item;Ljava/lang/String;Lnet/minecraft/data/client/Model;)V
+transitive-accessible	method	net/minecraft/data/client/ItemModelGenerator	register	(Lnet/minecraft/item/Item;Lnet/minecraft/item/Item;Lnet/minecraft/data/client/Model;)V
+transitive-accessible	method	net/minecraft/data/client/ItemModelGenerator	registerCompass	(Lnet/minecraft/item/Item;)V
+transitive-accessible	method	net/minecraft/data/client/ItemModelGenerator	registerClock	(Lnet/minecraft/item/Item;)V

--- a/fabric-data-generation-api-v1/template.accesswidener
+++ b/fabric-data-generation-api-v1/template.accesswidener
@@ -23,14 +23,17 @@ accessible  field   net/minecraft/data/DataGenerator$PathResolver directoryName 
 
 transitive-accessible   method  net/minecraft/data/family/BlockFamilies register    (Lnet/minecraft/block/Block;)Lnet/minecraft/data/family/BlockFamily$Builder;
 
-transitive-accessible    method    net/minecraft/data/client/ItemModelGenerator    register    (Lnet/minecraft/item/Item;Lnet/minecraft/data/client/Model;)V
-transitive-accessible    method    net/minecraft/data/client/ItemModelGenerator    register    (Lnet/minecraft/item/Item;Lnet/minecraft/item/Item;Lnet/minecraft/data/client/Model;)V
-transitive-accessible    method    net/minecraft/data/client/ItemModelGenerator    register    (Lnet/minecraft/item/Item;Ljava/lang/String;Lnet/minecraft/data/client/Model;)V
-
 transitive-accessible   field   net/minecraft/data/client/BlockStateModelGenerator    blockStateCollector Ljava/util/function/Consumer;
 transitive-accessible   field   net/minecraft/data/client/BlockStateModelGenerator    modelCollector  Ljava/util/function/BiConsumer;
 
-transitive-accessible   method  net/minecraft/data/client/TextureKey  of  (Ljava/lang/String;)Lnet/minecraft/data/client/TextureKey;
+transitive-accessible   method  net/minecraft/data/client/TextureKey	of  (Ljava/lang/String;)Lnet/minecraft/data/client/TextureKey;
 transitive-accessible   method  net/minecraft/data/client/TextureKey	of  (Ljava/lang/String;Lnet/minecraft/data/client/TextureKey;)Lnet/minecraft/data/client/TextureKey;
 
-transitive-extendable method net/minecraft/data/server/AbstractTagProvider$ObjectBuilder add ([Lnet/minecraft/util/registry/RegistryKey;)Lnet/minecraft/data/server/AbstractTagProvider$ObjectBuilder;
+transitive-extendable   method  net/minecraft/data/server/AbstractTagProvider$ObjectBuilder add ([Lnet/minecraft/util/registry/RegistryKey;)Lnet/minecraft/data/server/AbstractTagProvider$ObjectBuilder;
+
+transitive-accessible   method  net/minecraft/data/client/TexturedModel makeFactory (Ljava/util/function/Function;Lnet/minecraft/data/client/Model;)Lnet/minecraft/data/client/TexturedModel$Factory;
+
+transitive-accessible   class net/minecraft/data/client/BlockStateModelGenerator$TintType
+transitive-accessible   class net/minecraft/data/client/BlockStateModelGenerator$BlockTexturePool
+transitive-accessible   class net/minecraft/data/client/BlockStateModelGenerator$LogTexturePool
+transitive-accessible   class net/minecraft/data/client/BlockStateModelGenerator$BuiltinModelPool


### PR DESCRIPTION
- Added transitive-accessible wideners for `BlockStateModelGenerator$TintType`, `BlockStateModelGenerator$BlockTexturePool`, `BlockStateModelGenerator$LogTexturePool`, and `BlockStateModelGenerator$BuiltinModelPool` classes
- Added transitive-accessible widener for `TexturedModel#makeFactory` method
- Moved transitive-accessible wideners for `ItemModelGenerator` methods to the `generateAccessWideners` task, so it covers the 2 new methods `registerCompass` and `registerClock`, and any future new ones
- Fixed `generateAccessWideners` task so it can now find the jar
- Tweaked the whitespace in the accesswidener file a bit