### PR TITLE
Fix 1.19.1 command API bugs

### DIFF
--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/impl/command/client/ClientCommandInternals.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/impl/command/client/ClientCommandInternals.java
@@ -128,7 +128,7 @@ public final class ClientCommandInternals {
 		return type == builtins.dispatcherUnknownCommand() || type == builtins.dispatcherParseException();
 	}
 
-	// See CommandSuggestor.method_30505. That cannot be used directly as it returns an OrderedText instead of a Text.
+	// See ChatInputSuggestor.formatException. That cannot be used directly as it returns an OrderedText instead of a Text.
 	private static Text getErrorMessage(CommandSyntaxException e) {
 		Text message = Texts.toText(e.getRawMessage());
 		String context = e.getContext();

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientCommandSourceMixin.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientCommandSourceMixin.java
@@ -37,7 +37,8 @@ abstract class ClientCommandSourceMixin implements FabricClientCommandSource {
 
 	@Override
 	public void sendFeedback(Text message) {
-		this.client.getMessageHandler().onGameMessage(message, false);
+		this.client.inGameHud.getChatHud().addMessage(message);
+		this.client.getNarratorManager().narrate(message);
 	}
 
 	@Override

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPlayerEntityMixin.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPlayerEntityMixin.java
@@ -20,6 +20,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.text.Text;
@@ -28,6 +29,13 @@ import net.fabricmc.fabric.impl.command.client.ClientCommandInternals;
 
 @Mixin(ClientPlayerEntity.class)
 abstract class ClientPlayerEntityMixin {
+	@Inject(method = "sendCommand(Ljava/lang/String;)Z", at = @At("HEAD"), cancellable = true)
+	private void onSendCommand(String command, CallbackInfoReturnable<Boolean> cir) {
+		if (ClientCommandInternals.executeCommand(command)) {
+			cir.setReturnValue(true);
+		}
+	}
+
 	@Inject(method = "sendCommand(Ljava/lang/String;Lnet/minecraft/text/Text;)V", at = @At("HEAD"), cancellable = true)
 	private void onSendCommand(String command, Text preview, CallbackInfo info) {
 		if (ClientCommandInternals.executeCommand(command)) {


### PR DESCRIPTION
Resolves #2424 

This contains 2 fixes:

- Fixes wrong method being used to send client command feedback. `MessageHandler` should only be used to handle messages from the server. This once again directly adds the message to the HUD, but keeps the narration previously handled in `MessageHandler#onGameMessage`.
- Fixes client commands not being executed from `ClientPlayerEntity#executeCommand(String)` overload. Observable via click events.

Both are 1.19.1 only and is inapplicable in older versions.