### PR TITLE
Make static-only classes final and unconstructible

### DIFF
--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModifications.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModifications.java
@@ -39,6 +39,9 @@ import net.minecraft.world.gen.feature.PlacedFeature;
  * <p><b>Experimental feature</b>, may be removed or changed without further notice.
  */
 public final class BiomeModifications {
+	private BiomeModifications() {
+	}
+
 	/**
 	 * Convenience method to add a feature to one or more biomes.
 	 *

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/VillagerInteractionRegistries.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/VillagerInteractionRegistries.java
@@ -40,7 +40,7 @@ import net.fabricmc.fabric.mixin.content.registry.GiveGiftsToHeroTaskAccessor;
  * villagers have with the world.
  * @see VillagerPlantableRegistry for registering plants that farmers can plant
  */
-public class VillagerInteractionRegistries {
+public final class VillagerInteractionRegistries {
 	private static final Logger LOGGER = LoggerFactory.getLogger(VillagerInteractionRegistries.class);
 
 	private VillagerInteractionRegistries() {

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/VillagerPlantableRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/VillagerPlantableRegistry.java
@@ -35,7 +35,7 @@ import net.minecraft.util.registry.Registry;
 /**
  * Registry of items that farmer villagers can plant on farmland.
  */
-public class VillagerPlantableRegistry {
+public final class VillagerPlantableRegistry {
 	private static final Logger LOGGER = LoggerFactory.getLogger(VillagerPlantableRegistry.class);
 	private static final HashMap<Item, BlockState> PLANTABLES = new HashMap<>();
 	static {

--- a/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/api/tag/convention/v1/ConventionalBiomeTags.java
+++ b/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/api/tag/convention/v1/ConventionalBiomeTags.java
@@ -27,7 +27,10 @@ import net.fabricmc.fabric.impl.tag.convention.TagRegistration;
  * and as such certain biome tags exist to mirror vanilla tags, and should be preferred
  * over vanilla unless its behavior is desired.
  */
-public class ConventionalBiomeTags {
+public final class ConventionalBiomeTags {
+	private ConventionalBiomeTags() {
+	}
+
 	/**
 	 * Biomes that spawn in the Overworld.
 	 */

--- a/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/api/tag/convention/v1/ConventionalBlockTags.java
+++ b/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/api/tag/convention/v1/ConventionalBlockTags.java
@@ -26,7 +26,10 @@ import net.fabricmc.fabric.impl.tag.convention.TagRegistration;
  * See {@link net.minecraft.tag.BlockTags} for vanilla tags.
  * Note that addition to some vanilla tags implies having certain functionality.
  */
-public class ConventionalBlockTags {
+public final class ConventionalBlockTags {
+	private ConventionalBlockTags() {
+	}
+
 	public static final TagKey<Block> QUARTZ_ORES = register("quartz_ores");
 	public static final TagKey<Block> ORES = register("ores");
 	public static final TagKey<Block> CHESTS = register("chests");

--- a/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/api/tag/convention/v1/ConventionalEnchantmentTags.java
+++ b/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/api/tag/convention/v1/ConventionalEnchantmentTags.java
@@ -21,7 +21,10 @@ import net.minecraft.tag.TagKey;
 
 import net.fabricmc.fabric.impl.tag.convention.TagRegistration;
 
-public class ConventionalEnchantmentTags {
+public final class ConventionalEnchantmentTags {
+	private ConventionalEnchantmentTags() {
+	}
+
 	/**
 	 * A tag containing enchantments that increase the amount or
 	 * quality of drops from blocks, such as {@link net.minecraft.enchantment.Enchantments#FORTUNE}.

--- a/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/api/tag/convention/v1/ConventionalEntityTypeTags.java
+++ b/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/api/tag/convention/v1/ConventionalEntityTypeTags.java
@@ -25,7 +25,10 @@ import net.fabricmc.fabric.impl.tag.convention.TagRegistration;
  * See {@link net.minecraft.tag.EntityTypeTags} for vanilla tags.
  * Note that addition to some vanilla tags implies having certain functionality.
  */
-public class ConventionalEntityTypeTags {
+public final class ConventionalEntityTypeTags {
+	private ConventionalEntityTypeTags() {
+	}
+
 	/**
 	 * Tag containing entity types that display a boss health bar.
 	 */

--- a/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/api/tag/convention/v1/ConventionalFluidTags.java
+++ b/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/api/tag/convention/v1/ConventionalFluidTags.java
@@ -25,7 +25,10 @@ import net.fabricmc.fabric.impl.tag.convention.TagRegistration;
  * See {@link net.minecraft.tag.FluidTags} for vanilla tags.
  * Note that addition to some vanilla tags implies having certain functionality.
  */
-public class ConventionalFluidTags {
+public final class ConventionalFluidTags {
+	private ConventionalFluidTags() {
+	}
+
 	public static final TagKey<Fluid> LAVA = register("lava");
 	public static final TagKey<Fluid> WATER = register("water");
 	public static final TagKey<Fluid> MILK = register("milk");

--- a/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/api/tag/convention/v1/ConventionalItemTags.java
+++ b/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/api/tag/convention/v1/ConventionalItemTags.java
@@ -25,7 +25,10 @@ import net.fabricmc.fabric.impl.tag.convention.TagRegistration;
  * See {@link net.minecraft.tag.ItemTags} for vanilla tags.
  * Note that addition to some vanilla tags implies having certain functionality.
  */
-public class ConventionalItemTags {
+public final class ConventionalItemTags {
+	private ConventionalItemTags() {
+	}
+
 	// Tool tags
 	public static final TagKey<Item> PICKAXES = register("pickaxes");
 	public static final TagKey<Item> SHOVELS = register("shovels");

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientEntityEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientEntityEvents.java
@@ -27,7 +27,7 @@ import net.fabricmc.fabric.api.event.EventFactory;
 
 @Environment(EnvType.CLIENT)
 public final class ClientEntityEvents {
-	public ClientEntityEvents() {
+	private ClientEntityEvents() {
 	}
 
 	/**

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientTickEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientTickEvents.java
@@ -27,7 +27,7 @@ import net.fabricmc.fabric.api.event.EventFactory;
 
 @Environment(EnvType.CLIENT)
 public final class ClientTickEvents {
-	public ClientTickEvents() {
+	private ClientTickEvents() {
 	}
 
 	/**

--- a/fabric-loot-api-v2/src/main/java/net/fabricmc/fabric/api/loot/v2/LootTableEvents.java
+++ b/fabric-loot-api-v2/src/main/java/net/fabricmc/fabric/api/loot/v2/LootTableEvents.java
@@ -30,6 +30,9 @@ import net.fabricmc.fabric.api.event.EventFactory;
  * Events for manipulating loot tables.
  */
 public final class LootTableEvents {
+	private LootTableEvents() {
+	}
+
 	/**
 	 * This event can be used to replace loot tables.
 	 * If a loot table is replaced, the iteration will stop for that loot table.

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/entity/FabricDefaultAttributeRegistry.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/entity/FabricDefaultAttributeRegistry.java
@@ -45,6 +45,9 @@ public final class FabricDefaultAttributeRegistry {
 	 */
 	private static final Logger LOGGER = LoggerFactory.getLogger(FabricDefaultAttributeRegistry.class);
 
+	private FabricDefaultAttributeRegistry() {
+	}
+
 	/**
 	 * Registers a default attribute for a type of living entity.
 	 *

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/entity/MinecartComparatorLogicRegistry.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/entity/MinecartComparatorLogicRegistry.java
@@ -34,6 +34,9 @@ public final class MinecartComparatorLogicRegistry {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MinecartComparatorLogicRegistry.class);
 	private static final Map<EntityType<?>, MinecartComparatorLogic<?>> logics = new HashMap<>();
 
+	private MinecartComparatorLogicRegistry() {
+	}
+
 	/**
 	 * Gets the registered custom comparator logic for the specified minecart entity type.
 	 *

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/ModelHelper.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/ModelHelper.java
@@ -35,7 +35,7 @@ import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
 /**
  * Collection of utilities for model implementations.
  */
-public abstract class ModelHelper {
+public final class ModelHelper {
 	private ModelHelper() { }
 
 	/** Result from {@link #toFaceIndex(Direction)} for null values. */

--- a/fabric-transfer-api-v1/src/client/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRendering.java
+++ b/fabric-transfer-api-v1/src/client/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRendering.java
@@ -47,9 +47,12 @@ import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariantAttributes;
  */
 @ApiStatus.Experimental
 @Environment(EnvType.CLIENT)
-public class FluidVariantRendering {
+public final class FluidVariantRendering {
 	private static final ApiProviderMap<Fluid, FluidVariantRenderHandler> HANDLERS = ApiProviderMap.create();
 	private static final FluidVariantRenderHandler DEFAULT_HANDLER = new FluidVariantRenderHandler() { };
+
+	private FluidVariantRendering () {
+	}
 
 	/**
 	 * Register a render handler for the passed fluid.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariantAttributes.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariantAttributes.java
@@ -39,9 +39,12 @@ import net.fabricmc.fabric.impl.transfer.TransferApiImpl;
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-public class FluidVariantAttributes {
+public final class FluidVariantAttributes {
 	private static final ApiProviderMap<Fluid, FluidVariantAttributeHandler> HANDLERS = ApiProviderMap.create();
 	private static final FluidVariantAttributeHandler DEFAULT_HANDLER = new FluidVariantAttributeHandler() { };
+
+	private FluidVariantAttributes() {
+	}
 
 	/**
 	 * Register an attribute handler for the passed fluid.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StoragePreconditions.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StoragePreconditions.java
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.ApiStatus;
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-public class StoragePreconditions {
+public final class StoragePreconditions {
 	/**
 	 * Ensure that the passed transfer variant is not blank.
 	 *

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StorageUtil.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StorageUtil.java
@@ -43,6 +43,9 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
  */
 @ApiStatus.Experimental
 public final class StorageUtil {
+	private StorageUtil() {
+	}
+
 	/**
 	 * Move resources between two storages, matching the passed filter, and return the amount that was successfully transferred.
 	 *


### PR DESCRIPTION
The following classes have been made final and unconstructible:

- All convention tags classes
- `FluidVariantAttributes`
- `FluidVariantRendering`

The following classes have been made unconstructible:

- `BiomeModifications`
- `ClientEntityEvents`
- `ClientTickEvents`
- `LootTableEvents`
- `FabricDefaultAttributeRegistry`
- `MinecartComparatorLogicRegistry`
- `StorageUtil`

The following classes have been explicitly marked as final. Note that actually extending such class has always been impossible due to missing public constructor:

- `VillagerInteractionRegistries`
- `VillagerPlantableRegistry`
- `ModelHelper`
- `StoragePreconditions`

While the first two are technically breaking changes, there is no actual or observed usage for any of those. Just to be safe this targets `1.19.1` branch; there is no practical reason for backporting.

## Affected classes by module

|Class                          |Module            |Final   |Unconstructible|
|-------------------------------|------------------|--------|---------------|
|BiomeModifications             |Biome API         |Yes     |No             |
|VillagerInteractionRegistries  |Content Registries|Implicit|Yes            |
|VillagerPlantableRegistry      |Content Registries|Implicit|Yes            |
|ConventionalBiomeTags          |Convention Tags   |No      |No             |
|ConventionalBlockTags          |Convention Tags   |No      |No             |
|ConventionalEnchantmentTags    |Convention Tags   |No      |No             |
|ConventionalEntityTypeTags     |Convention Tags   |No      |No             |
|ConventionalFluidTags          |Convention Tags   |No      |No             |
|ConventionalItemTags           |Convention Tags   |No      |No             |
|ClientEntityEvents             |Lifecycle Events  |Yes     |No             |
|ClientTickEvents               |Lifecycle Events  |Yes     |No             |
|LootTableEvents                |Loot API          |Yes     |No             |
|FabricDefaultAttributeRegistry |Object Builder    |Yes     |No             |
|MinecartComparatorLogicRegistry|Object Builder    |Yes     |No             |
|ModelHelper                    |Renderer API      |Implicit|Yes            |
|FluidVariantAttributes         |Transfer API      |No      |No             |
|FluidVariantRendering          |Transfer API      |No      |No             |
|StoragePreconditions           |Transfer API      |Implicit|Yes            |
|StorageUtil                    |Transfer API      |Yes     |No             |
