### PR TITLE
Fix inconsistent ordering of item attribute modifiers by using a linked hashmap

### DIFF
--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemStackMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemStackMixin.java
@@ -18,7 +18,7 @@ package net.fabricmc.fabric.mixin.item;
 
 import java.util.function.Consumer;
 
-import com.google.common.collect.HashMultimap;
+import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -83,8 +83,8 @@ public abstract class ItemStackMixin {
 	)
 	public Multimap<EntityAttribute, EntityAttributeModifier> hookGetAttributeModifiers(Item item, EquipmentSlot slot) {
 		ItemStack stack = (ItemStack) (Object) this;
-		//we need to ensure it is modifiable for the callback
-		Multimap<EntityAttribute, EntityAttributeModifier> attributeModifiers = HashMultimap.create(item.getAttributeModifiers(stack, slot));
+		//we need to ensure it is modifiable for the callback, use linked map to preserve ordering
+		Multimap<EntityAttribute, EntityAttributeModifier> attributeModifiers = LinkedHashMultimap.create(item.getAttributeModifiers(stack, slot));
 		ModifyItemAttributeModifiersCallback.EVENT.invoker().modifyAttributeModifiers(stack, slot, attributeModifiers);
 		return attributeModifiers;
 	}


### PR DESCRIPTION
Issue reported on Discord in #mod-dev-2.

Testing:
- I did a bit of testing before the patch and the order was indeed random. Netherite chestplate is easy to check cause it has 6 possible permutations; I ran two tests and had two different attribute modifier orders, neither matching the one that I would expect from reading the constructor of `ArmorItem`.
- Order seems consistent after the patch (matches what's defined in the constructor).

Ordering will still not be consistent between multiple listeners of `ModifyItemAttributeModifiersCallback` that add modifiers to the same items, but these cases should be very rare, and can be solved by these mods using event phases.