### PR TITLE
ModNioResourcePack: don't extend AbstractFileResourcePack

### DIFF
--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModNioResourcePack.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModNioResourcePack.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +54,7 @@ import net.fabricmc.fabric.api.resource.ResourcePackActivationType;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.metadata.ModMetadata;
 
+@ApiStatus.Internal
 public class ModNioResourcePack implements ResourcePack, ModResourcePack {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ModNioResourcePack.class);
 	private static final Pattern RESOURCE_PACK_PATH = Pattern.compile("[a-z0-9-_.]+");

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModNioResourcePack.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModNioResourcePack.java
@@ -210,6 +210,7 @@ public class ModNioResourcePack implements ResourcePack, ModResourcePack {
 		if (fileName.contains("/") || fileName.contains("\\")) {
 			throw new IllegalArgumentException("Root resources can only be filenames, not paths (no / allowed!)");
 		}
+
 		return this.openFile(fileName);
 	}
 

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModNioResourcePack.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModNioResourcePack.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -185,7 +186,7 @@ public class ModNioResourcePack implements ResourcePack, ModResourcePack {
 		return !namespaces.get(type).contains(filename.substring(prefixLen, nsEnd));
 	}
 
-	protected InputStream openFile(String filename) throws IOException {
+	private InputStream openFile(String filename) throws IOException {
 		InputStream stream;
 
 		Path path = getPath(filename);
@@ -206,11 +207,10 @@ public class ModNioResourcePack implements ResourcePack, ModResourcePack {
 
 	@Override
 	public InputStream openRoot(String fileName) throws IOException {
-		if (!fileName.contains("/") && !fileName.contains("\\")) {
-			return this.openFile(fileName);
-		} else {
+		if (fileName.contains("/") || fileName.contains("\\")) {
 			throw new IllegalArgumentException("Root resources can only be filenames, not paths (no / allowed!)");
 		}
+		return this.openFile(fileName);
 	}
 
 	@Override
@@ -276,7 +276,7 @@ public class ModNioResourcePack implements ResourcePack, ModResourcePack {
 
 	@Override
 	public <T> T parseMetadata(ResourceMetadataReader<T> metaReader) throws IOException {
-		try (InputStream is = openRoot("pack.mcmeta")) {
+		try (InputStream is = openFile("pack.mcmeta")) {
 			return AbstractFileResourcePack.parseMetadata(metaReader, is);
 		}
 	}
@@ -316,6 +316,6 @@ public class ModNioResourcePack implements ResourcePack, ModResourcePack {
 	}
 
 	private static String getFilename(ResourceType type, Identifier id) {
-		return type.getDirectory() + "/" + id.getNamespace() + "/" + id.getPath();
+		return String.format(Locale.ROOT, "%s/%s/%s", type.getDirectory(), id.getNamespace(), id.getPath());
 	}
 }

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModNioResourcePack.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModNioResourcePack.java
@@ -55,7 +55,7 @@ import net.fabricmc.loader.api.metadata.ModMetadata;
 
 public class ModNioResourcePack implements ResourcePack, ModResourcePack {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ModNioResourcePack.class);
-	private static final Pattern RESOURCE_PACK_PATH = Pattern.compile("[a-z\\d-_.]+");
+	private static final Pattern RESOURCE_PACK_PATH = Pattern.compile("[a-z0-9-_.]+");
 	private static final FileSystem DEFAULT_FS = FileSystems.getDefault();
 
 	private final Identifier id;


### PR DESCRIPTION
When a mod comes across an AbstractFileResourcePack, it should be safe to assume that the pack is a resource pack based on a File (as the name suggests).
That is not true in this implementation as the attached "base" File is null.
This PR adjusts ModNioResourcePack to no longer extend AbstractFileResourcePack and instead implement the small number of features it provided manually.