### PR TITLE
Optimise file exists check for directory based ModNioResourcePacks

### DIFF
--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModNioResourcePack.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModNioResourcePack.java
@@ -20,6 +20,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -52,6 +54,7 @@ import net.fabricmc.loader.api.metadata.ModMetadata;
 public class ModNioResourcePack extends AbstractFileResourcePack implements ModResourcePack {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ModNioResourcePack.class);
 	private static final Pattern RESOURCE_PACK_PATH = Pattern.compile("[a-z0-9-_.]+");
+	private static final FileSystem DEFAULT_FS = FileSystems.getDefault();
 
 	private final String name;
 	private final ModMetadata modInfo;
@@ -74,7 +77,7 @@ public class ModNioResourcePack extends AbstractFileResourcePack implements ModR
 				path = path.toAbsolutePath().normalize();
 				Path childPath = path.resolve(subPath.replace("/", path.getFileSystem().getSeparator())).normalize();
 
-				if (!childPath.startsWith(path) || !Files.exists(childPath)) {
+				if (!childPath.startsWith(path) || !exists(childPath)) {
 					continue;
 				}
 
@@ -147,7 +150,7 @@ public class ModNioResourcePack extends AbstractFileResourcePack implements ModR
 		for (Path basePath : basePaths) {
 			Path childPath = basePath.resolve(filename.replace("/", basePath.getFileSystem().getSeparator())).toAbsolutePath().normalize();
 
-			if (childPath.startsWith(basePath) && Files.exists(childPath)) {
+			if (childPath.startsWith(basePath) && exists(childPath)) {
 				return childPath;
 			}
 		}
@@ -220,7 +223,7 @@ public class ModNioResourcePack extends AbstractFileResourcePack implements ModR
 			String separator = basePath.getFileSystem().getSeparator();
 			Path nsPath = basePath.resolve(type.getDirectory()).resolve(namespace);
 			Path searchPath = nsPath.resolve(path.replace("/", separator)).normalize();
-			if (!Files.exists(searchPath)) continue;
+			if (!exists(searchPath)) continue;
 
 			try {
 				Files.walkFileTree(searchPath, new SimpleFileVisitor<Path>() {
@@ -275,5 +278,10 @@ public class ModNioResourcePack extends AbstractFileResourcePack implements ModR
 	@Override
 	public String getName() {
 		return name;
+	}
+
+	private static boolean exists(Path path) {
+		// NIO Files.exists is notoriously slow when checking the file system
+		return path.getFileSystem() == DEFAULT_FS ? path.toFile().exists() : Files.exists(path);
 	}
 }


### PR DESCRIPTION
NIO Files.exists is notoriously slow and allocation heavy, when the path is on the computers FS using the legacy .exists API is much faster. This is only an issue when you have a directory based resource pack, zip files are not affected (What most people use anyway)

See:

![](https://cdn.discordapp.com/attachments/566276937035546624/987995309927964692/unknown.png)
[Nio vs Io File Absence performance](https://gist.github.com/CodingFabian/422b6cf4bfcdfece54c1)
[Open JDK does the same in 21 places](https://github.com/openjdk/jdk/blob/b544b8b7d43907e93263db31ba3cc6d5951bcaee/src/jdk.jfr/share/classes/jdk/jfr/internal/SecuritySupport.java#L388-L389)
"brings reload times from 30s to 5s or so in testmod client" - Technici4n

Still needs propper testing, but I think it should be good.