### PR TITLE
Cleanup incorrect mixin shadow annotations/access

### DIFF
--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/modification/MinecraftServerMixin.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/modification/MinecraftServerMixin.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.mixin.biome.modification;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -31,8 +32,9 @@ import net.fabricmc.fabric.impl.biome.modification.BiomeModificationImpl;
 
 @Mixin(MinecraftServer.class)
 public abstract class MinecraftServerMixin {
+	@Final
 	@Shadow
-	private SaveProperties saveProperties;
+	protected SaveProperties saveProperties;
 
 	@Shadow
 	public abstract DynamicRegistryManager.Immutable getRegistryManager();

--- a/fabric-blockrenderlayer-v1/src/client/java/net/fabricmc/fabric/mixin/blockrenderlayer/RenderLayersMixin.java
+++ b/fabric-blockrenderlayer-v1/src/client/java/net/fabricmc/fabric/mixin/blockrenderlayer/RenderLayersMixin.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.mixin.blockrenderlayer;
 
 import java.util.Map;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -33,8 +34,12 @@ import net.fabricmc.fabric.impl.blockrenderlayer.BlockRenderLayerMapImpl;
 
 @Mixin(RenderLayers.class)
 public class RenderLayersMixin {
-	@Shadow private static Map<Block, RenderLayer> BLOCKS;
-	@Shadow private static Map<Fluid, RenderLayer> FLUIDS;
+	@Shadow
+	@Final
+	private static Map<Block, RenderLayer> BLOCKS;
+	@Shadow
+	@Final
+	private static Map<Fluid, RenderLayer> FLUIDS;
 
 	@Inject(method = "<clinit>*", at = @At("RETURN"))
 	private static void onInitialize(CallbackInfo info) {

--- a/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/mixin/event/interaction/client/ClientPlayerInteractionManagerMixin.java
+++ b/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/mixin/event/interaction/client/ClientPlayerInteractionManagerMixin.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.mixin.event.interaction.client;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -56,8 +57,10 @@ import net.fabricmc.fabric.api.event.player.UseItemCallback;
 @Mixin(ClientPlayerInteractionManager.class)
 public abstract class ClientPlayerInteractionManagerMixin {
 	@Shadow
+	@Final
 	private MinecraftClient client;
 	@Shadow
+	@Final
 	private ClientPlayNetworkHandler networkHandler;
 	@Shadow
 	private GameMode gameMode;

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/ServerPlayNetworkHandlerMixin.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/ServerPlayNetworkHandlerMixin.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.mixin.event.interaction;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -37,10 +38,12 @@ import net.fabricmc.fabric.api.event.player.UseEntityCallback;
 @Mixin(targets = "net/minecraft/server/network/ServerPlayNetworkHandler$1")
 public abstract class ServerPlayNetworkHandlerMixin implements PlayerInteractEntityC2SPacket.Handler {
 	@Shadow
-	public ServerPlayNetworkHandler field_28963;
+	@Final
+	ServerPlayNetworkHandler field_28963;
 
 	@Shadow
-	public Entity field_28962;
+	@Final
+	Entity field_28962;
 
 	@Inject(method = "interactAt(Lnet/minecraft/util/Hand;Lnet/minecraft/util/math/Vec3d;)V", at = @At(value = "HEAD"), cancellable = true)
 	public void onPlayerInteractEntity(Hand hand, Vec3d hitPosition, CallbackInfo info) {

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/ServerPlayerInteractionManagerMixin.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/ServerPlayerInteractionManagerMixin.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.mixin.event.interaction;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -51,9 +52,10 @@ import net.fabricmc.fabric.api.event.player.UseItemCallback;
 @Mixin(ServerPlayerInteractionManager.class)
 public class ServerPlayerInteractionManagerMixin {
 	@Shadow
-	public ServerWorld world;
+	protected ServerWorld world;
+	@Final
 	@Shadow
-	public ServerPlayerEntity player;
+	protected ServerPlayerEntity player;
 
 	@Inject(at = @At("HEAD"), method = "processBlockBreakingAction", cancellable = true)
 	public void startBlockBreak(BlockPos pos, PlayerActionC2SPacket.Action playerAction, Direction direction, int worldHeight, int i, CallbackInfo info) {

--- a/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/mixin/gamerule/GameRuleCommandVisitorMixin.java
+++ b/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/mixin/gamerule/GameRuleCommandVisitorMixin.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.mixin.gamerule;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -31,8 +32,9 @@ import net.fabricmc.fabric.impl.gamerule.EnumRuleType;
 
 @Mixin(targets = "net/minecraft/server/command/GameRuleCommand$1")
 public abstract class GameRuleCommandVisitorMixin {
+	@Final
 	@Shadow
-	private LiteralArgumentBuilder<ServerCommandSource> field_19419;
+	LiteralArgumentBuilder<ServerCommandSource> field_19419;
 
 	@Inject(at = @At("HEAD"), method = "visit(Lnet/minecraft/world/GameRules$Key;Lnet/minecraft/world/GameRules$Type;)V", cancellable = true)
 	private <T extends GameRules.Rule<T>> void onRegisterCommand(GameRules.Key<T> key, GameRules.Type<T> type, CallbackInfo ci) {

--- a/fabric-models-v0/src/client/java/net/fabricmc/fabric/mixin/client/model/ModelLoaderMixin.java
+++ b/fabric-models-v0/src/client/java/net/fabricmc/fabric/mixin/client/model/ModelLoaderMixin.java
@@ -38,12 +38,16 @@ import net.fabricmc.fabric.impl.client.model.ModelLoadingRegistryImpl;
 @Mixin(ModelLoader.class)
 public abstract class ModelLoaderMixin implements ModelLoaderHooks {
 	// this is the first one
+	@Final
 	@Shadow
 	public static ModelIdentifier MISSING_ID;
+	@Final
 	@Shadow
 	private ResourceManager resourceManager;
+	@Final
 	@Shadow
 	private Set<Identifier> modelsToLoad;
+	@Final
 	@Shadow
 	private Map<Identifier, UnbakedModel> unbakedModels;
 	@Shadow

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/ClientPlayNetworkHandlerMixin.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/ClientPlayNetworkHandlerMixin.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.mixin.networking.client;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -39,6 +40,7 @@ import net.fabricmc.fabric.impl.networking.client.ClientPlayNetworkAddon;
 @Environment(EnvType.CLIENT)
 @Mixin(value = ClientPlayNetworkHandler.class, priority = 999)
 abstract class ClientPlayNetworkHandlerMixin implements NetworkHandlerExtensions {
+	@Final
 	@Shadow
 	private MinecraftClient client;
 

--- a/fabric-registry-sync-v0/src/client/java/net/fabricmc/fabric/mixin/registry/sync/client/BlockColorsMixin.java
+++ b/fabric-registry-sync-v0/src/client/java/net/fabricmc/fabric/mixin/registry/sync/client/BlockColorsMixin.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.mixin.registry.sync.client;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -31,6 +32,7 @@ import net.fabricmc.fabric.impl.registry.sync.trackers.IdListTracker;
 
 @Mixin(BlockColors.class)
 public class BlockColorsMixin {
+	@Final
 	@Shadow
 	private IdList<BlockColorProvider> providers;
 

--- a/fabric-registry-sync-v0/src/client/java/net/fabricmc/fabric/mixin/registry/sync/client/ItemColorsMixin.java
+++ b/fabric-registry-sync-v0/src/client/java/net/fabricmc/fabric/mixin/registry/sync/client/ItemColorsMixin.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.mixin.registry.sync.client;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -31,6 +32,7 @@ import net.fabricmc.fabric.impl.registry.sync.trackers.IdListTracker;
 
 @Mixin(ItemColors.class)
 public class ItemColorsMixin {
+	@Final
 	@Shadow
 	private IdList<ItemColorProvider> providers;
 

--- a/fabric-registry-sync-v0/src/client/java/net/fabricmc/fabric/mixin/registry/sync/client/ItemModelsMixin.java
+++ b/fabric-registry-sync-v0/src/client/java/net/fabricmc/fabric/mixin/registry/sync/client/ItemModelsMixin.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.mixin.registry.sync.client;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -33,8 +34,10 @@ import net.fabricmc.fabric.impl.registry.sync.trackers.Int2ObjectMapTracker;
 
 @Mixin(ItemModels.class)
 public class ItemModelsMixin {
+	@Final
 	@Shadow
 	public Int2ObjectMap<ModelIdentifier> modelIds;
+	@Final
 	@Shadow
 	private Int2ObjectMap<BakedModel> models;
 

--- a/fabric-registry-sync-v0/src/client/java/net/fabricmc/fabric/mixin/registry/sync/client/ParticleManagerMixin.java
+++ b/fabric-registry-sync-v0/src/client/java/net/fabricmc/fabric/mixin/registry/sync/client/ParticleManagerMixin.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.mixin.registry.sync.client;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -33,6 +34,7 @@ import net.fabricmc.fabric.impl.registry.sync.trackers.Int2ObjectMapTracker;
 
 @Mixin(ParticleManager.class)
 public class ParticleManagerMixin {
+	@Final
 	@Shadow
 	private Int2ObjectMap<ParticleFactory<?>> factories;
 

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/IdListMixin.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/IdListMixin.java
@@ -22,6 +22,7 @@ import java.util.List;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntMaps;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -34,8 +35,10 @@ import net.fabricmc.fabric.impl.registry.sync.RemovableIdList;
 public class IdListMixin<T> implements RemovableIdList<T> {
 	@Shadow
 	private int nextId;
+	@Final
 	@Shadow
 	private Object2IntMap<T> idMap;
+	@Final
 	@Shadow
 	private List<T> list;
 

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MinecraftServerMixin.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MinecraftServerMixin.java
@@ -34,7 +34,7 @@ import net.fabricmc.loader.api.FabricLoader;
 @Mixin(MinecraftServer.class)
 public class MinecraftServerMixin {
 	@Unique
-	private static Logger FABRIC_LOGGER = LoggerFactory.getLogger(MinecraftServerMixin.class);
+	private static final Logger FABRIC_LOGGER = LoggerFactory.getLogger(MinecraftServerMixin.class);
 
 	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;setupServer()Z"), method = "runServer")
 	private void beforeSetupServer(CallbackInfo info) {

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/SpriteAtlasTextureMixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/SpriteAtlasTextureMixin.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.mixin.renderer.client;
 
 import java.util.Map;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -32,6 +33,7 @@ import net.fabricmc.fabric.impl.renderer.SpriteFinderImpl;
 
 @Mixin(SpriteAtlasTexture.class)
 public class SpriteAtlasTextureMixin implements SpriteFinderImpl.SpriteFinderAccess {
+	@Final
 	@Shadow
 	private Map<Identifier, Sprite> sprites;
 

--- a/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/fluid/FluidRendererMixin.java
+++ b/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/fluid/FluidRendererMixin.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.mixin.client.rendering.fluid;
 
 import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -42,8 +43,10 @@ import net.fabricmc.fabric.impl.client.rendering.fluid.FluidRendererHookContaine
 
 @Mixin(FluidRenderer.class)
 public class FluidRendererMixin {
+	@Final
 	@Shadow
 	private Sprite[] lavaSprites;
+	@Final
 	@Shadow
 	private Sprite[] waterSprites;
 	@Shadow

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.mixin.client.rendering;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -48,10 +49,14 @@ import net.fabricmc.fabric.impl.client.rendering.WorldRenderContextImpl;
 
 @Mixin(WorldRenderer.class)
 public abstract class WorldRendererMixin {
-	@Shadow private BufferBuilderStorage bufferBuilders;
+	@Final
+	@Shadow
+	private BufferBuilderStorage bufferBuilders;
 	@Shadow private ClientWorld world;
 	@Shadow private ShaderEffect transparencyShader;
-	@Shadow private MinecraftClient client;
+	@Final
+	@Shadow
+	private MinecraftClient client;
 	@Unique private final WorldRenderContextImpl context = new WorldRenderContextImpl();
 	@Unique private boolean didRenderParticles;
 


### PR DESCRIPTION
I would like to enable `-Dmixin.debug.strict=true` to prevent this from happening again in the future however this seems to conflict with Loaders access fixer in dev.