### PR TITLE
Message API: fix outdated and incorrect javadoc

### DIFF
--- a/fabric-message-api-v1/src/main/java/net/fabricmc/fabric/api/message/v1/ServerMessageEvents.java
+++ b/fabric-message-api-v1/src/main/java/net/fabricmc/fabric/api/message/v1/ServerMessageEvents.java
@@ -30,14 +30,15 @@ public final class ServerMessageEvents {
 	/**
 	 * An event triggered when the server broadcasts a chat message sent by a player,
 	 * typically from a client GUI or a player-executed command. Mods can use this to block
-	 * the message.
+	 * the message body, but due to client-side limitations, the header (which includes the
+	 * sender profile) will always be sent.
 	 *
-	 * <p>If a listener returned {@code false}, the message will not be broadcast,
+	 * <p>If a listener returned {@code false}, the message body will not be broadcast,
 	 * the remaining listeners will not be called (if any), and {@link #CHAT_MESSAGE}
 	 * event will not be triggered.
 	 *
 	 * <p>If the message is from a player-executed command, this will be called
-	 * only if {@link #ALLOW_COMMAND_MESSAGE} event did not block the message,
+	 * only if {@link #ALLOW_COMMAND_MESSAGE} event did not block the message body,
 	 * and after triggering {@link #COMMAND_MESSAGE} event.
 	 */
 	public static final Event<AllowChatMessage> ALLOW_CHAT_MESSAGE = EventFactory.createArrayBacked(AllowChatMessage.class, handlers -> (message, sender, params) -> {
@@ -67,14 +68,15 @@ public final class ServerMessageEvents {
 
 	/**
 	 * An event triggered when the server broadcasts a command message to all players, such as one
-	 * from {@code /me}, {@code /msg}, {@code /say}, and {@code /tellraw}. Mods can use this
-	 * to block the message.
+	 * from {@code /me} and {@code /say} (but not ones that specify the recipients like
+	 * {@code /msg}). Mods can use this to block the message body, but due to client-side
+	 * limitations, the header (which includes the sender profile) will always be sent.
 	 *
-	 * <p>If a listener returned {@code false}, the message will not be broadcast,
+	 * <p>If a listener returned {@code false}, the message body will not be broadcast,
 	 * the remaining listeners will not be called (if any), and {@link #COMMAND_MESSAGE}
 	 * event will not be triggered.
 	 *
-	 * <p>If the command is executed by a player and the message is not blocked,
+	 * <p>If the command is executed by a player and the message body is not blocked,
 	 * {@link #ALLOW_CHAT_MESSAGE} and {@link #CHAT_MESSAGE} events will also be
 	 * triggered after triggering {@link #COMMAND_MESSAGE}.
 	 */
@@ -89,10 +91,10 @@ public final class ServerMessageEvents {
 	/**
 	 * An event triggered when the server broadcasts a chat message sent by a player, typically
 	 * from a client GUI or a player-executed command. Is not called when {@linkplain
-	 * #ALLOW_CHAT_MESSAGE chat messages are blocked}.
+	 * #ALLOW_CHAT_MESSAGE chat message bodies are blocked}.
 	 *
 	 * <p>If the message is from a player-executed command, this will be called
-	 * only if {@link #ALLOW_COMMAND_MESSAGE} event did not block the message,
+	 * only if {@link #ALLOW_COMMAND_MESSAGE} event did not block the message body,
 	 * and after triggering {@link #COMMAND_MESSAGE} event.
 	 */
 	public static final Event<ChatMessage> CHAT_MESSAGE = EventFactory.createArrayBacked(ChatMessage.class, handlers -> (message, sender, params) -> {
@@ -114,8 +116,9 @@ public final class ServerMessageEvents {
 
 	/**
 	 * An event triggered when the server broadcasts a command message to all players, such as one
-	 * from {@code /me}, {@code /msg}, {@code /say}, and {@code /tellraw}. Is not called
-	 * when {@linkplain #ALLOW_COMMAND_MESSAGE command messages are blocked}.
+	 * from {@code /me} and {@code /say} (but not ones that specify the recipients like
+	 * {@code /msg}). Is not called when {@linkplain #ALLOW_COMMAND_MESSAGE command message
+	 * bodies are blocked}.
 	 *
 	 * <p>If the command is executed by a player, {@link #ALLOW_CHAT_MESSAGE} and
 	 * {@link #CHAT_MESSAGE} events will also be triggered after this event.
@@ -134,17 +137,18 @@ public final class ServerMessageEvents {
 		/**
 		 * Called when the server broadcasts a chat message sent by a player, typically
 		 * from a client GUI or a player-executed command. Returning {@code false}
-		 * prevents the message from being broadcast and the {@link #CHAT_MESSAGE} event
-		 * from triggering.
+		 * prevents the message body from being broadcast and the {@link #CHAT_MESSAGE} event
+		 * from triggering. However, the header (which includes the sender profile) will always
+		 * be sent.
 		 *
 		 * <p>If the message is from a player-executed command, this will be called
-		 * only if {@link #ALLOW_COMMAND_MESSAGE} event did not block the message,
+		 * only if {@link #ALLOW_COMMAND_MESSAGE} event did not block the message body,
 		 * and after triggering {@link #COMMAND_MESSAGE} event.
 		 *
-		 * @param message the broadcast message with message decorators applied; use {@code message.raw().getContent()} to get the text
+		 * @param message the broadcast message with message decorators applied; use {@code message.getContent()} to get the text
 		 * @param sender  the player that sent the message
 		 * @param params the {@link MessageType.Parameters}
-		 * @return {@code true} if the message should be broadcast, otherwise {@code false}
+		 * @return {@code true} if the message body should be broadcast, otherwise {@code false}
 		 */
 		boolean allowChatMessage(SignedMessage message, ServerPlayerEntity sender, MessageType.Parameters params);
 	}
@@ -158,7 +162,7 @@ public final class ServerMessageEvents {
 		 * from triggering.
 		 *
 		 * @param server the server that sent the message
-		 * @param message the broadcast message; use {@code message.raw().getContent()} to get the text
+		 * @param message the broadcast message
 		 * @param overlay {@code true} when the message is an overlay
 		 * @return {@code true} if the message should be broadcast, otherwise {@code false}
 		 */
@@ -169,18 +173,19 @@ public final class ServerMessageEvents {
 	public interface AllowCommandMessage {
 		/**
 		 * Called when the server broadcasts a command message to all players, such as one
-		 * from {@code /me}, {@code /msg}, {@code /say}, and {@code /tellraw}. Returning {@code false}
-		 * prevents the message from being broadcast and the {@link #COMMAND_MESSAGE} event
-		 * from triggering.
+		 * from {@code /me} and {@code /say} (but not ones that specify the recipients like
+		 * {@code /msg}). Returning {@code false} prevents the message body from being broadcast
+		 * and the {@link #COMMAND_MESSAGE} event from triggering. However, the header (which
+		 * includes the sender profile) will always be sent.
 		 *
-		 * <p>If the command is executed by a player and the message is not blocked,
+		 * <p>If the command is executed by a player and the message body is not blocked,
 		 * {@link #ALLOW_CHAT_MESSAGE} and {@link #CHAT_MESSAGE} events will also be
 		 * triggered after triggering {@link #COMMAND_MESSAGE}.
 		 *
-		 * @param message the broadcast message with message decorators applied if applicable; use {@code message.raw().getContent()} to get the text
+		 * @param message the broadcast message with message decorators applied if applicable; use {@code message.getContent()} to get the text
 		 * @param source  the command source that sent the message
 		 * @param params the {@link MessageType.Parameters}
-		 * @return {@code true} if the message should be broadcast, otherwise {@code false}
+		 * @return {@code true} if the message body should be broadcast, otherwise {@code false}
 		 */
 		boolean allowCommandMessage(SignedMessage message, ServerCommandSource source, MessageType.Parameters params);
 	}
@@ -190,13 +195,13 @@ public final class ServerMessageEvents {
 		/**
 		 * Called when the server broadcasts a chat message sent by a player, typically
 		 * from a client GUI or a player-executed command. Is not called when {@linkplain
-		 * #ALLOW_CHAT_MESSAGE chat messages are blocked}.
+		 * #ALLOW_CHAT_MESSAGE chat message bodies are blocked}.
 		 *
 		 * <p>If the message is from a player-executed command, this will be called
-		 * only if {@link #ALLOW_COMMAND_MESSAGE} event did not block the message,
+		 * only if {@link #ALLOW_COMMAND_MESSAGE} event did not block the message body,
 		 * and after triggering {@link #COMMAND_MESSAGE} event.
 		 *
-		 * @param message the broadcast message with message decorators applied; use {@code message.raw().getContent()} to get the text
+		 * @param message the broadcast message with message decorators applied; use {@code message.getContent()} to get the text
 		 * @param sender  the player that sent the message
 		 * @param params the {@link MessageType.Parameters}
 		 */
@@ -211,7 +216,7 @@ public final class ServerMessageEvents {
 		 * when {@linkplain #ALLOW_GAME_MESSAGE game messages are blocked}.
 		 *
 		 * @param server the server that sent the message
-		 * @param message the broadcast message; use {@code message.raw().getContent()} to get the text
+		 * @param message the broadcast message
 		 * @param overlay {@code true} when the message is an overlay
 		 */
 		void onGameMessage(MinecraftServer server, Text message, boolean overlay);
@@ -221,13 +226,14 @@ public final class ServerMessageEvents {
 	public interface CommandMessage {
 		/**
 		 * Called when the server broadcasts a command message to all players, such as one
-		 * from {@code /me}, {@code /msg}, {@code /say}, and {@code /tellraw}. Is not called
-		 * when {@linkplain #ALLOW_COMMAND_MESSAGE command messages are blocked}.
+		 * from {@code /me} and {@code /say} (but not ones that specify the recipients like
+		 * {@code /msg}). Is not called when {@linkplain #ALLOW_COMMAND_MESSAGE command message
+		 * bodies are blocked}.
 		 *
 		 * <p>If the command is executed by a player, {@link #ALLOW_CHAT_MESSAGE} and
 		 * {@link #CHAT_MESSAGE} events will also be triggered after this event.
 		 *
-		 * @param message the broadcast message with message decorators applied if applicable; use {@code message.raw().getContent()} to get the text
+		 * @param message the broadcast message with message decorators applied if applicable; use {@code message.getContent()} to get the text
 		 * @param source  the command source that sent the message
 		 * @param params the {@link MessageType.Parameters}
 		 */


### PR DESCRIPTION
- Fix incorrect commands listed as caller. `/msg` is private message and does not "broadcast". `/tellraw` does not sign the content.
- Replace "Message" with "message body" when referencing to the event
- Add the note that events can only block the body and message headers are still broadcast
- Fix incorrect/outdated code example