### PR TITLE
Biome API: modify Nether biomes a bit earlier

### DIFF
--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/MinecraftServerMixin.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/MinecraftServerMixin.java
@@ -38,6 +38,7 @@ import net.minecraft.world.level.storage.LevelStorage;
 
 import net.fabricmc.fabric.impl.biome.NetherBiomeData;
 
+// Priority set just below biome modification mixin's
 @Mixin(value = MinecraftServer.class, priority = 990)
 public class MinecraftServerMixin {
 	@Shadow


### PR DESCRIPTION
PlayerManager now keeps its own copy of DRM, so modify nether biomes just before that. This mixin now applies just before biome modification kicks in.