### PR TITLE
Resource conditions: support all tags

### DIFF
--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/ConditionJsonProvider.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/ConditionJsonProvider.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.resource.conditions.v1;
 
+import java.util.Objects;
+
 import com.google.common.base.Preconditions;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -43,7 +45,8 @@ public interface ConditionJsonProvider {
 		JsonArray array = new JsonArray();
 
 		for (ConditionJsonProvider condition : conditions) {
-			if (condition != null) array.add(condition.toJson());
+			Objects.requireNonNull(condition, "condition cannot be null");
+			array.add(condition.toJson());
 		}
 
 		conditionalObject.add(ResourceConditions.CONDITIONS_KEY, array);

--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/ConditionJsonProvider.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/ConditionJsonProvider.java
@@ -43,7 +43,7 @@ public interface ConditionJsonProvider {
 		JsonArray array = new JsonArray();
 
 		for (ConditionJsonProvider condition : conditions) {
-			array.add(condition.toJson());
+			if (condition != null) array.add(condition.toJson());
 		}
 
 		conditionalObject.add(ResourceConditions.CONDITIONS_KEY, array);

--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/DefaultResourceConditions.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/DefaultResourceConditions.java
@@ -90,24 +90,30 @@ public final class DefaultResourceConditions {
 
 	/**
 	 * Create a condition that returns true if each of the passed block tags exists and has at least one element.
+	 * @deprecated Use {@link #tagsPopulated} instead.
 	 */
 	@SafeVarargs
+	@Deprecated
 	public static ConditionJsonProvider blockTagsPopulated(TagKey<Block>... tags) {
 		return ResourceConditionsImpl.tagsPopulated(BLOCK_TAGS_POPULATED, false, tags);
 	}
 
 	/**
 	 * Create a condition that returns true if each of the passed fluid tags exists and has at least one element.
+	 * @deprecated Use {@link #tagsPopulated} instead.
 	 */
 	@SafeVarargs
+	@Deprecated
 	public static ConditionJsonProvider fluidTagsPopulated(TagKey<Fluid>... tags) {
 		return ResourceConditionsImpl.tagsPopulated(FLUID_TAGS_POPULATED, false, tags);
 	}
 
 	/**
 	 * Create a condition that returns true if each of the passed item tags exists and has at least one element.
+	 * @deprecated Use {@link #tagsPopulated} instead.
 	 */
 	@SafeVarargs
+	@Deprecated
 	public static ConditionJsonProvider itemTagsPopulated(TagKey<Item>... tags) {
 		return ResourceConditionsImpl.tagsPopulated(ITEM_TAGS_POPULATED, false, tags);
 	}

--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/DefaultResourceConditions.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/DefaultResourceConditions.java
@@ -47,7 +47,7 @@ public final class DefaultResourceConditions {
 	 * Creates a NOT condition that returns true if its child condition is false, and false if its child is true.
 	 *
 	 * @apiNote This condition's ID is {@code fabric:not}, and takes one property, {@code value},
-	 * which is a condition provider.
+	 * which is a condition.
 	 */
 	public static ConditionJsonProvider not(ConditionJsonProvider value) {
 		return new ConditionJsonProvider() {
@@ -67,7 +67,7 @@ public final class DefaultResourceConditions {
 	 * Creates a condition that returns true if all of its child conditions are true.
 	 *
 	 * @apiNote This condition's ID is {@code fabric:and}, and takes one property, {@code values},
-	 * which is an array of condition providers.
+	 * which is an array of conditions.
 	 */
 	public static ConditionJsonProvider and(ConditionJsonProvider... values) {
 		return ResourceConditionsImpl.array(AND, values);
@@ -77,7 +77,7 @@ public final class DefaultResourceConditions {
 	 * Creates a condition that returns true if any of its child conditions are true.
 	 *
 	 * @apiNote This condition's ID is {@code fabric:or}, and takes one property, {@code values},
-	 * which is an array of condition providers.
+	 * which is an array of conditions.
 	 */
 	public static ConditionJsonProvider or(ConditionJsonProvider... values) {
 		return ResourceConditionsImpl.array(OR, values);

--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/DefaultResourceConditions.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/DefaultResourceConditions.java
@@ -20,9 +20,9 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 import net.minecraft.block.Block;
-import net.minecraft.tag.TagKey;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.item.Item;
+import net.minecraft.tag.TagKey;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.JsonHelper;
 import net.minecraft.util.registry.Registry;
@@ -41,6 +41,7 @@ public final class DefaultResourceConditions {
 	private static final Identifier BLOCK_TAGS_POPULATED = new Identifier("fabric:block_tags_populated");
 	private static final Identifier FLUID_TAGS_POPULATED = new Identifier("fabric:fluid_tags_populated");
 	private static final Identifier ITEM_TAGS_POPULATED = new Identifier("fabric:item_tags_populated");
+	private static final Identifier TAGS_POPULATED = new Identifier("fabric:tags_populated");
 
 	/**
 	 * Create a NOT condition: returns true if its child condition is false, and false if its child is true.
@@ -92,7 +93,7 @@ public final class DefaultResourceConditions {
 	 */
 	@SafeVarargs
 	public static ConditionJsonProvider blockTagsPopulated(TagKey<Block>... tags) {
-		return ResourceConditionsImpl.tagsPopulated(BLOCK_TAGS_POPULATED, tags);
+		return ResourceConditionsImpl.tagsPopulated(BLOCK_TAGS_POPULATED, false, tags);
 	}
 
 	/**
@@ -100,7 +101,7 @@ public final class DefaultResourceConditions {
 	 */
 	@SafeVarargs
 	public static ConditionJsonProvider fluidTagsPopulated(TagKey<Fluid>... tags) {
-		return ResourceConditionsImpl.tagsPopulated(FLUID_TAGS_POPULATED, tags);
+		return ResourceConditionsImpl.tagsPopulated(FLUID_TAGS_POPULATED, false, tags);
 	}
 
 	/**
@@ -108,7 +109,16 @@ public final class DefaultResourceConditions {
 	 */
 	@SafeVarargs
 	public static ConditionJsonProvider itemTagsPopulated(TagKey<Item>... tags) {
-		return ResourceConditionsImpl.tagsPopulated(ITEM_TAGS_POPULATED, tags);
+		return ResourceConditionsImpl.tagsPopulated(ITEM_TAGS_POPULATED, false, tags);
+	}
+
+	/**
+	 * Create a condition that returns true if each of the passed tags exists and has at least one element.
+	 * This works for any registries, and the registry ID of the tags is serialized to JSON as well as the tags.
+	 */
+	@SafeVarargs
+	public static <T> ConditionJsonProvider tagsPopulated(TagKey<T>... tags) {
+		return ResourceConditionsImpl.tagsPopulated(TAGS_POPULATED, true, tags);
 	}
 
 	static void init() {
@@ -133,6 +143,7 @@ public final class DefaultResourceConditions {
 		ResourceConditions.register(BLOCK_TAGS_POPULATED, object -> ResourceConditionsImpl.tagsPopulatedMatch(object, Registry.BLOCK_KEY));
 		ResourceConditions.register(FLUID_TAGS_POPULATED, object -> ResourceConditionsImpl.tagsPopulatedMatch(object, Registry.FLUID_KEY));
 		ResourceConditions.register(ITEM_TAGS_POPULATED, object -> ResourceConditionsImpl.tagsPopulatedMatch(object, Registry.ITEM_KEY));
+		ResourceConditions.register(TAGS_POPULATED, ResourceConditionsImpl::tagsPopulatedMatch);
 	}
 
 	private DefaultResourceConditions() {

--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/DefaultResourceConditions.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/DefaultResourceConditions.java
@@ -44,7 +44,10 @@ public final class DefaultResourceConditions {
 	private static final Identifier TAGS_POPULATED = new Identifier("fabric:tags_populated");
 
 	/**
-	 * Create a NOT condition: returns true if its child condition is false, and false if its child is true.
+	 * Creates a NOT condition that returns true if its child condition is false, and false if its child is true.
+	 *
+	 * @apiNote This condition's ID is {@code fabric:not}, and takes one property, {@code value},
+	 * which is a condition provider.
 	 */
 	public static ConditionJsonProvider not(ConditionJsonProvider value) {
 		return new ConditionJsonProvider() {
@@ -61,28 +64,40 @@ public final class DefaultResourceConditions {
 	}
 
 	/**
-	 * Create a condition that returns true if all of its child conditions are true.
+	 * Creates a condition that returns true if all of its child conditions are true.
+	 *
+	 * @apiNote This condition's ID is {@code fabric:and}, and takes one property, {@code values},
+	 * which is an array of condition providers.
 	 */
 	public static ConditionJsonProvider and(ConditionJsonProvider... values) {
 		return ResourceConditionsImpl.array(AND, values);
 	}
 
 	/**
-	 * Create a condition that returns true if at least one of its child conditions is true.
+	 * Creates a condition that returns true if any of its child conditions are true.
+	 *
+	 * @apiNote This condition's ID is {@code fabric:or}, and takes one property, {@code values},
+	 * which is an array of condition providers.
 	 */
 	public static ConditionJsonProvider or(ConditionJsonProvider... values) {
 		return ResourceConditionsImpl.array(OR, values);
 	}
 
 	/**
-	 * Create a condition that returns true if all the passed mod ids correspond to a loaded mod.
+	 * Creates a condition that returns true if all the passed mod ids correspond to a loaded mod.
+	 *
+	 * @apiNote This condition's ID is {@code fabric:all_mods_loaded}, and takes one property,
+	 * {@code values}, which is an array of string mod IDs.
 	 */
 	public static ConditionJsonProvider allModsLoaded(String... modIds) {
 		return ResourceConditionsImpl.mods(ALL_MODS_LOADED, modIds);
 	}
 
 	/**
-	 * Create a condition that returns true if at least one of the passed mod ids corresponds to a loaded mod.
+	 * Creates a condition that returns true if at least one of the passed mod ids corresponds to a loaded mod.
+	 *
+	 * @apiNote This condition's ID is {@code fabric:any_mod_loaded}, and takes one property,
+	 * {@code values}, which is an array of string mod IDs.
 	 */
 	public static ConditionJsonProvider anyModLoaded(String... modIds) {
 		return ResourceConditionsImpl.mods(ANY_MOD_LOADED, modIds);
@@ -119,8 +134,12 @@ public final class DefaultResourceConditions {
 	}
 
 	/**
-	 * Create a condition that returns true if each of the passed tags exists and has at least one element.
+	 * Creates a condition that returns true if each of the passed tags exists and has at least one element.
 	 * This works for any registries, and the registry ID of the tags is serialized to JSON as well as the tags.
+	 *
+	 * @apiNote This condition's ID is {@code fabric:tags_populated}, and takes up to two properties:
+	 * {@code values}, which is an array of string tag IDs, and {@code registry}, which is the ID of
+	 * the registry of the tags. If {@code registry} is not provided, it defaults to {@code minecraft:item}.
 	 */
 	@SafeVarargs
 	public static <T> ConditionJsonProvider tagsPopulated(TagKey<T>... tags) {

--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/package-info.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/package-info.java
@@ -15,9 +15,9 @@
  */
 
 /**
- * Provides a way of conditionally loading JSON-based resources. This can be used with
- * recipes, loot tables, advancements, predicates, and item modifiers. Conditions are
- * identified by an identifier and registered at {@link
+ * Provides a way of conditionally loading JSON-based resources. By default, this can
+ * be used with recipes, loot tables, advancements, predicates, and item modifiers.
+ * Conditions are identified by an identifier and registered at {@link
  * net.fabricmc.fabric.api.resource.conditions.v1.ResourceConditions}.
  *
  * <h2>JSON format</h2>

--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/package-info.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/package-info.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides a way of conditionally loading JSON-based resources. This can be used with
+ * recipes, loot tables, advancements, predicates, and item modifiers. Conditions are
+ * identified by an identifier and registered at {@link
+ * net.fabricmc.fabric.api.resource.conditions.v1.ResourceConditions}.
+ *
+ * <h2>JSON format</h2>
+ *
+ * <p>Add an array with the {@code fabric:load_conditions} key to the JSON file:
+ * <pre>{@code
+ * {
+ *   "type": "minecraft:crafting_shapeless",
+ *   "ingredients": [
+ *     {
+ *       "item": "minecraft:dirt"
+ *     }
+ *   ],
+ *   "result": {
+ *     "item": "minecraft:diamond"
+ *   },
+ *   "fabric:load_conditions": [
+ *     {
+ *       "condition": "<insert condition ID here>",
+ *       // values of the condition
+ *     }
+ *   ]
+ * }
+ * }</pre>
+ *
+ * <p>See {@link net.fabricmc.fabric.api.resource.conditions.v1.DefaultResourceConditions} for
+ * the list of built-in conditions. It is also possible to register a custom condition.
+ *
+ * <h2>Data generation integration</h2>
+ *
+ * <p>Fabric Data Generation API supports adding a {@link
+ * net.fabricmc.fabric.api.resource.conditions.v1.ConditionJsonProvider} to a generated file.
+ * Please check the documentation of the Data Generation API.
+ */
+package net.fabricmc.fabric.api.resource.conditions.v1;

--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/impl/resource/conditions/ResourceConditionsImpl.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/impl/resource/conditions/ResourceConditionsImpl.java
@@ -93,7 +93,7 @@ public class ResourceConditionsImpl {
 	}
 
 	@SafeVarargs
-	public static <T> ConditionJsonProvider tagsPopulated(Identifier id, TagKey<T>... tags) {
+	public static <T> ConditionJsonProvider tagsPopulated(Identifier id, boolean includeRegistry, TagKey<T>... tags) {
 		Preconditions.checkArgument(tags.length > 0, "Must register at least one tag.");
 
 		return new ConditionJsonProvider() {
@@ -111,6 +111,11 @@ public class ResourceConditionsImpl {
 				}
 
 				object.add("values", array);
+
+				if (includeRegistry) {
+					// tags[0] is guaranteed to exist
+					object.addProperty("registry", tags[0].registry().getValue().toString());
+				}
 			}
 		};
 	}
@@ -158,7 +163,13 @@ public class ResourceConditionsImpl {
 		LOADED_TAGS.remove();
 	}
 
-	public static <T> boolean tagsPopulatedMatch(JsonObject object, RegistryKey<? extends Registry<T>> registryKey) {
+	public static boolean tagsPopulatedMatch(JsonObject object) {
+		String key = JsonHelper.getString(object, "registry");
+		RegistryKey<? extends Registry<?>> registryRef = RegistryKey.ofRegistry(new Identifier(key));
+		return tagsPopulatedMatch(object, registryRef);
+	}
+
+	public static boolean tagsPopulatedMatch(JsonObject object, RegistryKey<? extends Registry<?>> registryKey) {
 		JsonArray array = JsonHelper.getArray(object, "values");
 		@Nullable
 		Map<RegistryKey<?>, Map<Identifier, Collection<RegistryEntry<?>>>> allTags = LOADED_TAGS.get();

--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/impl/resource/conditions/ResourceConditionsImpl.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/impl/resource/conditions/ResourceConditionsImpl.java
@@ -95,7 +95,7 @@ public final class ResourceConditionsImpl {
 	@SafeVarargs
 	public static <T> ConditionJsonProvider tagsPopulated(Identifier id, boolean includeRegistry, TagKey<T>... tags) {
 		Preconditions.checkArgument(tags.length > 0, "Must register at least one tag.");
-		final RegistryKey<? extends Registry<T>> registryRef = tags[0].registry();
+		final RegistryKey<? extends Registry<?>> registryRef = tags[0].registry();
 
 		return new ConditionJsonProvider() {
 			@Override

--- a/fabric-resource-conditions-api-v1/src/testmod/java/net/fabricmc/fabric/test/resource/conditions/ConditionalResourcesTest.java
+++ b/fabric-resource-conditions-api-v1/src/testmod/java/net/fabricmc/fabric/test/resource/conditions/ConditionalResourcesTest.java
@@ -50,12 +50,16 @@ public class ConditionalResourcesTest {
 			throw new AssertionError("tags_populated recipe should have been loaded.");
 		}
 
+		if (manager.get(id("tags_populated_default")).isEmpty()) {
+			throw new AssertionError("tags_populated_default recipe should have been loaded.");
+		}
+
 		if (manager.get(id("tags_not_populated")).isPresent()) {
 			throw new AssertionError("tags_not_populated recipe should not have been loaded.");
 		}
 
 		long loadedRecipes = manager.values().stream().filter(r -> r.getId().getNamespace().equals(MOD_ID)).count();
-		if (loadedRecipes != 3) throw new AssertionError("Unexpected loaded recipe count: " + loadedRecipes);
+		if (loadedRecipes != 4) throw new AssertionError("Unexpected loaded recipe count: " + loadedRecipes);
 
 		context.complete();
 	}

--- a/fabric-resource-conditions-api-v1/src/testmod/java/net/fabricmc/fabric/test/resource/conditions/ConditionalResourcesTest.java
+++ b/fabric-resource-conditions-api-v1/src/testmod/java/net/fabricmc/fabric/test/resource/conditions/ConditionalResourcesTest.java
@@ -46,6 +46,14 @@ public class ConditionalResourcesTest {
 			throw new AssertionError("item_tags_populated recipe should have been loaded.");
 		}
 
+		if (manager.get(id("tags_populated")).isEmpty()) {
+			throw new AssertionError("tags_populated recipe should have been loaded.");
+		}
+
+		if (manager.get(id("tags_not_populated")).isPresent()) {
+			throw new AssertionError("tags_not_populated recipe should not have been loaded.");
+		}
+
 		long loadedRecipes = manager.values().stream().filter(r -> r.getId().getNamespace().equals(MOD_ID)).count();
 		if (loadedRecipes != 2) throw new AssertionError("Unexpected loaded recipe count: " + loadedRecipes);
 

--- a/fabric-resource-conditions-api-v1/src/testmod/java/net/fabricmc/fabric/test/resource/conditions/ConditionalResourcesTest.java
+++ b/fabric-resource-conditions-api-v1/src/testmod/java/net/fabricmc/fabric/test/resource/conditions/ConditionalResourcesTest.java
@@ -55,7 +55,7 @@ public class ConditionalResourcesTest {
 		}
 
 		long loadedRecipes = manager.values().stream().filter(r -> r.getId().getNamespace().equals(MOD_ID)).count();
-		if (loadedRecipes != 2) throw new AssertionError("Unexpected loaded recipe count: " + loadedRecipes);
+		if (loadedRecipes != 3) throw new AssertionError("Unexpected loaded recipe count: " + loadedRecipes);
 
 		context.complete();
 	}

--- a/fabric-resource-conditions-api-v1/src/testmod/resources/data/fabric-resource-conditions-api-v1-testmod/recipes/tags_not_populated.json
+++ b/fabric-resource-conditions-api-v1/src/testmod/resources/data/fabric-resource-conditions-api-v1-testmod/recipes/tags_not_populated.json
@@ -1,0 +1,12 @@
+{
+  "__comment": "this is going to be skipped before any check, so /shrug.",
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:tags_populated",
+      "values": [
+        "fabric-resource-conditions-api-v1-testmod:test_condition"
+      ],
+      "registry": "fabric-resource-conditions-api-v1-testmod:missing"
+    }
+  ]
+}

--- a/fabric-resource-conditions-api-v1/src/testmod/resources/data/fabric-resource-conditions-api-v1-testmod/recipes/tags_populated.json
+++ b/fabric-resource-conditions-api-v1/src/testmod/resources/data/fabric-resource-conditions-api-v1-testmod/recipes/tags_populated.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:dirt"
+    }
+  ],
+  "result": {
+    "item": "minecraft:diamond"
+  },
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:tags_populated",
+      "values": [
+        "fabric-resource-conditions-api-v1-testmod:test_condition"
+      ],
+      "registry": "minecraft:item"
+    }
+  ]
+}

--- a/fabric-resource-conditions-api-v1/src/testmod/resources/data/fabric-resource-conditions-api-v1-testmod/recipes/tags_populated_default.json
+++ b/fabric-resource-conditions-api-v1/src/testmod/resources/data/fabric-resource-conditions-api-v1-testmod/recipes/tags_populated_default.json
@@ -2,19 +2,18 @@
   "type": "minecraft:crafting_shapeless",
   "ingredients": [
     {
-      "item": "minecraft:dirt"
+      "item": "minecraft:diamond"
     }
   ],
   "result": {
-    "item": "minecraft:diamond"
+    "item": "minecraft:dirt"
   },
   "fabric:load_conditions": [
     {
       "condition": "fabric:tags_populated",
       "values": [
         "fabric-resource-conditions-api-v1-testmod:test_condition"
-      ],
-      "registry": "minecraft:block"
+      ]
     }
   ]
 }

--- a/fabric-resource-conditions-api-v1/src/testmod/resources/data/fabric-resource-conditions-api-v1-testmod/tags/blocks/test_condition.json
+++ b/fabric-resource-conditions-api-v1/src/testmod/resources/data/fabric-resource-conditions-api-v1-testmod/tags/blocks/test_condition.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:dirt"
+  ]
+}


### PR DESCRIPTION
Should we deprecate registry-specific datagen methods?