### PR TITLE
Fix #2108: FlammableBlockRegistry ignores tags unless /reload

### DIFF
--- a/fabric-content-registries-v0/src/testmod/java/net/fabricmc/fabric/test/content/registry/ContentRegistryTest.java
+++ b/fabric-content-registries-v0/src/testmod/java/net/fabricmc/fabric/test/content/registry/ContentRegistryTest.java
@@ -22,10 +22,12 @@ import org.slf4j.LoggerFactory;
 import net.minecraft.block.Blocks;
 import net.minecraft.item.HoeItem;
 import net.minecraft.item.Items;
+import net.minecraft.tag.BlockTags;
 import net.minecraft.util.Identifier;
 import net.minecraft.village.VillagerProfession;
 
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
 import net.fabricmc.fabric.api.registry.FlattenableBlockRegistry;
 import net.fabricmc.fabric.api.registry.OxidizableBlocksRegistry;
 import net.fabricmc.fabric.api.registry.StrippableBlockRegistry;
@@ -47,7 +49,9 @@ public final class ContentRegistryTest implements ModInitializer {
 		//  - villagers can now collect, consume (at the same level of bread) and compost apples
 		//  - villagers can now collect and plant oak saplings
 		//  - assign a loot table to the nitwit villager type
+		//  - sand is now flammable
 
+		FlammableBlockRegistry.getDefaultInstance().add(BlockTags.SAND, 4, 4);
 		FlattenableBlockRegistry.register(Blocks.RED_WOOL, Blocks.YELLOW_WOOL.getDefaultState());
 		StrippableBlockRegistry.register(Blocks.QUARTZ_PILLAR, Blocks.HAY_BLOCK);
 

--- a/fabric-content-registries-v0/src/testmod/java/net/fabricmc/fabric/test/content/registry/FlammableTest.java
+++ b/fabric-content-registries-v0/src/testmod/java/net/fabricmc/fabric/test/content/registry/FlammableTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.content.registry;
+
+import net.minecraft.block.Blocks;
+import net.minecraft.test.GameTest;
+import net.minecraft.test.GameTestException;
+import net.minecraft.test.TestContext;
+
+import net.fabricmc.fabric.api.gametest.v1.FabricGameTest;
+import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
+
+public class FlammableTest {
+	/**
+	 * Regression test for <a href="https://github.com/FabricMC/fabric/issues/2108">FlammableBlockRegistry ignoring tags on first load</a>.
+	 */
+	@GameTest(structureName = FabricGameTest.EMPTY_STRUCTURE)
+	public void testFlammableTag(TestContext context) {
+		if (FlammableBlockRegistry.getDefaultInstance().get(Blocks.SAND).getBurnChance() != 4) {
+			throw new GameTestException("Expected blocks in the sand tag to be flammable!");
+		}
+
+		context.complete();
+	}
+}

--- a/fabric-content-registries-v0/src/testmod/resources/fabric.mod.json
+++ b/fabric-content-registries-v0/src/testmod/resources/fabric.mod.json
@@ -11,6 +11,9 @@
   "entrypoints": {
     "main": [
       "net.fabricmc.fabric.test.content.registry.ContentRegistryTest"
+    ],
+    "fabric-gametest": [
+      "net.fabricmc.fabric.test.content.registry.FlammableTest"
     ]
   }
 }


### PR DESCRIPTION
Switched to the approach used by the FuelRegistry.