### PR TITLE
Resource Loader: use Text for display name

### DIFF
--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/ResourceManagerHelper.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/ResourceManagerHelper.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.ApiStatus;
 
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.resource.ResourceType;
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.impl.resource.loader.ResourceManagerHelperImpl;
@@ -95,8 +96,31 @@ public interface ResourceManagerHelper {
 	 * @param activationType the activation type of the resource pack
 	 * @return {@code true} if successfully registered the resource pack, else {@code false}
 	 */
-	static boolean registerBuiltinResourcePack(Identifier id, ModContainer container, String displayName, ResourcePackActivationType activationType) {
+	static boolean registerBuiltinResourcePack(Identifier id, ModContainer container, Text displayName, ResourcePackActivationType activationType) {
 		return ResourceManagerHelperImpl.registerBuiltinResourcePack(id, "resourcepacks/" + id.getPath(), container, displayName, activationType);
+	}
+
+	/**
+	 * Registers a built-in resource pack.
+	 *
+	 * <p>A built-in resource pack is an extra resource pack provided by your mod which is not always active, it's similar to the "Programmer Art" resource pack.
+	 *
+	 * <p>Why and when to use it? A built-in resource pack should be used to provide extra assets/data that should be optional with your mod but still directly provided by it.
+	 * For example, it could provide textures of your mod in another resolution, or could allow to provide different styles of your assets.
+	 *
+	 * <p>The path in which the resource pack is located is in the mod JAR file under the {@code "resourcepacks/<id path>"} directory. {@code id path} being the path specified
+	 * in the identifier of this built-in resource pack.
+	 *
+	 * @param id             the identifier of the resource pack
+	 * @param container      the mod container
+	 * @param displayName    the display name of the resource pack, should include mod name for clarity
+	 * @param activationType the activation type of the resource pack
+	 * @return {@code true} if successfully registered the resource pack, else {@code false}
+	 * @deprecated Use {@link #registerBuiltinResourcePack(Identifier, ModContainer, Text, ResourcePackActivationType)} instead.
+	 */
+	@Deprecated
+	static boolean registerBuiltinResourcePack(Identifier id, ModContainer container, String displayName, ResourcePackActivationType activationType) {
+		return ResourceManagerHelperImpl.registerBuiltinResourcePack(id, "resourcepacks/" + id.getPath(), container, Text.literal(displayName), activationType);
 	}
 
 	/**

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModNioResourcePack.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModNioResourcePack.java
@@ -46,8 +46,9 @@ import net.minecraft.resource.InputSupplier;
 import net.minecraft.resource.ResourcePack;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.resource.metadata.ResourceMetadataReader;
-import net.minecraft.util.PathUtil;
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.PathUtil;
 
 import net.fabricmc.fabric.api.resource.ModResourcePack;
 import net.fabricmc.fabric.api.resource.ResourcePackActivationType;
@@ -61,7 +62,7 @@ public class ModNioResourcePack implements ResourcePack, ModResourcePack {
 	private static final FileSystem DEFAULT_FS = FileSystems.getDefault();
 
 	private final Identifier id;
-	private final String name;
+	private final Text name;
 	private final ModMetadata modInfo;
 	private final List<Path> basePaths;
 	private final ResourceType type;
@@ -69,7 +70,7 @@ public class ModNioResourcePack implements ResourcePack, ModResourcePack {
 	private final ResourcePackActivationType activationType;
 	private final Map<ResourceType, Set<String>> namespaces;
 
-	public static ModNioResourcePack create(Identifier id, String name, ModContainer mod, String subPath, ResourceType type, ResourcePackActivationType activationType) {
+	public static ModNioResourcePack create(Identifier id, Text name, ModContainer mod, String subPath, ResourceType type, ResourcePackActivationType activationType) {
 		List<Path> rootPaths = mod.getRootPaths();
 		List<Path> paths;
 
@@ -97,7 +98,7 @@ public class ModNioResourcePack implements ResourcePack, ModResourcePack {
 		return ret.getNamespaces(type).isEmpty() ? null : ret;
 	}
 
-	private ModNioResourcePack(Identifier id, String name, ModMetadata modInfo, List<Path> paths, ResourceType type, AutoCloseable closer, ResourcePackActivationType activationType) {
+	private ModNioResourcePack(Identifier id, Text name, ModMetadata modInfo, List<Path> paths, ResourceType type, AutoCloseable closer, ResourcePackActivationType activationType) {
 		this.id = id;
 		this.name = name;
 		this.modInfo = modInfo;
@@ -282,7 +283,7 @@ public class ModNioResourcePack implements ResourcePack, ModResourcePack {
 
 	@Override
 	public String getName() {
-		return name;
+		return name.getString();
 	}
 
 	public Identifier getId() {

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModResourcePackCreator.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModResourcePackCreator.java
@@ -79,7 +79,7 @@ public class ModResourcePackCreator implements ResourcePackProvider {
 			// Mod resource packs must always be enabled to avoid issues
 			// and inserted on top to ensure that they are applied before user resource packs and after default/programmer art resource pack.
 			// @TODO: "inserted on top" comment is deprecated, it does not guarantee the condition "applied before user resource packs".
-			MutableText title = Text.literal("Fabric Mods");
+			MutableText title = Text.translatable("pack.name.fabricMods");
 			ResourcePackProfile resourcePackProfile = ResourcePackProfile.create("fabric", title,
 					true, factory -> new FabricModResourcePack(this.type, packs), type, ResourcePackProfile.InsertionPosition.TOP,
 					RESOURCE_PACK_SOURCE);

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModResourcePackUtil.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModResourcePackUtil.java
@@ -34,6 +34,7 @@ import net.minecraft.resource.ResourcePack;
 import net.minecraft.resource.ResourcePackProfile;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.resource.featuretoggle.FeatureFlags;
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.api.resource.ModResourcePack;
@@ -96,11 +97,11 @@ public final class ModResourcePackUtil {
 		return GSON.toJson(metadata);
 	}
 
-	public static String getName(ModMetadata info) {
+	public static Text getName(ModMetadata info) {
 		if (info.getName() != null) {
-			return info.getName();
+			return Text.literal(info.getName());
 		} else {
-			return "Fabric Mod \"" + info.getId() + "\"";
+			return Text.translatable("pack.name.fabricMod", info.getId());
 		}
 	}
 

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ResourceManagerHelperImpl.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ResourceManagerHelperImpl.java
@@ -46,7 +46,7 @@ import net.fabricmc.loader.api.ModContainer;
 
 public class ResourceManagerHelperImpl implements ResourceManagerHelper {
 	private static final Map<ResourceType, ResourceManagerHelperImpl> registryMap = new HashMap<>();
-	private static final Set<Pair<String, ModNioResourcePack>> builtinResourcePacks = new HashSet<>();
+	private static final Set<Pair<Text, ModNioResourcePack>> builtinResourcePacks = new HashSet<>();
 	private static final Logger LOGGER = LoggerFactory.getLogger(ResourceManagerHelperImpl.class);
 
 	private final Set<Identifier> addedListenerIds = new HashSet<>();
@@ -65,26 +65,24 @@ public class ResourceManagerHelperImpl implements ResourceManagerHelper {
 	 * @param displayName    the display name of the resource pack
 	 * @param activationType the activation type of the resource pack
 	 * @return {@code true} if successfully registered the resource pack, else {@code false}
-	 * @see ResourceManagerHelper#registerBuiltinResourcePack(Identifier, ModContainer, String, ResourcePackActivationType)
+	 * @see ResourceManagerHelper#registerBuiltinResourcePack(Identifier, ModContainer, Text, ResourcePackActivationType)
 	 * @see ResourceManagerHelper#registerBuiltinResourcePack(Identifier, ModContainer, ResourcePackActivationType)
-	 * @see ResourceManagerHelper#registerBuiltinResourcePack(Identifier, String, ModContainer, boolean)
 	 */
-	public static boolean registerBuiltinResourcePack(Identifier id, String subPath, ModContainer container, String displayName, ResourcePackActivationType activationType) {
+	public static boolean registerBuiltinResourcePack(Identifier id, String subPath, ModContainer container, Text displayName, ResourcePackActivationType activationType) {
 		// Assuming the mod has multiple paths, we simply "hope" that the  file separator is *not* different across them
 		List<Path> paths = container.getRootPaths();
 		String separator = paths.get(0).getFileSystem().getSeparator();
 		subPath = subPath.replace("/", separator);
-		String name = displayName;
-		ModNioResourcePack resourcePack = ModNioResourcePack.create(id, name, container, subPath, ResourceType.CLIENT_RESOURCES, activationType);
-		ModNioResourcePack dataPack = ModNioResourcePack.create(id, name, container, subPath, ResourceType.SERVER_DATA, activationType);
+		ModNioResourcePack resourcePack = ModNioResourcePack.create(id, displayName, container, subPath, ResourceType.CLIENT_RESOURCES, activationType);
+		ModNioResourcePack dataPack = ModNioResourcePack.create(id, displayName, container, subPath, ResourceType.SERVER_DATA, activationType);
 		if (resourcePack == null && dataPack == null) return false;
 
 		if (resourcePack != null) {
-			builtinResourcePacks.add(new Pair<>(name, resourcePack));
+			builtinResourcePacks.add(new Pair<>(displayName, resourcePack));
 		}
 
 		if (dataPack != null) {
-			builtinResourcePacks.add(new Pair<>(name, dataPack));
+			builtinResourcePacks.add(new Pair<>(displayName, dataPack));
 		}
 
 		return true;
@@ -99,16 +97,15 @@ public class ResourceManagerHelperImpl implements ResourceManagerHelper {
 	 * @param activationType the activation type of the resource pack
 	 * @return {@code true} if successfully registered the resource pack, else {@code false}
 	 * @see ResourceManagerHelper#registerBuiltinResourcePack(Identifier, ModContainer, ResourcePackActivationType)
-	 * @see ResourceManagerHelper#registerBuiltinResourcePack(Identifier, ModContainer, String, ResourcePackActivationType)
-	 * @see ResourceManagerHelper#registerBuiltinResourcePack(Identifier, String, ModContainer, boolean)
+	 * @see ResourceManagerHelper#registerBuiltinResourcePack(Identifier, ModContainer, Text, ResourcePackActivationType)
 	 */
 	public static boolean registerBuiltinResourcePack(Identifier id, String subPath, ModContainer container, ResourcePackActivationType activationType) {
-		return registerBuiltinResourcePack(id, subPath, container, id.getNamespace() + "/" + id.getPath(), activationType);
+		return registerBuiltinResourcePack(id, subPath, container, Text.literal(id.getNamespace() + "/" + id.getPath()), activationType);
 	}
 
 	public static void registerBuiltinResourcePacks(ResourceType resourceType, Consumer<ResourcePackProfile> consumer) {
 		// Loop through each registered built-in resource packs and add them if valid.
-		for (Pair<String, ModNioResourcePack> entry : builtinResourcePacks) {
+		for (Pair<Text, ModNioResourcePack> entry : builtinResourcePacks) {
 			ModNioResourcePack pack = entry.getRight();
 
 			// Add the built-in pack only if namespaces for the specified resource type are present.
@@ -116,7 +113,7 @@ public class ResourceManagerHelperImpl implements ResourceManagerHelper {
 				// Make the resource pack profile for built-in pack, should never be always enabled.
 				ResourcePackProfile profile = ResourcePackProfile.create(
 						entry.getRight().getId().toString(),
-						Text.literal(entry.getLeft()),
+						entry.getLeft(),
 						pack.getActivationType() == ResourcePackActivationType.ALWAYS_ENABLED,
 						ignored -> entry.getRight(),
 						resourceType,

--- a/fabric-resource-loader-v0/src/main/resources/assets/fabric-resource-loader-v0/lang/en_us.json
+++ b/fabric-resource-loader-v0/src/main/resources/assets/fabric-resource-loader-v0/lang/en_us.json
@@ -1,4 +1,6 @@
 {
   "pack.source.fabricmod": "Fabric mod",
-  "pack.source.builtinMod": "built-in: %s"
+  "pack.source.builtinMod": "built-in: %s",
+  "pack.name.fabricMod": "Fabric Mod \"%s\"",
+  "pack.name.fabricMods": "Fabric Mods"
 }

--- a/fabric-resource-loader-v0/src/main/resources/assets/fabric-resource-loader-v0/lang/ja_jp.json
+++ b/fabric-resource-loader-v0/src/main/resources/assets/fabric-resource-loader-v0/lang/ja_jp.json
@@ -1,4 +1,5 @@
 {
   "pack.source.fabricmod": "Fabric mod",
-  "pack.source.builtinMod": "ビルトイン: %s"
+  "pack.source.builtinMod": "ビルトイン: %s",
+  "pack.name.fabricMods": "Fabric Mod"
 }

--- a/fabric-resource-loader-v0/src/testmod/java/net/fabricmc/fabric/test/resource/loader/BuiltinResourcePackTestMod.java
+++ b/fabric-resource-loader-v0/src/testmod/java/net/fabricmc/fabric/test/resource/loader/BuiltinResourcePackTestMod.java
@@ -22,6 +22,7 @@ import com.google.gson.JsonParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.api.ModInitializer;
@@ -42,7 +43,7 @@ public class BuiltinResourcePackTestMod implements ModInitializer {
 		// Should always be present as it's **this** mod.
 		FabricLoader.getInstance().getModContainer(MODID)
 				.map(container -> ResourceManagerHelper.registerBuiltinResourcePack(new Identifier(MODID, "test"),
-						container, "Fabric Resource Loader Test Pack", ResourcePackActivationType.DEFAULT_ENABLED))
+						container, Text.literal("Fabric Resource Loader Test Pack"), ResourcePackActivationType.DEFAULT_ENABLED))
 				.filter(success -> !success).ifPresent(success -> LOGGER.warn("Could not register built-in resource pack with custom name."));
 		FabricLoader.getInstance().getModContainer(MODID)
 				.map(container -> ResourceManagerHelper.registerBuiltinResourcePack(new Identifier(MODID, "test2"),


### PR DESCRIPTION
Based on #2611 (merge that PR first!)

This refactors resource loader to use `Text` instead of `String` as the display name. This allows them to be translated. The old String based API is deprecated.