### PR TITLE
Update Loom, Yarn, Checkstyle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -248,6 +248,12 @@ allprojects {
 		archiveClassifier = "testmod"
 	}
 
+	[jar, testmodJar, sourcesJar].each {
+		it.from(rootProject.file("LICENSE")) {
+			rename { "${it}-${project.archivesBaseName}"}
+		}
+	}
+
 	task remapTestmodJar(type: net.fabricmc.loom.task.RemapJarTask, dependsOn: testmodJar) {
 		input = testmodJar.archiveFile
 		archiveClassifier = "testmod"

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ plugins {
 	id "eclipse"
 	id "idea"
 	id "maven-publish"
-	id "fabric-loom" version "0.13.12" apply false
-	id "com.diffplug.spotless" version "6.5.1"
+	id "fabric-loom" version "1.0.7" apply false
+	id "com.diffplug.spotless" version "6.11.0"
 	id "org.ajoberstar.grgit" version "3.1.0"
 	id "com.matthewprenger.cursegradle" version "1.4.0"
 	id "com.modrinth.minotaur" version "2.4.3"
@@ -223,7 +223,7 @@ allprojects {
 
 	checkstyle {
 		configFile = rootProject.file("checkstyle.xml")
-		toolVersion = "9.1"
+		toolVersion = "10.3.3"
 	}
 
 	tasks.withType(AbstractArchiveTask) {

--- a/fabric-particles-v1/src/client/java/net/fabricmc/fabric/api/client/particle/v1/ParticleFactoryRegistry.java
+++ b/fabric-particles-v1/src/client/java/net/fabricmc/fabric/api/client/particle/v1/ParticleFactoryRegistry.java
@@ -54,7 +54,7 @@ public interface ParticleFactoryRegistry {
 	 * @param <T> The type of particle effects this factory deals with.
 	 */
 	@FunctionalInterface
-	public interface PendingParticleFactory<T extends ParticleEffect> {
+	interface PendingParticleFactory<T extends ParticleEffect> {
 		/**
 		 * Called to create a new particle factory.
 		 *

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/RenderContext.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/RenderContext.java
@@ -82,7 +82,7 @@ public interface RenderContext {
 	void popTransform();
 
 	@FunctionalInterface
-	public interface QuadTransform {
+	interface QuadTransform {
 		/**
 		 * Return false to filter out quads from rendering. When more than one transform
 		 * is in effect, returning false means unapplied transforms will not receive the quad.

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.parallel=true
 
 version=0.61.0
 minecraft_version=1.19.2
-yarn_version=+build.1
+yarn_version=+build.17
 loader_version=0.14.9
 
 prerelease=false


### PR DESCRIPTION
Checkstyle update is a bit stricter on redundant modifiers.

Loom update requires all modules to be bumped alongside the JavaDoc fixes PR.