### PR TITLE
Entity Selector Option API

### DIFF
--- a/fabric-command-api-v2/src/main/java/net/fabricmc/fabric/api/command/v2/EntitySelectorOptionRegistry.java
+++ b/fabric-command-api-v2/src/main/java/net/fabricmc/fabric/api/command/v2/EntitySelectorOptionRegistry.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.command.v2;
+
+import java.util.function.Predicate;
+
+import net.minecraft.command.EntitySelectorOptions;
+import net.minecraft.command.EntitySelectorReader;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.mixin.command.EntitySelectorOptionsAccessor;
+
+/**
+ * Contains a function to register an entity selector option.
+ */
+public final class EntitySelectorOptionRegistry {
+	private EntitySelectorOptionRegistry() {
+	}
+
+	/**
+	 * Registers an entity selector option. The added option is available under the underscore
+	 * separated ID.
+	 *
+	 * <p>Here's an example of a custom entity selector option. The option is registered under
+	 * {@code example_min_health} and can be used like {@code @e[example_min_health=5]}.
+	 * <pre>{@code
+	 * EntitySelectorOptionRegistry.register(
+	 * 	new Identifier("example", "min_health"),
+	 * 	Text.literal("Minimum entity health"),
+	 * 	(reader) -> {
+	 * 	    final float minHealth = reader.getReader().readFloat();
+	 *
+	 * 	    if (minHealth > 0) {
+	 * 	        reader.setPredicate((entity) -> entity instanceof LivingEntity livingEntity && livingEntity.getHealth() >= minHealth);
+	 * 	    }
+	 * 	},
+	 * 	(reader) -> true
+	 * );
+	 * }</pre>
+	 *
+	 * <p>By default, a selector option can be used multiple times. To make a non-repeatable
+	 * option, either use {@link FabricEntitySelectorReader} to flag the existence of an option
+	 * and check it inside {@code canUse}, or use {@link #registerNonRepeatable} instead of this
+	 * method.
+	 *
+	 * @param id the ID of the option
+	 * @param description the description of the option
+	 * @param handler the handler for the entity option that reads and sets the predicate
+	 * @param canUse the predicate that checks whether the option is syntactically valid
+	 */
+	public static void register(Identifier id, Text description, EntitySelectorOptions.SelectorHandler handler, Predicate<EntitySelectorReader> canUse) {
+		EntitySelectorOptionsAccessor.callPutOption(id.toUnderscoreSeparatedString(), handler, canUse, description);
+	}
+
+	/**
+	 * Registers an entity selector option. The added option is available under the underscore
+	 * separated ID. The added option cannot be used multiple times within a single selector.
+	 *
+	 * @param id the ID of the option
+	 * @param description the description of the option
+	 * @param handler the handler for the entity option that reads and sets the predicate
+	 */
+	public static void registerNonRepeatable(Identifier id, Text description, EntitySelectorOptions.SelectorHandler handler) {
+		register(id, description, (reader) -> {
+			handler.handle(reader);
+			reader.setCustomFlag(id, true);
+		}, (reader) -> !reader.getCustomFlag(id)); // has a flag = used before
+	}
+}

--- a/fabric-command-api-v2/src/main/java/net/fabricmc/fabric/api/command/v2/EntitySelectorOptionRegistry.java
+++ b/fabric-command-api-v2/src/main/java/net/fabricmc/fabric/api/command/v2/EntitySelectorOptionRegistry.java
@@ -78,7 +78,7 @@ public final class EntitySelectorOptionRegistry {
 	public static void registerNonRepeatable(Identifier id, Text description, EntitySelectorOptions.SelectorHandler handler) {
 		register(id, description, (reader) -> {
 			handler.handle(reader);
-			reader.setCustomFlag(id, true);
-		}, (reader) -> !reader.getCustomFlag(id)); // has a flag = used before
+			((FabricEntitySelectorReader) reader).setCustomFlag(id, true);
+		}, (reader) -> !((FabricEntitySelectorReader) reader).getCustomFlag(id)); // has a flag = used before
 	}
 }

--- a/fabric-command-api-v2/src/main/java/net/fabricmc/fabric/api/command/v2/EntitySelectorOptionRegistry.java
+++ b/fabric-command-api-v2/src/main/java/net/fabricmc/fabric/api/command/v2/EntitySelectorOptionRegistry.java
@@ -78,7 +78,7 @@ public final class EntitySelectorOptionRegistry {
 	public static void registerNonRepeatable(Identifier id, Text description, EntitySelectorOptions.SelectorHandler handler) {
 		register(id, description, (reader) -> {
 			handler.handle(reader);
-			((FabricEntitySelectorReader) reader).setCustomFlag(id, true);
-		}, (reader) -> !((FabricEntitySelectorReader) reader).getCustomFlag(id)); // has a flag = used before
+			reader.setCustomFlag(id, true);
+		}, (reader) -> !reader.getCustomFlag(id)); // has a flag = used before
 	}
 }

--- a/fabric-command-api-v2/src/main/java/net/fabricmc/fabric/api/command/v2/FabricEntitySelectorReader.java
+++ b/fabric-command-api-v2/src/main/java/net/fabricmc/fabric/api/command/v2/FabricEntitySelectorReader.java
@@ -30,12 +30,16 @@ public interface FabricEntitySelectorReader {
 	 * @param key the key of the flag
 	 * @param value the value of the flag
 	 */
-	void setCustomFlag(Identifier key, boolean value);
+	default void setCustomFlag(Identifier key, boolean value) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
 
 	/**
 	 * Gets the value of the flag.
 	 * @param key the key of the flag
 	 * @return the value, or {@code false} if the flag is not set
 	 */
-	boolean getCustomFlag(Identifier key);
+	default boolean getCustomFlag(Identifier key) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
 }

--- a/fabric-command-api-v2/src/main/java/net/fabricmc/fabric/api/command/v2/FabricEntitySelectorReader.java
+++ b/fabric-command-api-v2/src/main/java/net/fabricmc/fabric/api/command/v2/FabricEntitySelectorReader.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.command.v2;
+
+import net.minecraft.util.Identifier;
+
+/**
+ * Fabric extension to {@link net.minecraft.command.EntitySelectorReader}, implemented
+ * using interface injection. This allows custom entity selectors to
+ * set a custom flag to a reader. This can be used to implement mutually-exclusive
+ * or non-repeatable entity selector option.
+ */
+public interface FabricEntitySelectorReader {
+	/**
+	 * Sets a flag.
+	 * @param key the key of the flag
+	 * @param value the value of the flag
+	 */
+	void setCustomFlag(Identifier key, boolean value);
+
+	/**
+	 * Gets the value of the flag.
+	 * @param key the key of the flag
+	 * @return the value, or {@code false} if the flag is not set
+	 */
+	boolean getCustomFlag(Identifier key);
+}

--- a/fabric-command-api-v2/src/main/java/net/fabricmc/fabric/api/command/v2/FabricEntitySelectorReader.java
+++ b/fabric-command-api-v2/src/main/java/net/fabricmc/fabric/api/command/v2/FabricEntitySelectorReader.java
@@ -31,7 +31,7 @@ public interface FabricEntitySelectorReader {
 	 * @param value the value of the flag
 	 */
 	default void setCustomFlag(Identifier key, boolean value) {
-		throw new UnsupportedOperationException("Not implemented");
+		throw new UnsupportedOperationException("Implemented via mixin");
 	}
 
 	/**
@@ -40,6 +40,6 @@ public interface FabricEntitySelectorReader {
 	 * @return the value, or {@code false} if the flag is not set
 	 */
 	default boolean getCustomFlag(Identifier key) {
-		throw new UnsupportedOperationException("Not implemented");
+		throw new UnsupportedOperationException("Implemented via mixin");
 	}
 }

--- a/fabric-command-api-v2/src/main/java/net/fabricmc/fabric/mixin/command/EntitySelectorOptionsAccessor.java
+++ b/fabric-command-api-v2/src/main/java/net/fabricmc/fabric/mixin/command/EntitySelectorOptionsAccessor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.command;
+
+import java.util.function.Predicate;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import net.minecraft.command.EntitySelectorOptions;
+import net.minecraft.command.EntitySelectorReader;
+import net.minecraft.text.Text;
+
+@Mixin(EntitySelectorOptions.class)
+public interface EntitySelectorOptionsAccessor {
+	@Invoker
+	static void callPutOption(String id, EntitySelectorOptions.SelectorHandler handler, Predicate<EntitySelectorReader> condition, Text description) {
+	}
+}

--- a/fabric-command-api-v2/src/main/java/net/fabricmc/fabric/mixin/command/EntitySelectorReaderMixin.java
+++ b/fabric-command-api-v2/src/main/java/net/fabricmc/fabric/mixin/command/EntitySelectorReaderMixin.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.command;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+import net.minecraft.command.EntitySelectorReader;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.api.command.v2.FabricEntitySelectorReader;
+
+@Mixin(EntitySelectorReader.class)
+public class EntitySelectorReaderMixin implements FabricEntitySelectorReader {
+	@Unique
+	private final Set<Identifier> flags = new HashSet<>();
+
+	@Override
+	public void setCustomFlag(Identifier key, boolean value) {
+		if (value) {
+			this.flags.add(key);
+		} else {
+			this.flags.remove(key);
+		}
+	}
+
+	@Override
+	public boolean getCustomFlag(Identifier key) {
+		return this.flags.contains(key);
+	}
+}

--- a/fabric-command-api-v2/src/main/resources/fabric-command-api-v2.mixins.json
+++ b/fabric-command-api-v2/src/main/resources/fabric-command-api-v2.mixins.json
@@ -5,6 +5,8 @@
   "mixins": [
     "ArgumentTypesAccessor",
     "CommandManagerMixin",
+    "EntitySelectorOptionsAccessor",
+    "EntitySelectorReaderMixin",
     "HelpCommandAccessor"
   ],
   "injectors": {

--- a/fabric-command-api-v2/src/main/resources/fabric.mod.json
+++ b/fabric-command-api-v2/src/main/resources/fabric.mod.json
@@ -30,6 +30,9 @@
     }
   ],
   "custom": {
-    "fabric-api:module-lifecycle": "stable"
+    "fabric-api:module-lifecycle": "stable",
+    "loom:injected_interfaces": {
+      "net/minecraft/class_2303": ["net/fabricmc/fabric/api/command/v2/FabricEntitySelectorReader"]
+    }
   }
 }

--- a/fabric-command-api-v2/src/testmod/java/net/fabricmc/fabric/test/command/EntitySelectorGameTest.java
+++ b/fabric-command-api-v2/src/testmod/java/net/fabricmc/fabric/test/command/EntitySelectorGameTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.command;
+
+import java.util.Locale;
+
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.test.GameTest;
+import net.minecraft.test.TestContext;
+import net.minecraft.util.math.BlockPos;
+
+import net.fabricmc.fabric.api.gametest.v1.FabricGameTest;
+
+public class EntitySelectorGameTest {
+	private void spawn(TestContext context, float health) {
+		MobEntity entity = context.spawnMob(EntityType.CREEPER, BlockPos.ORIGIN);
+		entity.setAiDisabled(true);
+		entity.setHealth(health);
+	}
+
+	@GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)
+	public void testEntitySelector(TestContext context) {
+		BlockPos absolute = context.getAbsolutePos(BlockPos.ORIGIN);
+
+		spawn(context, 1.0f);
+		spawn(context, 5.0f);
+		spawn(context, 10.0f);
+
+		String command = String.format(
+				Locale.ROOT,
+				"/kill @e[x=%d, y=%d, z=%d, distance=..2, %s=5.0]",
+				absolute.getX(),
+				absolute.getY(),
+				absolute.getZ(),
+				CommandTest.SELECTOR_ID.toUnderscoreSeparatedString()
+		);
+
+		context.expectEntitiesAround(EntityType.CREEPER, BlockPos.ORIGIN, 3, 2.0);
+		MinecraftServer server = context.getWorld().getServer();
+		int result = server.getCommandManager().executeWithPrefix(server.getCommandSource(), command);
+		context.assertTrue(result == 2, "Expected 2 entities killed, got " + result);
+		context.expectEntitiesAround(EntityType.CREEPER, BlockPos.ORIGIN, 1, 2.0);
+		context.complete();
+	}
+}

--- a/fabric-command-api-v2/src/testmod/resources/fabric.mod.json
+++ b/fabric-command-api-v2/src/testmod/resources/fabric.mod.json
@@ -15,6 +15,9 @@
     ],
     "client": [
       "net.fabricmc.fabric.test.command.client.ClientCommandTest"
+    ],
+    "fabric-gametest": [
+      "net.fabricmc.fabric.test.command.EntitySelectorGameTest"
     ]
   }
 }


### PR DESCRIPTION
Adds an entity selector option API.

## FAQ
### Is this a port from (insert another API library)?
No. The underlying design might be similar (after all, this is just a wrapper method), but the code is written entirely by me. This also adds an easy way to make a non-repeatable selector.

### Is this tested?
Yes, actually this is tested using GameTest!