### PR TITLE
Add scaledWidth and scaledHeight parameters to the HudRenderCallback

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/HudRenderCallback.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/HudRenderCallback.java
@@ -22,9 +22,9 @@ import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
 public interface HudRenderCallback {
-	Event<HudRenderCallback> EVENT = EventFactory.createArrayBacked(HudRenderCallback.class, (listeners) -> (matrixStack, delta) -> {
+	Event<HudRenderCallback> EVENT = EventFactory.createArrayBacked(HudRenderCallback.class, (listeners) -> (matrixStack, delta, scaledWidth, scaledHeight) -> {
 		for (HudRenderCallback event : listeners) {
-			event.onHudRender(matrixStack, delta);
+			event.onHudRender(matrixStack, delta, scaledWidth, scaledHeight);
 		}
 	});
 
@@ -33,6 +33,8 @@ public interface HudRenderCallback {
 	 *
 	 * @param matrixStack the matrixStack
 	 * @param tickDelta Progress for linearly interpolating between the previous and current game state
+	 * @param scaledWidth scaled width of the screen
+	 * @param scaledHeight scaled height of the screen
 	 */
-	void onHudRender(MatrixStack matrixStack, float tickDelta);
+	void onHudRender(MatrixStack matrixStack, float tickDelta, int scaledWidth, int scaledHeight);
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/MixinInGameHud.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/MixinInGameHud.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.mixin.client.rendering;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Slice;
@@ -29,8 +30,13 @@ import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
 
 @Mixin(InGameHud.class)
 public class MixinInGameHud {
+	@Shadow
+	private int scaledWidth;
+	@Shadow
+	private int scaledHeight;
+
 	@Inject(method = "render", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;setShaderColor(FFFF)V"), slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/PlayerListHud;render(Lnet/minecraft/client/util/math/MatrixStack;ILnet/minecraft/scoreboard/Scoreboard;Lnet/minecraft/scoreboard/ScoreboardObjective;)V")))
 	public void render(MatrixStack matrixStack, float tickDelta, CallbackInfo callbackInfo) {
-		HudRenderCallback.EVENT.invoker().onHudRender(matrixStack, tickDelta);
+		HudRenderCallback.EVENT.invoker().onHudRender(matrixStack, tickDelta, scaledWidth, scaledHeight);
 	}
 }

--- a/fabric-transfer-api-v1/src/testmod/java/net/fabricmc/fabric/test/transfer/ingame/client/FluidVariantRenderTest.java
+++ b/fabric-transfer-api-v1/src/testmod/java/net/fabricmc/fabric/test/transfer/ingame/client/FluidVariantRenderTest.java
@@ -47,7 +47,7 @@ import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 public class FluidVariantRenderTest implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
-		HudRenderCallback.EVENT.register((matrices, tickDelta) -> {
+		HudRenderCallback.EVENT.register((matrices, tickDelta, scaledWidth, scaledHeight) -> {
 			PlayerEntity player = MinecraftClient.getInstance().player;
 			if (player == null) return;
 


### PR DESCRIPTION
When using the `HudRenderCallback` usually people want to add something onto the HUD. The position of custom HUD elements is always dependent on the scaled dimensions of the screen. Currently you would have to do get the scaled dimensions through `MinecraftClient` like this:
```
MinecraftClient client = MinecraftClient.getInstance();
int width = client.getWindow().getScaledWidth();
int height = client.getWindow().getScaledHeight();
```
By having access to the scaled height and width via the method parameter, this step can be dropped and it makes the code a bit cleaner. 