### PR TITLE
Fix many javadoc issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -287,7 +287,7 @@ javadoc {
 		charSet = "UTF-8"
 		memberLevel = JavadocMemberLevel.PACKAGE
 		links(
-				"https://guava.dev/releases/31.0/api/docs/",
+				"https://guava.dev/releases/31.0-jre/api/docs/",
 				"https://asm.ow2.io/javadoc/",
 				"https://docs.oracle.com/en/java/javase/17/docs/api/",
 				"https://jenkins.liteloader.com/job/Mixin/javadoc/",
@@ -295,7 +295,7 @@ javadoc {
 				"https://www.slf4j.org/apidocs/",
 				"https://netty.io/4.1/api/",
 				"https://javadoc.lwjgl.org/",
-				"https://www.javadoc.io/doc/com.google.code.gson/gson/latest/",
+				"https://www.javadoc.io/doc/com.google.code.gson/gson/2.9.1/",
 				"https://fastutil.di.unimi.it/docs/",
 				"https://maven.fabricmc.net/docs/yarn-${rootProject.minecraft_version}${project.yarn_version}/"
 		)

--- a/build.gradle
+++ b/build.gradle
@@ -287,12 +287,17 @@ javadoc {
 		charSet = "UTF-8"
 		memberLevel = JavadocMemberLevel.PACKAGE
 		links(
-				"https://guava.dev/releases/21.0/api/docs/",
+				"https://guava.dev/releases/31.0/api/docs/",
 				"https://asm.ow2.io/javadoc/",
-				"https://docs.oracle.com/javase/8/docs/api/",
-				"http://jenkins.liteloader.com/job/Mixin/javadoc/",
-				"https://logging.apache.org/log4j/2.x/log4j-api/apidocs/"
-				// Need to add minecraft jd publication etc once there is one available
+				"https://docs.oracle.com/en/java/javase/17/docs/api/",
+				"https://jenkins.liteloader.com/job/Mixin/javadoc/",
+				"https://logging.apache.org/log4j/2.x/log4j-api/apidocs/",
+				"https://www.slf4j.org/apidocs/",
+				"https://netty.io/4.1/api/",
+				"https://javadoc.lwjgl.org/",
+				"https://www.javadoc.io/doc/com.google.code.gson/gson/latest/",
+				"https://fastutil.di.unimi.it/docs/",
+				"https://maven.fabricmc.net/docs/yarn-${rootProject.minecraft_version}${project.yarn_version}/"
 		)
 		// Disable the crazy super-strict doclint tool in Java 8
 		addStringOption("Xdoclint:none", "-quiet")

--- a/deprecated/fabric-renderer-registries-v1/src/client/java/net/fabricmc/fabric/api/client/rendereregistry/v1/BlockEntityRendererRegistry.java
+++ b/deprecated/fabric-renderer-registries-v1/src/client/java/net/fabricmc/fabric/api/client/rendereregistry/v1/BlockEntityRendererRegistry.java
@@ -40,7 +40,7 @@ public interface BlockEntityRendererRegistry {
 	 * Register a BlockEntityRenderer for a BlockEntityType. Can be called clientside before the world is rendered.
 	 *
 	 * @param blockEntityType the {@link BlockEntityType} to register a renderer for
-	 * @param blockEntityRendererFactory a {@link class_5614} that creates a {@link BlockEntityRenderer}, called
+	 * @param blockEntityRendererFactory a {@link BlockEntityRendererFactory} that creates a {@link BlockEntityRenderer}, called
 	 *                            when {@link BlockEntityRenderDispatcher} is initialized or immediately if the dispatcher
 	 *                            class is already loaded
 	 * @param <E> the {@link BlockEntity}

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/util/BooleanFunction.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/util/BooleanFunction.java
@@ -17,7 +17,7 @@
 package net.fabricmc.fabric.api.util;
 
 /**
- * Represents a function that accepts an boolean-valued argument and produces a result.
+ * Represents a function that accepts a boolean-valued argument and produces a result.
  *
  * <p>This is the {@code boolean}-consuming primitive specialization for {@link java.util.function.Function}.
  */

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/util/NbtType.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/util/NbtType.java
@@ -22,7 +22,7 @@ import net.minecraft.nbt.NbtElement;
 /**
  * NBT type ID constants. Useful for filtering by value type in a few cases.
  *
- * <p>For the current list of types, check with {@link net.minecraft.nbt.NbtElement}.
+ * <p>For the current list of types, check with {@link NbtElement}.
  *
  * @see NbtCompound#contains(String, int)
  * @see net.minecraft.nbt.NbtTypes#byId(int)

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/util/NbtType.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/util/NbtType.java
@@ -22,7 +22,7 @@ import net.minecraft.nbt.NbtElement;
 /**
  * NBT type ID constants. Useful for filtering by value type in a few cases.
  *
- * <p>For the current list of types, check with {@link NbtElement#TYPES}.
+ * <p>For the current list of types, check with {@link net.minecraft.nbt.NbtElement}.
  *
  * @see NbtCompound#contains(String, int)
  * @see net.minecraft.nbt.NbtTypes#byId(int)

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/util/TriState.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/util/TriState.java
@@ -64,8 +64,8 @@ public enum TriState {
 	/**
 	 * Gets the value of the tri-state.
 	 *
-	 * @return true if the tri-state is {@link TriState#TRUE}.
-	 * Otherwise false.
+	 * @return true if the tri-state is {@link TriState#TRUE},
+	 * otherwise false.
 	 */
 	public boolean get() {
 		return this == TRUE;
@@ -86,7 +86,7 @@ public enum TriState {
 	 * Gets the value of this tri-state.
 	 * If the value is {@link TriState#DEFAULT} then use the supplied value.
 	 *
-	 * @param value the value to fallback to
+	 * @param value the value to fall back to
 	 * @return the value of the tri-state or the supplied value if {@link TriState#DEFAULT}.
 	 */
 	public boolean orElse(boolean value) {
@@ -97,7 +97,7 @@ public enum TriState {
 	 * Gets the value of this tri-state.
 	 * If the value is {@link TriState#DEFAULT} then use the supplied value.
 	 *
-	 * @param supplier the supplier used to get the value to fallback to
+	 * @param supplier the supplier used to get the value to fall back to
 	 * @return the value of the tri-state or the value of the supplier if the tri-state is {@link TriState#DEFAULT}.
 	 */
 	public boolean orElseGet(BooleanSupplier supplier) {

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/custom/ApiLookupMap.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/custom/ApiLookupMap.java
@@ -26,7 +26,7 @@ import net.fabricmc.fabric.impl.lookup.custom.ApiLookupMapImpl;
 
 //CHECKSTYLE.OFF: JavadocStyle - Checkstyle didn't like <A, C>, even though {@code ... } already escapes it.
 /**
- * A a map meant to be used as the backing storage for custom {@code ApiLookup} instances,
+ * A map meant to be used as the backing storage for custom {@code ApiLookup} instances,
  * to implement a custom equivalent of {@link net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup#get BlockApiLookup#get}.
  *
  * <p><h3>Usage Example</h3>

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModificationContext.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModificationContext.java
@@ -324,7 +324,7 @@ public interface BiomeModificationContext {
 		 * <p>This method is intended for use with the placed features found in
 		 * classes such as {@link net.minecraft.world.gen.feature.OrePlacedFeatures}.
 		 *
-		 * <p><b>NOTE:</b> In case the placed feature is overridden in a datapack, the datapacks version
+		 * <p><b>NOTE:</b> In case the placed feature is overridden in a data pack, the data packs version
 		 * will be used.
 		 */
 		default void addBuiltInFeature(GenerationStep.Feature step, PlacedFeature placedFeature) {
@@ -341,7 +341,7 @@ public interface BiomeModificationContext {
 		 *
 		 * <p>This method is intended for use with the configured carvers found in {@link net.minecraft.world.gen.carver.ConfiguredCarvers}.
 		 *
-		 * <p><b>NOTE:</b> In case the configured carver is overridden in a datapack, the datapacks version
+		 * <p><b>NOTE:</b> In case the configured carver is overridden in a data pack, the data packs version
 		 * will be used.
 		 */
 		default void addBuiltInCarver(GenerationStep.Carver step, ConfiguredCarver<?> configuredCarver) {

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModificationContext.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModificationContext.java
@@ -324,7 +324,7 @@ public interface BiomeModificationContext {
 		 * <p>This method is intended for use with the placed features found in
 		 * classes such as {@link net.minecraft.world.gen.feature.OrePlacedFeatures}.
 		 *
-		 * <p><b>NOTE:</b> In case the placed feature is overridden in a data pack, the data packs version
+		 * <p><b>NOTE:</b> In case the placed feature is overridden in a data pack, the data pack's version
 		 * will be used.
 		 */
 		default void addBuiltInFeature(GenerationStep.Feature step, PlacedFeature placedFeature) {

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModificationContext.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModificationContext.java
@@ -341,7 +341,7 @@ public interface BiomeModificationContext {
 		 *
 		 * <p>This method is intended for use with the configured carvers found in {@link net.minecraft.world.gen.carver.ConfiguredCarvers}.
 		 *
-		 * <p><b>NOTE:</b> In case the configured carver is overridden in a data pack, the data packs version
+		 * <p><b>NOTE:</b> In case the configured carver is overridden in a data pack, the data pack's version
 		 * will be used.
 		 */
 		default void addBuiltInCarver(GenerationStep.Carver step, ConfiguredCarver<?> configuredCarver) {

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModifications.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModifications.java
@@ -77,7 +77,7 @@ public final class BiomeModifications {
 		Preconditions.checkArgument(entityType.getSpawnGroup() != SpawnGroup.MISC,
 				"Cannot add spawns for entities with spawnGroup=MISC since they'd be replaced by pigs.");
 
-		// We need the entity type to be registered or we cannot deduce an ID otherwisea
+		// We need the entity type to be registered, or we cannot deduce an ID otherwise
 		Identifier id = Registry.ENTITY_TYPE.getId(entityType);
 		Preconditions.checkState(id != Registry.ENTITY_TYPE.getDefaultId(), "Unregistered entity type: %s", entityType);
 
@@ -87,7 +87,7 @@ public final class BiomeModifications {
 	}
 
 	/**
-	 * Create a new biome modification which will be applied whenever biomes are loaded from datapacks.
+	 * Create a new biome modification which will be applied whenever biomes are loaded from data packs.
 	 *
 	 * @param id An identifier for the new set of biome modifications that is returned. Is used for
 	 *           guaranteeing consistent ordering between the biome modifications added by different mods

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeSelectionContext.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeSelectionContext.java
@@ -119,7 +119,7 @@ public interface BiomeSelectionContext {
 	 * Returns true if the given built-in configured structure from {@link net.minecraft.util.registry.BuiltinRegistries}
 	 * can start in this biome in any of the chunk generators used by the current world-save.
 	 *
-	 * <p>This method is intended for use with the Vanilla configured structures found in {@link net.minecraft.world.gen.structure.StructureTypes}.
+	 * <p>This method is intended for use with the Vanilla configured structures found in {@link net.minecraft.world.gen.structure.Structures}.
 	 */
 	default boolean validForBuiltInStructure(Structure structureFeature) {
 		RegistryKey<Structure> key = BuiltInRegistryKeys.get(structureFeature);

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeSelectors.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeSelectors.java
@@ -48,7 +48,7 @@ public final class BiomeSelectors {
 	}
 
 	/**
-	 * Matches Biomes that have not been originally defined in a datapack, but that are defined in code.
+	 * Matches Biomes that have not been originally defined in a data pack, but that are defined in code.
 	 */
 	public static Predicate<BiomeSelectionContext> builtIn() {
 		return context -> BuiltinRegistries.BIOME.containsId(context.getBiomeKey().getValue());
@@ -94,7 +94,7 @@ public final class BiomeSelectors {
 	/**
 	 * Returns a biome selector that will match all biomes in the given tag.
 	 *
-	 * @see net.fabricmc.fabric.api.tag.TagFactory#BIOME
+	 * @see net.minecraft.tag.BiomeTags
 	 */
 	public static Predicate<BiomeSelectionContext> tag(TagKey<Biome> tag) {
 		return context -> context.hasTag(tag);
@@ -109,7 +109,7 @@ public final class BiomeSelectors {
 	}
 
 	/**
-	 * Returns a selector that will reject any biome whos keys is in the given collection of keys.
+	 * Returns a selector that will reject any biome whose key is in the given collection of keys.
 	 *
 	 * <p>This is useful for allowing a list of biomes to be defined in the config file, where
 	 * a certain feature should not spawn.
@@ -127,7 +127,7 @@ public final class BiomeSelectors {
 	}
 
 	/**
-	 * Returns a selector that will accept only biomes whos keys are in the given collection of keys.
+	 * Returns a selector that will accept only biomes whose keys are in the given collection of keys.
 	 *
 	 * <p>This is useful for allowing a list of biomes to be defined in the config file, where
 	 * a certain feature should spawn exclusively.

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
@@ -94,7 +94,7 @@ public final class TheEndBiomes {
 	 * the edge of the large outer islands and are similar to edge biomes in the overworld. If you don't call
 	 * this method, the vanilla biome will be used by default.</p>
 	 *
-	 * @param highlands The highlands biome to where the barrends biome is added
+	 * @param highlands The highlands biome to where the barrens biome is added
 	 * @param barrens   the biome to be added as a barrens biome
 	 * @param weight    the weight of the entry. The weight in this method corresponds to its selection likelihood, with
 	 *                  heavier biomes being more likely to be selected and lighter biomes being selected with less likelihood.

--- a/fabric-blockrenderlayer-v1/src/client/java/net/fabricmc/fabric/api/blockrenderlayer/v1/BlockRenderLayerMap.java
+++ b/fabric-blockrenderlayer-v1/src/client/java/net/fabricmc/fabric/api/blockrenderlayer/v1/BlockRenderLayerMap.java
@@ -57,7 +57,7 @@ public interface BlockRenderLayerMap {
 	void putBlocks(RenderLayer renderLayer, Block... blocks);
 
 	/**
-	 * Map (or re-map) a item with a render layer.  Re-mapping is not recommended but if done, last one in wins.
+	 * Map (or re-map) an item with a render layer.  Re-mapping is not recommended but if done, last one in wins.
 	 * Must be called from client thread prior to world load/rendering. Best practice will be to call from mod's client initializer.
 	 *
 	 * @param item Identifies item to be mapped.

--- a/fabric-command-api-v2/src/main/java/net/fabricmc/fabric/api/command/v2/CommandRegistrationCallback.java
+++ b/fabric-command-api-v2/src/main/java/net/fabricmc/fabric/api/command/v2/CommandRegistrationCallback.java
@@ -30,12 +30,12 @@ import net.fabricmc.fabric.api.event.EventFactory;
  *
  * <p>To register some commands, you would register an event listener and implement the callback.
  *
- * <pre><code>
+ * <pre>{@code
  * CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
  *     // For example, this command is only registered on an integrated server like the vanilla publish command
  *     if (environment.integrated) dispatcher.register(CommandManager.literal("integrated_command").executes(context -> {...}));
  * })};
- * </code></pre>
+ * }</pre>
  */
 public interface CommandRegistrationCallback {
 	Event<CommandRegistrationCallback> EVENT = EventFactory.createArrayBacked(CommandRegistrationCallback.class, (callbacks) -> (dispatcher, registryAccess, environment) -> {

--- a/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/api/tag/convention/v1/ConventionalBiomeTags.java
+++ b/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/api/tag/convention/v1/ConventionalBiomeTags.java
@@ -111,7 +111,7 @@ public final class ConventionalBiomeTags {
 	 */
 	public static final TagKey<Biome> FLORAL = register("floral");
 	/**
-	 * For biomes where snow, and not ice, naturally spawns as an predominant feature.
+	 * For biomes where snow, and not ice, naturally spawns as a predominant feature.
 	 * For biomes where ice is a predominant feature, see {@link ConventionalBiomeTags#ICY}.
 	 */
 	public static final TagKey<Biome> SNOWY = register("snowy");

--- a/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/api/tag/convention/v1/ConventionalEnchantmentTags.java
+++ b/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/api/tag/convention/v1/ConventionalEnchantmentTags.java
@@ -44,7 +44,7 @@ public final class ConventionalEnchantmentTags {
 	 */
 	public static final TagKey<Enchantment> ENTITY_MOVEMENT_ENHANCEMENT = register("entity_movement_enhancement");
 	/**
-	 * For enchantments that decrease damage taken or otherwise benefit, in regards to damage, the entity wearing armor enchanted with it.
+	 * For enchantments that decrease damage taken or otherwise benefit, in regard to damage, the entity wearing armor enchanted with it.
 	 */
 	public static final TagKey<Enchantment> ENTITY_DEFENSE_ENHANCEMENT = register("entity_defense_enhancement");
 

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricAdvancementProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricAdvancementProvider.java
@@ -52,7 +52,7 @@ public abstract class FabricAdvancementProvider implements DataProvider {
 	/**
 	 * Implement this method to register advancements to generate use the consumer callback to register advancements.
 	 *
-	 * <p>Use {@link Advancement.Task#build(Consumer, String)} to help build advancements.
+	 * <p>Use {@link Advancement.Builder#build(Consumer, String)} to help build advancements.
 	 */
 	public abstract void generateAdvancement(Consumer<Advancement> consumer);
 

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricRecipeProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricRecipeProvider.java
@@ -48,7 +48,7 @@ public abstract class FabricRecipeProvider extends RecipeProvider {
 	}
 
 	/**
-	 * Implement this method and then use the range of methods in {@link RecipeProvider} or from one of the recipe json factories such as {@link ShapedRecipeJsonBuilder} & {@link ShapelessRecipeJsonBuilder}.
+	 * Implement this method and then use the range of methods in {@link RecipeProvider} or from one of the recipe json factories such as {@link ShapedRecipeJsonBuilder} or {@link ShapelessRecipeJsonBuilder}.
 	 */
 	protected abstract void generateRecipes(Consumer<RecipeJsonProvider> exporter);
 

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/block/BlockAttackInteractionAware.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/block/BlockAttackInteractionAware.java
@@ -24,7 +24,7 @@ import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
 
 /**
- * Convienence interface for blocks which listen to "break interactions" (left-click).
+ * Convenience interface for blocks which listen to "break interactions" (left-click).
  */
 public interface BlockAttackInteractionAware {
 	/**

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/PlayerBlockBreakEvents.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/PlayerBlockBreakEvents.java
@@ -33,8 +33,8 @@ public final class PlayerBlockBreakEvents {
 	 * Only called on the server, however updates are synced with the client.
 	 *
 	 * <p>If any listener cancels a block breaking action, that block breaking
-	 * action is cancelled and {@link CANCELED} event is fired. Otherwise, the
-	 * {@link AFTER} event is fired.</p>
+	 * action is cancelled and {@link #CANCELED} event is fired. Otherwise, the
+	 * {@link #AFTER} event is fired.</p>
 	 */
 	public static final Event<Before> BEFORE = EventFactory.createArrayBacked(Before.class,
 			(listeners) -> (world, player, pos, state, entity) -> {

--- a/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/api/gamerule/v1/GameRuleFactory.java
+++ b/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/api/gamerule/v1/GameRuleFactory.java
@@ -38,7 +38,7 @@ import net.fabricmc.fabric.mixin.gamerule.GameRulesBooleanRuleAccessor;
  * A game rule is a persisted, per server data value which may control gameplay aspects.
  *
  * <p>Some factory methods allow specification of a callback that is invoked when the value of a game rule has changed.
- * Typically the callback is used for game rules which may influence game logic, such as {@link GameRules#DISABLE_RAIDS disabling raids}.
+ * Typically, the callback is used for game rules which may influence game logic, such as {@link GameRules#DISABLE_RAIDS disabling raids}.
  *
  * <p>To register a game rule, you can use {@link GameRuleRegistry#register(String, GameRules.Category, GameRules.Type)}.
  * For example, to register a game rule that is an integer where the acceptable values are between 0 and 10, one would use the following:

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
@@ -33,7 +33,7 @@ import net.minecraft.util.Hand;
  * <p>Note: This interface is automatically implemented on all items via Mixin and interface injection.
  *
  * <p>Note to maintainers: Functions should only be added to this interface if they are general-purpose enough,
- * to be evaluated on a case-by-case basis. Otherwise they are better suited for more specialized APIs.
+ * to be evaluated on a case-by-case basis. Otherwise, they are better suited for more specialized APIs.
  */
 public interface FabricItem {
 	/**

--- a/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/api/client/itemgroup/FabricItemGroupBuilder.java
+++ b/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/api/client/itemgroup/FabricItemGroupBuilder.java
@@ -35,7 +35,7 @@ import net.fabricmc.fabric.impl.item.group.ItemGroupExtensions;
  * inventory.
  *
  * <p>Example of creating an empty group (recommended for modded item-only group):</p>
- * <pre><code>
+ * <pre>{@code
  * MY_GROUP = FabricItemGroupBuilder.build(
  * 	new Identifier("my_mod", "example_group"),
  * 	() -> new ItemStack(MY_ITEM);
@@ -43,10 +43,10 @@ import net.fabricmc.fabric.impl.item.group.ItemGroupExtensions;
  * // Use item settings to assign a group. Otherwise, it won't appear on creative inventory
  * // search result.
  * MY_ITEM = new Item(new Item.Settings().group(MY_GROUP));
- * </code></pre>
+ * }</pre>
  *
  * <p>Example of creating a group with vanilla item stacks:</p>
- * <pre><code>
+ * <pre>{@code
  * ItemGroup myGroup = FabricItemGroupBuilder.create(new Identifier("my_mod", "group_2"))
  * 	.icon(Items.STONE::getDefaultStack)
  * 	.appendItems((stacks) -> {
@@ -54,7 +54,7 @@ import net.fabricmc.fabric.impl.item.group.ItemGroupExtensions;
  * 	   stacks.add(new ItemStack(Items.COBBLESTONE));
  * 	})
  * 	.build();
- * </code></pre>
+ * }</pre>
  *
  * <h2 id="search">Creative inventory searching</h2>
  * <p>Creative inventory search is implemented as a special item group. Adding items with

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingHelper.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingHelper.java
@@ -27,10 +27,10 @@ import net.fabricmc.fabric.mixin.client.keybinding.KeyBindingAccessor;
  *
  * <p>Helper class for {@link KeyBinding} for use by Fabric mods.</p>
  *
- * <pre><code>
+ * <pre>{@code
  * KeyBinding left = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.example.left", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_P, "key.category.example"));
  * KeyBinding right = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.example.right", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_U, "key.category.example"));
- * </code></pre>
+ * }</pre>
  */
 public final class KeyBindingHelper {
 	private KeyBindingHelper() {

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkEvents.java
@@ -28,7 +28,7 @@ public final class ServerChunkEvents {
 	}
 
 	/**
-	 * Called when an chunk is loaded into a ServerWorld.
+	 * Called when a chunk is loaded into a ServerWorld.
 	 *
 	 * <p>When this event is called, the chunk is already in the world.
 	 */
@@ -52,7 +52,7 @@ public final class ServerChunkEvents {
 	});
 
 	/**
-	 * Called when an chunk is unloaded from a ServerWorld.
+	 * Called when a chunk is unloaded from a ServerWorld.
 	 *
 	 * <p>When this event is called, the chunk is still present in the world.
 	 */

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerLifecycleEvents.java
@@ -54,7 +54,7 @@ public final class ServerLifecycleEvents {
 	 * Called when a Minecraft server has started shutting down.
 	 * This occurs before the server's network channel is closed and before any players are disconnected.
 	 *
-	 * <p>For example, an integrated server will begin stopping, but it's client may continue to run.
+	 * <p>For example, an integrated server will begin stopping, but its client may continue to run.
 	 *
 	 * <p>All worlds are still present and can be modified.
 	 */
@@ -68,8 +68,8 @@ public final class ServerLifecycleEvents {
 	 * Called when a Minecraft server has stopped.
 	 * All worlds have been closed and all (block)entities and players have been unloaded.
 	 *
-	 * <p>For example, an {@link net.fabricmc.api.EnvType#CLIENT integrated server} will begin stopping, but it's client may continue to run.
-	 * Meanwhile for a {@link net.fabricmc.api.EnvType#SERVER dedicated server}, this will be the last event called.
+	 * <p>For example, an {@link net.fabricmc.api.EnvType#CLIENT integrated server} will begin stopping, but its client may continue to run.
+	 * Meanwhile, for a {@link net.fabricmc.api.EnvType#SERVER dedicated server}, this will be the last event called.
 	 */
 	public static final Event<ServerStopped> SERVER_STOPPED = EventFactory.createArrayBacked(ServerStopped.class, callbacks -> server -> {
 		for (ServerStopped callback : callbacks) {

--- a/fabric-message-api-v1/src/main/java/net/fabricmc/fabric/api/message/v1/ServerMessageDecoratorEvent.java
+++ b/fabric-message-api-v1/src/main/java/net/fabricmc/fabric/api/message/v1/ServerMessageDecoratorEvent.java
@@ -50,25 +50,25 @@ import net.fabricmc.fabric.api.event.EventFactory;
  *
  * <p>Example of registering a content phase message decorator:
  *
- * <pre><code>
+ * <pre>{@code
  * ServerMessageDecoratorEvent.EVENT.register(ServerMessageDecoratorEvent.CONTENT_PHASE, (sender, message) -> {
  *     // Add smiley face. Has to copy() to get a MutableText with siblings and styles.
  *     return message.copy().append(" :)");
  * });
- * </code></pre>
+ * }</pre>
  *
  * <p>Example of registering a styling phase message decorator:
  *
- * <pre><code>
+ * <pre>{@code
  * ServerMessageDecoratorEvent.EVENT.register(ServerMessageDecoratorEvent.STYLING_PHASE, (sender, message) -> {
  *     // Apply orange color to messages sent by server operators
- *     if (sender != null &amp;&amp; sender.server.getPlayerManager().isOperator(sender.getGameProfile())) {
+ *     if (sender != null && sender.server.getPlayerManager().isOperator(sender.getGameProfile())) {
  *         return CompletableFuture.completedFuture(
  *             message.copy().styled(style -> style.withColor(0xFFA500)));
  *     }
  *     return CompletableFuture.completedFuture(message);
  * });
- * </code></pre>
+ * }</pre>
  */
 public final class ServerMessageDecoratorEvent {
 	private ServerMessageDecoratorEvent() {

--- a/fabric-message-api-v1/src/main/java/net/fabricmc/fabric/api/message/v1/ServerMessageDecoratorEvent.java
+++ b/fabric-message-api-v1/src/main/java/net/fabricmc/fabric/api/message/v1/ServerMessageDecoratorEvent.java
@@ -62,7 +62,7 @@ import net.fabricmc.fabric.api.event.EventFactory;
  * <pre><code>
  * ServerMessageDecoratorEvent.EVENT.register(ServerMessageDecoratorEvent.STYLING_PHASE, (sender, message) -> {
  *     // Apply orange color to messages sent by server operators
- *     if (sender != null && sender.server.getPlayerManager().isOperator(sender.getGameProfile())) {
+ *     if (sender != null &amp;&amp; sender.server.getPlayerManager().isOperator(sender.getGameProfile())) {
  *         return CompletableFuture.completedFuture(
  *             message.copy().styled(style -> style.withColor(0xFFA500)));
  *     }

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientPlayConnectionEvents.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientPlayConnectionEvents.java
@@ -46,7 +46,7 @@ public final class ClientPlayConnectionEvents {
 	 * An event for notification when the client play network handler is ready to send packets to the server.
 	 *
 	 * <p>At this stage, the network handler is ready to send packets to the server.
-	 * Since the client's local state has been setup.
+	 * Since the client's local state has been set up.
 	 */
 	public static final Event<Join> JOIN = EventFactory.createArrayBacked(Join.class, callbacks -> (handler, sender, client) -> {
 		for (Join callback : callbacks) {

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientPlayNetworking.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientPlayNetworking.java
@@ -183,7 +183,7 @@ public final class ClientPlayNetworking {
 	}
 
 	/**
-	 * Creates a packet which may be sent to a the connected server.
+	 * Creates a packet which may be sent to the connected server.
 	 *
 	 * @param channelName the channel name
 	 * @param buf the packet byte buf which represents the payload of the packet

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/EntityTrackingEvents.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/EntityTrackingEvents.java
@@ -28,7 +28,7 @@ import net.fabricmc.fabric.api.event.EventFactory;
 public final class EntityTrackingEvents {
 	/**
 	 * An event that is called before player starts tracking an entity.
-	 * Typically this occurs when an entity enters a client's view distance.
+	 * Typically, this occurs when an entity enters a client's view distance.
 	 * This event is called before the player's client is sent the entity's {@link Entity#createSpawnPacket() spawn packet}.
 	 */
 	public static final Event<StartTracking> START_TRACKING = EventFactory.createArrayBacked(StartTracking.class, callbacks -> (trackedEntity, player) -> {

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/ServerLoginNetworking.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/ServerLoginNetworking.java
@@ -36,7 +36,6 @@ import net.fabricmc.fabric.mixin.networking.accessor.ServerLoginNetworkHandlerAc
  * <p>Server-side networking functionalities include receiving serverbound query responses and sending clientbound query requests.
  *
  * @see ServerPlayNetworking
- * @see net.fabricmc.fabric.api.client.networking.v1.ClientLoginNetworking
  */
 public final class ServerLoginNetworking {
 	/**
@@ -150,7 +149,7 @@ public final class ServerLoginNetworking {
 	}
 
 	/**
-	 * Allows blocking client log-in until all all futures passed into {@link LoginSynchronizer#waitFor(Future)} are completed.
+	 * Allows blocking client log-in until all futures passed into {@link LoginSynchronizer#waitFor(Future)} are completed.
 	 *
 	 * @apiNote this interface is not intended to be implemented by users of api.
 	 */

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/ServerPlayNetworking.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/ServerPlayNetworking.java
@@ -38,7 +38,6 @@ import net.fabricmc.fabric.impl.networking.server.ServerNetworkingImpl;
  * <p>This class should be only used for the logical server.
  *
  * @see ServerLoginNetworking
- * @see net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking
  */
 public final class ServerPlayNetworking {
 	/**
@@ -159,7 +158,7 @@ public final class ServerPlayNetworking {
 	}
 
 	/**
-	 * Gets all channel names that a the connected client declared the ability to receive a packets on.
+	 * Gets all channel names that a connected client declared the ability to receive a packets on.
 	 *
 	 * @param handler the network handler
 	 * @return True if the connected client has declared the ability to receive a packet on the specified channel
@@ -198,7 +197,7 @@ public final class ServerPlayNetworking {
 	}
 
 	/**
-	 * Creates a packet which may be sent to a the connected client.
+	 * Creates a packet which may be sent to a connected client.
 	 *
 	 * @param channelName the channel name
 	 * @param buf the packet byte buf which represents the payload of the packet

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/entity/MinecartComparatorLogicRegistry.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/entity/MinecartComparatorLogicRegistry.java
@@ -28,7 +28,7 @@ import net.minecraft.entity.vehicle.AbstractMinecartEntity;
 import net.minecraft.util.registry.Registry;
 
 /**
- * A registry for {@linkplain MinecartComparatorLogic custom minecart compator logic}.
+ * A registry for {@linkplain MinecartComparatorLogic custom minecart comparator logic}.
  */
 public final class MinecartComparatorLogicRegistry {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MinecartComparatorLogicRegistry.class);

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/trade/TradeOfferHelper.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/trade/TradeOfferHelper.java
@@ -31,7 +31,7 @@ public final class TradeOfferHelper {
 	/**
 	 * Registers trade offer factories for use by villagers.
 	 *
-	 * <p>Below is an example, of registering a trade off factory to be added a blacksmith with a profession level of 3:
+	 * <p>Below is an example, of registering a trade offer factory to be added a blacksmith with a profession level of 3:
 	 * <blockquote><pre>
 	 * TradeOfferHelper.registerVillagerOffers(VillagerProfession.BLACKSMITH, 3, factories -> {
 	 * 	factories.add(new CustomTradeFactory(...);

--- a/fabric-particles-v1/src/client/java/net/fabricmc/fabric/api/client/particle/v1/FabricSpriteProvider.java
+++ b/fabric-particles-v1/src/client/java/net/fabricmc/fabric/api/client/particle/v1/FabricSpriteProvider.java
@@ -29,9 +29,9 @@ import net.minecraft.particle.ParticleType;
  * but in a way that's accessible to mods, and that exposes the atlas as well.
  *
  * <p>Custom sprites registered using ParticleFactoryRegistry have the options
- * to supply a particle factory which will recieve an instance of this
+ * to supply a particle factory which will receive an instance of this
  * interface containing the sprites set loaded for their particle from the
- * active resourcepacks.
+ * active resource packs.
  *
  * @see ParticleFactoryRegistry#register(ParticleType, ParticleFactory)
  * @see ParticleFactoryRegistry.PendingParticleFactory
@@ -44,7 +44,7 @@ public interface FabricSpriteProvider extends SpriteProvider {
 
 	/**
 	 * Gets the list of all sprites available for this particle to use.
-	 * This is defined in your resourcepack.
+	 * This is defined in your resource pack.
 	 */
 	List<Sprite> getSprites();
 }

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/api/particle/v1/FabricParticleTypes.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/api/particle/v1/FabricParticleTypes.java
@@ -38,8 +38,6 @@ import net.minecraft.particle.ParticleType;
  * }}
  * </pre>
  * </blockquote>
- *
- * @see ParticleModClient in the fabric example mods for a more complete usage.
  */
 public final class FabricParticleTypes {
 	private FabricParticleTypes() { }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
@@ -77,7 +77,7 @@ public interface MutableQuadView extends QuadView {
 	/**
 	 * When set, U texture coordinates for the given sprite are
 	 * flipped as part of baking. Can be useful for some randomization
-	 * and texture mapping scenarios. Results are different than what
+	 * and texture mapping scenarios. Results are different from what
 	 * can be obtained via rotation and both can be applied.
 	 * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
 	 */
@@ -114,7 +114,7 @@ public interface MutableQuadView extends QuadView {
 	 * <p>When called with a non-null value, also sets {@link #nominalFace(Direction)}
 	 * to the same value.
 	 *
-	 * <p>This is different than the value reported by {@link BakedQuad#getFace()}. That value
+	 * <p>This is different from the value reported by {@link BakedQuad#getFace()}. That value
 	 * is computed based on face geometry and must be non-null in vanilla quads.
 	 * That computed value is returned by {@link #lightFace()}.
 	 */
@@ -149,7 +149,7 @@ public interface MutableQuadView extends QuadView {
 	 *
 	 * <p>Calling this method does not emit the quad.
 	 *
-	 * @deprecated Use {@link #fromVanilla(BakedQuad, RenderMaterial, Direction, int[], int)}
+	 * @deprecated Use {@link #fromVanilla(BakedQuad, RenderMaterial, Direction)}
 	 * which has better encapsulation and removed outdated item flag
 	 */
 	@Deprecated

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/FabricBakedModel.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/FabricBakedModel.java
@@ -62,8 +62,8 @@ public interface FabricBakedModel {
 	 * in the model. Models must output all quads/meshes in a single pass.
 	 *
 	 * <p>Also called to render block models outside of chunk rebuild or block entity rendering.
-	 * Typically this happens when the block is being rendered as an entity, not as a block placed in the world.
-	 * Currently this happens for falling blocks and blocks being pushed by a piston, but renderers
+	 * Typically, this happens when the block is being rendered as an entity, not as a block placed in the world.
+	 * Currently, this happens for falling blocks and blocks being pushed by a piston, but renderers
 	 * should invoke this for all calls to {@link BlockModelRenderer#render(BlockRenderView, BakedModel, BlockState, BlockPos, MatrixStack, VertexConsumer, boolean, Random, long, int)}
 	 * that occur outside of chunk rebuilds to allow for features added by mods, unless
 	 * {@link #isVanillaAdapter()} returns true.
@@ -104,7 +104,7 @@ public interface FabricBakedModel {
 	 * <p>Vanilla item rendering is normally very limited. It ignores lightmaps, vertex colors,
 	 * and vertex normals. Renderers are expected to implement enhanced features for item
 	 * models. If a feature is impractical due to performance or other concerns, then the
-	 * renderer must at least give acceptable visual results without the need for special-
+	 * renderer must at least give acceptable visual results without the need for special
 	 * case handling in model implementations.
 	 *
 	 * <p>Calls to this method will generally happen on the main client thread but nothing

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/SpriteFinder.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/SpriteFinder.java
@@ -34,7 +34,7 @@ import net.fabricmc.fabric.impl.renderer.SpriteFinderImpl;
 public interface SpriteFinder {
 	/**
 	 * Retrieves or creates the finder for the given atlas.
-	 * Instances should not be retained as fields or they must be
+	 * Instances should not be retained as fields, or they must be
 	 * refreshed whenever there is a resource reload or other event
 	 * that causes atlas textures to be re-stitched.
 	 */

--- a/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/api/client/render/fluid/v1/FluidRenderHandler.java
+++ b/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/api/client/render/fluid/v1/FluidRenderHandler.java
@@ -68,7 +68,7 @@ public interface FluidRenderHandler {
 
 	/**
 	 * Tessellate your fluid. This method will be invoked before the default
-	 * fluid renderer. By default it will call the default fluid renderer. Call
+	 * fluid renderer. By default, it will call the default fluid renderer. Call
 	 * {@code FluidRenderHandler.super.renderFluid} if you want to render over
 	 * the default fluid renderer.
 	 *
@@ -81,7 +81,6 @@ public interface FluidRenderHandler {
 	 * @param vertexConsumer The vertex consumer to tessellate the fluid in.
 	 * @param blockState The block state being rendered.
 	 * @param fluidState The fluid state being rendered.
-	 * @return Whether anything is tessellated.
 	 */
 	default void renderFluid(BlockPos pos, BlockRenderView world, VertexConsumer vertexConsumer, BlockState blockState, FluidState fluidState) {
 		((FluidRenderHandlerRegistryImpl) FluidRenderHandlerRegistry.INSTANCE).renderFluid(pos, world, vertexConsumer, blockState, fluidState);

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/ColorProviderRegistry.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/ColorProviderRegistry.java
@@ -44,7 +44,7 @@ public interface ColorProviderRegistry<T, Provider> {
 	 * <p>Please note that the underlying registry may not be fully populated or stable until the game has started,
 	 * as other mods may overwrite the registry.
 	 *
-	 * @param object The object to acquire the provide for.
+	 * @param object The object to acquire the provider for.
 	 * @return The registered mapper for this provider, or {@code null} if none is registered or available.
 	 */
 	@Nullable

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/LivingEntityFeatureRendererRegistrationCallback.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/LivingEntityFeatureRendererRegistrationCallback.java
@@ -39,7 +39,7 @@ import net.fabricmc.fabric.api.event.EventFactory;
  * Listeners should filter out the specific entity renderer they want to hook into, usually through {@code instanceof} checks or filtering by entity type.
  * Once listeners find a suitable entity renderer, they should register their feature renderer via the registration helper.
  *
- * <p>For example, to register a feature renderer for a player model, the example below may used:
+ * <p>For example, to register a feature renderer for a player model, the example below may be used:
  * <blockquote><pre>
  * LivingEntityFeatureRendererRegistrationCallback.EVENT.register((entityType, entityRenderer, registrationHelper) -> {
  * 	if (entityRenderer instanceof PlayerEntityModel) {

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/IdentifiableResourceReloadListener.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/IdentifiableResourceReloadListener.java
@@ -25,7 +25,7 @@ import net.minecraft.util.Identifier;
 /**
  * Interface for "identifiable" resource reload listeners.
  *
- * <p>"Identifiable" listeners have an unique identifier, which can be depended on,
+ * <p>"Identifiable" listeners have a unique identifier, which can be depended on,
  * and can provide dependencies that they would like to see executed before
  * themselves.
  *

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/ResourceManagerHelper.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/ResourceManagerHelper.java
@@ -61,7 +61,7 @@ public interface ResourceManagerHelper {
 	 * <p>A built-in resource pack is an extra resource pack provided by your mod which is not always active, it's similar to the "Programmer Art" resource pack.
 	 *
 	 * <p>Why and when to use it? A built-in resource pack should be used to provide extra assets/data that should be optional with your mod but still directly provided by it.
-	 * For example it could provide textures of your mod in another resolution, or could allow to provide different styles of your assets.
+	 * For example, it could provide textures of your mod in another resolution, or could allow to provide different styles of your assets.
 	 *
 	 * <p>The path in which the resource pack is located is in the mod JAR file under the {@code "resourcepacks/<id path>"} directory. {@code id path} being the path specified
 	 * in the identifier of this built-in resource pack.
@@ -81,7 +81,7 @@ public interface ResourceManagerHelper {
 	 * <p>A built-in resource pack is an extra resource pack provided by your mod which is not always active, it's similar to the "Programmer Art" resource pack.
 	 *
 	 * <p>Why and when to use it? A built-in resource pack should be used to provide extra assets/data that should be optional with your mod but still directly provided by it.
-	 * For example it could provide textures of your mod in another resolution, or could allow to provide different styles of your assets.
+	 * For example, it could provide textures of your mod in another resolution, or could allow to provide different styles of your assets.
 	 *
 	 * <p>The path in which the resource pack is located is in the mod JAR file under the {@code "resourcepacks/<id path>"} directory. {@code id path} being the path specified
 	 * in the identifier of this built-in resource pack.
@@ -102,7 +102,7 @@ public interface ResourceManagerHelper {
 	 * <p>A built-in resource pack is an extra resource pack provided by your mod which is not always active, it's similar to the "Programmer Art" resource pack.
 	 *
 	 * <p>Why and when to use it? A built-in resource pack should be used to provide extra assets/data that should be optional with your mod but still directly provided by it.
-	 * For example it could provide textures of your mod in another resolution, or could allow to provide different styles of your assets.
+	 * For example, it could provide textures of your mod in another resolution, or could allow to provide different styles of your assets.
 	 *
 	 * <p>The {@code subPath} corresponds to a path in the JAR file which points to the resource pack folder. For example the subPath can be {@code "resourcepacks/extra"}.
 	 *

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenEvents.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenEvents.java
@@ -34,8 +34,8 @@ import net.fabricmc.fabric.impl.client.screen.ScreenExtensions;
  * <p>Some events require a screen instance in order to obtain an event instance.
  * The events that require a screen instance can be identified by the use of a method passing a screen instance.
  * All events in {@link ScreenKeyboardEvents} and {@link ScreenMouseEvents} require a screen instance.
- * This registration model is used since a screen being (re)initialized will reset the screen to it's default state, therefore reverting all changes a mod developer may have applied to a screen.
- * Furthermore this design was chosen to reduce the amount of wasted iterations of events as a mod developer would only need to register screen events for rendering, ticking, keyboards and mice if needed on a per instance basis.
+ * This registration model is used since a screen being (re)initialized will reset the screen to its default state, therefore reverting all changes a mod developer may have applied to a screen.
+ * Furthermore, this design was chosen to reduce the amount of wasted iterations of events as a mod developer would only need to register screen events for rendering, ticking, keyboards and mice if needed on a per instance basis.
  *
  * <p>The primary entrypoint into a screen is when it is being opened, this is signified by an event {@link ScreenEvents#BEFORE_INIT before} and {@link ScreenEvents#AFTER_INIT after} initialization of the screen.
  *
@@ -46,7 +46,7 @@ import net.fabricmc.fabric.impl.client.screen.ScreenExtensions;
 @Environment(EnvType.CLIENT)
 public final class ScreenEvents {
 	/**
-	 * An event that is called before {@link Screen#init(MinecraftClient, int, int) a screen is initialized} to it's default state.
+	 * An event that is called before {@link Screen#init(MinecraftClient, int, int) a screen is initialized} to its default state.
 	 * It should be noted some of the methods in {@link Screens} such as a screen's {@link Screens#getTextRenderer(Screen) text renderer} may not be initialized yet, and as such their use is discouraged.
 	 *
 	 * <!--<p>Typically this event is used to register screen events such as listening to when child elements are added to the screen. ------ Uncomment when child add/remove event is added for elements-->
@@ -78,7 +78,7 @@ public final class ScreenEvents {
 	});
 
 	/**
-	 * An event that is called after {@link Screen#init(MinecraftClient, int, int) a screen is initialized} to it's default state.
+	 * An event that is called after {@link Screen#init(MinecraftClient, int, int) a screen is initialized} to its default state.
 	 *
 	 * <p>Typically this event is used to modify a screen after the screen has been initialized.
 	 * Modifications such as changing sizes of buttons, removing buttons and adding/removing child elements to the screen can be done safely using this event.
@@ -92,8 +92,8 @@ public final class ScreenEvents {
 	 * });
 	 * }</pre>
 	 *
-	 * <p>Note that by adding an element to a screen, the element is not automatically {@link net.minecraft.client.gui.screen.TickableElement ticked} or {@link net.minecraft.client.gui.Drawable drawn}.
-	 * Unless the element is button, you need to call the specific {@link TickableElement#tick() tick} and {@link net.minecraft.client.gui.Drawable#render(MatrixStack, int, int, float) render} methods in the corresponding screen events.
+	 * <p>Note that by adding an element to a screen, the element is not automatically {@link net.minecraft.client.gui.Drawable drawn}.
+	 * Unless the element is button, you need to call the specific {@link net.minecraft.client.gui.Drawable#render(MatrixStack, int, int, float) render} methods in the corresponding screen events.
 	 *
 	 * <p>This event can also indicate that the previous screen has been closed.
 	 * @see ScreenEvents#BEFORE_INIT

--- a/fabric-transfer-api-v1/src/client/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRenderHandler.java
+++ b/fabric-transfer-api-v1/src/client/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRenderHandler.java
@@ -73,7 +73,7 @@ public interface FluidVariantRenderHandler {
 	}
 
 	/**
-	 * Return the color to use when rendering {@linkplain #getSprite the sprite} of this fluid variant.
+	 * Return the color to use when rendering {@linkplain FluidVariantRendering#getSprite the sprite} of this fluid variant.
 	 * Transparency (alpha) will generally be taken into account and should be specified as well.
 	 *
 	 * <p>The world and position are optional context parameters and may be {@code null}.

--- a/fabric-transfer-api-v1/src/client/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRenderHandler.java
+++ b/fabric-transfer-api-v1/src/client/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRenderHandler.java
@@ -73,7 +73,7 @@ public interface FluidVariantRenderHandler {
 	}
 
 	/**
-	 * Return the color to use when rendering {@linkplain FluidVariantRendering#getSprite the sprite} of this fluid variant.
+	 * Return the color to use when rendering {@linkplain #getSprites the sprites} of this fluid variant.
 	 * Transparency (alpha) will generally be taken into account and should be specified as well.
 	 *
 	 * <p>The world and position are optional context parameters and may be {@code null}.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/context/ContainerItemContext.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/context/ContainerItemContext.java
@@ -165,7 +165,7 @@ public interface ContainerItemContext {
 
 	/**
 	 * Return the current item variant of this context, that is the variant in the slot of the context.
-	 * If the result is non blank, {@link #getAmount} should be
+	 * If the result is not blank, {@link #getAmount} should be positive.
 	 */
 	default ItemVariant getItemVariant() {
 		return getMainSlot().getResource();
@@ -214,7 +214,7 @@ public interface ContainerItemContext {
 	 * @param newVariant The variant of the items after the conversion. May not be blank.
 	 * @param maxAmount The maximum amount of items to convert. May not be negative.
 	 * @param transaction The transaction this operation is part of.
-	 * @return A nonnegative integer not greater than maxAmount: the amount that was transformed.
+	 * @return A non-negative integer not greater than maxAmount: the amount that was transformed.
 	 */
 	default long exchange(ItemVariant newVariant, long maxAmount, TransactionContext transaction) {
 		StoragePreconditions.notBlankNotNegative(newVariant, maxAmount);

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidConstants.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidConstants.java
@@ -23,7 +23,7 @@ import net.minecraft.fluid.FlowableFluid;
 /**
  * Constants for fluid transfer. In general, 1 bucket = 81000 droplets = 1 block.
  *
- * <p>If you don't know how much droplets you should pick for a specific resource that has a block form,
+ * <p>If you don't know how many droplets you should pick for a specific resource that has a block form,
  * the convention is to use 81000 droplets for what is worth one block of that resource.
  *
  * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariant.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariant.java
@@ -34,8 +34,8 @@ import net.fabricmc.fabric.impl.transfer.fluid.FluidVariantImpl;
  *
  * <p>{@link net.fabricmc.fabric.api.transfer.v1.client.fluid.FluidVariantRendering} can be used for client-side rendering of fluid variants.
  *
- * <p><b>Fluid variants must always be compared with {@link #equals}, never by reference!</b>
- * {@link #hashCode} is guaranteed to be correct and constant time independently of the size of the NBT.
+ * <p><b>Fluid variants must always be compared with {@code equals}, never by reference!</b>
+ * {@code hashCode} is guaranteed to be correct and constant time independently of the size of the NBT.
  *
  * <p><b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/base/SingleFluidStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/base/SingleFluidStorage.java
@@ -28,7 +28,7 @@ import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleVariantStorage;
 
 /**
  * A storage that can store a single fluid variant at any given time.
- * Implementors should at least override {@link #getCapacity(FluidVariant)},
+ * Implementors should at least override {@code getCapacity(FluidVariant)},
  * and probably {@link #onFinalCommit} as well for {@code markDirty()} and similar calls.
  *
  * <p>This is a convenient specialization of {@link SingleVariantStorage} for fluids that additionally offers methods

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/base/SingleFluidStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/base/SingleFluidStorage.java
@@ -24,11 +24,12 @@ import net.minecraft.nbt.NbtCompound;
 
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.StoragePreconditions;
+import net.fabricmc.fabric.api.transfer.v1.storage.TransferVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleVariantStorage;
 
 /**
  * A storage that can store a single fluid variant at any given time.
- * Implementors should at least override {@code getCapacity(FluidVariant)},
+ * Implementors should at least override {@link #getCapacity(TransferVariant) getCapacity(FluidVariant)},
  * and probably {@link #onFinalCommit} as well for {@code markDirty()} and similar calls.
  *
  * <p>This is a convenient specialization of {@link SingleVariantStorage} for fluids that additionally offers methods

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/base/SingleFluidStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/base/SingleFluidStorage.java
@@ -42,7 +42,7 @@ public abstract class SingleFluidStorage extends SingleVariantStorage<FluidVaria
 	/**
 	 * Create a fluid storage with a fixed capacity and a change handler.
 	 *
-	 * @param capacity Fixed capacity of the fluid storage. Must be nonnegative.
+	 * @param capacity Fixed capacity of the fluid storage. Must be non-negative.
 	 * @param onChange Change handler, generally for {@code markDirty()} or similar calls. May not be null.
 	 */
 	public static SingleFluidStorage withFixedCapacity(long capacity, Runnable onChange) {

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/PlayerInventoryStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/PlayerInventoryStorage.java
@@ -35,7 +35,7 @@ import net.fabricmc.fabric.impl.transfer.item.CursorSlotWrapper;
  * with an additional transactional wrapper for {@link PlayerInventory#offerOrDrop}.
  *
  * <p>Note that this is a wrapper around all the slots of the player inventory.
- * However, {@link #insert} is overriden to behave like {@link #offer}.
+ * However, {@link #insert} is overridden to behave like {@link #offer}.
  * For simple insertions, {@link #offer} or {@link #offerOrDrop} is recommended.
  * {@link #getSlots} can also be used and combined with {@link CombinedStorage} to retrieve a wrapper around a specific range of slots.
  *

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleItemStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleItemStorage.java
@@ -21,11 +21,12 @@ import org.jetbrains.annotations.ApiStatus;
 import net.minecraft.nbt.NbtCompound;
 
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import net.fabricmc.fabric.api.transfer.v1.storage.TransferVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleVariantStorage;
 
 /**
  * A storage that can store a single item variant at any given time.
- * Implementors should at least override {@code getCapacity(ItemVariant)},
+ * Implementors should at least override {@link #getCapacity(TransferVariant) getCapacity(ItemVariant)},
  * and probably {@link #onFinalCommit} as well for {@code markDirty()} and similar calls.
  *
  * <p>This is a convenient specialization of {@link SingleVariantStorage} for items that additionally offers methods

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleItemStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleItemStorage.java
@@ -25,7 +25,7 @@ import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleVariantStorage;
 
 /**
  * A storage that can store a single item variant at any given time.
- * Implementors should at least override {@link #getCapacity(ItemVariant)},
+ * Implementors should at least override {@code getCapacity(ItemVariant)},
  * and probably {@link #onFinalCommit} as well for {@code markDirty()} and similar calls.
  *
  * <p>This is a convenient specialization of {@link SingleVariantStorage} for items that additionally offers methods

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/Storage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/Storage.java
@@ -88,7 +88,7 @@ public interface Storage<T> extends Iterable<StorageView<T>> {
 	 * @param resource The resource to insert. May not be blank.
 	 * @param maxAmount The maximum amount of resource to insert. May not be negative.
 	 * @param transaction The transaction this operation is part of.
-	 * @return A nonnegative integer not greater than maxAmount: the amount that was inserted.
+	 * @return A non-negative integer not greater than maxAmount: the amount that was inserted.
 	 */
 	long insert(T resource, long maxAmount, TransactionContext transaction);
 
@@ -119,7 +119,7 @@ public interface Storage<T> extends Iterable<StorageView<T>> {
 	 * @param resource The resource to extract. May not be blank.
 	 * @param maxAmount The maximum amount of resource to extract. May not be negative.
 	 * @param transaction The transaction this operation is part of.
-	 * @return A nonnegative integer not greater than maxAmount: the amount that was extracted.
+	 * @return A non-negative integer not greater than maxAmount: the amount that was extracted.
 	 */
 	long extract(T resource, long maxAmount, TransactionContext transaction);
 

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/TransferVariant.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/TransferVariant.java
@@ -30,8 +30,8 @@ import net.minecraft.network.PacketByteBuf;
  * <p>This is exposed for convenience for code that needs to be generic across multiple transfer variants,
  * but note that a {@link Storage} is not necessarily bound to {@code TransferVariant}. Its generic parameter can be any immutable object.
  *
- * <p><b>Transfer variants must always be compared with {@link #equals}, never by reference!</b>
- * {@link #hashCode} is guaranteed to be correct and constant time independently of the size of the NBT.
+ * <p><b>Transfer variants must always be compared with {@code equals}, never by reference!</b>
+ * {@code hashCode} is guaranteed to be correct and constant time independently of the size of the NBT.
  *
  * @param <O> The type of the immutable object instance, for example {@code Item} or {@code Fluid}.
  *

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/SingleVariantItemStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/SingleVariantItemStorage.java
@@ -92,7 +92,7 @@ public abstract class SingleVariantItemStorage<T extends TransferVariant<?>> imp
 	 * Implementors should generally convert the passed {@code currentVariant} to a stack,
 	 * then edit the NBT of the stack so it contains the correct resource and amount.
 	 *
-	 * <p>When the new amount is 0, it is recommended that the subtags corresponding to the resource and amount
+	 * <p>When the new amount is 0, it is recommended that the sub-NBTs corresponding to the resource and amount
 	 * be removed, for example using {@link ItemStack#removeSubNbt}, so that newly-crafted containers can stack with
 	 * emptied containers.
 	 *

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/transaction/Transaction.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/transaction/Transaction.java
@@ -104,7 +104,7 @@ public interface Transaction extends AutoCloseable, TransactionContext {
 	}
 
 	/**
-	 * Open a nested transaction if {@code maybeParent} is non null, or an outer transaction if {@code maybeParent} is null.
+	 * Open a nested transaction if {@code maybeParent} is non-null, or an outer transaction if {@code maybeParent} is null.
 	 */
 	static Transaction openNested(@Nullable TransactionContext maybeParent) {
 		return maybeParent == null ? openOuter() : maybeParent.openNested();


### PR DESCRIPTION
This is a comprehensive javadoc-fix PR. I recommend bumping all minor versions due to javadoc linking change.

## Javadoc Links
The following external links are now resolved:

- Minecraft (yarn) (why didn't we do this MUCH earlier??)
- Libraries that we currently link to: Netty (Networking), LWJGL (Screen), Gson (Resource Conditions), fastutil (Registry Sync)
- SLF4J (since Log4J is currently resolved)
- Guava docs now link to version 31, the one actually used by the game.
- The following libraries are not added, because they are either undocumented or unnecessary: Brigadier, DFU, Authlib, joptsimple, oshi, Apache Commons (IO, lang3), ICU4J, etc

I am unsure if this means every MC version bump now requires all mod versions to be bumped too if they have a javadoc; I suppose so. Not a big deal, imo.

## Typo and rendering issue fix
Note: this does not fix issues arising due to access error (javadoc fails to link to access-restricted things).

- `BlockEntityRendererRegistry` (Renderer Registries, deprecated): replace intermediary w/ named
- `BooleanFunction` (API Base): fix `an boolean-valued`
- `NbtType` (API Base): fix linking
- `TriState` (API Base): fix missing comma, "fallback to"/"fall back to"
- `ApiLookupMap` (API Lookup): fix `A a`
- `BiomeModificationContext` (Biome): fix `datapack` (Yarn convention is `data pack`)
- `BiomeModifications` (Biome): fix comma, "datapack"
- `BiomeSelectionContext` (Biome): fix link to renamed class
- `BiomeSelectors` (Biome): fix "datapack", links to now-removed Fabric Biome Tag API, typos (`whos keys is`, `barrends`)
- `BlockRenderLayerMap` (Block Render Layer): fix `a item`
- `ConventionalBiomeTags` (Conventional Tags): fix `an predominant`
- `ConventionalEnchantmentTags` (Conventional Tags): fix `in regards to`
- `FabricAdvancementProvider` (Datagen): fix link to renamed class
- `FabricRecipeProvider` (Datagen): fix escaping
- `BlockAttackInteractionAware` (Interaction Events): fix typo `Convienence`
- `PlayerBlockBreakEvents` (Interaction Events): fix wrong link syntax
- `GameRuleFactory` (Game Rule): fix comma
- `FabricItem` (Item): fix comma
- `ServerChunkEvents` (Lifecycle Events): fix `an chunk`
- `ServerLifecycleEvents` (Lifecycle Events): fix `it's client`
- `ServerMessageDecoratorEvent` (Messaging): fix escaping
- `ClientPlayConnectionEvents` (Networking): fix `setup` to `set up`
- `ClientPlayNetworking` (Networking): fix `a the`
- `EntityTrackingEvents` (Networking): fix comma
- `ServerLoginNetworking` (Networking): fix link to client code, typo `all all`
- `ServerPlayNetworking` (Networking): fix link to client code, `a the`
- `MinecartComparatorLogicRegistry` (Object Builder): fix `compator`
- `TradeOfferHelper` (Object Builder): fix `trade off factory`
- `FabricSpriteProvider` (Particle): fix `recieve`, `resourcepacks`
- `FabricParticleTypes` (Particle): fix link to non-existent class
- `MutableQuadView` (Renderer): fix `different than` (not from), wrong link to method
- `FabricBakedModel` (Renderer): fix comma, `special- cased` (notice the space)
- `SpriteFinder` (Renderer): fix comma
- `FluidRenderHandler` (Fluid Rendering): fix comma, `@return` on `void` method
- `ColorProviderRegistry` (Rendering): fix `acquire the provide for`
- `LivingEntityFeatureRendererRegistrationCallback` (Rendering): fix `may used`
- `IdentifiableResourceReloadListener` (Resource Loader): fix `an unique`
- `ResourceManagerHelper` (Resource Loader): fix comma
- `ScreenEvents` (Screen): fix `it's`, comma, links to removed method
- `FluidVariantRenderHandler` (Transfer): fix method link
- `ContainerItemContext` (Transfer): fix missing word after `should be`, hyphenate "nonnegative"
- `FluidConstants` (Transfer): fix "how much droplets" (droplets are countable)
- `FluidVariant` (Transfer): fix method links by replacing with `@code`
- `SingleFluidStorage` (Transfer): hyphenate "nonnegative"
- `PlayerInventoryStorage` (Transfer): fix `overriden`
- `Storage` (Transfer): hyphenate "nonnegative"
- `TransferVariant` (Transfer): fix method links by replacing with `@code`
- `SingleVariantItemStorage` (Transfer): replace "subtags" with "sub-NBTs"
- `Transaction` (Transfer): hyphenate "non null"
