### PR TITLE
Split vanilla play packets if it's too big

### DIFF
--- a/fabric-networking-api-v1/build.gradle
+++ b/fabric-networking-api-v1/build.gradle
@@ -6,7 +6,8 @@ moduleDependencies(project, [
 ])
 
 testDependencies(project, [
-	':fabric-command-api-v2',
-	':fabric-lifecycle-events-v1',
-	':fabric-key-binding-api-v1'
+		':fabric-command-api-v2',
+		':fabric-lifecycle-events-v1',
+		':fabric-key-binding-api-v1',
+		':fabric-screen-handler-api-v1'
 ])

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientNetworkingImpl.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientNetworkingImpl.java
@@ -39,7 +39,7 @@ import net.fabricmc.fabric.api.client.networking.v1.ClientLoginNetworking;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
-import net.fabricmc.fabric.impl.networking.ChannelInfoHolder;
+import net.fabricmc.fabric.impl.networking.ClientConnectionExtensions;
 import net.fabricmc.fabric.impl.networking.GlobalReceiverRegistry;
 import net.fabricmc.fabric.impl.networking.NetworkHandlerExtensions;
 import net.fabricmc.fabric.impl.networking.NetworkingImpl;
@@ -123,7 +123,7 @@ public final class ClientNetworkingImpl {
 				ids.add(buf.readIdentifier());
 			}
 
-			((ChannelInfoHolder) handler.getConnection()).getPendingChannelsNames().addAll(ids);
+			((ClientConnectionExtensions) handler.getConnection()).getPendingChannelsNames().addAll(ids);
 			NetworkingImpl.LOGGER.debug("Received accepted channels from the server");
 
 			PacketByteBuf response = PacketByteBufs.create();
@@ -137,5 +137,8 @@ public final class ClientNetworkingImpl {
 			NetworkingImpl.LOGGER.debug("Sent accepted channels to the server");
 			return CompletableFuture.completedFuture(response);
 		});
+
+		ClientPlayNetworking.registerGlobalReceiver(NetworkingImpl.SPLIT_CHANNEL, (client, handler, buf, responseSender) ->
+				((ClientConnectionExtensions) handler.getConnection()).getPacketMerger().handle(buf));
 	}
 }

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientPlayNetworkAddon.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientPlayNetworkAddon.java
@@ -33,7 +33,7 @@ import net.fabricmc.fabric.api.client.networking.v1.C2SPlayChannelEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.impl.networking.AbstractChanneledNetworkAddon;
-import net.fabricmc.fabric.impl.networking.ChannelInfoHolder;
+import net.fabricmc.fabric.impl.networking.ClientConnectionExtensions;
 import net.fabricmc.fabric.impl.networking.NetworkingImpl;
 
 @Environment(EnvType.CLIENT)
@@ -48,7 +48,7 @@ public final class ClientPlayNetworkAddon extends AbstractChanneledNetworkAddon<
 		this.client = client;
 
 		// Must register pending channels via lateinit
-		this.registerPendingChannels((ChannelInfoHolder) this.connection);
+		this.registerPendingChannels((ClientConnectionExtensions) this.connection);
 
 		// Register global receivers and attach to session
 		this.receiver.startSession(this);

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/AbstractChanneledNetworkAddon.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/AbstractChanneledNetworkAddon.java
@@ -65,7 +65,7 @@ public abstract class AbstractChanneledNetworkAddon<H> extends AbstractNetworkAd
 
 	public abstract void lateInit();
 
-	protected void registerPendingChannels(ChannelInfoHolder holder) {
+	protected void registerPendingChannels(ClientConnectionExtensions holder) {
 		final Collection<Identifier> pending = holder.getPendingChannelsNames();
 
 		if (!pending.isEmpty()) {

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/ClientConnectionExtensions.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/ClientConnectionExtensions.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.networking;
+
+import java.util.Collection;
+
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.impl.networking.vanilla.PacketMerger;
+
+public interface ClientConnectionExtensions {
+	/**
+	 * @return Channels which are declared as receivable by the other side but have not been declared yet.
+	 */
+	Collection<Identifier> getPendingChannelsNames();
+
+	PacketMerger getPacketMerger();
+}

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/NetworkingImpl.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/NetworkingImpl.java
@@ -20,8 +20,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.util.Identifier;
@@ -47,6 +47,8 @@ public final class NetworkingImpl {
 	 * Dynamic registration of supported channels is still allowed using {@link NetworkingImpl#REGISTER_CHANNEL} and {@link NetworkingImpl#UNREGISTER_CHANNEL}.
 	 */
 	public static final Identifier EARLY_REGISTRATION_CHANNEL = new Identifier(MOD_ID, "early_registration");
+
+	public static final Identifier SPLIT_CHANNEL = new Identifier(MOD_ID, "split");
 
 	public static void init() {
 		// Login setup
@@ -77,9 +79,12 @@ public final class NetworkingImpl {
 				ids.add(buf.readIdentifier());
 			}
 
-			((ChannelInfoHolder) handler.getConnection()).getPendingChannelsNames().addAll(ids);
+			((ClientConnectionExtensions) handler.getConnection()).getPendingChannelsNames().addAll(ids);
 			NetworkingImpl.LOGGER.debug("Received accepted channels from the client for \"{}\"", handler.getConnectionInfo());
 		});
+
+		ServerPlayNetworking.registerGlobalReceiver(SPLIT_CHANNEL, (server, player, handler, buf, responseSender) ->
+				((ClientConnectionExtensions) handler.connection).getPacketMerger().handle(buf));
 	}
 
 	public static boolean isReservedPlayChannel(Identifier channelName) {

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/server/ServerPlayNetworkAddon.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/server/ServerPlayNetworkAddon.java
@@ -31,7 +31,7 @@ import net.fabricmc.fabric.api.networking.v1.S2CPlayChannelEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.impl.networking.AbstractChanneledNetworkAddon;
-import net.fabricmc.fabric.impl.networking.ChannelInfoHolder;
+import net.fabricmc.fabric.impl.networking.ClientConnectionExtensions;
 import net.fabricmc.fabric.impl.networking.NetworkingImpl;
 import net.fabricmc.fabric.mixin.networking.accessor.CustomPayloadC2SPacketAccessor;
 
@@ -46,7 +46,7 @@ public final class ServerPlayNetworkAddon extends AbstractChanneledNetworkAddon<
 		this.server = server;
 
 		// Must register pending channels via lateinit
-		this.registerPendingChannels((ChannelInfoHolder) this.connection);
+		this.registerPendingChannels((ClientConnectionExtensions) this.connection);
 
 		// Register global receivers and attach to session
 		this.receiver.startSession(this);

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/vanilla/PacketEncoderExtensions.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/vanilla/PacketEncoderExtensions.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.networking.vanilla;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+
+import net.minecraft.network.Packet;
+
+public interface PacketEncoderExtensions {
+	boolean fabric_tryEncode(ChannelHandlerContext ctx, Packet<?> packet, ByteBuf out) throws Exception;
+}

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/vanilla/PacketMerger.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/vanilla/PacketMerger.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.networking.vanilla;
+
+import java.util.Objects;
+import java.util.concurrent.RejectedExecutionException;
+
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.minecraft.network.ClientConnection;
+import net.minecraft.network.NetworkState;
+import net.minecraft.network.OffThreadException;
+import net.minecraft.network.Packet;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.listener.PacketListener;
+import net.minecraft.text.Text;
+
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+
+public class PacketMerger {
+	private static final Logger LOGGER = LoggerFactory.getLogger(PacketMerger.class);
+
+	private final ClientConnection connection;
+
+	@Nullable
+	private Handled handled;
+
+	public PacketMerger(ClientConnection connection) {
+		this.connection = connection;
+	}
+
+	/**
+	 * @see ClientConnection#channelRead0(ChannelHandlerContext, Packet)
+	 */
+	@SuppressWarnings({"unchecked", "JavadocReference"})
+	public void handle(PacketByteBuf buf) {
+		int packetId = buf.readVarInt();
+		boolean end = buf.readBoolean();
+
+		if (handled == null) {
+			handled = new Handled(packetId, PacketByteBufs.create());
+		}
+
+		handled.partCount++;
+		handled.maxPartSize = Math.max(handled.maxPartSize, buf.readableBytes());
+		handled.buf.writeBytes(buf);
+
+		if (handled.id != packetId) {
+			throw new IllegalStateException("Packet out of order! Received part for packet id " + packetId + " while handling " + handled.id);
+		}
+
+		if (end) {
+			// Needs to be set to null before calling apply otherwise it won't get set, threading issue?
+			Handled finished = handled;
+			handled = null;
+
+			int packetSize = finished.buf.readableBytes();
+			Packet<PacketListener> packet = (Packet<PacketListener>) NetworkState.PLAY.getPacketHandler(connection.getSide(), finished.id, finished.buf);
+			finished.buf.release();
+			Objects.requireNonNull(packet, () -> "Unknown packet with id " + finished.id);
+
+			try {
+				packet.apply(connection.getPacketListener());
+			} catch (OffThreadException ignored) {
+				// no-op
+			} catch (RejectedExecutionException rejectedExecutionException) {
+				connection.disconnect(Text.translatable("multiplayer.disconnect.server_shutdown"));
+			} catch (ClassCastException classCastException) {
+				LOGGER.error("Received {} that couldn't be processed", packet.getClass(), classCastException);
+				connection.disconnect(Text.translatable("multiplayer.disconnect.invalid_packet"));
+			}
+
+			if (LOGGER.isDebugEnabled()) {
+				LOGGER.debug("Merged {} packet sized {} from {} parts {} each max", packet.getClass().getSimpleName(), packetSize, finished.partCount, finished.maxPartSize);
+			}
+		}
+	}
+
+	private static final class Handled {
+		private final int id;
+		private final PacketByteBuf buf;
+
+		private int maxPartSize = 0;
+		private int partCount = 0;
+
+		private Handled(int id, PacketByteBuf buf) {
+			this.id = id;
+			this.buf = buf;
+		}
+	}
+}

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/vanilla/PacketSplitter.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/vanilla/PacketSplitter.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.networking.vanilla;
+
+import java.util.List;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageEncoder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.minecraft.network.ClientConnection;
+import net.minecraft.network.NetworkSide;
+import net.minecraft.network.NetworkState;
+import net.minecraft.network.Packet;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket;
+import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
+
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.fabricmc.fabric.impl.networking.AbstractChanneledNetworkAddon;
+import net.fabricmc.fabric.impl.networking.NetworkHandlerExtensions;
+import net.fabricmc.fabric.impl.networking.NetworkingImpl;
+
+public class PacketSplitter extends MessageToMessageEncoder<Packet<?>> {
+	public static final String ID = "fabric:packet_splitter";
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(PacketSplitter.class);
+
+	private static final int MAX_S2C_CUSTOM_PACKET_SIZE = 0x100000;
+	private static final int MAX_C2S_CUSTOM_PACKET_SIZE = Short.MAX_VALUE;
+
+	private final ChannelHandler delegate;
+	private final ClientConnection connection;
+
+	public PacketSplitter(ChannelHandler delegate, ClientConnection connection) {
+		this.delegate = delegate;
+		this.connection = connection;
+	}
+
+	@Override
+	protected void encode(ChannelHandlerContext ctx, Packet<?> packet, List<Object> out) throws Exception {
+		NetworkState state = ctx.channel().attr(ClientConnection.PROTOCOL_ATTRIBUTE_KEY).get();
+
+		// Only try to split non-custom play packets if the encoder is present.
+		// Encoder only present when connected to non-local receiver.
+		if (state != NetworkState.PLAY
+				|| !(delegate instanceof PacketEncoderExtensions encoder)
+				|| packet instanceof CustomPayloadS2CPacket
+				|| packet instanceof CustomPayloadC2SPacket
+		) {
+			out.add(packet);
+			return;
+		}
+
+		// Only try to split when receiver accepts the split packet.
+		if (connection.getPacketListener() instanceof NetworkHandlerExtensions ext
+				&& ext.getAddon() instanceof AbstractChanneledNetworkAddon<?> addon
+				&& !addon.getSendableChannels().contains(NetworkingImpl.SPLIT_CHANNEL)
+		) {
+			out.add(packet);
+			return;
+		}
+
+		PacketByteBuf buf = PacketByteBufs.create();
+
+		// First run vanilla encoder with size error messages suppressed, return the buf as-is if it succeeded.
+		// Vanilla encoder output format: varint(packet id), byte[](message).
+		if (encoder.fabric_tryEncode(ctx, packet, buf)) {
+			out.add(buf);
+			return;
+		}
+
+		int maxPartSize = connection.getOppositeSide() == NetworkSide.CLIENTBOUND ? MAX_S2C_CUSTOM_PACKET_SIZE : MAX_C2S_CUSTOM_PACKET_SIZE;
+		int packetId = buf.readVarInt();
+		int packetSize = buf.readableBytes();
+		int partCount = 0;
+
+		// Part format: varint(packet id), bool(end mark), byte[](part).
+		while (buf.isReadable()) {
+			PacketByteBuf partBuf = new PacketByteBuf(Unpooled.buffer(maxPartSize));
+			partBuf.writeVarInt(packetId);
+			int partSize = Math.min(buf.readableBytes(), maxPartSize - partBuf.writerIndex() - 1);
+			partBuf.writeBoolean(partSize == buf.readableBytes());
+			partBuf.writeBytes(buf, partSize);
+
+			switch (connection.getOppositeSide()) {
+			case CLIENTBOUND -> out.add(new CustomPayloadS2CPacket(NetworkingImpl.SPLIT_CHANNEL, partBuf));
+			case SERVERBOUND -> out.add(new CustomPayloadC2SPacket(NetworkingImpl.SPLIT_CHANNEL, partBuf));
+			}
+
+			partCount++;
+		}
+
+		if (LOGGER.isDebugEnabled()) {
+			LOGGER.debug("Split {} packet sized {} into {} with {} each max", packet.getClass().getSimpleName(), packetSize, partCount, maxPartSize);
+		}
+
+		buf.release();
+	}
+}

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/PacketEncoderMixin.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/PacketEncoderMixin.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.networking;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.network.Packet;
+import net.minecraft.network.PacketEncoder;
+
+import net.fabricmc.fabric.impl.networking.vanilla.PacketEncoderExtensions;
+
+@Mixin(PacketEncoder.class)
+abstract class PacketEncoderMixin implements PacketEncoderExtensions {
+	@Shadow
+	protected abstract void encode(ChannelHandlerContext channelHandlerContext, Packet<?> packet, ByteBuf byteBuf) throws Exception;
+
+	@Unique
+	private boolean suppressSizeError;
+
+	@Unique
+	private boolean success;
+
+	@Inject(method = "encode(Lio/netty/channel/ChannelHandlerContext;Lnet/minecraft/network/Packet;Lio/netty/buffer/ByteBuf;)V",
+			at = @At(value = "NEW", target = "java/lang/IllegalArgumentException"), cancellable = true)
+	private void suppressSizeError(ChannelHandlerContext channelHandlerContext, Packet<?> packet, ByteBuf byteBuf, CallbackInfo ci) {
+		if (suppressSizeError) {
+			success = false;
+			ci.cancel();
+		}
+	}
+
+	@Override
+	public boolean fabric_tryEncode(ChannelHandlerContext ctx, Packet<?> packet, ByteBuf out) throws Exception {
+		success = true;
+		suppressSizeError = true;
+		encode(ctx, packet, out);
+		suppressSizeError = false;
+		return success;
+	}
+}

--- a/fabric-networking-api-v1/src/main/resources/fabric-networking-api-v1.mixins.json
+++ b/fabric-networking-api-v1/src/main/resources/fabric-networking-api-v1.mixins.json
@@ -5,6 +5,7 @@
   "mixins": [
     "ClientConnectionMixin",
     "EntityTrackerEntryMixin",
+    "PacketEncoderMixin",
     "PlayerManagerMixin",
     "ServerLoginNetworkHandlerMixin",
     "ServerPlayNetworkHandlerMixin",

--- a/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/packetsplitter/BigRecipe.java
+++ b/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/packetsplitter/BigRecipe.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.networking.packetsplitter;
+
+import com.google.gson.JsonObject;
+
+import net.minecraft.inventory.CraftingInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.recipe.Recipe;
+import net.minecraft.recipe.RecipeSerializer;
+import net.minecraft.recipe.RecipeType;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.World;
+
+public class BigRecipe implements Recipe<CraftingInventory> {
+	public static final Serializer SERIALIZER = new Serializer();
+
+	private final Identifier id;
+
+	public BigRecipe(Identifier id) {
+		this.id = id;
+	}
+
+	@Override
+	public boolean matches(CraftingInventory inventory, World world) {
+		return false;
+	}
+
+	@Override
+	public ItemStack craft(CraftingInventory inventory) {
+		return ItemStack.EMPTY;
+	}
+
+	@Override
+	public boolean fits(int width, int height) {
+		return false;
+	}
+
+	@Override
+	public ItemStack getOutput() {
+		return ItemStack.EMPTY;
+	}
+
+	@Override
+	public Identifier getId() {
+		return id;
+	}
+
+	@Override
+	public RecipeSerializer<?> getSerializer() {
+		return SERIALIZER;
+	}
+
+	@Override
+	public RecipeType<?> getType() {
+		return RecipeType.CRAFTING;
+	}
+
+	public static class Serializer implements RecipeSerializer<BigRecipe> {
+		@Override
+		public BigRecipe read(Identifier id, JsonObject json) {
+			return new BigRecipe(id);
+		}
+
+		@Override
+		public BigRecipe read(Identifier id, PacketByteBuf buf) {
+			buf.readBytes(0x1000000);
+			return new BigRecipe(id);
+		}
+
+		@Override
+		public void write(PacketByteBuf buf, BigRecipe recipe) {
+			buf.writeBytes(new byte[0x1000000]);
+		}
+	}
+}

--- a/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/packetsplitter/PacketSplitterTest.java
+++ b/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/packetsplitter/PacketSplitterTest.java
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.impl.networking;
+package net.fabricmc.fabric.test.networking.packetsplitter;
 
-import java.util.Collection;
+import net.minecraft.util.registry.Registry;
 
-import net.minecraft.util.Identifier;
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.test.networking.NetworkingTestmods;
 
-public interface ChannelInfoHolder {
-	/**
-	 * @return Channels which are declared as receivable by the other side but have not been declared yet.
-	 */
-	Collection<Identifier> getPendingChannelsNames();
+public class PacketSplitterTest implements ModInitializer {
+	@Override
+	public void onInitialize() {
+		Registry.register(Registry.RECIPE_SERIALIZER, NetworkingTestmods.id("big_recipe"), BigRecipe.SERIALIZER);
+	}
 }

--- a/fabric-networking-api-v1/src/testmod/resources/data/fabric-networking-api-v1-testmod/recipes/big_recipe.json
+++ b/fabric-networking-api-v1/src/testmod/resources/data/fabric-networking-api-v1-testmod/recipes/big_recipe.json
@@ -1,0 +1,3 @@
+{
+  "type": "fabric-networking-api-v1-testmod:big_recipe"
+}

--- a/fabric-networking-api-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-networking-api-v1/src/testmod/resources/fabric.mod.json
@@ -13,6 +13,7 @@
       "net.fabricmc.fabric.test.networking.channeltest.NetworkingChannelTest",
       "net.fabricmc.fabric.test.networking.keybindreciever.NetworkingKeybindPacketTest",
       "net.fabricmc.fabric.test.networking.login.NetworkingLoginQueryTest",
+      "net.fabricmc.fabric.test.networking.packetsplitter.PacketSplitterTest",
       "net.fabricmc.fabric.test.networking.play.NetworkingPlayPacketTest"
     ],
     "client": [


### PR DESCRIPTION
Resolves `Packet too big (is x, should be less than 8388608)` error, most commonly caused by `SynchronizeRecipesS2CPacket` becoming too big because of too many recipes, but any packet can cause this, especially if NBT is involved.

`CustomPayload*Packet` (mod packets) are not affected by this PR and will still error if it exceeds the limit (1mb for S2C, 32kb for C2S), should Fabric also handle splitting those?