### PR TITLE
Load modded translations on the server

### DIFF
--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/LanguageMixin.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/LanguageMixin.java
@@ -53,7 +53,7 @@ class LanguageMixin {
 		Map<String, String> map = new HashMap<>(cir.buildOrThrow());
 
 		for (ModContainer mod : FabricLoader.getInstance().getAllMods()) {
-			loadModLanguage(mod, map::put);
+			if (!mod.getMetadata().getType().equals("builtin")) loadModLanguage(mod, map::put);
 		}
 
 		return ImmutableMap.copyOf(map);

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/LanguageMixin.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/LanguageMixin.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.resource.loader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonParseException;
+import org.slf4j.Logger;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.util.Language;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+
+@Mixin(Language.class)
+class LanguageMixin {
+	@Shadow
+	@Final
+	private static Logger LOGGER;
+
+	@Shadow
+	@Final
+	public static String DEFAULT_LANGUAGE;
+
+	@Redirect(method = "create", at = @At(value = "INVOKE", target = "Lcom/google/common/collect/ImmutableMap$Builder;build()Lcom/google/common/collect/ImmutableMap;"))
+	private static ImmutableMap<String, String> create(ImmutableMap.Builder<String, String> cir) {
+		Map<String, String> map = new HashMap<>(cir.buildOrThrow());
+
+		for (ModContainer mod : FabricLoader.getInstance().getAllMods()) {
+			loadModLanguage(mod, map::put);
+		}
+
+		return ImmutableMap.copyOf(map);
+	}
+
+	private static void loadModLanguage(ModContainer container, BiConsumer<String, String> entryConsumer) {
+		Path path = container.findPath("/assets/" + container.getMetadata().getId() + "/lang/" + DEFAULT_LANGUAGE + ".json").orElse(null);
+		if (path == null || !Files.isRegularFile(path)) return;
+
+		try (InputStream stream = Files.newInputStream(path)) {
+			LOGGER.debug("Loading translations from {}", path);
+			load(stream, entryConsumer);
+		} catch (JsonParseException | IOException e) {
+			LOGGER.error("Couldn't read strings from {}", path, e);
+		}
+	}
+
+	@Shadow
+	public static void load(InputStream inputStream, BiConsumer<String, String> entryConsumer) {
+	}
+}

--- a/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
+++ b/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
@@ -6,6 +6,7 @@
     "DefaultResourcePackMixin",
     "FileResourcePackProviderAccessor",
     "KeyedResourceReloadListenerMixin",
+    "LanguageMixin",
     "LifecycledResourceManagerImplMixin",
     "MainMixin",
     "MinecraftServerMixin",

--- a/fabric-resource-loader-v0/src/testmod/java/net/fabricmc/fabric/test/resource/loader/LanguageTestMod.java
+++ b/fabric-resource-loader-v0/src/testmod/java/net/fabricmc/fabric/test/resource/loader/LanguageTestMod.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.resource.loader;
+
+import net.minecraft.text.Text;
+
+import net.fabricmc.api.ModInitializer;
+
+public class LanguageTestMod implements ModInitializer {
+	@Override
+	public void onInitialize() {
+		testTranslationLoaded();
+	}
+
+	private static void testTranslationLoaded() {
+		String expected = "Fabric mod";
+		String actual = Text.translatable("pack.source.fabricmod").getString();
+
+		if (!expected.equals(actual)) {
+			throw new AssertionError("Expected 'pack.source.fabricmod' to translate to " + expected + ", but translated to " + actual);
+		}
+	}
+}

--- a/fabric-resource-loader-v0/src/testmod/resources/fabric.mod.json
+++ b/fabric-resource-loader-v0/src/testmod/resources/fabric.mod.json
@@ -11,6 +11,7 @@
   "entrypoints": {
     "main": [
       "net.fabricmc.fabric.test.resource.loader.BuiltinResourcePackTestMod",
+      "net.fabricmc.fabric.test.resource.loader.LanguageTestMod",
       "net.fabricmc.fabric.test.resource.loader.ResourceReloadListenerTestMod"
     ]
   }


### PR DESCRIPTION
This is an alternative version of #1501. This aims to solve the same problems, but in a slightly more stripped down way.

## Motivation
Vanilla Minecraft initially loads translations through `ClassLoader.getResourceAsStream`, rather than using the currently loaded resource packs. While these translations are later replaced on the client, this does not happen on the server, meaning modded language keys are never translated.

This is especially annoying when in the server console. For instance, even on a server with _just_ fabric-resource-loader-v0-testmod loaded, it's very easy to start seeing untranslated strings:

```
> /datapack list
There are 2 data packs enabled: [vanilla (built-in)], [Fabric Mods (pack.source.fabricmod)]
There are 1 data packs available: [fabric-resource-loader-v0-testmod/test2 (pack.source.builtinMod)]
```

## Changes
This PR loops through all currently loaded mods, reads `/assets/lang/{mod_id}/en_us.json` and adds its entries to the currently loaded language map.

Unlike the vanilla language loader, we use a `HashMap`, meaning that duplicate language keys are allowed. Mods are iterated in load-order, with later mods overriding earlier ones. I don't think this behaviour should be relied on, just noting it for completeness.

## Scope
This PR is intentionally limited in scope: its aiming to fix a flaw in Fabric API and mimic vanilla behaviour, rather than adding a more fleshed-out language system. Support for server-side resource packs or alternative languages are (IMO) better served by mods like [Server Translations](https://github.com/NucleoidMC/Server-Translations).