### PR TITLE
[Lifecycles] Client Startup Finished Event

### DIFF
--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientLifecycleEvents.java
@@ -51,6 +51,18 @@ public final class ClientLifecycleEvents {
 		}
 	});
 
+	/**
+	 * Called once Minecraft has completed the initial resource reload.
+	 * Everything is loaded in this state.
+	 *
+	 * <p>This will be called when the splash screen begins to fade.
+	 */
+	public static final Event<ClientStartupFinished> CLIENT_STARTUP_FINISHED = EventFactory.createArrayBacked(ClientStartupFinished.class, callbacks -> client -> {
+		for (ClientStartupFinished callback : callbacks) {
+			callback.onClientStartupFinished(client);
+		}
+	});
+
 	@FunctionalInterface
 	public interface ClientStarted {
 		void onClientStarted(MinecraftClient client);
@@ -59,5 +71,10 @@ public final class ClientLifecycleEvents {
 	@FunctionalInterface
 	public interface ClientStopping {
 		void onClientStopping(MinecraftClient client);
+	}
+
+	@FunctionalInterface
+	public interface ClientStartupFinished {
+		void onClientStartupFinished(MinecraftClient client);
 	}
 }

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/MinecraftClientMixin.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/MinecraftClientMixin.java
@@ -16,6 +16,9 @@
 
 package net.fabricmc.fabric.mixin.event.lifecycle.client;
 
+import java.util.List;
+import java.io.File;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -31,9 +34,6 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
-
-import java.io.File;
-import java.util.List;
 
 @Environment(EnvType.CLIENT)
 @Mixin(MinecraftClient.class)

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientLifecycleTests.java
@@ -25,6 +25,7 @@ import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 public final class ClientLifecycleTests implements ClientModInitializer {
 	private boolean startCalled;
 	private boolean stopCalled;
+	private boolean startFinishedCalled;
 
 	@Override
 	public void onInitializeClient() {
@@ -46,6 +47,15 @@ public final class ClientLifecycleTests implements ClientModInitializer {
 
 			stopCalled = true;
 			System.out.println("Client has started stopping!");
+		});
+
+		ClientLifecycleEvents.CLIENT_STARTUP_FINISHED.register(client -> {
+			if (startFinishedCalled) {
+				throw new IllegalStateException("Start finished was already called!");
+			}
+
+			startFinishedCalled = true;
+			System.out.println("Client has finished starting");
 		});
 	}
 }


### PR DESCRIPTION
## Summary
This event is called when the initial resource reload has completed and the splash-screen is beginning to fade to the title screen.

## Why is it needed?
It may be necessary for some mods to do post-startup tasks like displaying a toast. It guarantees an environment of safety where everything is loaded and the game has actually started up fully. An example of it's use is in [Zoomify](https://github.com/isXander/Zoomify/blob/1.19/src/main/kotlin/dev/isxander/zoomify/Zoomify.kt#L143).
