### PR TITLE
Split all duplicated packages

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -194,7 +194,7 @@
 			- largely unconstained trailing subpackages
 			-->
 			<property name="format"
-			value="^net\.fabricmc\.fabric\.(api(?!\.common\.)(\.client|\.server|)(\.(?!client\.|server\.)[a-z]+([a-rt-z]|ss))+\.v[0-9]+|(impl|mixin|test)(?!\.common\.)(\.client|\.server|)(\.(?!client\.|server\.)[a-z]+([a-rt-z]|ss))+(\.v[1-9][0-9]*)?|api\.(event|util|biomes\.v1|registry|client\.screen|container|block|entity|client\.itemgroup|client\.keybinding|tag|tools|client\.model|network|server|client\.render|resource|client\.texture))(|\.[a-z]+(\.[a-z0-9]+)*)$"/>
+			value="^net\.fabricmc\.fabric\.(api(?!\.common\.)(\.client|\.server|)(\.(?!client\.|server\.)[a-z]+([a-rt-z]|ss))+\.v[0-9]+|(impl|mixin|test)(?!\.common\.)(\.client|\.server|)(\.(?!client\.|server\.)[a-z]+([a-rt-z]|ss))+(\.v[0-9]+)?|api\.(event|util|biomes\.v1|registry|client\.screen|container|block|entity|client\.itemgroup|client\.keybinding|tag|tools|client\.model|network|server|client\.render|resource|client\.texture))(|\.[a-z]+(\.[a-z0-9]+)*)$"/>
 		</module>
 
 		<!--<module name="InvalidJavadocPosition"/>-->

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -181,7 +181,7 @@
 			- net.fabricmc.fabric.(impl|mixin).<module-name>[.v<version>][.<extra packages...>]
 			- <any legacy package>
 			where <module-name> is a set of '.'-separated words, all in singular (not ending with s except for ss) and not starting with client. or server.
-			and <version> is a positive integer (1, 2, 3, ...)
+			and <version> is a non-negative integer (0, 1, 2, 3, ...)
 			and <extra packages...> is a set of '.'-separated words with all the first potentially containing digits.
 			Negative lookahead ensures that client/server can't be replaced with common disguised as the module name.
 
@@ -194,7 +194,7 @@
 			- largely unconstained trailing subpackages
 			-->
 			<property name="format"
-			value="^net\.fabricmc\.fabric\.(api(?!\.common\.)(\.client|\.server|)(\.(?!client\.|server\.)[a-z]+([a-rt-z]|ss))+\.v[1-9][0-9]*|(impl|mixin|test)(?!\.common\.)(\.client|\.server|)(\.(?!client\.|server\.)[a-z]+([a-rt-z]|ss))+(\.v[1-9][0-9]*)?|api\.(event|util|biomes\.v1|registry|client\.screen|container|block|entity|client\.itemgroup|client\.keybinding|tag|tools|client\.model|network|server|client\.render|resource|client\.texture))(|\.[a-z]+(\.[a-z0-9]+)*)$"/>
+			value="^net\.fabricmc\.fabric\.(api(?!\.common\.)(\.client|\.server|)(\.(?!client\.|server\.)[a-z]+([a-rt-z]|ss))+\.v[0-9]+|(impl|mixin|test)(?!\.common\.)(\.client|\.server|)(\.(?!client\.|server\.)[a-z]+([a-rt-z]|ss))+(\.v[1-9][0-9]*)?|api\.(event|util|biomes\.v1|registry|client\.screen|container|block|entity|client\.itemgroup|client\.keybinding|tag|tools|client\.model|network|server|client\.render|resource|client\.texture))(|\.[a-z]+(\.[a-z0-9]+)*)$"/>
 		</module>
 
 		<!--<module name="InvalidJavadocPosition"/>-->

--- a/deprecated/fabric-events-lifecycle-v0/src/client/java/net/fabricmc/fabric/impl/event/lifecycle/v0/client/LegacyClientEventInvokers.java
+++ b/deprecated/fabric-events-lifecycle-v0/src/client/java/net/fabricmc/fabric/impl/event/lifecycle/v0/client/LegacyClientEventInvokers.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.impl.event.lifecycle.client;
+package net.fabricmc.fabric.impl.event.lifecycle.v0.client;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;

--- a/deprecated/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/impl/event/lifecycle/v0/LegacyEventInvokers.java
+++ b/deprecated/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/impl/event/lifecycle/v0/LegacyEventInvokers.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.impl.event.lifecycle;
+package net.fabricmc.fabric.impl.event.lifecycle.v0;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;

--- a/deprecated/fabric-events-lifecycle-v0/src/main/resources/fabric.mod.json
+++ b/deprecated/fabric-events-lifecycle-v0/src/main/resources/fabric.mod.json
@@ -17,10 +17,10 @@
   ],
   "entrypoints": {
     "main": [
-      "net.fabricmc.fabric.impl.event.lifecycle.LegacyEventInvokers"
+      "net.fabricmc.fabric.impl.event.lifecycle.v0.LegacyEventInvokers"
     ],
     "client": [
-      "net.fabricmc.fabric.impl.event.lifecycle.client.LegacyClientEventInvokers"
+      "net.fabricmc.fabric.impl.event.lifecycle.v0.client.LegacyClientEventInvokers"
     ]
   },
   "depends": {

--- a/deprecated/fabric-networking-v0/src/client/java/net/fabricmc/fabric/api/network/ClientSidePacketRegistry.java
+++ b/deprecated/fabric-networking-v0/src/client/java/net/fabricmc/fabric/api/network/ClientSidePacketRegistry.java
@@ -23,7 +23,7 @@ import net.minecraft.network.Packet;
 import net.minecraft.util.Identifier;
 import net.minecraft.network.PacketByteBuf;
 
-import net.fabricmc.fabric.impl.networking.ClientSidePacketRegistryImpl;
+import net.fabricmc.fabric.impl.networking.v0.ClientSidePacketRegistryImpl;
 
 /**
  * The client-side packet registry.

--- a/deprecated/fabric-networking-v0/src/client/java/net/fabricmc/fabric/api/network/ClientSidePacketRegistry.java
+++ b/deprecated/fabric-networking-v0/src/client/java/net/fabricmc/fabric/api/network/ClientSidePacketRegistry.java
@@ -23,7 +23,7 @@ import net.minecraft.network.Packet;
 import net.minecraft.util.Identifier;
 import net.minecraft.network.PacketByteBuf;
 
-import net.fabricmc.fabric.impl.networking.v0.ClientSidePacketRegistryImpl;
+import net.fabricmc.fabric.impl.client.networking.v0.ClientSidePacketRegistryImpl;
 
 /**
  * The client-side packet registry.

--- a/deprecated/fabric-networking-v0/src/client/java/net/fabricmc/fabric/impl/client/networking/v0/ClientSidePacketRegistryImpl.java
+++ b/deprecated/fabric-networking-v0/src/client/java/net/fabricmc/fabric/impl/client/networking/v0/ClientSidePacketRegistryImpl.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 
-import net.fabricmc.fabric.impl.networking.GenericFutureListenerHolder;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.Packet;
@@ -35,6 +34,7 @@ import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
 import net.fabricmc.fabric.api.network.PacketConsumer;
 import net.fabricmc.fabric.api.network.PacketContext;
 import net.fabricmc.fabric.api.network.PacketRegistry;
+import net.fabricmc.fabric.impl.networking.GenericFutureListenerHolder;
 
 public class ClientSidePacketRegistryImpl implements ClientSidePacketRegistry, PacketRegistry {
 	@Override

--- a/deprecated/fabric-networking-v0/src/client/java/net/fabricmc/fabric/impl/client/networking/v0/ClientSidePacketRegistryImpl.java
+++ b/deprecated/fabric-networking-v0/src/client/java/net/fabricmc/fabric/impl/client/networking/v0/ClientSidePacketRegistryImpl.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.impl.networking.v0;
+package net.fabricmc.fabric.impl.client.networking.v0;
 
 import java.util.Objects;
 

--- a/deprecated/fabric-networking-v0/src/client/java/net/fabricmc/fabric/impl/client/networking/v0/OldClientNetworkingHooks.java
+++ b/deprecated/fabric-networking-v0/src/client/java/net/fabricmc/fabric/impl/client/networking/v0/OldClientNetworkingHooks.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.impl.networking.v0;
+package net.fabricmc.fabric.impl.client.networking.v0;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.event.network.S2CPacketTypeCallback;

--- a/deprecated/fabric-networking-v0/src/client/java/net/fabricmc/fabric/impl/networking/v0/OldClientNetworkingHooks.java
+++ b/deprecated/fabric-networking-v0/src/client/java/net/fabricmc/fabric/impl/networking/v0/OldClientNetworkingHooks.java
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.impl.client.rendering;
+package net.fabricmc.fabric.impl.networking.v0;
 
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.client.rendering.v1.InvalidateRenderStateCallback;
+import net.fabricmc.fabric.api.event.network.S2CPacketTypeCallback;
+import net.fabricmc.fabric.api.client.networking.v1.C2SPlayChannelEvents;
 
-public class RenderingCallbackInvoker implements ClientModInitializer {
+public final class OldClientNetworkingHooks implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
-		InvalidateRenderStateCallback.EVENT.register(() -> net.fabricmc.fabric.api.client.render.InvalidateRenderStateCallback.EVENT.invoker().onInvalidate());
+		// Must be lambdas below
+		C2SPlayChannelEvents.REGISTER.register((handler, client, sender, channels) -> S2CPacketTypeCallback.REGISTERED.invoker().accept(channels));
+		C2SPlayChannelEvents.UNREGISTER.register((handler, client, sender, channels) -> S2CPacketTypeCallback.UNREGISTERED.invoker().accept(channels));
 	}
 }

--- a/deprecated/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/network/ServerSidePacketRegistry.java
+++ b/deprecated/fabric-networking-v0/src/main/java/net/fabricmc/fabric/api/network/ServerSidePacketRegistry.java
@@ -26,7 +26,7 @@ import net.minecraft.network.PacketByteBuf;
 
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.api.server.PlayerStream;
-import net.fabricmc.fabric.impl.networking.ServerSidePacketRegistryImpl;
+import net.fabricmc.fabric.impl.networking.v0.ServerSidePacketRegistryImpl;
 
 /**
  * The server-side packet registry.

--- a/deprecated/fabric-networking-v0/src/main/java/net/fabricmc/fabric/impl/networking/v0/OldNetworkingHooks.java
+++ b/deprecated/fabric-networking-v0/src/main/java/net/fabricmc/fabric/impl/networking/v0/OldNetworkingHooks.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.impl.networking;
+package net.fabricmc.fabric.impl.networking.v0;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.network.C2SPacketTypeCallback;

--- a/deprecated/fabric-networking-v0/src/main/java/net/fabricmc/fabric/impl/networking/v0/ServerSidePacketRegistryImpl.java
+++ b/deprecated/fabric-networking-v0/src/main/java/net/fabricmc/fabric/impl/networking/v0/ServerSidePacketRegistryImpl.java
@@ -21,8 +21,6 @@ import java.util.Objects;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 
-import net.fabricmc.fabric.impl.networking.GenericFutureListenerHolder;
-
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.Packet;
 import net.minecraft.network.PacketByteBuf;
@@ -37,6 +35,7 @@ import net.fabricmc.fabric.api.network.PacketContext;
 import net.fabricmc.fabric.api.network.PacketRegistry;
 import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.fabricmc.fabric.impl.networking.GenericFutureListenerHolder;
 
 public class ServerSidePacketRegistryImpl implements ServerSidePacketRegistry, PacketRegistry {
 	@Override

--- a/deprecated/fabric-networking-v0/src/main/resources/fabric.mod.json
+++ b/deprecated/fabric-networking-v0/src/main/resources/fabric.mod.json
@@ -17,10 +17,10 @@
   ],
   "entrypoints": {
     "main": [
-      "net.fabricmc.fabric.impl.networking.OldNetworkingHooks"
+      "net.fabricmc.fabric.impl.networking.v0.OldNetworkingHooks"
     ],
     "client": [
-      "net.fabricmc.fabric.impl.networking.OldClientNetworkingHooks"
+      "net.fabricmc.fabric.impl.networking.v0.OldClientNetworkingHooks"
     ]
   },
   "depends": {

--- a/deprecated/fabric-networking-v0/src/main/resources/fabric.mod.json
+++ b/deprecated/fabric-networking-v0/src/main/resources/fabric.mod.json
@@ -20,7 +20,7 @@
       "net.fabricmc.fabric.impl.networking.v0.OldNetworkingHooks"
     ],
     "client": [
-      "net.fabricmc.fabric.impl.networking.v0.OldClientNetworkingHooks"
+      "net.fabricmc.fabric.impl.client.networking.v0.OldClientNetworkingHooks"
     ]
   },
   "depends": {

--- a/deprecated/fabric-rendering-v0/src/client/java/net/fabricmc/fabric/impl/client/rendering/v0/RenderingCallbackInvoker.java
+++ b/deprecated/fabric-rendering-v0/src/client/java/net/fabricmc/fabric/impl/client/rendering/v0/RenderingCallbackInvoker.java
@@ -14,17 +14,14 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.impl.networking;
+package net.fabricmc.fabric.impl.client.rendering.v0;
 
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.event.network.S2CPacketTypeCallback;
-import net.fabricmc.fabric.api.client.networking.v1.C2SPlayChannelEvents;
+import net.fabricmc.fabric.api.client.rendering.v1.InvalidateRenderStateCallback;
 
-public final class OldClientNetworkingHooks implements ClientModInitializer {
+public class RenderingCallbackInvoker implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
-		// Must be lambdas below
-		C2SPlayChannelEvents.REGISTER.register((handler, client, sender, channels) -> S2CPacketTypeCallback.REGISTERED.invoker().accept(channels));
-		C2SPlayChannelEvents.UNREGISTER.register((handler, client, sender, channels) -> S2CPacketTypeCallback.UNREGISTERED.invoker().accept(channels));
+		InvalidateRenderStateCallback.EVENT.register(() -> net.fabricmc.fabric.api.client.render.InvalidateRenderStateCallback.EVENT.invoker().onInvalidate());
 	}
 }

--- a/deprecated/fabric-rendering-v0/src/client/resources/fabric.mod.json
+++ b/deprecated/fabric-rendering-v0/src/client/resources/fabric.mod.json
@@ -17,7 +17,7 @@
   ],
   "entrypoints": {
     "client": [
-      "net.fabricmc.fabric.impl.client.rendering.RenderingCallbackInvoker"
+      "net.fabricmc.fabric.impl.client.rendering.v0.RenderingCallbackInvoker"
     ]
   },
   "depends": {

--- a/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/mixin/client/entity/event/elytra/ClientPlayerEntityMixin.java
+++ b/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/mixin/client/entity/event/elytra/ClientPlayerEntityMixin.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.mixin.entity.event.elytra;
+package net.fabricmc.fabric.mixin.client.entity.event.elytra;
 
 import com.mojang.authlib.GameProfile;
 import org.spongepowered.asm.mixin.Final;

--- a/fabric-entity-events-v1/src/client/resources/fabric-entity-events-v1.client.mixins.json
+++ b/fabric-entity-events-v1/src/client/resources/fabric-entity-events-v1.client.mixins.json
@@ -1,6 +1,6 @@
 {
   "required": true,
-  "package": "net.fabricmc.fabric.mixin.entity.event",
+  "package": "net.fabricmc.fabric.mixin.client.entity.event",
   "compatibilityLevel": "JAVA_16",
   "client": [
     "elytra.ClientPlayerEntityMixin"

--- a/fabric-item-groups-v0/src/client/java/net/fabricmc/fabric/impl/client/item/group/CreativeGuiExtensions.java
+++ b/fabric-item-groups-v0/src/client/java/net/fabricmc/fabric/impl/client/item/group/CreativeGuiExtensions.java
@@ -14,20 +14,16 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.mixin.networking.accessor;
+package net.fabricmc.fabric.impl.client.item.group;
 
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.gen.Accessor;
+public interface CreativeGuiExtensions {
+	void fabric_nextPage();
 
-import net.minecraft.client.gui.screen.ConnectScreen;
-import net.minecraft.network.ClientConnection;
+	void fabric_previousPage();
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
+	int fabric_currentPage();
 
-@Environment(EnvType.CLIENT)
-@Mixin(ConnectScreen.class)
-public interface ConnectScreenAccessor {
-	@Accessor
-	ClientConnection getConnection();
+	boolean fabric_isButtonVisible(FabricCreativeGuiComponents.Type type);
+
+	boolean fabric_isButtonEnabled(FabricCreativeGuiComponents.Type type);
 }

--- a/fabric-item-groups-v0/src/client/java/net/fabricmc/fabric/impl/client/item/group/FabricCreativeGuiComponents.java
+++ b/fabric-item-groups-v0/src/client/java/net/fabricmc/fabric/impl/client/item/group/FabricCreativeGuiComponents.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.impl.item.group;
+package net.fabricmc.fabric.impl.client.item.group;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/fabric-item-groups-v0/src/client/java/net/fabricmc/fabric/mixin/item/group/client/CreativeInventoryScreenMixin.java
+++ b/fabric-item-groups-v0/src/client/java/net/fabricmc/fabric/mixin/item/group/client/CreativeInventoryScreenMixin.java
@@ -31,8 +31,8 @@ import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.text.Text;
 
-import net.fabricmc.fabric.impl.item.group.CreativeGuiExtensions;
-import net.fabricmc.fabric.impl.item.group.FabricCreativeGuiComponents;
+import net.fabricmc.fabric.impl.client.item.group.CreativeGuiExtensions;
+import net.fabricmc.fabric.impl.client.item.group.FabricCreativeGuiComponents;
 
 @Mixin(CreativeInventoryScreen.class)
 public abstract class CreativeInventoryScreenMixin extends AbstractInventoryScreen implements CreativeGuiExtensions {

--- a/fabric-item-groups-v0/src/client/java/net/fabricmc/fabric/mixin/item/group/client/ItemGroupMixin.java
+++ b/fabric-item-groups-v0/src/client/java/net/fabricmc/fabric/mixin/item/group/client/ItemGroupMixin.java
@@ -24,7 +24,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.item.ItemGroup;
 
-import net.fabricmc.fabric.impl.item.group.FabricCreativeGuiComponents;
+import net.fabricmc.fabric.impl.client.item.group.FabricCreativeGuiComponents;
 
 @Mixin(ItemGroup.class)
 public abstract class ItemGroupMixin {

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/impl/client/event/lifecycle/ClientLifecycleEventsImpl.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/impl/client/event/lifecycle/ClientLifecycleEventsImpl.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.impl.event.lifecycle;
+package net.fabricmc.fabric.impl.client.event.lifecycle;
 
 import net.minecraft.block.entity.BlockEntity;
 
@@ -23,6 +23,7 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientBlockEntityEvents;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientChunkEvents;
+import net.fabricmc.fabric.impl.event.lifecycle.LoadedChunksCache;
 
 @Environment(EnvType.CLIENT)
 public final class ClientLifecycleEventsImpl implements ClientModInitializer {

--- a/fabric-lifecycle-events-v1/src/main/resources/fabric.mod.json
+++ b/fabric-lifecycle-events-v1/src/main/resources/fabric.mod.json
@@ -20,7 +20,7 @@
       "net.fabricmc.fabric.impl.event.lifecycle.LifecycleEventsImpl"
     ],
     "client": [
-      "net.fabricmc.fabric.impl.event.lifecycle.ClientLifecycleEventsImpl"
+      "net.fabricmc.fabric.impl.client.event.lifecycle.ClientLifecycleEventsImpl"
     ]
   },
   "mixins": [

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientNetworkingImpl.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientNetworkingImpl.java
@@ -43,8 +43,8 @@ import net.fabricmc.fabric.impl.networking.ChannelInfoHolder;
 import net.fabricmc.fabric.impl.networking.GlobalReceiverRegistry;
 import net.fabricmc.fabric.impl.networking.NetworkHandlerExtensions;
 import net.fabricmc.fabric.impl.networking.NetworkingImpl;
-import net.fabricmc.fabric.mixin.networking.accessor.ConnectScreenAccessor;
-import net.fabricmc.fabric.mixin.networking.accessor.MinecraftClientAccessor;
+import net.fabricmc.fabric.mixin.networking.client.accessor.ConnectScreenAccessor;
+import net.fabricmc.fabric.mixin.networking.client.accessor.MinecraftClientAccessor;
 
 @Environment(EnvType.CLIENT)
 public final class ClientNetworkingImpl {

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/accessor/ConnectScreenAccessor.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/accessor/ConnectScreenAccessor.java
@@ -14,22 +14,20 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.mixin.networking.accessor;
+package net.fabricmc.fabric.mixin.networking.client.accessor;
 
-import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
-import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.ConnectScreen;
 import net.minecraft.network.ClientConnection;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 
 @Environment(EnvType.CLIENT)
-@Mixin(MinecraftClient.class)
-public interface MinecraftClientAccessor {
-	@Nullable
-	@Accessor("integratedServerConnection")
+@Mixin(ConnectScreen.class)
+public interface ConnectScreenAccessor {
+	@Accessor
 	ClientConnection getConnection();
 }

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/accessor/MinecraftClientAccessor.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/accessor/MinecraftClientAccessor.java
@@ -14,16 +14,22 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.impl.item.group;
+package net.fabricmc.fabric.mixin.networking.client.accessor;
 
-public interface CreativeGuiExtensions {
-	void fabric_nextPage();
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
 
-	void fabric_previousPage();
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.network.ClientConnection;
 
-	int fabric_currentPage();
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 
-	boolean fabric_isButtonVisible(FabricCreativeGuiComponents.Type type);
-
-	boolean fabric_isButtonEnabled(FabricCreativeGuiComponents.Type type);
+@Environment(EnvType.CLIENT)
+@Mixin(MinecraftClient.class)
+public interface MinecraftClientAccessor {
+	@Nullable
+	@Accessor("integratedServerConnection")
+	ClientConnection getConnection();
 }

--- a/fabric-networking-api-v1/src/client/resources/fabric-networking-api-v1.client.mixins.json
+++ b/fabric-networking-api-v1/src/client/resources/fabric-networking-api-v1.client.mixins.json
@@ -1,13 +1,13 @@
 {
   "required": true,
-  "package": "net.fabricmc.fabric.mixin.networking",
+  "package": "net.fabricmc.fabric.mixin.networking.client",
   "compatibilityLevel": "JAVA_16",
   "client": [
     "accessor.ConnectScreenAccessor",
     "accessor.MinecraftClientAccessor",
-    "client.ClientLoginNetworkHandlerMixin",
-    "client.ClientPlayNetworkHandlerMixin",
-    "client.DisconnectedScreenMixin"
+    "ClientLoginNetworkHandlerMixin",
+    "ClientPlayNetworkHandlerMixin",
+    "DisconnectedScreenMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/fabric-registry-sync-v0/src/client/java/net/fabricmc/fabric/impl/client/registry/sync/FabricRegistryClientInit.java
+++ b/fabric-registry-sync-v0/src/client/java/net/fabricmc/fabric/impl/client/registry/sync/FabricRegistryClientInit.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.impl.registry.sync;
+package net.fabricmc.fabric.impl.client.registry.sync;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,6 +23,7 @@ import net.minecraft.text.Text;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.fabricmc.fabric.impl.registry.sync.RegistrySyncManager;
 import net.fabricmc.fabric.impl.registry.sync.packet.RegistryPacketHandler;
 
 public class FabricRegistryClientInit implements ClientModInitializer {

--- a/fabric-registry-sync-v0/src/main/resources/fabric.mod.json
+++ b/fabric-registry-sync-v0/src/main/resources/fabric.mod.json
@@ -33,7 +33,7 @@
       "net.fabricmc.fabric.impl.registry.sync.FabricRegistryInit"
     ],
     "client": [
-      "net.fabricmc.fabric.impl.registry.sync.FabricRegistryClientInit"
+      "net.fabricmc.fabric.impl.client.registry.sync.FabricRegistryClientInit"
     ]
   },
   "custom": {


### PR DESCRIPTION
This consists of two parts:
<ol><li>splitting packages duplicated between v0/v1 modules (#2616)
<ul><li>here I used the package naming convention from fabric-command-api-v1 where the v0 impl packages have a v0 subpackage</ul>
<li>splitting packages duplicated between client and main in the same module
<ul><li>if a client impl/mixin package already existed, the classes were moved there or to a subpackage
<li>otherwise I followed the newer convention of <code>impl.client.ModuleName</code> (as opposed to <code>impl.ModuleName.client</code>)
</ul></ol>

This is a prerequisite for #2615 since both issues cause problems with duplicated package-info files (either in the same sources jar or in multiple compiled jars)