### PR TITLE
Fix incorrect check in GlobalReceiverRegistry

### DIFF
--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/GlobalReceiverRegistry.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/GlobalReceiverRegistry.java
@@ -68,7 +68,7 @@ public final class GlobalReceiverRegistry<H> {
 		try {
 			final boolean replaced = this.handlers.putIfAbsent(channelName, handler) == null;
 
-			if (!replaced) {
+			if (replaced) {
 				this.handleRegistration(channelName, handler);
 			}
 


### PR DESCRIPTION
Fixes #2359 
Lock issue needs to be investigated later, not now since it doesn't seem to be actually causing a bug.
Also, this file has never been modified since the networking v1 PR... wow.