### PR TITLE
Make screen API crash easier to debug

### DIFF
--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/ScreenMixin.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/ScreenMixin.java
@@ -150,7 +150,7 @@ abstract class ScreenMixin implements ScreenExtensions {
 	@Unique
 	private <T> Event<T> ensureEventsAreInitialised(Event<T> event) {
 		if (event == null) {
-			throw new IllegalStateException(String.format("[fabric-screen-api-v1] The current screen (%s) has not been correctly initialised, please send this crash log to the mod author. This is usually caused by the screen not calling super.init(Lnet/minecraft/client/MinecraftClient;II)V", this.getClass().getSuperclass().getName()));
+			throw new IllegalStateException(String.format("[fabric-screen-api-v1] The current screen (%s) has not been correctly initialised, please send this crash log to the mod author. This is usually caused by calling setScreen on the wrong thread.", this.getClass().getSuperclass().getName()));
 		}
 
 		return event;

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/ScreenMixin.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/ScreenMixin.java
@@ -150,7 +150,7 @@ abstract class ScreenMixin implements ScreenExtensions {
 	@Unique
 	private <T> Event<T> ensureEventsAreInitialised(Event<T> event) {
 		if (event == null) {
-			throw new IllegalStateException(String.format("[fabric-screen-api-v1] The current screen (%s) has not been correctly initialised, please send this crash log to the mod author. This is usually caused by calling setScreen on the wrong thread.", this.getClass().getSuperclass().getName()));
+			throw new IllegalStateException(String.format("[fabric-screen-api-v1] The current screen (%s) has not been correctly initialised, please send this crash log to the mod author. This is usually caused by calling setScreen on the wrong thread.", this.getClass().getName()));
 		}
 
 		return event;


### PR DESCRIPTION
Resolves #1569 

The original crash `ScreenMixin` was trying to catch can no longer happen after 1.17. However, the crash still occurs on off-thread `setScreen` as that introduces a race condition. This PR fixes the crash message.

Additionally, this also adds a check for current thread on `setScreen` itself. The vanilla check is only for `isDevelopment` environment and the error was too short. Our error includes the screen class name and the thread name which should make it clear what's going on (calling setScreen on Netty thread/Server thread/etc).