### PR TITLE
Fix custom dimension not loaded on world preset other than default

### DIFF
--- a/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/MoreOptionsDialogAccessor.java
+++ b/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/MoreOptionsDialogAccessor.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.resource.loader.client;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import net.minecraft.client.gui.screen.world.MoreOptionsDialog;
+import net.minecraft.client.world.GeneratorOptionsHolder;
+
+@Mixin(MoreOptionsDialog.class)
+public interface MoreOptionsDialogAccessor {
+	@Invoker
+	void callSetGeneratorOptionsHolder(GeneratorOptionsHolder generatorOptionsHolder);
+}

--- a/fabric-resource-loader-v0/src/client/resources/fabric-resource-loader-v0.client.mixins.json
+++ b/fabric-resource-loader-v0/src/client/resources/fabric-resource-loader-v0.client.mixins.json
@@ -7,7 +7,8 @@
     "CreateWorldScreenMixin",
     "FontManagerResourceReloadListenerMixin",
     "GameOptionsMixin",
-    "KeyedResourceReloadListenerClientMixin"
+    "KeyedResourceReloadListenerClientMixin",
+    "MoreOptionsDialogAccessor"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Fix https://github.com/FabricMC/fabric/pull/2345#issuecomment-1179474099

Loads the DRM again before the integrated server starts and replace the `GeneratorOptions` with newly parsed one.
I tried capturing the DRM and `RegistryOps` instance from `create` and `applyDataPacks` lamdas and using it to parse but it only works for default preset ¯\\\_(ツ)\_/¯.

Dedicated server is not affected.

Also for yarn contributors: `GeneratorOptionsHolder` doesn't seem to be the correct name as it holds more than a `GeneratorOptions`.