### PR TITLE
Fix `@SafeVarargs` warnings in Resource Conditions and `ColorProviderRegistry`

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/ColorProviderRegistry.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/ColorProviderRegistry.java
@@ -36,6 +36,7 @@ public interface ColorProviderRegistry<T, Provider> {
 	 * @param provider The color provider to register.
 	 * @param objects  The objects which should be colored using this provider.
 	 */
+	@SuppressWarnings("unchecked") // @SafeVarargs is not allowed on interface methods.
 	void register(Provider provider, T... objects);
 
 	/**

--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/DefaultResourceConditions.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/DefaultResourceConditions.java
@@ -90,6 +90,7 @@ public final class DefaultResourceConditions {
 	/**
 	 * Create a condition that returns true if each of the passed block tags exists and has at least one element.
 	 */
+	@SafeVarargs
 	public static ConditionJsonProvider blockTagsPopulated(TagKey<Block>... tags) {
 		return ResourceConditionsImpl.tagsPopulated(BLOCK_TAGS_POPULATED, tags);
 	}
@@ -97,6 +98,7 @@ public final class DefaultResourceConditions {
 	/**
 	 * Create a condition that returns true if each of the passed fluid tags exists and has at least one element.
 	 */
+	@SafeVarargs
 	public static ConditionJsonProvider fluidTagsPopulated(TagKey<Fluid>... tags) {
 		return ResourceConditionsImpl.tagsPopulated(FLUID_TAGS_POPULATED, tags);
 	}
@@ -104,6 +106,7 @@ public final class DefaultResourceConditions {
 	/**
 	 * Create a condition that returns true if each of the passed item tags exists and has at least one element.
 	 */
+	@SafeVarargs
 	public static ConditionJsonProvider itemTagsPopulated(TagKey<Item>... tags) {
 		return ResourceConditionsImpl.tagsPopulated(ITEM_TAGS_POPULATED, tags);
 	}

--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/impl/resource/conditions/ResourceConditionsImpl.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/impl/resource/conditions/ResourceConditionsImpl.java
@@ -92,6 +92,7 @@ public class ResourceConditionsImpl {
 		};
 	}
 
+	@SafeVarargs
 	public static <T> ConditionJsonProvider tagsPopulated(Identifier id, TagKey<T>... tags) {
 		Preconditions.checkArgument(tags.length > 0, "Must register at least one tag.");
 


### PR DESCRIPTION
I noticed this warning when trying to use `DefaultResourceConditions.itemTagsPopulated`, and I figured I'd also fix it in the other places.