### PR TITLE
Allow client commands to open a screen without thread schedule

### DIFF
--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ChatScreenMixin.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ChatScreenMixin.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.command.client;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.client.gui.screen.ChatScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.text.Text;
+
+@Mixin(ChatScreen.class)
+public class ChatScreenMixin extends Screen {
+	protected ChatScreenMixin(Text title) {
+		super(title);
+	}
+
+	@Inject(method = "keyPressed", cancellable = true, at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;setScreen(Lnet/minecraft/client/gui/screen/Screen;)V", ordinal = 1))
+	private void setScreen(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> cir) {
+		// Cancel the closing of the screen if the currentScreen is already changed.
+		// This allows client commands to open another screen without hacky thread scheduling.
+		if (client.currentScreen != this) {
+			cir.setReturnValue(true);
+		}
+	}
+}

--- a/fabric-command-api-v2/src/client/resources/fabric-command-api-v2.client.mixins.json
+++ b/fabric-command-api-v2/src/client/resources/fabric-command-api-v2.client.mixins.json
@@ -3,6 +3,7 @@
   "package": "net.fabricmc.fabric.mixin.command.client",
   "compatibilityLevel": "JAVA_16",
   "client": [
+    "ChatScreenMixin",
     "ClientCommandSourceMixin",
     "ClientPlayerEntityMixin",
     "ClientPlayNetworkHandlerMixin"

--- a/fabric-command-api-v2/src/testmod/java/net/fabricmc/fabric/test/command/client/ClientCommandTest.java
+++ b/fabric-command-api-v2/src/testmod/java/net/fabricmc/fabric/test/command/client/ClientCommandTest.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.GameMenuScreen;
 import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.command.argument.ItemStackArgument;
 import net.minecraft.command.argument.ItemStackArgumentType;
@@ -93,6 +94,12 @@ public final class ClientCommandTest implements ClientModInitializer {
 						return 0;
 					})
 			));
+
+			dispatcher.register(ClientCommandManager.literal("test_open_game_menu_screen").executes(context -> {
+				MinecraftClient client = context.getSource().getClient();
+				client.execute(() -> client.setScreen(new GameMenuScreen(true)));
+				return 0;
+			}));
 
 			// Tests
 


### PR DESCRIPTION
Right now to open a screen via a command you would need to use some sort of thread schedule like `Timer`:
```java
new Timer().schedule(new TimerTask() {
    @Override
    public void run() {
        client.execute(() -> client.setScreen(screen));
    }
}, 1);
```
This is caused by ChatScreen calling `client.setScreen(null)` when enter key is pressed. This PR would make that unnecessary.