### PR TITLE
Create `es_es` translations for `resource-loader` and `item-groups`

### DIFF
--- a/fabric-item-groups-v0/src/main/resources/assets/fabric/lang/es_es.json
+++ b/fabric-item-groups-v0/src/main/resources/assets/fabric/lang/es_es.json
@@ -1,0 +1,3 @@
+{
+  "fabric.gui.creativeTabPage": "Página %d/%d"
+}

--- a/fabric-resource-loader-v0/src/main/resources/assets/fabric-resource-loader-v0/lang/es_es.json
+++ b/fabric-resource-loader-v0/src/main/resources/assets/fabric-resource-loader-v0/lang/es_es.json
@@ -1,0 +1,4 @@
+{
+  "pack.source.fabricmod": "Mod de Fabric",
+  "pack.source.builtinMod": "integrado en: %s"
+}


### PR DESCRIPTION
Adds those. The one for `item-groups` is basically the same as the existing for `es_mx`.