### PR TITLE
Resource loader: mark impl as internal, fix deprecated loader API use

### DIFF
--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/ResourceManagerHelper.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/ResourceManagerHelper.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.resource;
 
+import org.jetbrains.annotations.ApiStatus;
+
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.util.Identifier;
@@ -26,6 +28,7 @@ import net.fabricmc.loader.api.ModContainer;
 /**
  * Helper for working with {@link ResourceManager} instances, and other resource loader generalities.
  */
+@ApiStatus.NonExtendable
 public interface ResourceManagerHelper {
 	/**
 	 * Add a resource reload listener for a given registry.
@@ -39,14 +42,14 @@ public interface ResourceManagerHelper {
 	}
 
 	/**
-	 * Register a resource reload listener for a given resource manager type.
+	 * Registers a resource reload listener for a given resource manager type.
 	 *
 	 * @param listener The resource reload listener.
 	 */
 	void registerReloadListener(IdentifiableResourceReloadListener listener);
 
 	/**
-	 * Get the ResourceManagerHelper instance for a given resource type.
+	 * Gets the ResourceManagerHelper instance for a given resource type.
 	 *
 	 * @param type The given resource type.
 	 * @return The ResourceManagerHelper instance.

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/SimpleResourceReloadListener.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/SimpleResourceReloadListener.java
@@ -52,7 +52,7 @@ public interface SimpleResourceReloadListener<T> extends IdentifiableResourceRel
 	}
 
 	/**
-	 * Asynchronously process and load resource-based data. The code
+	 * Asynchronously processes and loads resource-based data. The code
 	 * must be thread-safe and not modify game state!
 	 *
 	 * @param manager  The resource manager used during reloading.
@@ -63,7 +63,7 @@ public interface SimpleResourceReloadListener<T> extends IdentifiableResourceRel
 	CompletableFuture<T> load(ResourceManager manager, Profiler profiler, Executor executor);
 
 	/**
-	 * Synchronously apply loaded data to the game state.
+	 * Synchronously applies loaded data to the game state.
 	 *
 	 * @param manager  The resource manager used during reloading.
 	 * @param profiler The profiler which may be used for this stage.

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/package-info.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/package-info.java
@@ -43,7 +43,7 @@
  * <p>The Resource Loader allows mods to register resource reload listeners through
  * {@link net.fabricmc.fabric.api.resource.ResourceManagerHelper#registerReloadListener(net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener)},
  * which are triggered when resources are reloaded.
- * A resource reload listener can depend on another and vanilla resource reload listener identifiers may be found in {@link net.fabricmc.fabric.api.resource.ResourceReloadListenerKeys}.</p>
+ * A resource reload listener can depend on vanilla resource reload listener by using identifiers found in {@link net.fabricmc.fabric.api.resource.ResourceReloadListenerKeys}.</p>
  */
 
 package net.fabricmc.fabric.api.resource;

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/FabricModResourcePack.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/FabricModResourcePack.java
@@ -35,7 +35,7 @@ import net.fabricmc.fabric.api.resource.ModResourcePack;
 import net.fabricmc.loader.api.FabricLoader;
 
 /**
- * The Fabric mods resource pack, holds all the mod resource packs as one pack.
+ * The Fabric mods resource pack that holds all the mod resource packs as one pack.
  */
 public class FabricModResourcePack extends GroupResourcePack {
 	public FabricModResourcePack(ResourceType type, List<ModResourcePack> packs) {
@@ -50,8 +50,7 @@ public class FabricModResourcePack extends GroupResourcePack {
 			return IOUtils.toInputStream(pack, Charsets.UTF_8);
 		} else if ("pack.png".equals(fileName)) {
 			InputStream stream = FabricLoader.getInstance().getModContainer("fabric-resource-loader-v0")
-					.flatMap(container -> container.getMetadata().getIconPath(512).map(container::getPath))
-					.filter(Files::exists)
+					.flatMap(container -> container.getMetadata().getIconPath(512).flatMap(container::findPath))
 					.map(iconPath -> {
 						try {
 							return Files.newInputStream(iconPath);

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/GroupResourcePack.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/GroupResourcePack.java
@@ -40,7 +40,7 @@ import net.fabricmc.fabric.api.resource.ModResourcePack;
 import net.fabricmc.fabric.mixin.resource.loader.NamespaceResourceManagerAccessor;
 
 /**
- * Represents a group resource pack, holds multiple resource packs as one.
+ * Represents a group resource pack that holds multiple resource packs as one.
  */
 public abstract class GroupResourcePack implements ResourcePack {
 	protected final ResourceType type;

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ResourceManagerHelperImpl.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ResourceManagerHelperImpl.java
@@ -18,7 +18,7 @@ package net.fabricmc.fabric.impl.resource.loader;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -43,7 +43,7 @@ import net.fabricmc.fabric.api.resource.ResourcePackActivationType;
 import net.fabricmc.loader.api.ModContainer;
 
 public class ResourceManagerHelperImpl implements ResourceManagerHelper {
-	private static final Map<ResourceType, ResourceManagerHelperImpl> registryMap = new HashMap<>();
+	private static final Map<ResourceType, ResourceManagerHelperImpl> registryMap = new EnumMap<>(ResourceType.class);
 	private static final Set<Pair<String, ModNioResourcePack>> builtinResourcePacks = new HashSet<>();
 	private static final Logger LOGGER = LoggerFactory.getLogger(ResourceManagerHelperImpl.class);
 
@@ -65,10 +65,9 @@ public class ResourceManagerHelperImpl implements ResourceManagerHelper {
 	 * @return {@code true} if successfully registered the resource pack, else {@code false}
 	 * @see ResourceManagerHelper#registerBuiltinResourcePack(Identifier, ModContainer, String, ResourcePackActivationType)
 	 * @see ResourceManagerHelper#registerBuiltinResourcePack(Identifier, ModContainer, ResourcePackActivationType)
-	 * @see ResourceManagerHelper#registerBuiltinResourcePack(Identifier, String, ModContainer, boolean)
 	 */
 	public static boolean registerBuiltinResourcePack(Identifier id, String subPath, ModContainer container, String displayName, ResourcePackActivationType activationType) {
-		String separator = container.getRootPath().getFileSystem().getSeparator();
+		String separator = container.getRootPaths().get(0).getFileSystem().getSeparator();
 		subPath = subPath.replace("/", separator);
 		String name = displayName;
 		ModNioResourcePack resourcePack = ModNioResourcePack.create(id, name, container, subPath, ResourceType.CLIENT_RESOURCES, activationType);
@@ -96,7 +95,6 @@ public class ResourceManagerHelperImpl implements ResourceManagerHelper {
 	 * @return {@code true} if successfully registered the resource pack, else {@code false}
 	 * @see ResourceManagerHelper#registerBuiltinResourcePack(Identifier, ModContainer, ResourcePackActivationType)
 	 * @see ResourceManagerHelper#registerBuiltinResourcePack(Identifier, ModContainer, String, ResourcePackActivationType)
-	 * @see ResourceManagerHelper#registerBuiltinResourcePack(Identifier, String, ModContainer, boolean)
 	 */
 	public static boolean registerBuiltinResourcePack(Identifier id, String subPath, ModContainer container, ResourcePackActivationType activationType) {
 		return registerBuiltinResourcePack(id, subPath, container, id.getNamespace() + "/" + id.getPath(), activationType);

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ResourcePackSourceTracker.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ResourcePackSourceTracker.java
@@ -27,7 +27,7 @@ import net.minecraft.resource.ResourcePackSource;
  * so we store the source in the map when the resource packs are created.
  * See {@link net.fabricmc.fabric.mixin.resource.loader.ResourcePackProfileMixin ResourcePackProfileMixin}.
  *
- * <p>The sources are later read for use in {@link FabricResource} and {@link FabricResourceImpl}.
+ * <p>The sources are later read for use in {@link FabricResource}.
  * See {@link net.fabricmc.fabric.mixin.resource.loader.NamespaceResourceManagerMixin NamespaceResourceManagerMixin}.
  */
 public final class ResourcePackSourceTracker {

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/client/pack/ProgrammerArtResourcePack.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/client/pack/ProgrammerArtResourcePack.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.resource.AbstractFileResourcePack;
@@ -43,6 +44,7 @@ import net.fabricmc.fabric.impl.resource.loader.GroupResourcePack;
  * will be searched in the provided modded resource packs.
  */
 @Environment(EnvType.CLIENT)
+@ApiStatus.Internal
 public class ProgrammerArtResourcePack extends GroupResourcePack {
 	private final AbstractFileResourcePack originalResourcePack;
 

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/package-info.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/package-info.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import org.jetbrains.annotations.ApiStatus;
-
 /**
  * Contains implementations for Fabric Resource Loader.
  * Mods should never use code in this package.
  */
 @ApiStatus.Internal
 package net.fabricmc.fabric.impl.resource.loader;
+
+import org.jetbrains.annotations.ApiStatus;

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/package-info.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Contains implementations for Fabric Resource Loader.
+ * Mods should never use code in this package.
+ */
+@ApiStatus.Internal
+package net.fabricmc.fabric.impl.resource.loader;


### PR DESCRIPTION
This marks the rest of impl classes as internal, marks `ResourceManagerHelper` as non-extendable, fixes use of deprecated Loader APIs, and fixes javadocs.

Originally included changes on keyed reloaders (support for predicate/modifier) but excluded in this PR. In v1 we should make this use event phases.