### PR TITLE
add fix to AFTER_PLAYER_CHANGE_WORLD

### DIFF
--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/PlayerBetweenEndAndOverworldTracker.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/PlayerBetweenEndAndOverworldTracker.java
@@ -1,0 +1,31 @@
+package net.fabricmc.fabric;
+
+import net.fabricmc.fabric.api.entity.event.v1.ServerEntityWorldChangeEvents;
+import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class PlayerBetweenEndAndOverworldTracker {
+
+	private static final Map<UUID, Entry> playersBetweenEndAndOverworld = new HashMap<>();
+
+	public static void setPlayerIsBetweenEndAndOverworld(UUID playerUUID, ServerWorld origin, ServerWorld destination) {
+		playersBetweenEndAndOverworld.put(playerUUID, new Entry(origin, destination));
+	}
+
+	public static boolean isPlayerBetweenEndAndOverworld(ServerPlayerEntity player) {
+		return playersBetweenEndAndOverworld.containsKey(player.getUuid());
+	}
+
+	public static Entry setPlayerIsNotBetweenEndAndOverworld(UUID playerUUID) {
+		return playersBetweenEndAndOverworld.remove(playerUUID);
+	}
+
+	public record Entry(ServerWorld origin, ServerWorld destination) {}
+
+}

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -51,7 +51,11 @@ import net.fabricmc.fabric.api.entity.event.v1.ServerEntityCombatEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
 
 @Mixin(LivingEntity.class)
-abstract class LivingEntityMixin {
+abstract class LivingEntityMixin extends Entity {
+	public LivingEntityMixin(EntityType<?> type, World world) {
+		super(type, world);
+	}
+
 	@Shadow
 	public abstract boolean isDead();
 

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/ServerPlayerEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/ServerPlayerEntityMixin.java
@@ -19,6 +19,11 @@ package net.fabricmc.fabric.mixin.entity.event;
 import java.util.List;
 
 import com.mojang.datafixers.util.Either;
+
+import net.fabricmc.fabric.PlayerBetweenEndAndOverworldTracker;
+
+import net.minecraft.entity.EntityType;
+
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -52,6 +57,10 @@ import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
 
 @Mixin(ServerPlayerEntity.class)
 abstract class ServerPlayerEntityMixin extends LivingEntityMixin {
+	public ServerPlayerEntityMixin(EntityType<?> type, World world) {
+		super(type, world);
+	}
+
 	@Shadow
 	public abstract ServerWorld getWorld();
 
@@ -78,6 +87,16 @@ abstract class ServerPlayerEntityMixin extends LivingEntityMixin {
 	@Inject(method = "worldChanged(Lnet/minecraft/server/world/ServerWorld;)V", at = @At("TAIL"))
 	private void afterWorldChanged(ServerWorld origin, CallbackInfo ci) {
 		ServerEntityWorldChangeEvents.AFTER_PLAYER_CHANGE_WORLD.invoker().afterChangeWorld((ServerPlayerEntity) (Object) this, origin, this.getWorld());
+	}
+
+	/**
+	 * worldChanged is not called when a player moves from the end to the overworld.
+	 */
+	@Inject(method = "moveToWorld", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayerEntity;detach()V"))
+	private void moveWorld(ServerWorld destination, CallbackInfoReturnable<Entity> cir) {
+		if (destination.getRegistryKey() == World.OVERWORLD) {
+			PlayerBetweenEndAndOverworldTracker.setPlayerIsBetweenEndAndOverworld(super.getUuid(), getWorld(), destination);
+		}
 	}
 
 	@Inject(method = "copyFrom", at = @At("TAIL"))


### PR DESCRIPTION
Adds a workaround to still call the AFTER_PLAYER_CHANGE_WORLD event when a player is moving from the end to the overworld.