### PR TITLE
Enable parallel builds by default.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: gradle/wrapper-validation-action@v1
-      - run: ./gradlew check build publishToMavenLocal --stacktrace --parallel --warning-mode=fail
+      - run: ./gradlew check build publishToMavenLocal --stacktrace --warning-mode=fail -Porg.gradle.parallel.threads=4
       - run: mkdir run && echo "eula=true" >> run/eula.txt
       - run: ./gradlew runAutoTestServer --stacktrace --warning-mode=fail
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           context: changelog
           workflow_id: release.yml
       - uses: gradle/wrapper-validation-action@v1
-      - run: ./gradlew checkVersion build publish curseforge github modrinth --stacktrace
+      - run: ./gradlew checkVersion build publish curseforge github modrinth --stacktrace -Porg.gradle.parallel.threads=4
         env:
           MAVEN_URL: ${{ secrets.MAVEN_URL }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 	id "org.ajoberstar.grgit" version "3.1.0"
 	id "com.matthewprenger.cursegradle" version "1.4.0"
 	id "com.modrinth.minotaur" version "1.1.0"
-	id "me.modmuss50.remotesign" version "0.2.4" apply false
+	id "me.modmuss50.remotesign" version "0.3.0" apply false
 }
 
 def ENV = System.getenv()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 org.gradle.jvmargs=-Xmx2560M
+org.gradle.parallel=true
 
 version=0.57.0
 minecraft_version=1.19


### PR DESCRIPTION
Update remotesign to a parallel capable version.
Set org.gradle.parallel.threads in actions as we are IO bound a lot of time (signing, and publishing to maven). (Might be best to only set for releases)