### PR TITLE
Add ServerEntityEvents.EquipmentChange event

### DIFF
--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerEntityEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerEntityEvents.java
@@ -101,6 +101,6 @@ public final class ServerEntityEvents {
 
 	@FunctionalInterface
 	public interface EquipmentChange {
-		void onChange(LivingEntity livingEntity, EquipmentSlot equipmentSlot, ItemStack previousStack, ItemStack nextStack);
+		void onChange(LivingEntity livingEntity, EquipmentSlot equipmentSlot, ItemStack previousStack, ItemStack currentStack);
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerEntityEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerEntityEvents.java
@@ -17,6 +17,9 @@
 package net.fabricmc.fabric.api.event.lifecycle.v1;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.profiler.Profiler;
 
@@ -75,6 +78,17 @@ public final class ServerEntityEvents {
 		}
 	});
 
+	/**
+	 * Called when an Entity's equipment is changed.
+	 *
+	 * <p>This event is also called when the entity joins the world.
+	 */
+	public static final Event<EquipmentChange> EQUIPMENT_CHANGE = EventFactory.createArrayBacked(ServerEntityEvents.EquipmentChange.class, callbacks -> (livingEntity, equipmentSlot, previous, next) -> {
+		for (EquipmentChange callback : callbacks) {
+			callback.onChange(livingEntity, equipmentSlot, previous, next);
+		}
+	});
+
 	@FunctionalInterface
 	public interface Load {
 		void onLoad(Entity entity, ServerWorld world);
@@ -83,5 +97,10 @@ public final class ServerEntityEvents {
 	@FunctionalInterface
 	public interface Unload {
 		void onUnload(Entity entity, ServerWorld world);
+	}
+
+	@FunctionalInterface
+	public interface EquipmentChange {
+		void onChange(LivingEntity livingEntity, EquipmentSlot equipmentSlot, ItemStack previousStack, ItemStack nextStack);
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerEntityEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerEntityEvents.java
@@ -79,7 +79,7 @@ public final class ServerEntityEvents {
 	});
 
 	/**
-	 * Called during {@link LivingEntity#tick()} after the Entity's equipment has been changed.
+	 * Called during {@link LivingEntity#tick()} if the Entity's equipment has been changed.
 	 *
 	 * <p>This event is also called when the entity joins the world.
 	 */

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerEntityEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerEntityEvents.java
@@ -79,7 +79,7 @@ public final class ServerEntityEvents {
 	});
 
 	/**
-	 * Called when an Entity's equipment is changed.
+	 * Called during {@link LivingEntity#tick()} after the Entity's equipment has been changed.
 	 *
 	 * <p>This event is also called when the entity joins the world.
 	 */

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerEntityEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerEntityEvents.java
@@ -79,9 +79,10 @@ public final class ServerEntityEvents {
 	});
 
 	/**
-	 * Called during {@link LivingEntity#tick()} if the Entity's equipment has been changed.
+	 * Called during {@link LivingEntity#tick()} if the Entity's equipment has been changed or mutated.
 	 *
 	 * <p>This event is also called when the entity joins the world.
+	 * A change in equipment is determined by {@link ItemStack#areEqual(ItemStack, ItemStack)}.
 	 */
 	public static final Event<EquipmentChange> EQUIPMENT_CHANGE = EventFactory.createArrayBacked(ServerEntityEvents.EquipmentChange.class, callbacks -> (livingEntity, equipmentSlot, previous, next) -> {
 		for (EquipmentChange callback : callbacks) {

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/LivingEntityMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/LivingEntityMixin.java
@@ -34,7 +34,7 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityEvents;
 @Mixin(LivingEntity.class)
 public abstract class LivingEntityMixin {
 	@Inject(method = "getEquipmentChanges", at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"), locals = LocalCapture.CAPTURE_FAILHARD)
-	private void getEquipmentChanges(CallbackInfoReturnable<@Nullable Map<EquipmentSlot, ItemStack>> cir, Map<EquipmentSlot, ItemStack> changes, EquipmentSlot[] slots, int slotsSize, int slotIndex, EquipmentSlot equipmentSlot, ItemStack previousStack, ItemStack nextStack) {
-		ServerEntityEvents.EQUIPMENT_CHANGE.invoker().onChange((LivingEntity) (Object) this, equipmentSlot, previousStack, nextStack);
+	private void getEquipmentChanges(CallbackInfoReturnable<@Nullable Map<EquipmentSlot, ItemStack>> cir, Map<EquipmentSlot, ItemStack> changes, EquipmentSlot[] slots, int slotsSize, int slotIndex, EquipmentSlot equipmentSlot, ItemStack previousStack, ItemStack currentStack) {
+		ServerEntityEvents.EQUIPMENT_CHANGE.invoker().onChange((LivingEntity) (Object) this, equipmentSlot, previousStack, currentStack);
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/LivingEntityMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/LivingEntityMixin.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.event.lifecycle;
+
+import java.util.Map;
+
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityEvents;
+
+@Mixin(LivingEntity.class)
+public abstract class LivingEntityMixin {
+	@Inject(method = "getEquipmentChanges", at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"), locals = LocalCapture.CAPTURE_FAILHARD)
+	private void getEquipmentChanges(CallbackInfoReturnable<@Nullable Map<EquipmentSlot, ItemStack>> cir, Map<EquipmentSlot, ItemStack> changes, EquipmentSlot[] slots, int slotsSize, int slotIndex, EquipmentSlot equipmentSlot, ItemStack previousStack, ItemStack nextStack) {
+		ServerEntityEvents.EQUIPMENT_CHANGE.invoker().onChange((LivingEntity) (Object) this, equipmentSlot, previousStack, nextStack);
+	}
+}

--- a/fabric-lifecycle-events-v1/src/main/resources/fabric-lifecycle-events-v1.mixins.json
+++ b/fabric-lifecycle-events-v1/src/main/resources/fabric-lifecycle-events-v1.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_16",
   "mixins": [
     "DataPackContentsMixin",
+    "LivingEntityMixin",
     "MinecraftServerMixin",
     "PlayerManagerMixin",
     "ServerWorldServerEntityHandlerMixin",

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerEntityLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerEntityLifecycleTests.java
@@ -58,9 +58,9 @@ public final class ServerEntityLifecycleTests implements ModInitializer {
 			}
 		});
 
-		ServerEntityEvents.EQUIPMENT_CHANGE.register((livingEntity, equipmentSlot, previousStack, nextStack) -> {
+		ServerEntityEvents.EQUIPMENT_CHANGE.register((livingEntity, equipmentSlot, previousStack, currentStack) -> {
 			if (PRINT_SERVER_ENTITY_MESSAGES) {
-				logger.info("[SERVER] Entity equipment change: Entity: {}, Slot {}, Previous: {}, Next {} ", livingEntity, equipmentSlot.name(), previousStack, nextStack);
+				logger.info("[SERVER] Entity equipment change: Entity: {}, Slot {}, Previous: {}, Current {} ", livingEntity, equipmentSlot.name(), previousStack, currentStack);
 			}
 		});
 

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerEntityLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerEntityLifecycleTests.java
@@ -58,6 +58,12 @@ public final class ServerEntityLifecycleTests implements ModInitializer {
 			}
 		});
 
+		ServerEntityEvents.EQUIPMENT_CHANGE.register((livingEntity, equipmentSlot, previousStack, nextStack) -> {
+			if (PRINT_SERVER_ENTITY_MESSAGES) {
+				logger.info("[SERVER] Entity equipment change: Entity: {}, Slot {}, Previous: {}, Next {} ", livingEntity, equipmentSlot.name(), previousStack, nextStack);
+			}
+		});
+
 		ServerTickEvents.END_SERVER_TICK.register(server -> {
 			if (this.serverTicks++ % 200 == 0) {
 				int entities = 0;


### PR DESCRIPTION
Very simple event on the LivingEntity equipment change, needed to remove a mixin from my (and other people's) mod :)

This is only fired on the server and also fires when the entity joins the world.