### PR TITLE
Restore vanilla's gametest structure loading

### DIFF
--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/mixin/gametest/StructureTestUtilMixin.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/mixin/gametest/StructureTestUtilMixin.java
@@ -38,7 +38,7 @@ import net.minecraft.util.Identifier;
 public abstract class StructureTestUtilMixin {
 	private static final String GAMETEST_STRUCTURE_PATH = "gametest/structures/";
 
-	// Replace the default test structure loading with something that works a bit better for mods.
+	// Add a handler which looks in data/<mod>/gametest/structures/*.snbt before searching the default paths.
 	@Inject(at = @At("HEAD"), method = "createStructureTemplate(Ljava/lang/String;Lnet/minecraft/server/world/ServerWorld;)Lnet/minecraft/structure/StructureTemplate;", cancellable = true)
 	private static void createStructure(String id, ServerWorld world, CallbackInfoReturnable<StructureTemplate> cir) {
 		Identifier baseId = new Identifier(id);
@@ -47,9 +47,7 @@ public abstract class StructureTestUtilMixin {
 		try {
 			Resource resource = world.getServer().getResourceManager().getResource(structureId).orElse(null);
 
-			if (resource == null) {
-				throw new RuntimeException("Unable to get resource: " + structureId);
-			}
+			if (resource == null) return;
 
 			String snbt;
 


### PR DESCRIPTION
If a structure cannot be found, we now fall back to vanilla's codepath, rather than throwing an exception. This offers the following advantages:

 - Makes it easier to use game tests in multi-loader setups, as the structure path is consistent across loaders.
 - As structures are now looked up from `testStructuresDirectoryName`, it's now possible to store structures in plain text (.snbt) rather than their binary form (.nbt).
