### PR TITLE
Fix POI types not being registered properly

### DIFF
--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/world/poi/PointOfInterestHelper.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/world/poi/PointOfInterestHelper.java
@@ -76,6 +76,7 @@ public final class PointOfInterestHelper {
 	// INTERNAL METHODS
 
 	private static PointOfInterestType register(Identifier id, int ticketCount, int searchDistance, Set<BlockState> states) {
+		PointOfInterestTypes.POI_STATES.addAll(states);
 		return PointOfInterestTypes.register(Registry.POINT_OF_INTEREST_TYPE, RegistryKey.of(Registry.POINT_OF_INTEREST_TYPE_KEY, id), states, ticketCount, searchDistance);
 	}
 }

--- a/fabric-object-builder-api-v1/src/main/resources/fabric-object-builder-api-v1.accesswidener
+++ b/fabric-object-builder-api-v1/src/main/resources/fabric-object-builder-api-v1.accesswidener
@@ -2,6 +2,7 @@ accessWidener	v1	named
 extendable  method    net/minecraft/block/AbstractBlock$Settings    <init>  (Lnet/minecraft/block/Material;Ljava/util/function/Function;)V
 extendable  method    net/minecraft/block/AbstractBlock$Settings    <init>  (Lnet/minecraft/block/Material;Lnet/minecraft/block/MapColor;)V
 
+accessible    field     net/minecraft/world/poi/PointOfInterestTypes    POI_STATES  Ljava/util/Set;
 accessible    method    net/minecraft/world/poi/PointOfInterestTypes    register    (Lnet/minecraft/util/registry/Registry;Lnet/minecraft/util/registry/RegistryKey;Ljava/util/Set;II)Lnet/minecraft/world/poi/PointOfInterestType;
 
 extendable class net/minecraft/block/entity/BlockEntityType$BlockEntityFactory


### PR DESCRIPTION
`PointOfInterestType` must be registered in `PointOfInterestTypes.POI_STATES`, otherwise the deserializer ignores the serialized POI and re-creates it. `PointOfInterestHelper` now adds the states to the set. (See also MC-254634)

Forwardport needed to 1.19.1, backport to 1.18.2 is not needed