### PR TITLE
Split icy tag into ICY and AQUATIC_ICY

### DIFF
--- a/fabric-convention-tags-v1/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BiomeTagGenerator.java
+++ b/fabric-convention-tags-v1/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BiomeTagGenerator.java
@@ -102,10 +102,11 @@ public class BiomeTagGenerator extends FabricTagProvider.DynamicRegistryTagProvi
 				.add(BiomeKeys.WINDSWEPT_SAVANNA)
 				.add(BiomeKeys.SAVANNA);
 		getOrCreateTagBuilder(ConventionalBiomeTags.ICY)
-				.add(BiomeKeys.FROZEN_RIVER)
 				.add(BiomeKeys.FROZEN_PEAKS)
+				.add(BiomeKeys.ICE_SPIKES);
+		getOrCreateTagBuilder(ConventionalBiomeTags.AQUATIC_ICY)
+				.add(BiomeKeys.FROZEN_RIVER)
 				.add(BiomeKeys.DEEP_FROZEN_OCEAN)
-				.add(BiomeKeys.ICE_SPIKES)
 				.add(BiomeKeys.FROZEN_OCEAN);
 		getOrCreateTagBuilder(ConventionalBiomeTags.SNOWY)
 				.add(BiomeKeys.SNOWY_BEACH)

--- a/fabric-convention-tags-v1/src/generated/resources/data/c/tags/worldgen/biome/aquatic_icy.json
+++ b/fabric-convention-tags-v1/src/generated/resources/data/c/tags/worldgen/biome/aquatic_icy.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:frozen_river",
+    "minecraft:deep_frozen_ocean",
+    "minecraft:frozen_ocean"
+  ]
+}

--- a/fabric-convention-tags-v1/src/generated/resources/data/c/tags/worldgen/biome/icy.json
+++ b/fabric-convention-tags-v1/src/generated/resources/data/c/tags/worldgen/biome/icy.json
@@ -1,10 +1,7 @@
 {
   "replace": false,
   "values": [
-    "minecraft:frozen_river",
     "minecraft:frozen_peaks",
-    "minecraft:deep_frozen_ocean",
-    "minecraft:ice_spikes",
-    "minecraft:frozen_ocean"
+    "minecraft:ice_spikes"
   ]
 }

--- a/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/api/tag/convention/v1/ConventionalBiomeTags.java
+++ b/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/api/tag/convention/v1/ConventionalBiomeTags.java
@@ -52,10 +52,15 @@ public class ConventionalBiomeTags {
 	public static final TagKey<Biome> PLAINS = register("plains");
 	public static final TagKey<Biome> SAVANNA = register("savanna");
 	/**
-	 * For biomes where ice naturally spawns.
+	 * For land biomes where ice naturally spawns.
 	 * For biomes where snow alone spawns, see {@link ConventionalBiomeTags#SNOWY}.
 	 */
 	public static final TagKey<Biome> ICY = register("icy");
+	/**
+	 * For water biomes where ice naturally spawns.
+	 * For biomes where snow alone spawns, see {@link ConventionalBiomeTags#SNOWY}.
+	 */
+	public static final TagKey<Biome> AQUATIC_ICY = register("aquatic_icy");
 	/**
 	 * Biomes that exist on the shoreline of a body of water.
 	 */


### PR DESCRIPTION
Makes the ICY tag now usable for people. Before, if one makes an ice-based structure and wants it to spawn in icy land biomes like icy spikes or so, the current ICY tag will spawn the structure in the middle of the ocean (froze ocean) which looks wrong and terrible. Thus making the tag unusable. 

This PR adds a middle ground by taking out the watery biomes that are icy out of ICY tag and put them into a AQUATIC_ICY tag so they can still be used by anyone looking for watery super cold biomes and makes the ICY tag usable for land structures again.