### PR TITLE
Create parent directory when writing test report

### DIFF
--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/FabricGameTestHelper.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/FabricGameTestHelper.java
@@ -37,7 +37,6 @@ import net.minecraft.test.TestFunction;
 import net.minecraft.test.TestFunctions;
 import net.minecraft.test.TestServer;
 import net.minecraft.test.TestUtil;
-import net.minecraft.test.XmlReportingTestCompletionListener;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.level.storage.LevelStorage;
 
@@ -56,7 +55,7 @@ public final class FabricGameTestHelper {
 
 		if (reportPath != null) {
 			try {
-				TestFailureLogger.setCompletionListener(new XmlReportingTestCompletionListener(new File(reportPath)));
+				TestFailureLogger.setCompletionListener(new SavingXmlReportingTestCompletionListener(new File(reportPath)));
 			} catch (ParserConfigurationException e) {
 				throw new RuntimeException(e);
 			}

--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/SavingXmlReportingTestCompletionListener.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/SavingXmlReportingTestCompletionListener.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.gametest;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+
+import net.minecraft.test.XmlReportingTestCompletionListener;
+
+public class SavingXmlReportingTestCompletionListener extends XmlReportingTestCompletionListener {
+	public SavingXmlReportingTestCompletionListener(File file) throws ParserConfigurationException {
+		super(file);
+	}
+
+	@Override
+	public void saveReport(File file) throws TransformerException {
+		try {
+			Files.createDirectories(file.toPath().getParent());
+		} catch (IOException e) {
+			throw new TransformerException("Failed to create parent directory", e);
+		}
+
+		super.saveReport(file);
+	}
+}

--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/SavingXmlReportingTestCompletionListener.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/SavingXmlReportingTestCompletionListener.java
@@ -25,6 +25,10 @@ import javax.xml.transform.TransformerException;
 
 import net.minecraft.test.XmlReportingTestCompletionListener;
 
+/**
+ * An extension of {@link XmlReportingTestCompletionListener} which creates the destination directory before saving
+ * the report.
+ */
 final class SavingXmlReportingTestCompletionListener extends XmlReportingTestCompletionListener {
 	SavingXmlReportingTestCompletionListener(File file) throws ParserConfigurationException {
 		super(file);

--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/SavingXmlReportingTestCompletionListener.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/SavingXmlReportingTestCompletionListener.java
@@ -25,8 +25,8 @@ import javax.xml.transform.TransformerException;
 
 import net.minecraft.test.XmlReportingTestCompletionListener;
 
-public class SavingXmlReportingTestCompletionListener extends XmlReportingTestCompletionListener {
-	public SavingXmlReportingTestCompletionListener(File file) throws ParserConfigurationException {
+final class SavingXmlReportingTestCompletionListener extends XmlReportingTestCompletionListener {
+	SavingXmlReportingTestCompletionListener(File file) throws ParserConfigurationException {
 		super(file);
 	}
 


### PR DESCRIPTION
This is useful when writing test reports to a child directory, such as `$buildDir/reports/tests/gametest.xml` instead.

The alternative option here would be to put this call inside a mixin to `XmlReportingTestCompletionListener`. Creating a subclass felt more elegant, but happy to use a mixin if preferred!