### PR TITLE
Deprecated BlockEntityRendererRegistry in favor of vanilla's BlockEntityRendererFactories

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockEntityRendererRegistry.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockEntityRendererRegistry.java
@@ -28,7 +28,10 @@ import net.fabricmc.fabric.impl.client.rendering.BlockEntityRendererRegistryImpl
 
 /**
  * Helper class for registering BlockEntityRenderers.
+ *
+ * <p>Use {@link net.minecraft.client.render.block.entity.BlockEntityRendererFactories#register(BlockEntityType, BlockEntityRendererFactory)} instead.
  */
+@Deprecated
 @Environment(EnvType.CLIENT)
 public final class BlockEntityRendererRegistry {
 	/**
@@ -40,7 +43,7 @@ public final class BlockEntityRendererRegistry {
 	 *                            class is already loaded
 	 * @param <E> the {@link BlockEntity}
 	 */
-	public static <E extends BlockEntity> void register(BlockEntityType<E> blockEntityType, BlockEntityRendererFactory<? super E> blockEntityRendererFactory) {
+	public static <E extends BlockEntity> void register(BlockEntityType<E> blockEntityType, BlockEntityRendererFactory<E> blockEntityRendererFactory) {
 		BlockEntityRendererRegistryImpl.register(blockEntityType, blockEntityRendererFactory);
 	}
 

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockEntityRendererRegistry.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockEntityRendererRegistry.java
@@ -43,7 +43,7 @@ public final class BlockEntityRendererRegistry {
 	 *                            class is already loaded
 	 * @param <E> the {@link BlockEntity}
 	 */
-	public static <E extends BlockEntity> void register(BlockEntityType<E> blockEntityType, BlockEntityRendererFactory<E> blockEntityRendererFactory) {
+	public static <E extends BlockEntity> void register(BlockEntityType<E> blockEntityType, BlockEntityRendererFactory<? super E> blockEntityRendererFactory) {
 		BlockEntityRendererRegistryImpl.register(blockEntityType, blockEntityRendererFactory);
 	}
 

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockEntityRendererRegistry.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockEntityRendererRegistry.java
@@ -29,8 +29,9 @@ import net.fabricmc.fabric.impl.client.rendering.BlockEntityRendererRegistryImpl
 /**
  * Helper class for registering BlockEntityRenderers.
  *
- *  @deprecated Replaced with transitive access wideners in Fabric Transitive Access Wideners (v1).
  * <p>Use {@link net.minecraft.client.render.block.entity.BlockEntityRendererFactories#register(BlockEntityType, BlockEntityRendererFactory)} instead.
+ *
+ * @deprecated Replaced with transitive access wideners in Fabric Transitive Access Wideners (v1).
  */
 @Deprecated
 @Environment(EnvType.CLIENT)

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockEntityRendererRegistry.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockEntityRendererRegistry.java
@@ -29,6 +29,7 @@ import net.fabricmc.fabric.impl.client.rendering.BlockEntityRendererRegistryImpl
 /**
  * Helper class for registering BlockEntityRenderers.
  *
+ *  @deprecated Replaced with transitive access wideners in Fabric Transitive Access Wideners (v1).
  * <p>Use {@link net.minecraft.client.render.block.entity.BlockEntityRendererFactories#register(BlockEntityType, BlockEntityRendererFactory)} instead.
  */
 @Deprecated

--- a/fabric-transitive-access-wideners-v1/build.gradle
+++ b/fabric-transitive-access-wideners-v1/build.gradle
@@ -5,6 +5,12 @@ loom {
 	accessWidenerPath = file('src/main/resources/fabric-transitive-access-wideners-v1.accesswidener')
 }
 
+testDependencies(project, [
+		':fabric-rendering-v1',
+		':fabric-object-builder-api-v1'
+])
+
+
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.Type

--- a/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.accesswidener
+++ b/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.accesswidener
@@ -82,7 +82,7 @@ transitive-accessible class net/minecraft/client/model/ModelPart$Quad
 # Creating custom render layers
 transitive-accessible method net/minecraft/client/render/RenderLayer of (Lnet/minecraft/client/render/RenderPhase$Shader;)Lnet/minecraft/client/render/RenderLayer$MultiPhaseParameters;
 
-# Registering custom block entity renderer's
+# Registering custom block entity renderers
 transitive-accessible method net/minecraft/client/render/block/entity/BlockEntityRendererFactories register (Lnet/minecraft/block/entity/BlockEntityType;Lnet/minecraft/client/render/block/entity/BlockEntityRendererFactory;)V
 
 # Creating custom sensor types

--- a/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.accesswidener
+++ b/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.accesswidener
@@ -82,6 +82,9 @@ transitive-accessible class net/minecraft/client/model/ModelPart$Quad
 # Creating custom render layers
 transitive-accessible method net/minecraft/client/render/RenderLayer of (Lnet/minecraft/client/render/RenderPhase$Shader;)Lnet/minecraft/client/render/RenderLayer$MultiPhaseParameters;
 
+# Registering custom block entity renderer's
+transitive-accessible method net/minecraft/client/render/block/entity/BlockEntityRendererFactories register (Lnet/minecraft/block/entity/BlockEntityType;Lnet/minecraft/client/render/block/entity/BlockEntityRendererFactory;)V
+
 # Creating custom sensor types
 transitive-accessible method net/minecraft/entity/ai/brain/sensor/SensorType <init> (Ljava/util/function/Supplier;)V
 

--- a/fabric-transitive-access-wideners-v1/src/testmod/java/net/fabricmc/fabric/test/access/BlockEntityRendererTest.java
+++ b/fabric-transitive-access-wideners-v1/src/testmod/java/net/fabricmc/fabric/test/access/BlockEntityRendererTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.access;
+
+import net.minecraft.client.render.block.entity.BlockEntityRendererFactories;
+import net.minecraft.client.render.block.entity.SignBlockEntityRenderer;
+
+import net.fabricmc.api.ClientModInitializer;
+
+public class BlockEntityRendererTest implements ClientModInitializer {
+	@Override
+	public void onInitializeClient() {
+		BlockEntityRendererFactories.register(SignTestBlockEntity.TEST_SIGN_BLOCK_ENTITY, SignBlockEntityRenderer::new);
+	}
+}

--- a/fabric-transitive-access-wideners-v1/src/testmod/java/net/fabricmc/fabric/test/access/BlockEntityRendererTest.java
+++ b/fabric-transitive-access-wideners-v1/src/testmod/java/net/fabricmc/fabric/test/access/BlockEntityRendererTest.java
@@ -24,6 +24,6 @@ import net.fabricmc.api.ClientModInitializer;
 public class BlockEntityRendererTest implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
-		BlockEntityRendererFactories.register(SignTestBlockEntity.TEST_SIGN_BLOCK_ENTITY, SignBlockEntityRenderer::new);
+		BlockEntityRendererFactories.register(SignBlockEntityTest.TEST_SIGN_BLOCK_ENTITY, SignBlockEntityRenderer::new);
 	}
 }

--- a/fabric-transitive-access-wideners-v1/src/testmod/java/net/fabricmc/fabric/test/access/SignBlockEntityTest.java
+++ b/fabric-transitive-access-wideners-v1/src/testmod/java/net/fabricmc/fabric/test/access/SignBlockEntityTest.java
@@ -34,7 +34,7 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
 
-public class SignTestBlockEntity implements ModInitializer {
+public final class SignBlockEntityTest implements ModInitializer {
 	public static final String MOD_ID = "fabric-transitive-access-wideners-v1-testmod";
 	public static final SignBlock TEST_SIGN = new SignBlock(FabricBlockSettings.copy(Blocks.OAK_SIGN), SignType.OAK) {
 		@Override

--- a/fabric-transitive-access-wideners-v1/src/testmod/java/net/fabricmc/fabric/test/access/SignTestBlockEntity.java
+++ b/fabric-transitive-access-wideners-v1/src/testmod/java/net/fabricmc/fabric/test/access/SignTestBlockEntity.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.access;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.SignBlock;
+import net.minecraft.block.WallSignBlock;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.block.entity.SignBlockEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.SignItem;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.SignType;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.registry.Registry;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
+import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
+
+public class SignTestBlockEntity implements ModInitializer {
+	public static final String MOD_ID = "fabric-transitive-access-wideners-v1-testmod";
+	public static final SignBlock TEST_SIGN = new SignBlock(FabricBlockSettings.copy(Blocks.OAK_SIGN), SignType.OAK) {
+		@Override
+		public BlockEntity createBlockEntity(BlockPos pos, BlockState state) {
+			return new TestSign(pos, state);
+		}
+	};
+	public static final WallSignBlock TEST_WALL_SIGN = new WallSignBlock(FabricBlockSettings.copy(Blocks.OAK_SIGN), SignType.OAK) {
+		@Override
+		public BlockEntity createBlockEntity(BlockPos pos, BlockState state) {
+			return new TestSign(pos, state);
+		}
+	};
+	public static final SignItem TEST_SIGN_ITEM = new SignItem(new Item.Settings(), TEST_SIGN, TEST_WALL_SIGN);
+	public static final BlockEntityType<TestSign> TEST_SIGN_BLOCK_ENTITY = FabricBlockEntityTypeBuilder.create(TestSign::new, TEST_SIGN, TEST_WALL_SIGN).build();
+
+	@Override
+	public void onInitialize() {
+		Registry.register(Registry.BLOCK, new Identifier(MOD_ID, "test_sign"), TEST_SIGN);
+		Registry.register(Registry.BLOCK, new Identifier(MOD_ID, "test_wall_sign"), TEST_WALL_SIGN);
+		Registry.register(Registry.ITEM, new Identifier(MOD_ID, "test_sign"), TEST_SIGN_ITEM);
+		Registry.register(Registry.BLOCK_ENTITY_TYPE, new Identifier(MOD_ID, "test_sign"), TEST_SIGN_BLOCK_ENTITY);
+	}
+
+	public static class TestSign extends SignBlockEntity {
+		public TestSign(BlockPos pos, BlockState state) {
+			super(pos, state);
+		}
+
+		@Override
+		public BlockEntityType<?> getType() {
+			return TEST_SIGN_BLOCK_ENTITY;
+		}
+	}
+}

--- a/fabric-transitive-access-wideners-v1/src/testmod/resources/assets/fabric-transitive-access-wideners-v1-testmod/blockstates/test_sign.json
+++ b/fabric-transitive-access-wideners-v1/src/testmod/resources/assets/fabric-transitive-access-wideners-v1-testmod/blockstates/test_sign.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "fabric-transitive-access-wideners-v1-testmod:block/test_sign"
+    }
+  }
+}

--- a/fabric-transitive-access-wideners-v1/src/testmod/resources/assets/fabric-transitive-access-wideners-v1-testmod/blockstates/test_wall_sign.json
+++ b/fabric-transitive-access-wideners-v1/src/testmod/resources/assets/fabric-transitive-access-wideners-v1-testmod/blockstates/test_wall_sign.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "fabric-transitive-access-wideners-v1-testmod:block/test_sign"
+    }
+  }
+}

--- a/fabric-transitive-access-wideners-v1/src/testmod/resources/assets/fabric-transitive-access-wideners-v1-testmod/models/block/test_sign.json
+++ b/fabric-transitive-access-wideners-v1/src/testmod/resources/assets/fabric-transitive-access-wideners-v1-testmod/models/block/test_sign.json
@@ -1,0 +1,5 @@
+{
+  "textures": {
+    "particle": "minecraft:block/oak_planks"
+  }
+}

--- a/fabric-transitive-access-wideners-v1/src/testmod/resources/assets/fabric-transitive-access-wideners-v1-testmod/models/item/test_sign.json
+++ b/fabric-transitive-access-wideners-v1/src/testmod/resources/assets/fabric-transitive-access-wideners-v1-testmod/models/item/test_sign.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "minecraft:item/oak_sign"
+  }
+}

--- a/fabric-transitive-access-wideners-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-transitive-access-wideners-v1/src/testmod/resources/fabric.mod.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "id": "fabric-transitive-access-wideners-v1-testmod",
+  "name": "Fabric Transitive Access Wideners (v1) Test Mod",
+  "version": "1.0.0",
+  "environment": "*",
+  "license": "Apache-2.0",
+  "depends": {
+    "fabric-transitive-access-wideners-v1": "*",
+    "fabric-object-builder-api-v1": "*"
+  },
+  "entrypoints": {
+    "main": [
+      "net.fabricmc.fabric.test.access.SignTestBlockEntity"
+    ],
+    "client": [
+      "net.fabricmc.fabric.test.access.BlockEntityRendererTest"
+    ]
+  }
+}

--- a/fabric-transitive-access-wideners-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-transitive-access-wideners-v1/src/testmod/resources/fabric.mod.json
@@ -11,7 +11,7 @@
   },
   "entrypoints": {
     "main": [
-      "net.fabricmc.fabric.test.access.SignTestBlockEntity"
+      "net.fabricmc.fabric.test.access.SignBlockEntityTest"
     ],
     "client": [
       "net.fabricmc.fabric.test.access.BlockEntityRendererTest"

--- a/fabric-transitive-access-wideners-v1/template.accesswidener
+++ b/fabric-transitive-access-wideners-v1/template.accesswidener
@@ -82,6 +82,9 @@ transitive-accessible class net/minecraft/client/model/ModelPart$Quad
 # Creating custom render layers
 transitive-accessible method net/minecraft/client/render/RenderLayer of (Lnet/minecraft/client/render/RenderPhase$Shader;)Lnet/minecraft/client/render/RenderLayer$MultiPhaseParameters;
 
+# Registering custom block entity renderers
+transitive-accessible method net/minecraft/client/render/block/entity/BlockEntityRendererFactories register (Lnet/minecraft/block/entity/BlockEntityType;Lnet/minecraft/client/render/block/entity/BlockEntityRendererFactory;)V
+
 # Creating custom sensor types
 transitive-accessible method net/minecraft/entity/ai/brain/sensor/SensorType <init> (Ljava/util/function/Supplier;)V
 


### PR DESCRIPTION
Currently its not possible to register a SignBlockEntityRenderer without making a accessor to the vanilla registry because of a generic mismatch. This PR solves that problem by just making the vanilla registry public and deprecating the old one