### PR TITLE
Item Group API: fix bugs in 22w45a port

### DIFF
--- a/fabric-item-group-api-v1/src/client/java/net/fabricmc/fabric/impl/itemgroup/CreativeGuiExtensions.java
+++ b/fabric-item-group-api-v1/src/client/java/net/fabricmc/fabric/impl/itemgroup/CreativeGuiExtensions.java
@@ -16,6 +16,9 @@
 
 package net.fabricmc.fabric.impl.itemgroup;
 
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
 public interface CreativeGuiExtensions {
 	void fabric_nextPage();
 

--- a/fabric-item-group-api-v1/src/client/java/net/fabricmc/fabric/impl/itemgroup/FabricCreativeGuiComponents.java
+++ b/fabric-item-group-api-v1/src/client/java/net/fabricmc/fabric/impl/itemgroup/FabricCreativeGuiComponents.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+import org.jetbrains.annotations.ApiStatus;
 
 import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
@@ -29,6 +30,7 @@ import net.minecraft.item.ItemGroups;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
+@ApiStatus.Internal
 public class FabricCreativeGuiComponents {
 	private static final Identifier BUTTON_TEX = new Identifier("fabric", "textures/gui/creative_buttons.png");
 	public static final Set<ItemGroup> COMMON_GROUPS = Set.of(ItemGroups.SEARCH, ItemGroups.INVENTORY, ItemGroups.HOTBAR);

--- a/fabric-item-group-api-v1/src/client/java/net/fabricmc/fabric/mixin/itemgroup/client/CreativeInventoryScreenMixin.java
+++ b/fabric-item-group-api-v1/src/client/java/net/fabricmc/fabric/mixin/itemgroup/client/CreativeInventoryScreenMixin.java
@@ -70,7 +70,7 @@ public abstract class CreativeInventoryScreenMixin<T extends ScreenHandler> exte
 
 	@Override
 	public boolean fabric_isButtonVisible(FabricCreativeGuiComponents.Type type) {
-		return ItemGroups.getGroupsToDisplay().size() > 14;
+		return ItemGroups.getGroupsToDisplay().size() > (ItemGroups.operatorEnabled ? 14 : 13);
 	}
 
 	@Override

--- a/fabric-item-group-api-v1/src/client/java/net/fabricmc/fabric/mixin/itemgroup/client/CreativeInventoryScreenMixin.java
+++ b/fabric-item-group-api-v1/src/client/java/net/fabricmc/fabric/mixin/itemgroup/client/CreativeInventoryScreenMixin.java
@@ -35,6 +35,7 @@ import net.minecraft.text.Text;
 import net.fabricmc.fabric.impl.itemgroup.CreativeGuiExtensions;
 import net.fabricmc.fabric.impl.itemgroup.FabricCreativeGuiComponents;
 import net.fabricmc.fabric.impl.itemgroup.FabricItemGroup;
+import net.fabricmc.fabric.impl.itemgroup.ItemGroupHelper;
 
 @Mixin(CreativeInventoryScreen.class)
 public abstract class CreativeInventoryScreenMixin<T extends ScreenHandler> extends AbstractInventoryScreen<T> implements CreativeGuiExtensions {
@@ -87,7 +88,7 @@ public abstract class CreativeInventoryScreenMixin<T extends ScreenHandler> exte
 	}
 
 	private void fabric_updateSelection() {
-		ItemGroups.getGroupsToDisplay().stream()
+		ItemGroupHelper.sortedGroups.stream()
 				.filter(this::fabric_isGroupVisible)
 				.findFirst()
 				.ifPresent(this::setSelectedTab);

--- a/fabric-item-group-api-v1/src/main/java/net/fabricmc/fabric/impl/itemgroup/ItemGroupHelper.java
+++ b/fabric-item-group-api-v1/src/main/java/net/fabricmc/fabric/impl/itemgroup/ItemGroupHelper.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.impl.itemgroup;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.jetbrains.annotations.ApiStatus;
 
@@ -30,6 +31,11 @@ public final class ItemGroupHelper {
 	private ItemGroupHelper() {
 	}
 
+	/**
+	 * A list of item groups, but with special groups grouped at the end.
+	 */
+	public static List<ItemGroup> sortedGroups = ItemGroups.getGroups();
+
 	public static void appendItemGroup(ItemGroup itemGroup) {
 		for (ItemGroup existingGroup : ItemGroups.getGroups()) {
 			if (existingGroup.getId().equals(itemGroup.getId())) {
@@ -40,6 +46,12 @@ public final class ItemGroupHelper {
 		var itemGroups = new ArrayList<>(ItemGroups.getGroups());
 		itemGroups.add(itemGroup);
 
-		ItemGroupsAccessor.setGroups(ItemGroupsAccessor.invokeCollect(itemGroups.toArray(ItemGroup[]::new)));
+		List<ItemGroup> validated = ItemGroupsAccessor.invokeCollect(itemGroups.toArray(ItemGroup[]::new));
+		ItemGroupsAccessor.setGroups(validated);
+		sortedGroups = validated.stream().sorted((a, b) -> {
+			if (a.isSpecial() && !b.isSpecial()) return 1;
+			if (!a.isSpecial() && b.isSpecial()) return -1;
+			return 0;
+		}).toList();
 	}
 }

--- a/fabric-item-group-api-v1/src/main/java/net/fabricmc/fabric/mixin/itemgroup/ItemGroupMixin.java
+++ b/fabric-item-group-api-v1/src/main/java/net/fabricmc/fabric/mixin/itemgroup/ItemGroupMixin.java
@@ -62,10 +62,10 @@ abstract class ItemGroupMixin implements IdentifiableItemGroup, FabricItemGroup 
 	public void getStacks(FeatureSet enabledFeatures, boolean operatorEnabled, CallbackInfo ci) {
 		ItemGroup self = (ItemGroup) (Object) this;
 
-		// Do not modify special item groups at all.
+		// Do not modify special item groups (except Operator Blocks) at all.
 		// Special item groups include Saved Hotbars, Search, and Survival Inventory.
 		// Note, search gets modified as part of the parent item group.
-		if (self.isSpecial()) return;
+		if (self.isSpecial() && self != ItemGroups.OPERATOR) return;
 
 		// Sanity check for the injection point. It should be after these fields are set.
 		Objects.requireNonNull(displayStacks, "displayStacks");

--- a/fabric-item-group-api-v1/src/main/java/net/fabricmc/fabric/mixin/itemgroup/ItemGroupMixin.java
+++ b/fabric-item-group-api-v1/src/main/java/net/fabricmc/fabric/mixin/itemgroup/ItemGroupMixin.java
@@ -60,6 +60,13 @@ abstract class ItemGroupMixin implements IdentifiableItemGroup, FabricItemGroup 
 	@SuppressWarnings("ConstantConditions")
 	@Inject(method = "updateEntries", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemGroup;reloadSearchProvider()V"))
 	public void getStacks(FeatureSet enabledFeatures, boolean operatorEnabled, CallbackInfo ci) {
+		ItemGroup self = (ItemGroup) (Object) this;
+
+		// Do not modify special item groups at all.
+		// Special item groups include Saved Hotbars, Search, and Survival Inventory.
+		// Note, search gets modified as part of the parent item group.
+		if (self.isSpecial()) return;
+
 		// Sanity check for the injection point. It should be after these fields are set.
 		Objects.requireNonNull(displayStacks, "displayStacks");
 		Objects.requireNonNull(searchTabStacks, "searchTabStacks");
@@ -76,8 +83,6 @@ abstract class ItemGroupMixin implements IdentifiableItemGroup, FabricItemGroup 
 		}
 
 		// Now trigger the global event
-		ItemGroup self = (ItemGroup) (Object) this;
-
 		if (self != ItemGroups.OPERATOR || ItemGroups.operatorEnabled) {
 			ItemGroupEvents.MODIFY_ENTRIES_ALL.invoker().modifyEntries(self, entries);
 		}


### PR DESCRIPTION
- Resolves #2652 
- Fixes #2603 - a bug where special item groups get modified (observable via tooltips showing "Survival Inventory" or "Saved Hotbars")
- Fixes a bug where switching a page always selects Saved Hotbars tab due to sort order
- Marks the client impl as internal