### PR TITLE
ModelHelper: remove useless contract

### DIFF
--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/ModelHelper.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/ModelHelper.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
-import org.jetbrains.annotations.Contract;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.model.BakedQuad;
@@ -57,7 +56,6 @@ public abstract class ModelHelper {
 	 * optionally including the null face. (Use &lt; or  &lt;= {@link #NULL_FACE_ID}
 	 * to exclude or include the null value, respectively.)
 	 */
-	@Contract("null -> null")
 	public static Direction faceFromIndex(int faceIndex) {
 		return FACES[faceIndex];
 	}


### PR DESCRIPTION
The contract `null -> null` is useless, since the parameter is `int` and `null` cannot be passed there.