### PR TITLE
Methods in `TheEndBiomeData` that query the intended type.

### DIFF
--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
@@ -105,16 +105,36 @@ public final class TheEndBiomes {
 	}
 
 	/**
-	 * Returns true if the given biome was added in the end, considering the Vanilla end biomes,
+	 * Returns true if the given biome was added as a main end Biome in the end, considering the Vanilla end biomes,
 	 * and any biomes added to the End by mods.
+	 * @param biome The biome to search for
 	 */
-	public static boolean canGenerateAsEndBiome(RegistryKey<Biome> biome){
-		return TheEndBiomeData.canGenerateAsEndBiome(biome);
+	public static boolean canGenerateAsMainIslandBiome(RegistryKey<Biome> biome){
+		return TheEndBiomeData.canGenerateAsEndBiomeIn(BiomeKeys.THE_END, biome);
+	}
+
+	/**
+	 * Returns true if the given biome was added as a small end islands Biome in the end, considering the Vanilla end biomes,
+	 * and any biomes added to the End by mods.
+	 * @param biome The biome to search for
+	 */
+	public static boolean canGenerateAsSmallIslandsBiome(RegistryKey<Biome> biome){
+		return TheEndBiomeData.canGenerateAsEndBiomeIn(BiomeKeys.SMALL_END_ISLANDS, biome);
+	}
+
+	/**
+	 * Returns true if the given biome was added as a Highland Biome in the end, considering the Vanilla end biomes,
+	 * and any biomes added to the End by mods.
+	 * @param biome The biome to search for
+	 */
+	public static boolean canGenerateAsHighlandsBiome(RegistryKey<Biome> biome){
+		return TheEndBiomeData.canGenerateAsEndBiomeIn(BiomeKeys.END_HIGHLANDS, biome);
 	}
 
 	/**
 	 * Returns true if the given biome was added as midland biome in the end, considering the Vanilla end biomes,
 	 * and any biomes added to the End as midland biome by mods.
+	 * @param biome The biome to search for
 	 */
 	public static boolean canGenerateAsEndMidlands(RegistryKey<Biome> biome){
 		return TheEndBiomeData.canGenerateAsEndMidlands(biome);
@@ -123,6 +143,7 @@ public final class TheEndBiomes {
 	/**
 	 * Returns true if the given biome was added as barrens biome in the end, considering the Vanilla end biomes,
 	 * and any biomes added to the End as barrens biome by mods.
+	 * @param biome The biome to search for
 	 */
 	public static boolean canGenerateAsEndBarrens(RegistryKey<Biome> biome){
 		return TheEndBiomeData.canGenerateAsEndBarrens(biome);

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
@@ -108,23 +108,23 @@ public final class TheEndBiomes {
 	 * Returns true if the given biome was added in the end, considering the Vanilla end biomes,
 	 * and any biomes added to the End by mods.
 	 */
-	public static boolean isIntendedForEndBiome(RegistryKey<Biome> biome){
-		return TheEndBiomeData.isIntendedForEndBiome(biome);
+	public static boolean canGenerateAsEndBiome(RegistryKey<Biome> biome){
+		return TheEndBiomeData.canGenerateAsEndBiome(biome);
 	}
 
 	/**
 	 * Returns true if the given biome was added as midland biome in the end, considering the Vanilla end biomes,
 	 * and any biomes added to the End as midland biome by mods.
 	 */
-	public static boolean isIntendedForEndMidlands(RegistryKey<Biome> biome){
-		return TheEndBiomeData.isIntendedForEndMidlands(biome);
+	public static boolean canGenerateAsEndMidlands(RegistryKey<Biome> biome){
+		return TheEndBiomeData.canGenerateAsEndMidlands(biome);
 	}
 
 	/**
 	 * Returns true if the given biome was added as barrens biome in the end, considering the Vanilla end biomes,
 	 * and any biomes added to the End as barrens biome by mods.
 	 */
-	public static boolean isIntendedForEndBarrens(RegistryKey<Biome> biome){
-		return TheEndBiomeData.isIntendedForEndBarrens(biome);
+	public static boolean canGenerateAsEndBarrens(RegistryKey<Biome> biome){
+		return TheEndBiomeData.canGenerateAsEndBarrens(biome);
 	}
 }

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
@@ -103,4 +103,16 @@ public final class TheEndBiomes {
 	public static void addBarrensBiome(RegistryKey<Biome> highlands, RegistryKey<Biome> barrens, double weight) {
 		TheEndBiomeData.addEndBarrensReplacement(highlands, barrens, weight);
 	}
+
+	public static boolean isIntendedForEndBiome(RegistryKey<Biome> biome){
+		return TheEndBiomeData.isIntendedForEndBiome(biome);
+	}
+
+	public static boolean isIntendedForEndMidlands(RegistryKey<Biome> biome){
+		return TheEndBiomeData.isIntendedForEndMidlands(biome);
+	}
+
+	public static boolean isIntendedForBarrens(RegistryKey<Biome> biome){
+		return TheEndBiomeData.isIntendedForBarrens(biome);
+	}
 }

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
@@ -110,7 +110,7 @@ public final class TheEndBiomes {
 	 * @param biome The biome to search for
 	 */
 	public static boolean canGenerateAsMainIslandBiome(RegistryKey<Biome> biome){
-		return TheEndBiomeData.canGenerateAsEndBiomeIn(BiomeKeys.THE_END, biome);
+		return TheEndBiomeData.ADDED_BIOMES.get(biome) == BiomeKeys.THE_END;
 	}
 
 	/**
@@ -119,7 +119,7 @@ public final class TheEndBiomes {
 	 * @param biome The biome to search for
 	 */
 	public static boolean canGenerateAsSmallIslandsBiome(RegistryKey<Biome> biome){
-		return TheEndBiomeData.canGenerateAsEndBiomeIn(BiomeKeys.SMALL_END_ISLANDS, biome);
+		return TheEndBiomeData.ADDED_BIOMES.get(biome) == BiomeKeys.SMALL_END_ISLANDS;
 	}
 
 	/**
@@ -128,7 +128,7 @@ public final class TheEndBiomes {
 	 * @param biome The biome to search for
 	 */
 	public static boolean canGenerateAsHighlandsBiome(RegistryKey<Biome> biome){
-		return TheEndBiomeData.canGenerateAsEndBiomeIn(BiomeKeys.END_HIGHLANDS, biome);
+		return TheEndBiomeData.ADDED_BIOMES.get(biome) == BiomeKeys.END_HIGHLANDS;
 	}
 
 	/**
@@ -137,7 +137,7 @@ public final class TheEndBiomes {
 	 * @param biome The biome to search for
 	 */
 	public static boolean canGenerateAsEndMidlands(RegistryKey<Biome> biome){
-		return TheEndBiomeData.canGenerateAsEndMidlands(biome);
+		return TheEndBiomeData.ADDED_BIOMES.get(biome) == BiomeKeys.END_MIDLANDS;
 	}
 
 	/**
@@ -146,6 +146,6 @@ public final class TheEndBiomes {
 	 * @param biome The biome to search for
 	 */
 	public static boolean canGenerateAsEndBarrens(RegistryKey<Biome> biome){
-		return TheEndBiomeData.canGenerateAsEndBarrens(biome);
+		return TheEndBiomeData.ADDED_BIOMES.get(biome) == BiomeKeys.END_BARRENS;
 	}
 }

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
@@ -127,7 +127,7 @@ public final class TheEndBiomes {
 	 * and any biomes added to the End by mods.
 	 * @param biome The biome to search for
 	 */
-	public static boolean isHighlandsBiome(RegistryKey<Biome> biome){
+	public static boolean isHighlandsBiome(RegistryKey<Biome> biome) {
 		return TheEndBiomeData.ADDED_BIOMES.get(biome) == BiomeKeys.END_HIGHLANDS;
 	}
 

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
@@ -136,7 +136,7 @@ public final class TheEndBiomes {
 	 * and any biomes added to the End as midland biome by mods.
 	 * @param biome The biome to search for
 	 */
-	public static boolean isMidlandsBiome(RegistryKey<Biome> biome){
+	public static boolean isMidlandsBiome(RegistryKey<Biome> biome) {
 		return TheEndBiomeData.ADDED_BIOMES.get(biome) == BiomeKeys.END_MIDLANDS;
 	}
 

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
@@ -118,7 +118,7 @@ public final class TheEndBiomes {
 	 * and any biomes added to the End by mods.
 	 * @param biome The biome to search for
 	 */
-	public static boolean isSmallIslandsBiome(RegistryKey<Biome> biome){
+	public static boolean isSmallIslandsBiome(RegistryKey<Biome> biome) {
 		return TheEndBiomeData.ADDED_BIOMES.get(biome) == BiomeKeys.SMALL_END_ISLANDS;
 	}
 

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
@@ -109,7 +109,7 @@ public final class TheEndBiomes {
 	 * and any biomes added to the End by mods.
 	 * @param biome The biome to search for
 	 */
-	public static boolean canGenerateAsMainIslandBiome(RegistryKey<Biome> biome){
+	public static boolean isMainIslandBiome(RegistryKey<Biome> biome){
 		return TheEndBiomeData.ADDED_BIOMES.get(biome) == BiomeKeys.THE_END;
 	}
 
@@ -118,7 +118,7 @@ public final class TheEndBiomes {
 	 * and any biomes added to the End by mods.
 	 * @param biome The biome to search for
 	 */
-	public static boolean canGenerateAsSmallIslandsBiome(RegistryKey<Biome> biome){
+	public static boolean isSmallIslandsBiome(RegistryKey<Biome> biome){
 		return TheEndBiomeData.ADDED_BIOMES.get(biome) == BiomeKeys.SMALL_END_ISLANDS;
 	}
 
@@ -127,7 +127,7 @@ public final class TheEndBiomes {
 	 * and any biomes added to the End by mods.
 	 * @param biome The biome to search for
 	 */
-	public static boolean canGenerateAsHighlandsBiome(RegistryKey<Biome> biome){
+	public static boolean isHighlandsBiome(RegistryKey<Biome> biome){
 		return TheEndBiomeData.ADDED_BIOMES.get(biome) == BiomeKeys.END_HIGHLANDS;
 	}
 
@@ -136,7 +136,7 @@ public final class TheEndBiomes {
 	 * and any biomes added to the End as midland biome by mods.
 	 * @param biome The biome to search for
 	 */
-	public static boolean canGenerateAsEndMidlands(RegistryKey<Biome> biome){
+	public static boolean isMidlandsBiome(RegistryKey<Biome> biome){
 		return TheEndBiomeData.ADDED_BIOMES.get(biome) == BiomeKeys.END_MIDLANDS;
 	}
 
@@ -145,7 +145,7 @@ public final class TheEndBiomes {
 	 * and any biomes added to the End as barrens biome by mods.
 	 * @param biome The biome to search for
 	 */
-	public static boolean canGenerateAsEndBarrens(RegistryKey<Biome> biome){
+	public static boolean isBarrensBiome(RegistryKey<Biome> biome){
 		return TheEndBiomeData.ADDED_BIOMES.get(biome) == BiomeKeys.END_BARRENS;
 	}
 }

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
@@ -104,15 +104,27 @@ public final class TheEndBiomes {
 		TheEndBiomeData.addEndBarrensReplacement(highlands, barrens, weight);
 	}
 
+	/**
+	 * Returns true if the given biome was added in the end, considering the Vanilla end biomes,
+	 * and any biomes added to the End by mods.
+	 */
 	public static boolean isIntendedForEndBiome(RegistryKey<Biome> biome){
 		return TheEndBiomeData.isIntendedForEndBiome(biome);
 	}
 
+	/**
+	 * Returns true if the given biome was added as midland biome in the end, considering the Vanilla end biomes,
+	 * and any biomes added to the End as midland biome by mods.
+	 */
 	public static boolean isIntendedForEndMidlands(RegistryKey<Biome> biome){
 		return TheEndBiomeData.isIntendedForEndMidlands(biome);
 	}
 
-	public static boolean isIntendedForBarrens(RegistryKey<Biome> biome){
-		return TheEndBiomeData.isIntendedForBarrens(biome);
+	/**
+	 * Returns true if the given biome was added as barrens biome in the end, considering the Vanilla end biomes,
+	 * and any biomes added to the End as barrens biome by mods.
+	 */
+	public static boolean isIntendedForEndBarrens(RegistryKey<Biome> biome){
+		return TheEndBiomeData.isIntendedForEndBarrens(biome);
 	}
 }

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
@@ -145,7 +145,7 @@ public final class TheEndBiomes {
 	 * and any biomes added to the End as barrens biome by mods.
 	 * @param biome The biome to search for
 	 */
-	public static boolean isBarrensBiome(RegistryKey<Biome> biome){
+	public static boolean isBarrensBiome(RegistryKey<Biome> biome) {
 		return TheEndBiomeData.ADDED_BIOMES.get(biome) == BiomeKeys.END_BARRENS;
 	}
 }

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
@@ -109,7 +109,7 @@ public final class TheEndBiomes {
 	 * and any biomes added to the End by mods.
 	 * @param biome The biome to search for
 	 */
-	public static boolean isMainIslandBiome(RegistryKey<Biome> biome){
+	public static boolean isMainIslandBiome(RegistryKey<Biome> biome) {
 		return TheEndBiomeData.ADDED_BIOMES.get(biome) == BiomeKeys.THE_END;
 	}
 

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/TheEndBiomeData.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/TheEndBiomeData.java
@@ -95,11 +95,15 @@ public final class TheEndBiomeData {
 	}
 
 	/**
-	 * Returns true if the given biome was added in the end, considering the Vanilla end biomes,
+	 * Returns true if the given biome was added for the specified keyBiome in the end, considering the Vanilla end biomes,
 	 * and any biomes added to the End by mods.
+	 *
+	 * @param keyBiome The parent biome type
+	 * @param biome The biome you are looking for
 	 */
-	public static boolean canGenerateAsEndBiome(RegistryKey<Biome> biome){
-		return END_BIOMES_MAP.containsKey(biome) || containsValue(END_BIOMES_MAP, biome);
+	public static boolean canGenerateAsEndBiomeIn(RegistryKey<Biome> keyBiome, RegistryKey<Biome> biome){
+		WeightedPicker<RegistryKey<Biome>> highlandBiomes = END_BIOMES_MAP.get(keyBiome);
+		return highlandBiomes!=null && highlandBiomes.getAny(biome).isPresent();
 	}
 
 	/**

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/TheEndBiomeData.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/TheEndBiomeData.java
@@ -90,12 +90,16 @@ public final class TheEndBiomeData {
 		ADDED_BIOMES.add(barrens);
 	}
 
+	private static boolean containsValue(Map<RegistryKey<Biome>, WeightedPicker<RegistryKey<Biome>>> map, RegistryKey<Biome> biome){
+		return map.values().stream().anyMatch(w->w.getAny(biome).isPresent());
+	}
+
 	/**
 	 * Returns true if the given biome was added in the end, considering the Vanilla end biomes,
 	 * and any biomes added to the End by mods.
 	 */
 	public static boolean isIntendedForEndBiome(RegistryKey<Biome> biome){
-		return END_BIOMES_MAP.containsKey(biome);
+		return END_BIOMES_MAP.containsKey(biome) || containsValue(END_BIOMES_MAP, biome);
 	}
 
 	/**
@@ -103,7 +107,7 @@ public final class TheEndBiomeData {
 	 * and any biomes added to the End as midland biome by mods.
 	 */
 	public static boolean isIntendedForEndMidlands(RegistryKey<Biome> biome){
-		return END_MIDLANDS_MAP.containsKey(biome);
+		return containsValue(END_MIDLANDS_MAP, biome);
 	}
 
 	/**
@@ -111,7 +115,7 @@ public final class TheEndBiomeData {
 	 * and any biomes added to the End as barrens biome by mods.
 	 */
 	public static boolean isIntendedForEndBarrens(RegistryKey<Biome> biome){
-		return END_BARRENS_MAP.containsKey(biome);
+		return containsValue(END_BARRENS_MAP, biome);
 	}
 
 	public static Overrides createOverrides(Registry<Biome> biomeRegistry) {

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/TheEndBiomeData.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/TheEndBiomeData.java
@@ -90,6 +90,30 @@ public final class TheEndBiomeData {
 		ADDED_BIOMES.add(barrens);
 	}
 
+	/**
+	 * Returns true if the given biome was added in the end, considering the Vanilla end biomes,
+	 * and any biomes added to the End by mods.
+	 */
+	public static boolean isIntendedForEndBiome(RegistryKey<Biome> biome){
+		return END_BARRENS_MAP.containsKey(biome);
+	}
+
+	/**
+	 * Returns true if the given biome was added as midland biome in the end, considering the Vanilla end biomes,
+	 * and any biomes added to the End as midland biome by mods.
+	 */
+	public static boolean isIntendedForEndMidlands(RegistryKey<Biome> biome){
+		return END_MIDLANDS_MAP.containsKey(biome);
+	}
+
+	/**
+	 * Returns true if the given biome was added as barrens biome in the end, considering the Vanilla end biomes,
+	 * and any biomes added to the End as barrens biome by mods.
+	 */
+	public static boolean isIntendedForBarrens(RegistryKey<Biome> biome){
+		return END_BARRENS_MAP.containsKey(biome);
+	}
+
 	public static Overrides createOverrides(Registry<Biome> biomeRegistry) {
 		return new Overrides(biomeRegistry);
 	}

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/TheEndBiomeData.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/TheEndBiomeData.java
@@ -95,7 +95,7 @@ public final class TheEndBiomeData {
 	 * and any biomes added to the End by mods.
 	 */
 	public static boolean isIntendedForEndBiome(RegistryKey<Biome> biome){
-		return END_BARRENS_MAP.containsKey(biome);
+		return END_BIOMES_MAP.containsKey(biome);
 	}
 
 	/**

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/TheEndBiomeData.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/TheEndBiomeData.java
@@ -16,7 +16,7 @@
 
 package net.fabricmc.fabric.impl.biome;
 
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -26,9 +26,9 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import com.google.common.base.Preconditions;
-import org.jetbrains.annotations.ApiStatus;
 import it.unimi.dsi.fastutil.Hash;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenCustomHashMap;
+import org.jetbrains.annotations.ApiStatus;
 
 import net.minecraft.util.math.noise.PerlinNoiseSampler;
 import net.minecraft.util.registry.Registry;
@@ -44,7 +44,7 @@ import net.minecraft.world.biome.source.util.MultiNoiseUtil;
  */
 @ApiStatus.Internal
 public final class TheEndBiomeData {
-	public static final Set<RegistryKey<Biome>> ADDED_BIOMES = new HashSet<>();
+	public static final Map<RegistryKey<Biome>, RegistryKey<Biome>> ADDED_BIOMES = new HashMap<>();
 	private static final Map<RegistryKey<Biome>, WeightedPicker<RegistryKey<Biome>>> END_BIOMES_MAP = new IdentityHashMap<>();
 	private static final Map<RegistryKey<Biome>, WeightedPicker<RegistryKey<Biome>>> END_MIDLANDS_MAP = new IdentityHashMap<>();
 	private static final Map<RegistryKey<Biome>, WeightedPicker<RegistryKey<Biome>>> END_BARRENS_MAP = new IdentityHashMap<>();
@@ -71,7 +71,7 @@ public final class TheEndBiomeData {
 		Preconditions.checkNotNull(variant, "variant entry is null");
 		Preconditions.checkArgument(weight > 0.0, "Weight is less than or equal to 0.0 (got %s)", weight);
 		END_BIOMES_MAP.computeIfAbsent(replaced, key -> new WeightedPicker<>()).add(variant, weight);
-		ADDED_BIOMES.add(variant);
+		ADDED_BIOMES.put(variant, replaced);
 	}
 
 	public static void addEndMidlandsReplacement(RegistryKey<Biome> highlands, RegistryKey<Biome> midlands, double weight) {
@@ -79,7 +79,7 @@ public final class TheEndBiomeData {
 		Preconditions.checkNotNull(midlands, "midlands entry is null");
 		Preconditions.checkArgument(weight > 0.0, "Weight is less than or equal to 0.0 (got %s)", weight);
 		END_MIDLANDS_MAP.computeIfAbsent(highlands, key -> new WeightedPicker<>()).add(midlands, weight);
-		ADDED_BIOMES.add(midlands);
+		ADDED_BIOMES.put(midlands, BiomeKeys.END_MIDLANDS);
 	}
 
 	public static void addEndBarrensReplacement(RegistryKey<Biome> highlands, RegistryKey<Biome> barrens, double weight) {
@@ -87,39 +87,7 @@ public final class TheEndBiomeData {
 		Preconditions.checkNotNull(barrens, "midlands entry is null");
 		Preconditions.checkArgument(weight > 0.0, "Weight is less than or equal to 0.0 (got %s)", weight);
 		END_BARRENS_MAP.computeIfAbsent(highlands, key -> new WeightedPicker<>()).add(barrens, weight);
-		ADDED_BIOMES.add(barrens);
-	}
-
-	private static boolean containsValue(Map<RegistryKey<Biome>, WeightedPicker<RegistryKey<Biome>>> map, RegistryKey<Biome> biome){
-		return map.values().stream().anyMatch(w->w.getAny(biome).isPresent());
-	}
-
-	/**
-	 * Returns true if the given biome was added for the specified keyBiome in the end, considering the Vanilla end biomes,
-	 * and any biomes added to the End by mods.
-	 *
-	 * @param keyBiome The parent biome type
-	 * @param biome The biome you are looking for
-	 */
-	public static boolean canGenerateAsEndBiomeIn(RegistryKey<Biome> keyBiome, RegistryKey<Biome> biome){
-		WeightedPicker<RegistryKey<Biome>> highlandBiomes = END_BIOMES_MAP.get(keyBiome);
-		return highlandBiomes!=null && highlandBiomes.getAny(biome).isPresent();
-	}
-
-	/**
-	 * Returns true if the given biome was added as midland biome in the end, considering the Vanilla end biomes,
-	 * and any biomes added to the End as midland biome by mods.
-	 */
-	public static boolean canGenerateAsEndMidlands(RegistryKey<Biome> biome){
-		return containsValue(END_MIDLANDS_MAP, biome);
-	}
-
-	/**
-	 * Returns true if the given biome was added as barrens biome in the end, considering the Vanilla end biomes,
-	 * and any biomes added to the End as barrens biome by mods.
-	 */
-	public static boolean canGenerateAsEndBarrens(RegistryKey<Biome> biome){
-		return containsValue(END_BARRENS_MAP, biome);
+		ADDED_BIOMES.put(barrens, BiomeKeys.END_BARRENS);
 	}
 
 	public static Overrides createOverrides(Registry<Biome> biomeRegistry) {
@@ -146,7 +114,7 @@ public final class TheEndBiomeData {
 		private final Map<MultiNoiseUtil.MultiNoiseSampler, PerlinNoiseSampler> samplers = new WeakHashMap<>();
 
 		public Overrides(Registry<Biome> biomeRegistry) {
-			this.customBiomes = ADDED_BIOMES.stream().map(biomeRegistry::entryOf).collect(Collectors.toSet());
+			this.customBiomes = ADDED_BIOMES.keySet().stream().map(biomeRegistry::entryOf).collect(Collectors.toSet());
 
 			this.endMidlands = biomeRegistry.entryOf(BiomeKeys.END_MIDLANDS);
 			this.endBarrens = biomeRegistry.entryOf(BiomeKeys.END_BARRENS);

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/TheEndBiomeData.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/TheEndBiomeData.java
@@ -98,7 +98,7 @@ public final class TheEndBiomeData {
 	 * Returns true if the given biome was added in the end, considering the Vanilla end biomes,
 	 * and any biomes added to the End by mods.
 	 */
-	public static boolean isIntendedForEndBiome(RegistryKey<Biome> biome){
+	public static boolean canGenerateAsEndBiome(RegistryKey<Biome> biome){
 		return END_BIOMES_MAP.containsKey(biome) || containsValue(END_BIOMES_MAP, biome);
 	}
 
@@ -106,7 +106,7 @@ public final class TheEndBiomeData {
 	 * Returns true if the given biome was added as midland biome in the end, considering the Vanilla end biomes,
 	 * and any biomes added to the End as midland biome by mods.
 	 */
-	public static boolean isIntendedForEndMidlands(RegistryKey<Biome> biome){
+	public static boolean canGenerateAsEndMidlands(RegistryKey<Biome> biome){
 		return containsValue(END_MIDLANDS_MAP, biome);
 	}
 
@@ -114,7 +114,7 @@ public final class TheEndBiomeData {
 	 * Returns true if the given biome was added as barrens biome in the end, considering the Vanilla end biomes,
 	 * and any biomes added to the End as barrens biome by mods.
 	 */
-	public static boolean isIntendedForEndBarrens(RegistryKey<Biome> biome){
+	public static boolean canGenerateAsEndBarrens(RegistryKey<Biome> biome){
 		return containsValue(END_BARRENS_MAP, biome);
 	}
 

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/TheEndBiomeData.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/TheEndBiomeData.java
@@ -110,7 +110,7 @@ public final class TheEndBiomeData {
 	 * Returns true if the given biome was added as barrens biome in the end, considering the Vanilla end biomes,
 	 * and any biomes added to the End as barrens biome by mods.
 	 */
-	public static boolean isIntendedForBarrens(RegistryKey<Biome> biome){
+	public static boolean isIntendedForEndBarrens(RegistryKey<Biome> biome){
 		return END_BARRENS_MAP.containsKey(biome);
 	}
 

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/WeightedPicker.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/WeightedPicker.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.impl.biome;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 import com.google.common.base.Preconditions;
@@ -98,6 +99,16 @@ public final class WeightedPicker<T> {
 		}
 
 		return entries.get(low);
+	}
+
+	/**
+	 * Returns any {@link WeightedEntry} that contains the passed element.
+	 *
+	 * @param element The Element you are looking for
+	 * @return The result of the search
+	 */
+	Optional<WeightedEntry<T>> getAny(T element){
+		return entries.stream().filter(w -> w.entry==element).findAny();
 	}
 
 	/**

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/WeightedPicker.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/WeightedPicker.java
@@ -18,7 +18,6 @@ package net.fabricmc.fabric.impl.biome;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 
 import com.google.common.base.Preconditions;

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/WeightedPicker.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/WeightedPicker.java
@@ -102,16 +102,6 @@ public final class WeightedPicker<T> {
 	}
 
 	/**
-	 * Returns any {@link WeightedEntry} that contains the passed element.
-	 *
-	 * @param element The Element you are looking for
-	 * @return The result of the search
-	 */
-	Optional<WeightedEntry<T>> getAny(T element){
-		return entries.stream().filter(w -> w.entry==element).findAny();
-	}
-
-	/**
 	 * Represents a modded entry in a list, and its corresponding weight.
 	 *
 	 * @param entry            the entry


### PR DESCRIPTION
When implementing a custom BiomeSource for the End, we need to know what the intended placement of an End-biome was. This PR adds Methods to `TheEndBiomeData` that are similar to `NetherBiomes.canGenerateInNether`.