### PR TITLE
Remove maven specific jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -408,24 +408,11 @@ subprojects {
 	}
 }
 
-task remapMavenJar(type: net.fabricmc.loom.task.RemapJarTask, dependsOn: jar) {
-	input = jar.archiveFile
-	archiveFileName = "${archivesBaseName}-${project.version}-maven.jar"
-	addNestedDependencies = false
-}
-build.dependsOn remapMavenJar
-
-if (signingEnabled) {
-	remoteSign {
-		sign remapMavenJar
-	}
-}
-
 publishing {
 	publications {
 		mavenJava(MavenPublication) {
-			artifact(signingEnabled ? signRemapMavenJar.output : remapMavenJar) {
-				builtBy(signingEnabled ? signRemapMavenJar : remapMavenJar)
+			artifact(signingEnabled ? signRemapJar.output : remapJar) {
+				builtBy(signingEnabled ? signRemapJar : remapJar)
 			}
 
 			artifact(sourcesJar) {


### PR DESCRIPTION
This has not be required for years as loom removes nested jars from mod dependencies. This means that the normal jar (that is uploaded to CF and GitHub) will now also be on maven.