### PR TITLE
Add `AFTER_DEATH` and `ALLOW_DAMAGE` events; generalise `ALLOW_DEATH` to living entities

### DIFF
--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
@@ -25,7 +25,7 @@ import net.fabricmc.fabric.api.event.EventFactory;
 /**
  * Various server-side only events related to living entities.
  */
-public class ServerLivingEntityEvents {
+public final class ServerLivingEntityEvents {
 	/**
 	 * An event that is called when a living entity is going to take damage.
 	 *
@@ -110,5 +110,8 @@ public class ServerLivingEntityEvents {
 		 * @param damageSource the source of the fatal damage
 		 */
 		void afterDeath(LivingEntity entity, DamageSource damageSource);
+	}
+
+	private ServerLivingEntityEvents() {
 	}
 }

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
@@ -28,8 +28,8 @@ import net.fabricmc.fabric.api.event.EventFactory;
 public final class ServerLivingEntityEvents {
 	/**
 	 * An event that is called when a living entity is going to take damage.
-	 *
-	 * <p>Mods can cancel this to prevent the damage entirely.
+	 * This is fired from {@link LivingEntity#damage}, before armor or any other mitigation are applied.
+	 * Mods can cancel this to prevent the damage entirely.
 	 */
 	public static final Event<AllowDamage> ALLOW_DAMAGE = EventFactory.createArrayBacked(AllowDamage.class, callbacks -> (entity, source, amount) -> {
 		for (AllowDamage callback : callbacks) {
@@ -54,9 +54,9 @@ public final class ServerLivingEntityEvents {
 	 *     <li>a mod that changes death mechanics switching the player over to the mod's play-mode, where death doesn't apply</li>
 	 * </ul>
 	 */
-	public static final Event<AllowDeath> ALLOW_DEATH = EventFactory.createArrayBacked(AllowDeath.class, callbacks -> (player, damageSource, damageAmount) -> {
+	public static final Event<AllowDeath> ALLOW_DEATH = EventFactory.createArrayBacked(AllowDeath.class, callbacks -> (entity, damageSource, damageAmount) -> {
 		for (AllowDeath callback : callbacks) {
-			if (!callback.allowDeath(player, damageSource, damageAmount)) {
+			if (!callback.allowDeath(entity, damageSource, damageAmount)) {
 				return false;
 			}
 		}
@@ -67,9 +67,9 @@ public final class ServerLivingEntityEvents {
 	/**
 	 * An event that is called when a living entity dies.
 	 */
-	public static final Event<AfterDeath> AFTER_DEATH = EventFactory.createArrayBacked(AfterDeath.class, callbacks -> (player, damageSource) -> {
+	public static final Event<AfterDeath> AFTER_DEATH = EventFactory.createArrayBacked(AfterDeath.class, callbacks -> (entity, damageSource) -> {
 		for (AfterDeath callback : callbacks) {
-			callback.afterDeath(player, damageSource);
+			callback.afterDeath(entity, damageSource);
 		}
 	});
 

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.entity.event.v1;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+/**
+ * Various server-side only events related to living entities.
+ */
+public class ServerLivingEntityEvents {
+	/**
+	 * An event that is called when a living entity is going to take damage.
+	 *
+	 * <p>Mods can cancel this to prevent the damage entirely.
+	 */
+	public static final Event<AllowDamage> ALLOW_DAMAGE = EventFactory.createArrayBacked(AllowDamage.class, callbacks -> (entity, source, amount) -> {
+		for (AllowDamage callback : callbacks) {
+			if (!callback.allowDamage(entity, source, amount)) {
+				return false;
+			}
+		}
+
+		return true;
+	});
+
+	/**
+	 * An event that is called when an entity takes fatal damage.
+	 *
+	 * <p>Mods can cancel this to keep the entity alive.
+	 *
+	 * <p>Vanilla checks for entity health {@code <= 0} each tick (with {@link LivingEntity#isDead()}), and kills if true -
+	 * so the entity will still die next tick if this event is cancelled.
+	 * It's assumed that the listener will do something to prevent this, for example, if the entity is a player:
+	 * <ul>
+	 *     <li>a minigame mod teleporting the player into a 'respawn room' and setting their health to 20.0</li>
+	 *     <li>a mod that changes death mechanics switching the player over to the mod's play-mode, where death doesn't apply</li>
+	 * </ul>
+	 */
+	public static final Event<AllowDeath> ALLOW_DEATH = EventFactory.createArrayBacked(AllowDeath.class, callbacks -> (player, damageSource, damageAmount) -> {
+		for (AllowDeath callback : callbacks) {
+			if (!callback.allowDeath(player, damageSource, damageAmount)) {
+				return false;
+			}
+		}
+
+		return true;
+	});
+
+	/**
+	 * An event that is called when a living entity dies.
+	 */
+	public static final Event<AfterDeath> AFTER_DEATH = EventFactory.createArrayBacked(AfterDeath.class, callbacks -> (player, damageSource) -> {
+		for (AfterDeath callback : callbacks) {
+			callback.afterDeath(player, damageSource);
+		}
+	});
+
+	@FunctionalInterface
+	public interface AllowDamage {
+		/**
+		 * Called when a living entity is going to take damage. Can be used to cancel the damage entirely.
+		 *
+		 * <p>The amount corresponds to the "incoming" damage amount, before armor and other mitigations have been applied.
+		 *
+		 * @param entity the entity
+		 * @param source the source of the damage
+		 * @param amount the amount of damage that the entity will take (before mitigations)
+		 * @return true if the damage should go ahead, false to cancel the damage.
+		 */
+		boolean allowDamage(LivingEntity entity, DamageSource source, float amount);
+	}
+
+	@FunctionalInterface
+	public interface AllowDeath {
+		/**
+		 * Called when a living entity takes fatal damage (before totems of undying can take effect).
+		 *
+		 * @param entity the entity
+		 * @param damageSource the source of the fatal damage
+		 * @param damageAmount the amount of damage that has killed the entity
+		 * @return true if the death should go ahead, false to cancel the death.
+		 */
+		boolean allowDeath(LivingEntity entity, DamageSource damageSource, float damageAmount);
+	}
+
+	@FunctionalInterface
+	public interface AfterDeath {
+		/**
+		 * Called when a living entity dies. The death cannot be canceled at this point.
+		 *
+		 * @param entity the entity
+		 * @param damageSource the source of the fatal damage
+		 */
+		void afterDeath(LivingEntity entity, DamageSource damageSource);
+	}
+}

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.fabric.api.entity.event.v1;
 
-import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 
@@ -50,18 +49,9 @@ public final class ServerPlayerEvents {
 	/**
 	 * An event that is called when a player takes fatal damage.
 	 *
-	 * <p>Mods can cancel this to keep the player alive.
-	 *
-	 * <p>Vanilla checks for player health {@code <= 0} each tick (with {@link LivingEntity#isDead()}), and kills if true -
-	 * so the player will still die next tick if this event is cancelled. It's assumed that the listener will do
-	 * something to prevent this, for example:
-	 *
-	 * <ul>
-	 *     <li>a minigame mod teleporting the player into a 'respawn room' and setting their health to 20.0</li>
-	 *     <li>a mod that changes death mechanics switching the player over to the mod's play-mode, where death doesn't
-	 *     apply</li>
-	 * </ul>
+	 * @deprecated Use the more general {@link ServerLivingEntityEvents#ALLOW_DEATH} event instead and check for {@code instanceof ServerPlayerEntity}.
 	 */
+	@Deprecated
 	public static final Event<AllowDeath> ALLOW_DEATH = EventFactory.createArrayBacked(AllowDeath.class, callbacks -> (player, damageSource, damageAmount) -> {
 		for (AllowDeath callback : callbacks) {
 			if (!callback.allowDeath(player, damageSource, damageAmount)) {
@@ -110,5 +100,16 @@ public final class ServerPlayerEvents {
 	}
 
 	private ServerPlayerEvents() {
+	}
+
+	static {
+		// Forward general living entity event to (older) player-specific event.
+		ServerLivingEntityEvents.ALLOW_DEATH.register((entity, damageSource, damageAmount) -> {
+			if (entity instanceof ServerPlayerEntity player) {
+				return ServerPlayerEvents.ALLOW_DEATH.invoker().allowDeath(player, damageSource, damageAmount);
+			}
+
+			return true;
+		});
 	}
 }

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -86,6 +86,10 @@ public final class ServerPlayerEvents {
 		void afterRespawn(ServerPlayerEntity oldPlayer, ServerPlayerEntity newPlayer, boolean alive);
 	}
 
+	/**
+	 * @deprecated Use the more general {@link ServerLivingEntityEvents#ALLOW_DEATH} event instead and check for {@code instanceof ServerPlayerEntity}.
+	 */
+	@Deprecated
 	@FunctionalInterface
 	public interface AllowDeath {
 		/**

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/ServerPlayerEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/ServerPlayerEntityMixin.java
@@ -48,6 +48,7 @@ import net.minecraft.world.World;
 import net.fabricmc.fabric.api.entity.event.v1.EntitySleepEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerEntityCombatEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerEntityWorldChangeEvents;
+import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
 
 @Mixin(ServerPlayerEntity.class)
@@ -69,6 +70,11 @@ abstract class ServerPlayerEntityMixin extends LivingEntityMixin {
 			attacker.onKilledOther(this.getWorld(), (ServerPlayerEntity) (Object) this);
 			ServerEntityCombatEvents.AFTER_KILLED_OTHER_ENTITY.invoker().afterKilledOtherEntity(this.getWorld(), attacker, (ServerPlayerEntity) (Object) this);
 		}
+	}
+
+	@Inject(method = "onDeath", at = @At("TAIL"))
+	private void notifyDeath(DamageSource source, CallbackInfo ci) {
+		ServerLivingEntityEvents.AFTER_DEATH.invoker().afterDeath((ServerPlayerEntity) (Object) this, source);
 	}
 
 	/**


### PR DESCRIPTION
Add a new `ServerLivingEntityEvents` class, with the following events:
- `ALLOW_DAMAGE` to block damage entirely, for example because the player is wearing a "creative mode" armor (my use case).
- `ALLOW_DEATH` to prevent entity death. It is the exact same event as `ServerPlayerEvents.ALLOW_DEATH`, but generalised to living entities. The old event in `ServerPlayerEvents.ALLOW_DEATH` is now deprecated.
- `AFTER_DEATH` to react on entity death. Closes #2551.