### PR TITLE
Fix Indigo not rendering replaced models

### DIFF
--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
@@ -106,15 +106,10 @@ public class ItemRenderContext extends AbstractRenderContext {
 		this.vanillaHandler = vanillaHandler;
 		computeOutputInfo();
 
-		matrixStack.push();
-		model.getTransformation().getTransformation(transformMode).apply(invert, matrixStack);
-		matrixStack.translate(-0.5D, -0.5D, -0.5D);
 		matrix = matrixStack.peek().getPositionMatrix();
 		normalMatrix = matrixStack.peek().getNormalMatrix();
 
 		((FabricBakedModel) model).emitItemQuads(itemStack, randomSupplier, this);
-
-		matrixStack.pop();
 
 		this.itemStack = null;
 		this.matrixStack = null;

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/mixin/client/indigo/renderer/MixinItemRenderer.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/mixin/client/indigo/renderer/MixinItemRenderer.java
@@ -49,10 +49,11 @@ public abstract class MixinItemRenderer {
 	@Unique
 	private final VanillaQuadHandler fabric_vanillaHandler = new IndigoQuadHandler((ItemRenderer) (Object) this);
 
-	@Inject(at = @At("HEAD"), method = "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformation$Mode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V", cancellable = true)
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/model/BakedModel;isBuiltin()Z"), method = "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformation$Mode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V", cancellable = true)
 	public void hook_renderItem(ItemStack stack, ModelTransformation.Mode transformMode, boolean invert, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int light, int overlay, BakedModel model, CallbackInfo ci) {
-		if (!stack.isEmpty() && !((FabricBakedModel) model).isVanillaAdapter()) {
+		if (!((FabricBakedModel) model).isVanillaAdapter()) {
 			fabric_contexts.get().renderModel(stack, transformMode, invert, matrixStack, vertexConsumerProvider, light, overlay, model, fabric_vanillaHandler);
+			matrixStack.pop();
 			ci.cancel();
 		}
 	}


### PR DESCRIPTION
- Move `ItemRenderer` injection point from `HEAD` to before `BakedModel.isBuiltin` check.
- This allows model replacement to run before Indigo renders items so that 2D trident and spyglass models can be rendered with Indigo as well.
- Additionally, this change may improve mod compatibility.
- Copied code in `ItemRendererContext` has been removed to accommodate the later injection point.
- This fix should be backported to 1.18.2.