### PR TITLE
Message API: 1.19.1 changes

### DIFF
--- a/fabric-message-api-v1/src/main/java/net/fabricmc/fabric/api/message/v1/ServerMessageDecoratorEvent.java
+++ b/fabric-message-api-v1/src/main/java/net/fabricmc/fabric/api/message/v1/ServerMessageDecoratorEvent.java
@@ -41,10 +41,12 @@ import net.fabricmc.fabric.api.event.EventFactory;
  * function. If not given, the message decorator will run in the default phase, which is between
  * the content phase and the styling phase.
  *
- * <p>When implementing a message decorator, it is <strong>very important that the decorator be
- * pure; i.e. return the same text when called multiple times for the same arguments (message and
- * sender)</strong> - otherwise the server detects a mismatch between the preview and the actual message,
- * and discards the message because it was improperly signed.
+ * <p>The message decorator's result is cached (as of 1.19.1) if the chat preview is enabled.
+ * If the original message did not change between the last preview and submission, the decorator
+ * is not called during submission and the cached preview is used instead. Note that the
+ * decorator can still be called during submission if the chat preview is disabled, the
+ * sent message was not the same as the previewed message, or if text filtering was enabled and
+ * it produced a different message.
  *
  * <p>Example of registering a content phase message decorator:
  *

--- a/fabric-message-api-v1/src/main/java/net/fabricmc/fabric/api/message/v1/ServerMessageEvents.java
+++ b/fabric-message-api-v1/src/main/java/net/fabricmc/fabric/api/message/v1/ServerMessageEvents.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.api.message.v1;
 
 import net.minecraft.network.message.MessageType;
 import net.minecraft.network.message.SignedMessage;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.filter.FilteredMessage;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -57,9 +58,9 @@ public final class ServerMessageEvents {
 	 * the remaining listeners will not be called (if any), and {@link #GAME_MESSAGE}
 	 * event will not be triggered.
 	 */
-	public static final Event<AllowGameMessage> ALLOW_GAME_MESSAGE = EventFactory.createArrayBacked(AllowGameMessage.class, handlers -> (message, typeKey) -> {
+	public static final Event<AllowGameMessage> ALLOW_GAME_MESSAGE = EventFactory.createArrayBacked(AllowGameMessage.class, handlers -> (server, message, typeKey) -> {
 		for (AllowGameMessage handler : handlers) {
-			if (!handler.allowGameMessage(message, typeKey)) return false;
+			if (!handler.allowGameMessage(server, message, typeKey)) return false;
 		}
 
 		return true;
@@ -106,9 +107,9 @@ public final class ServerMessageEvents {
 	 * include death messages, join/leave messages, and advancement messages. Is not called
 	 * when {@linkplain #ALLOW_GAME_MESSAGE game messages are blocked}.
 	 */
-	public static final Event<GameMessage> GAME_MESSAGE = EventFactory.createArrayBacked(GameMessage.class, handlers -> (message, typeKey) -> {
+	public static final Event<GameMessage> GAME_MESSAGE = EventFactory.createArrayBacked(GameMessage.class, handlers -> (server, message, typeKey) -> {
 		for (GameMessage handler : handlers) {
-			handler.onGameMessage(message, typeKey);
+			handler.onGameMessage(server, message, typeKey);
 		}
 	});
 
@@ -157,11 +158,12 @@ public final class ServerMessageEvents {
 		 * prevents the message from being broadcast and the {@link #GAME_MESSAGE} event
 		 * from triggering.
 		 *
+		 * @param server the server that sent the message
 		 * @param message the broadcast message; use {@code message.raw().getContent()} to get the text
 		 * @param overlay true when the message is an overlay
 		 * @return {@code true} if the message should be broadcast, otherwise {@code false}
 		 */
-		boolean allowGameMessage(Text message, boolean overlay);
+		boolean allowGameMessage(MinecraftServer server, Text message, boolean overlay);
 	}
 
 	@FunctionalInterface
@@ -209,10 +211,11 @@ public final class ServerMessageEvents {
 		 * include death messages, join/leave messages, and advancement messages. Is not called
 		 * when {@linkplain #ALLOW_GAME_MESSAGE game messages are blocked}.
 		 *
+		 * @param server the server that sent the message
 		 * @param message the broadcast message; use {@code message.raw().getContent()} to get the text
 		 * @param overlay true when the message is an overlay
 		 */
-		void onGameMessage(Text message, boolean overlay);
+		void onGameMessage(MinecraftServer server, Text message, boolean overlay);
 	}
 
 	@FunctionalInterface

--- a/fabric-message-api-v1/src/main/java/net/fabricmc/fabric/api/message/v1/ServerMessageEvents.java
+++ b/fabric-message-api-v1/src/main/java/net/fabricmc/fabric/api/message/v1/ServerMessageEvents.java
@@ -41,9 +41,9 @@ public final class ServerMessageEvents {
 	 * only if {@link #ALLOW_COMMAND_MESSAGE} event did not block the message,
 	 * and after triggering {@link #COMMAND_MESSAGE} event.
 	 */
-	public static final Event<AllowChatMessage> ALLOW_CHAT_MESSAGE = EventFactory.createArrayBacked(AllowChatMessage.class, handlers -> (message, sender, typeKey) -> {
+	public static final Event<AllowChatMessage> ALLOW_CHAT_MESSAGE = EventFactory.createArrayBacked(AllowChatMessage.class, handlers -> (message, sender, params) -> {
 		for (AllowChatMessage handler : handlers) {
-			if (!handler.allowChatMessage(message, sender, typeKey)) return false;
+			if (!handler.allowChatMessage(message, sender, params)) return false;
 		}
 
 		return true;
@@ -58,9 +58,9 @@ public final class ServerMessageEvents {
 	 * the remaining listeners will not be called (if any), and {@link #GAME_MESSAGE}
 	 * event will not be triggered.
 	 */
-	public static final Event<AllowGameMessage> ALLOW_GAME_MESSAGE = EventFactory.createArrayBacked(AllowGameMessage.class, handlers -> (server, message, typeKey) -> {
+	public static final Event<AllowGameMessage> ALLOW_GAME_MESSAGE = EventFactory.createArrayBacked(AllowGameMessage.class, handlers -> (server, message, overlay) -> {
 		for (AllowGameMessage handler : handlers) {
-			if (!handler.allowGameMessage(server, message, typeKey)) return false;
+			if (!handler.allowGameMessage(server, message, overlay)) return false;
 		}
 
 		return true;
@@ -79,9 +79,9 @@ public final class ServerMessageEvents {
 	 * {@link #ALLOW_CHAT_MESSAGE} and {@link #CHAT_MESSAGE} events will also be
 	 * triggered after triggering {@link #COMMAND_MESSAGE}.
 	 */
-	public static final Event<AllowCommandMessage> ALLOW_COMMAND_MESSAGE = EventFactory.createArrayBacked(AllowCommandMessage.class, handlers -> (message, source, typeKey) -> {
+	public static final Event<AllowCommandMessage> ALLOW_COMMAND_MESSAGE = EventFactory.createArrayBacked(AllowCommandMessage.class, handlers -> (message, source, params) -> {
 		for (AllowCommandMessage handler : handlers) {
-			if (!handler.allowCommandMessage(message, source, typeKey)) return false;
+			if (!handler.allowCommandMessage(message, source, params)) return false;
 		}
 
 		return true;
@@ -96,9 +96,9 @@ public final class ServerMessageEvents {
 	 * only if {@link #ALLOW_COMMAND_MESSAGE} event did not block the message,
 	 * and after triggering {@link #COMMAND_MESSAGE} event.
 	 */
-	public static final Event<ChatMessage> CHAT_MESSAGE = EventFactory.createArrayBacked(ChatMessage.class, handlers -> (message, sender, typeKey) -> {
+	public static final Event<ChatMessage> CHAT_MESSAGE = EventFactory.createArrayBacked(ChatMessage.class, handlers -> (message, sender, params) -> {
 		for (ChatMessage handler : handlers) {
-			handler.onChatMessage(message, sender, typeKey);
+			handler.onChatMessage(message, sender, params);
 		}
 	});
 
@@ -107,9 +107,9 @@ public final class ServerMessageEvents {
 	 * include death messages, join/leave messages, and advancement messages. Is not called
 	 * when {@linkplain #ALLOW_GAME_MESSAGE game messages are blocked}.
 	 */
-	public static final Event<GameMessage> GAME_MESSAGE = EventFactory.createArrayBacked(GameMessage.class, handlers -> (server, message, typeKey) -> {
+	public static final Event<GameMessage> GAME_MESSAGE = EventFactory.createArrayBacked(GameMessage.class, handlers -> (server, message, overlay) -> {
 		for (GameMessage handler : handlers) {
-			handler.onGameMessage(server, message, typeKey);
+			handler.onGameMessage(server, message, overlay);
 		}
 	});
 
@@ -121,9 +121,9 @@ public final class ServerMessageEvents {
 	 * <p>If the command is executed by a player, {@link #ALLOW_CHAT_MESSAGE} and
 	 * {@link #CHAT_MESSAGE} events will also be triggered after this event.
 	 */
-	public static final Event<CommandMessage> COMMAND_MESSAGE = EventFactory.createArrayBacked(CommandMessage.class, handlers -> (message, source, typeKey) -> {
+	public static final Event<CommandMessage> COMMAND_MESSAGE = EventFactory.createArrayBacked(CommandMessage.class, handlers -> (message, source, params) -> {
 		for (CommandMessage handler : handlers) {
-			handler.onCommandMessage(message, source, typeKey);
+			handler.onCommandMessage(message, source, params);
 		}
 	});
 

--- a/fabric-message-api-v1/src/main/java/net/fabricmc/fabric/api/message/v1/ServerMessageEvents.java
+++ b/fabric-message-api-v1/src/main/java/net/fabricmc/fabric/api/message/v1/ServerMessageEvents.java
@@ -160,7 +160,7 @@ public final class ServerMessageEvents {
 		 *
 		 * @param server the server that sent the message
 		 * @param message the broadcast message; use {@code message.raw().getContent()} to get the text
-		 * @param overlay true when the message is an overlay
+		 * @param overlay {@code true} when the message is an overlay
 		 * @return {@code true} if the message should be broadcast, otherwise {@code false}
 		 */
 		boolean allowGameMessage(MinecraftServer server, Text message, boolean overlay);
@@ -213,7 +213,7 @@ public final class ServerMessageEvents {
 		 *
 		 * @param server the server that sent the message
 		 * @param message the broadcast message; use {@code message.raw().getContent()} to get the text
-		 * @param overlay true when the message is an overlay
+		 * @param overlay {@code true} when the message is an overlay
 		 */
 		void onGameMessage(MinecraftServer server, Text message, boolean overlay);
 	}

--- a/fabric-message-api-v1/src/testmod/java/net/fabricmc/fabric/test/message/ChatTest.java
+++ b/fabric-message-api-v1/src/testmod/java/net/fabricmc/fabric/test/message/ChatTest.java
@@ -84,18 +84,18 @@ public class ChatTest implements ModInitializer {
 
 		// ServerMessageEvents
 		ServerMessageEvents.CHAT_MESSAGE.register(
-				(message, sender, typeKey) -> LOGGER.info("ChatTest: {} sent \"{}\"", sender, message)
+				(message, sender, params) -> LOGGER.info("ChatTest: {} sent \"{}\"", sender, message)
 		);
 		ServerMessageEvents.GAME_MESSAGE.register(
 				(server, message, overlay) -> LOGGER.info("ChatTest: server sent \"{}\"", message)
 		);
 		ServerMessageEvents.COMMAND_MESSAGE.register(
-				(message, source, typeKey) -> LOGGER.info("ChatTest: command sent \"{}\"", message)
+				(message, source, params) -> LOGGER.info("ChatTest: command sent \"{}\"", message)
 		);
 
 		// ServerMessageEvents blocking
 		ServerMessageEvents.ALLOW_CHAT_MESSAGE.register(
-				(message, sender, typeKey) -> !message.raw().getContent().getString().contains("sadtater")
+				(message, sender, params) -> !message.raw().getContent().getString().contains("sadtater")
 		);
 		ServerMessageEvents.ALLOW_GAME_MESSAGE.register((server, message, overlay) -> {
 			if (message.getContent() instanceof TranslatableTextContent translatable) {
@@ -105,7 +105,7 @@ public class ChatTest implements ModInitializer {
 			return true;
 		});
 		ServerMessageEvents.ALLOW_COMMAND_MESSAGE.register(
-				(message, source, typeKey) -> !message.raw().getContent().getString().contains("sadtater")
+				(message, source, params) -> !message.raw().getContent().getString().contains("sadtater")
 		);
 	}
 }

--- a/fabric-message-api-v1/src/testmod/java/net/fabricmc/fabric/test/message/ChatTest.java
+++ b/fabric-message-api-v1/src/testmod/java/net/fabricmc/fabric/test/message/ChatTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Executor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableTextContent;
 import net.minecraft.util.Util;
 import net.minecraft.util.math.random.Random;
@@ -41,6 +42,15 @@ public class ChatTest implements ModInitializer {
 		ServerMessageDecoratorEvent.EVENT.register(ServerMessageDecoratorEvent.CONTENT_PHASE, (sender, message) -> {
 			if (message.getString().contains("tater")) {
 				return CompletableFuture.completedFuture(message.copy().append(" :tiny_potato:"));
+			}
+
+			return CompletableFuture.completedFuture(message);
+		});
+
+		// Content phase testing, with variable info
+		ServerMessageDecoratorEvent.EVENT.register(ServerMessageDecoratorEvent.CONTENT_PHASE, (sender, message) -> {
+			if (message.getString().contains("random")) {
+				return CompletableFuture.completedFuture(Text.of(String.valueOf(Random.create().nextBetween(0, 100))));
 			}
 
 			return CompletableFuture.completedFuture(message);
@@ -77,7 +87,7 @@ public class ChatTest implements ModInitializer {
 				(message, sender, typeKey) -> LOGGER.info("ChatTest: {} sent \"{}\"", sender, message)
 		);
 		ServerMessageEvents.GAME_MESSAGE.register(
-				(message, typeKey) -> LOGGER.info("ChatTest: server sent \"{}\"", message)
+				(server, message, overlay) -> LOGGER.info("ChatTest: server sent \"{}\"", message)
 		);
 		ServerMessageEvents.COMMAND_MESSAGE.register(
 				(message, source, typeKey) -> LOGGER.info("ChatTest: command sent \"{}\"", message)
@@ -87,7 +97,7 @@ public class ChatTest implements ModInitializer {
 		ServerMessageEvents.ALLOW_CHAT_MESSAGE.register(
 				(message, sender, typeKey) -> !message.raw().getContent().getString().contains("sadtater")
 		);
-		ServerMessageEvents.ALLOW_GAME_MESSAGE.register((message, typeKey) -> {
+		ServerMessageEvents.ALLOW_GAME_MESSAGE.register((server, message, overlay) -> {
 			if (message.getContent() instanceof TranslatableTextContent translatable) {
 				return !translatable.getKey().startsWith("death.attack.badRespawnPoint.");
 			}


### PR DESCRIPTION
## Changes
- **BREAKING**: Provide `MinecraftServer` in `AllowGameMessage` and `GameMessage` events, since they do not have a parameter that allows server access.
- Update javadoc to reflect 1.19.1-pre6 change removing the pure decorator requirement.
- Update testmod to test non-pure decorator and reflect other changes.

## Testing
Tested on dev env (without signing).

## To Do
There is one remaining issue: the current `AllowChatMessage`/`AllowCommandMessage` implementation likely fails in authenticated environments, as the message chain will be split if the sender sends another message after a blocked message, disconnecting the sender. If that is true, there are 2 potential fixes, both with pros and cons:

1. Send the message header to all players, without body. This is what they do for messages fully censored using text filtering. Pros: small change, compatible. Cons: all clients receive the sender's UUID and message hash, which might not be expected in some cases.
2. Move the mixin point before unpacking. This is what they do for messages that fail validation, etc. Pros: does not have to send message header. Cons: requires API-breaking change and introduces inconsistency with unprefixed `ChatMessage`/`GameMessage` events.

We first have to check that this is actually a bug (and not a theoretical issue), and try those fixes. Unfortunately it's not easy for me to test these, as my computer isn't beefy enough to run both the dedicated server and the client, and I do not have the second account for testing situations with other players.