### PR TITLE
ModResourcePackUtil: Properly handle special chars in mod name

### DIFF
--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModResourcePackUtil.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModResourcePackUtil.java
@@ -77,17 +77,20 @@ public final class ModResourcePackUtil {
 		switch (filename) {
 		case "pack.mcmeta":
 			String description = Objects.requireNonNullElse(info.getName(), "");
-
-			JsonObject pack = new JsonObject();
-			pack.addProperty("pack_format", type.getPackVersion(SharedConstants.getGameVersion()));
-			pack.addProperty("description", description);
-			JsonObject metadata = new JsonObject();
-			metadata.add("pack", pack);
-
-			return IOUtils.toInputStream(GSON.toJson(metadata), Charsets.UTF_8);
+			String metadata = serializeMetadata(type.getPackVersion(SharedConstants.getGameVersion()), description);
+			return IOUtils.toInputStream(metadata, Charsets.UTF_8);
 		default:
 			return null;
 		}
+	}
+
+	public static String serializeMetadata(int packVersion, String description) {
+		JsonObject pack = new JsonObject();
+		pack.addProperty("pack_format", packVersion);
+		pack.addProperty("description", description);
+		JsonObject metadata = new JsonObject();
+		metadata.add("pack", pack);
+		return GSON.toJson(metadata);
 	}
 
 	public static String getName(ModMetadata info) {

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModResourcePackUtil.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModResourcePackUtil.java
@@ -19,8 +19,11 @@ package net.fabricmc.fabric.impl.resource.loader;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import com.google.common.base.Charsets;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import org.apache.commons.io.IOUtils;
 import org.jetbrains.annotations.Nullable;
 
@@ -40,6 +43,8 @@ import net.fabricmc.loader.api.metadata.ModMetadata;
  * Internal utilities for managing resource packs.
  */
 public final class ModResourcePackUtil {
+	private static final Gson GSON = new Gson();
+
 	private ModResourcePackUtil() {
 	}
 
@@ -71,16 +76,15 @@ public final class ModResourcePackUtil {
 	public static InputStream openDefault(ModMetadata info, ResourceType type, String filename) {
 		switch (filename) {
 		case "pack.mcmeta":
-			String description = info.getName();
+			String description = Objects.requireNonNullElse(info.getName(), "");
 
-			if (description == null) {
-				description = "";
-			} else {
-				description = description.replaceAll("\"", "\\\"");
-			}
+			JsonObject pack = new JsonObject();
+			pack.addProperty("pack_format", type.getPackVersion(SharedConstants.getGameVersion()));
+			pack.addProperty("description", description);
+			JsonObject metadata = new JsonObject();
+			metadata.add("pack", pack);
 
-			String pack = String.format("{\"pack\":{\"pack_format\":" + type.getPackVersion(SharedConstants.getGameVersion()) + ",\"description\":\"%s\"}}", description);
-			return IOUtils.toInputStream(pack, Charsets.UTF_8);
+			return IOUtils.toInputStream(GSON.toJson(metadata), Charsets.UTF_8);
 		default:
 			return null;
 		}

--- a/fabric-resource-loader-v0/src/testmod/java/net/fabricmc/fabric/test/resource/loader/BuiltinResourcePackTestMod.java
+++ b/fabric-resource-loader-v0/src/testmod/java/net/fabricmc/fabric/test/resource/loader/BuiltinResourcePackTestMod.java
@@ -65,7 +65,7 @@ public class BuiltinResourcePackTestMod implements ModInitializer {
 			throw new AssertionError("Metadata parsing test for description \"%s\" failed".formatted(description), exc);
 		}
 
-		String parsedDescription = json.get("description").getAsString();
+		String parsedDescription = json.get("pack").getAsJsonObject().get("description").getAsString();
 
 		if (!description.equals(parsedDescription)) {
 			throw new AssertionError("Metadata parsing test for description failed: expected \"%s\", got \"%s\"".formatted(description, parsedDescription));

--- a/fabric-resource-loader-v0/src/testmod/java/net/fabricmc/fabric/test/resource/loader/BuiltinResourcePackTestMod.java
+++ b/fabric-resource-loader-v0/src/testmod/java/net/fabricmc/fabric/test/resource/loader/BuiltinResourcePackTestMod.java
@@ -16,20 +16,26 @@
 
 package net.fabricmc.fabric.test.resource.loader;
 
-import org.slf4j.LoggerFactory;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.fabricmc.fabric.api.resource.ResourcePackActivationType;
+import net.fabricmc.fabric.impl.resource.loader.ModResourcePackUtil;
 import net.fabricmc.loader.api.FabricLoader;
 
 public class BuiltinResourcePackTestMod implements ModInitializer {
 	public static final String MODID = "fabric-resource-loader-v0-testmod";
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(BuiltinResourcePackTestMod.class);
+
+	private static final Gson GSON = new Gson();
 
 	@Override
 	public void onInitialize() {
@@ -42,5 +48,27 @@ public class BuiltinResourcePackTestMod implements ModInitializer {
 				.map(container -> ResourceManagerHelper.registerBuiltinResourcePack(new Identifier(MODID, "test2"),
 						container, ResourcePackActivationType.NORMAL))
 				.filter(success -> !success).ifPresent(success -> LOGGER.warn("Could not register built-in resource pack."));
+
+		// Test various metadata serialization issues (#2407)
+		testMetadataSerialization("");
+		testMetadataSerialization("Quotes: \"\" \"");
+		testMetadataSerialization("Backslash: \\ \\\\");
+	}
+
+	private void testMetadataSerialization(String description) {
+		String metadata = ModResourcePackUtil.serializeMetadata(1, description);
+		JsonObject json;
+
+		try {
+			json = GSON.fromJson(metadata, JsonObject.class);
+		} catch (JsonParseException exc) {
+			throw new AssertionError("Metadata parsing test for description \"%s\" failed".formatted(description), exc);
+		}
+
+		String parsedDescription = json.get("description").getAsString();
+
+		if (!description.equals(parsedDescription)) {
+			throw new AssertionError("Metadata parsing test for description failed: expected \"%s\", got \"%s\"".formatted(description, parsedDescription));
+		}
 	}
 }


### PR DESCRIPTION
Discovered while auditing `String.format`.

`ModResourcePackUtil#openDefault` in resource loader is used to provide `pack.mcmeta` fallback when one does not exist in a registered pack. This previously constructed the file contents via `String.format`. This contains a mod's name, which can include special characters (usually a quote, but sometimes backslashes).

Note that it's not easy to properly add those special characters in `fabric.mod.json`: due to Gradle's templating system used in many setups to substitute versions, backslashes are interpreted during build-time jar processing. Of course, the build result must still be a valid JSON. Therefore, to use `\ "` as the mod's name `" \\" \\\\"` must be written instead. Since this is not well-known I expect few people would encounter this issue in the first place.

If they do, however, and this method is called, then the method is expected to return the stream of a valid JSON. However, they don't, for a couple of reasons:

1. The current escaping only considers quotes. However, trailing backslashes can cause the string-terminating quote to be escaped.
2. Actually, this escaping doesn't work at all, because of [a quirk with `String#replaceAll`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html#replaceAll(java.lang.String,java.lang.String)). Either the second argument [should've been quoted](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/Matcher.html#quoteReplacement(java.lang.String)) or it should've been [`String#replace` instead](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html#replace(java.lang.CharSequence,java.lang.CharSequence)).

Instead of trying to fix the escaping, I just made it use Gson, which is more readable. Note that [the other code](https://github.com/FabricMC/fabric/blob/1.19/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/FabricModResourcePack.java#L49) still uses string replacement since it's unaffected.