### PR TITLE
Make `DEFAULT_ENABLED` works with client resource pack

### DIFF
--- a/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/GameOptionsMixin.java
+++ b/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/GameOptionsMixin.java
@@ -16,9 +16,20 @@
 
 package net.fabricmc.fabric.mixin.resource.loader.client;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
+import org.slf4j.Logger;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -28,30 +39,90 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import net.minecraft.client.option.GameOptions;
 import net.minecraft.resource.ResourcePack;
 import net.minecraft.resource.ResourcePackProfile;
+import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.impl.resource.loader.ModNioResourcePack;
 import net.fabricmc.fabric.impl.resource.loader.ModResourcePackCreator;
+import net.fabricmc.loader.api.FabricLoader;
 
 @Mixin(GameOptions.class)
 public class GameOptionsMixin {
 	@Shadow
 	public List<String> resourcePacks;
 
+	@Shadow
+	@Final
+	static Logger LOGGER;
+
 	@Inject(method = "load", at = @At("RETURN"))
 	private void onLoad(CallbackInfo ci) {
-		// Add built-in resource packs if they are enabled by default only if the options file is blank.
-		if (this.resourcePacks.isEmpty()) {
-			List<ResourcePackProfile> profiles = new ArrayList<>();
-			ModResourcePackCreator.CLIENT_RESOURCE_PACK_PROVIDER.register(profiles::add);
-			this.resourcePacks = new ArrayList<>();
+		// Track built-in resource packs if they are enabled by default.
+		// - If there is NO line with the resource pack id, add it to the enabled packs and to the tracker file.
+		// - If there is a line with the pack id, do not add it to the enabled packs and let
+		//   the options value decides if it is enabled or not.
+		// - If there is a line without matching pack id (e.g. because the mod is removed),
+		//   remove it from the tracker file so that it would be enabled again if added back later.
 
-			for (ResourcePackProfile profile : profiles) {
-				ResourcePack pack = profile.createResourcePack();
-				if (profile.getSource() == ModResourcePackCreator.RESOURCE_PACK_SOURCE
-						|| (pack instanceof ModNioResourcePack && ((ModNioResourcePack) pack).getActivationType().isEnabledByDefault())) {
-					this.resourcePacks.add(profile.getName());
+		File configDir = FabricLoader.getInstance().getConfigDir().resolve("fabric").toFile();
+
+		if (!configDir.exists() && !configDir.mkdirs()) {
+			LOGGER.warn("[Fabric Resource Loader] Could not create configuration directory: " + configDir.getAbsolutePath());
+		}
+
+		File trackerFile = new File(configDir, "default_resource_pack_tracker.txt");
+		Set<Identifier> trackedPacks = new HashSet<>();
+
+		if (trackerFile.exists()) {
+			try (BufferedReader reader = new BufferedReader(new FileReader(trackerFile, StandardCharsets.UTF_8))) {
+				String line;
+
+				while ((line = reader.readLine()) != null) {
+					if (!line.isBlank() && !line.startsWith("#")) {
+						trackedPacks.add(new Identifier(line));
+					}
+				}
+			} catch (IOException e) {
+				LOGGER.warn("[Fabric Resource Loader] Could not read " + trackerFile.getAbsolutePath(), e);
+			}
+		}
+
+		Set<Identifier> removedPacks = new HashSet<>(trackedPacks);
+		Set<String> resourcePacks = new LinkedHashSet<>(this.resourcePacks);
+
+		List<ResourcePackProfile> profiles = new ArrayList<>();
+		ModResourcePackCreator.CLIENT_RESOURCE_PACK_PROVIDER.register(profiles::add);
+
+		for (ResourcePackProfile profile : profiles) {
+			// Always add "Fabric Mods" pack to enabled resource packs.
+			if (profile.getSource() == ModResourcePackCreator.RESOURCE_PACK_SOURCE) {
+				resourcePacks.add(profile.getName());
+				continue;
+			}
+
+			ResourcePack pack = profile.createResourcePack();
+
+			if (pack instanceof ModNioResourcePack builtinPack && builtinPack.getActivationType().isEnabledByDefault()) {
+				if (trackedPacks.add(builtinPack.getId())) {
+					resourcePacks.add(profile.getName());
+				} else {
+					removedPacks.remove(builtinPack.getId());
 				}
 			}
 		}
+
+		try (FileWriter writer = new FileWriter(trackerFile, StandardCharsets.UTF_8)) {
+			writer.write("# DO NOT MODIFY THIS FILE\n");
+
+			for (Identifier id : trackedPacks) {
+				if (!removedPacks.contains(id)) {
+					writer.write(id.toString());
+					writer.write('\n');
+				}
+			}
+		} catch (IOException e) {
+			LOGGER.warn("[Fabric Resource Loader] Could not write to " + trackerFile.getAbsolutePath(), e);
+		}
+
+		this.resourcePacks = new ArrayList<>(resourcePacks);
 	}
 }

--- a/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/GameOptionsMixin.java
+++ b/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/GameOptionsMixin.java
@@ -58,10 +58,10 @@ public class GameOptionsMixin {
 	@Inject(method = "load", at = @At("RETURN"))
 	private void onLoad(CallbackInfo ci) {
 		// Track built-in resource packs if they are enabled by default.
-		// - If there is NO line with the resource pack id, add it to the enabled packs and to the tracker file.
-		// - If there is a line with the pack id, do not add it to the enabled packs and let
+		// - If there is NO value with matching resource pack id, add it to the enabled packs and the tracker file.
+		// - If there is a matching value and pack id, do not add it to the enabled packs and let
 		//   the options value decides if it is enabled or not.
-		// - If there is a line without matching pack id (e.g. because the mod is removed),
+		// - If there is a value without matching pack id (e.g. because the mod is removed),
 		//   remove it from the tracker file so that it would be enabled again if added back later.
 
 		File dataDir = FabricLoader.getInstance().getGameDir().resolve("data").toFile();

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/ResourcePackActivationType.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/ResourcePackActivationType.java
@@ -26,8 +26,6 @@ public enum ResourcePackActivationType {
 	NORMAL,
 	/**
 	 * Enabled by default. The user has still full control over the activation of the resource pack.
-	 *
-	 * <p>Note: this setting can only be satisfied on data packs, client resource packs cannot be by default enabled.
 	 */
 	DEFAULT_ENABLED,
 	/**

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModNioResourcePack.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModNioResourcePack.java
@@ -56,6 +56,7 @@ public class ModNioResourcePack extends AbstractFileResourcePack implements ModR
 	private static final Pattern RESOURCE_PACK_PATH = Pattern.compile("[a-z0-9-_.]+");
 	private static final FileSystem DEFAULT_FS = FileSystems.getDefault();
 
+	private final Identifier id;
 	private final String name;
 	private final ModMetadata modInfo;
 	private final List<Path> basePaths;
@@ -64,7 +65,7 @@ public class ModNioResourcePack extends AbstractFileResourcePack implements ModR
 	private final ResourcePackActivationType activationType;
 	private final Map<ResourceType, Set<String>> namespaces;
 
-	public static ModNioResourcePack create(String name, ModContainer mod, String subPath, ResourceType type, ResourcePackActivationType activationType) {
+	public static ModNioResourcePack create(Identifier id, String name, ModContainer mod, String subPath, ResourceType type, ResourcePackActivationType activationType) {
 		List<Path> rootPaths = mod.getRootPaths();
 		List<Path> paths;
 
@@ -87,14 +88,15 @@ public class ModNioResourcePack extends AbstractFileResourcePack implements ModR
 
 		if (paths.isEmpty()) return null;
 
-		ModNioResourcePack ret = new ModNioResourcePack(name, mod.getMetadata(), paths, type, null, activationType);
+		ModNioResourcePack ret = new ModNioResourcePack(id, name, mod.getMetadata(), paths, type, null, activationType);
 
 		return ret.getNamespaces(type).isEmpty() ? null : ret;
 	}
 
-	private ModNioResourcePack(String name, ModMetadata modInfo, List<Path> paths, ResourceType type, AutoCloseable closer, ResourcePackActivationType activationType) {
+	private ModNioResourcePack(Identifier id, String name, ModMetadata modInfo, List<Path> paths, ResourceType type, AutoCloseable closer, ResourcePackActivationType activationType) {
 		super(null);
 
+		this.id = id;
 		this.name = name;
 		this.modInfo = modInfo;
 		this.basePaths = paths;
@@ -158,8 +160,8 @@ public class ModNioResourcePack extends AbstractFileResourcePack implements ModR
 		return null;
 	}
 
-	private static final String resPrefix = ResourceType.CLIENT_RESOURCES.getDirectory()+"/";
-	private static final String dataPrefix = ResourceType.SERVER_DATA.getDirectory()+"/";
+	private static final String resPrefix = ResourceType.CLIENT_RESOURCES.getDirectory() + "/";
+	private static final String dataPrefix = ResourceType.SERVER_DATA.getDirectory() + "/";
 
 	private boolean hasAbsentNs(String filename) {
 		int prefixLen;
@@ -278,6 +280,10 @@ public class ModNioResourcePack extends AbstractFileResourcePack implements ModR
 	@Override
 	public String getName() {
 		return name;
+	}
+
+	public Identifier getId() {
+		return id;
 	}
 
 	private static boolean exists(Path path) {

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModResourcePackUtil.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModResourcePackUtil.java
@@ -29,6 +29,7 @@ import net.minecraft.resource.DataPackSettings;
 import net.minecraft.resource.ResourcePack;
 import net.minecraft.resource.ResourcePackProfile;
 import net.minecraft.resource.ResourceType;
+import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.api.resource.ModResourcePack;
 import net.fabricmc.fabric.api.resource.ResourcePackActivationType;
@@ -56,7 +57,7 @@ public final class ModResourcePackUtil {
 				continue;
 			}
 
-			ModResourcePack pack = ModNioResourcePack.create(getName(container.getMetadata()), container, null, type, ResourcePackActivationType.ALWAYS_ENABLED);
+			ModResourcePack pack = ModNioResourcePack.create(new Identifier("fabric", container.getMetadata().getId()), getName(container.getMetadata()), container, null, type, ResourcePackActivationType.ALWAYS_ENABLED);
 
 			if (pack != null) {
 				packs.add(pack);

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ResourceManagerHelperImpl.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ResourceManagerHelperImpl.java
@@ -71,8 +71,8 @@ public class ResourceManagerHelperImpl implements ResourceManagerHelper {
 		String separator = container.getRootPath().getFileSystem().getSeparator();
 		subPath = subPath.replace("/", separator);
 		String name = displayName;
-		ModNioResourcePack resourcePack = ModNioResourcePack.create(name, container, subPath, ResourceType.CLIENT_RESOURCES, activationType);
-		ModNioResourcePack dataPack = ModNioResourcePack.create(name, container, subPath, ResourceType.SERVER_DATA, activationType);
+		ModNioResourcePack resourcePack = ModNioResourcePack.create(id, name, container, subPath, ResourceType.CLIENT_RESOURCES, activationType);
+		ModNioResourcePack dataPack = ModNioResourcePack.create(id, name, container, subPath, ResourceType.SERVER_DATA, activationType);
 		if (resourcePack == null && dataPack == null) return false;
 
 		if (resourcePack != null) {

--- a/fabric-resource-loader-v0/src/testmod/java/net/fabricmc/fabric/test/resource/loader/BuiltinResourcePackTestMod.java
+++ b/fabric-resource-loader-v0/src/testmod/java/net/fabricmc/fabric/test/resource/loader/BuiltinResourcePackTestMod.java
@@ -36,7 +36,7 @@ public class BuiltinResourcePackTestMod implements ModInitializer {
 		// Should always be present as it's **this** mod.
 		FabricLoader.getInstance().getModContainer(MODID)
 				.map(container -> ResourceManagerHelper.registerBuiltinResourcePack(new Identifier(MODID, "test"),
-						container, "Fabric Resource Loader Test Pack", ResourcePackActivationType.NORMAL))
+						container, "Fabric Resource Loader Test Pack", ResourcePackActivationType.DEFAULT_ENABLED))
 				.filter(success -> !success).ifPresent(success -> LOGGER.warn("Could not register built-in resource pack with custom name."));
 		FabricLoader.getInstance().getModContainer(MODID)
 				.map(container -> ResourceManagerHelper.registerBuiltinResourcePack(new Identifier(MODID, "test2"),

--- a/fabric-resource-loader-v0/src/testmod/resources/resourcepacks/test/pack.mcmeta
+++ b/fabric-resource-loader-v0/src/testmod/resources/resourcepacks/test/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 8,
+    "pack_format": 9,
     "description": "Fabric Resource Loader Test Builtin Pack."
   }
 }


### PR DESCRIPTION
Right now client resource pack with `DEFAULT_ENABLED` only works when `options.txt > resourcePacks` is an empty array, which only happens when the resource pack selection screen is never opened.

This PR makes it work by tracking pack ids in an NBT file (`<gameDir>/data/fabricDefaultResourcePacks.dat`):
- If there is NO value with matching resource pack id, add it to the enabled packs and the tracker file.
- If there is a matching value and pack id, do not add it to the enabled packs and let the options value decides if it is enabled or not.
- If there is a value without matching pack id (e.g. because the mod is removed), remove it from the tracker file so that it would be enabled again if added back later.

Also possible bug fix (not really tested):
`Fabric Mods` client resource pack _technically_ only gets added to the default packs when there's at least one mod that has a file in the `assets` directory, but since the resource loader module itself has its icon in the `assets` it gets added regardless.