### PR TITLE
[1.18.2 Backport] Rename modid to "fabric-api" and provide "fabric"

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,6 +1,9 @@
 {
   "schemaVersion": 1,
-  "id": "fabric",
+  "id": "fabric-api",
+  "provides": [
+    "fabric"
+  ],
   "name": "Fabric API",
   "version": "${version}",
   "environment": "*",


### PR DESCRIPTION
Backport of https://github.com/FabricMC/fabric/pull/2446
Fixes: https://github.com/FabricMC/fabric/issues/2527

I dont believe there is a major wish for this in 1.17, if there is let me know.