### PR TITLE
Add DataGeneratorEntrypoint.getEffectiveModId

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/DataGeneratorEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/DataGeneratorEntrypoint.java
@@ -35,8 +35,8 @@ public interface DataGeneratorEntrypoint {
 	void onInitializeDataGenerator(FabricDataGenerator fabricDataGenerator);
 
 	/**
-	 * Returns the modid of the mod the data is being generated for.
-	 * A {@code null} return will run the data generator using the modid that registered the current entrypoint.
+	 * Returns the mod ID of the mod the data is being generated for.
+	 * A {@code null} return will run the data generator using the mod ID that registered the current entrypoint.
 	 *
 	 * @return a {@link String} or {@code null}
 	 */

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/DataGeneratorEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/DataGeneratorEntrypoint.java
@@ -16,6 +16,10 @@
 
 package net.fabricmc.fabric.api.datagen.v1;
 
+import org.jetbrains.annotations.Nullable;
+
+import net.fabricmc.loader.api.ModContainer;
+
 /**
  * An entry point for data generation.
  *
@@ -31,4 +35,15 @@ public interface DataGeneratorEntrypoint {
 	 * @param fabricDataGenerator The {@link FabricDataGenerator} instance
 	 */
 	void onInitializeDataGenerator(FabricDataGenerator fabricDataGenerator);
+
+	/**
+	 * Return the {@link ModContainer} of the mod the data is being generated for.
+	 * A null return will run the data generation using the {@link ModContainer} that registered the current entrypoint.
+	 *
+	 * @return a {@link ModContainer} or null
+	 */
+	@Nullable
+	default ModContainer getEffectiveModContainer() {
+		return null;
+	}
 }

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/DataGeneratorEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/DataGeneratorEntrypoint.java
@@ -39,6 +39,7 @@ public interface DataGeneratorEntrypoint {
 	 * A {@code null} return will run the data generator using the mod ID that registered the current entrypoint.
 	 *
 	 * @return a {@link String} or {@code null}
+	 * @throws RuntimeException If the mod ID does not exist.
 	 */
 	@Nullable
 	default String getEffectiveModId() {

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/DataGeneratorEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/DataGeneratorEntrypoint.java
@@ -35,10 +35,10 @@ public interface DataGeneratorEntrypoint {
 	void onInitializeDataGenerator(FabricDataGenerator fabricDataGenerator);
 
 	/**
-	 * Return the modid of the mod the data is being generated for.
-	 * A null return will run the data generation using the modid that registered the current entrypoint.
+	 * Returns the modid of the mod the data is being generated for.
+	 * A {@code null} return will run the data generator using the modid that registered the current entrypoint.
 	 *
-	 * @return a {@link String} or null
+	 * @return a {@link String} or {@code null}
 	 */
 	@Nullable
 	default String getEffectiveModId() {

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/DataGeneratorEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/DataGeneratorEntrypoint.java
@@ -18,8 +18,6 @@ package net.fabricmc.fabric.api.datagen.v1;
 
 import org.jetbrains.annotations.Nullable;
 
-import net.fabricmc.loader.api.ModContainer;
-
 /**
  * An entry point for data generation.
  *
@@ -37,13 +35,13 @@ public interface DataGeneratorEntrypoint {
 	void onInitializeDataGenerator(FabricDataGenerator fabricDataGenerator);
 
 	/**
-	 * Return the {@link ModContainer} of the mod the data is being generated for.
-	 * A null return will run the data generation using the {@link ModContainer} that registered the current entrypoint.
+	 * Return the modid of the mod the data is being generated for.
+	 * A null return will run the data generation using the modid that registered the current entrypoint.
 	 *
-	 * @return a {@link ModContainer} or null
+	 * @return a {@link String} or null
 	 */
 	@Nullable
-	default ModContainer getEffectiveModContainer() {
+	default String getEffectiveModId() {
 		return null;
 	}
 }

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricDataGenerator.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricDataGenerator.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.api.datagen.v1;
 
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.function.Function;
 
 import org.jetbrains.annotations.ApiStatus;
@@ -38,7 +39,7 @@ public final class FabricDataGenerator extends DataGenerator {
 	@ApiStatus.Internal
 	public FabricDataGenerator(Path output, ModContainer mod, boolean strictValidation) {
 		super(output, Collections.emptyList(), SharedConstants.getGameVersion(), true);
-		this.modContainer = mod;
+		this.modContainer = Objects.requireNonNull(mod);
 		this.strictValidation = strictValidation;
 	}
 

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGenHelper.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGenHelper.java
@@ -117,7 +117,7 @@ public final class FabricDataGenHelper {
 				ModContainer modContainer = entrypointContainer.getProvider();
 
 				if (effectiveModId != null) {
-					modContainer = FabricLoader.getInstance().getModContainer(effectiveModId).orElseThrow(() -> new RuntimeException("Failed to find effective mod container for modid (%s)".formatted(effectiveModId)));
+					modContainer = FabricLoader.getInstance().getModContainer(effectiveModId).orElseThrow(() -> new RuntimeException("Failed to find effective mod container for mod id (%s)".formatted(effectiveModId)));
 				}
 
 				FabricDataGenerator dataGenerator = new FabricDataGenerator(outputDir, modContainer, STRICT_VALIDATION);

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGenHelper.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGenHelper.java
@@ -111,14 +111,15 @@ public final class FabricDataGenHelper {
 
 			LOGGER.info("Running data generator for {}", id);
 
-			final DataGeneratorEntrypoint entrypoint = entrypointContainer.getEntrypoint();
-			ModContainer modContainer = entrypoint.getEffectiveModContainer();
-
-			if (modContainer == null) {
-				modContainer = entrypointContainer.getProvider();
-			}
-
 			try {
+				final DataGeneratorEntrypoint entrypoint = entrypointContainer.getEntrypoint();
+				final String effectiveModId = entrypoint.getEffectiveModId();
+				ModContainer modContainer = entrypointContainer.getProvider();
+
+				if (effectiveModId != null) {
+					modContainer = FabricLoader.getInstance().getModContainer(effectiveModId).orElseThrow(() -> new RuntimeException("Failed to find effective mod container for modid (%s)".formatted(effectiveModId)));
+				}
+
 				FabricDataGenerator dataGenerator = new FabricDataGenerator(outputDir, modContainer, STRICT_VALIDATION);
 				entrypoint.onInitializeDataGenerator(dataGenerator);
 				dataGenerator.run();

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGenHelper.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGenHelper.java
@@ -42,6 +42,7 @@ import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider.DynamicRegistryTagProvider;
 import net.fabricmc.fabric.api.resource.conditions.v1.ConditionJsonProvider;
 import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
 
 @ApiStatus.Internal
@@ -110,9 +111,16 @@ public final class FabricDataGenHelper {
 
 			LOGGER.info("Running data generator for {}", id);
 
+			final DataGeneratorEntrypoint entrypoint = entrypointContainer.getEntrypoint();
+			ModContainer modContainer = entrypoint.getEffectiveModContainer();
+
+			if (modContainer == null) {
+				modContainer = entrypointContainer.getProvider();
+			}
+
 			try {
-				FabricDataGenerator dataGenerator = new FabricDataGenerator(outputDir, entrypointContainer.getProvider(), STRICT_VALIDATION);
-				entrypointContainer.getEntrypoint().onInitializeDataGenerator(dataGenerator);
+				FabricDataGenerator dataGenerator = new FabricDataGenerator(outputDir, modContainer, STRICT_VALIDATION);
+				entrypoint.onInitializeDataGenerator(dataGenerator);
 				dataGenerator.run();
 			} catch (Throwable t) {
 				throw new RuntimeException("Failed to run data generator from mod (%s)".formatted(id), t);


### PR DESCRIPTION
This change is needed to allow other mods to generate data for a different modid. My usecase is that I have a `techreborn-datagen` mod that is not shipped in production builds that generates data for the `techreborn` mod.

This is needed as the Fabric data gen api has a number of places where it uses the modid in the data generation logic such as: https://github.com/FabricMC/fabric/blob/1.19.2/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/ModelProviderMixin.java#L119 
