### PR TITLE
Fixed ScreenEvents Javadoc

### DIFF
--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenEvents.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenEvents.java
@@ -35,7 +35,7 @@ import net.fabricmc.fabric.impl.client.screen.ScreenExtensions;
  * The events that require a screen instance can be identified by the use of a method passing a screen instance.
  * All events in {@link ScreenKeyboardEvents} and {@link ScreenMouseEvents} require a screen instance.
  * This registration model is used since a screen being (re)initialized will reset the screen to its default state, therefore reverting all changes a mod developer may have applied to a screen.
- * Furthermore, this design was chosen to reduce the amount of wasted iterations of events as a mod developer would only need to register screen events for rendering, ticking, keyboards and mice if needed on a per instance basis.
+ * Furthermore, this design was chosen to reduce the amount of wasted iterations of events as a mod developer would only need to register screen events for rendering, ticking, keyboards and mice if needed on a per-instance basis.
  *
  * <p>The primary entrypoint into a screen is when it is being opened, this is signified by an event {@link ScreenEvents#BEFORE_INIT before} and {@link ScreenEvents#AFTER_INIT after} initialization of the screen.
  *
@@ -47,7 +47,7 @@ import net.fabricmc.fabric.impl.client.screen.ScreenExtensions;
 public final class ScreenEvents {
 	/**
 	 * An event that is called before {@link Screen#init(MinecraftClient, int, int) a screen is initialized} to its default state.
-	 * It should be noted some of the methods in {@link Screens} such as a screen's {@link Screens#getTextRenderer(Screen) text renderer} may not be initialized yet, and as such their use is discouraged.
+	 * It should be noted some methods in {@link Screens} such as a screen's {@link Screens#getTextRenderer(Screen) text renderer} may not be initialized yet, and as such their use is discouraged.
 	 *
 	 * <!--<p>Typically this event is used to register screen events such as listening to when child elements are added to the screen. ------ Uncomment when child add/remove event is added for elements-->
 	 * You can still use {@link ScreenEvents#AFTER_INIT} to register events such as keyboard and mouse events.
@@ -59,7 +59,7 @@ public final class ScreenEvents {
 	 * public void onInitializeClient() {
 	 * 	ScreenEvents.BEFORE_INIT.register((client, screen, scaledWidth, scaledHeight) -> {
 	 * 		if (screen instanceof AbstractInventoryScreen) {
-	 * 			ScreenEvents.getAfterRenderEvent(screen).register((matrices, mouseX, mouseY, tickDelta) -> {
+	 * 			ScreenEvents.afterRender(screen).register((screen1, matrices, mouseX, mouseY, tickDelta) -> {
 	 * 				...
 	 * 			});
 	 * 		}


### PR DESCRIPTION
Small fix for obsolete code in ScreenEvents Javadoc. Also, some random grammatical errors that Intellij yelled at me for.