### PR TITLE
Add automated client smoke tests.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Run Auto test Client
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: ./gradlew runAutoTestClient --stacktrace --warning-mode=fail
+          run: ./gradlew runProductionAutoTestClient --stacktrace --warning-mode=fail
       - uses: actions/upload-artifact@v2
         with:
           name: Test Screenshots

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,8 @@ jobs:
           distribution: 'microsoft'
           java-version: '17'
       - uses: GabrielBB/xvfb-action@v1
-      - run: ./gradlew runAutoTestClient --stacktrace --warning-mode=fail -Porg.gradle.parallel.threads=4
+        with:
+          run: ./gradlew runAutoTestClient --stacktrace --warning-mode=fail
       - uses: actions/upload-artifact@v2
         with:
           name: Test Screenshots

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           path: /root/.m2/repository
 
   client_test:
-    runs-on: macos-12
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -45,6 +45,7 @@ jobs:
         with:
           distribution: 'microsoft'
           java-version: '17'
+      - uses: openrndr/setup-opengl@v1.1
       - run: ./gradlew runAutoTestClient --stacktrace --warning-mode=fail -Porg.gradle.parallel.threads=4
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           distribution: 'microsoft'
           java-version: '17'
-      - run: ./gradlew runAutoTestClient--stacktrace --warning-mode=fail -Porg.gradle.parallel.threads=4
+      - run: ./gradlew runAutoTestClient --stacktrace --warning-mode=fail -Porg.gradle.parallel.threads=4
       - uses: actions/upload-artifact@v2
         with:
           name: Test Screenshots

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,10 +46,11 @@ jobs:
           distribution: 'microsoft'
           java-version: '17'
       - name: Run Auto test Client
-        uses: GabrielBB/xvfb-action@v1
+        uses: modmuss50/xvfb-action@v1
         with:
           run: ./gradlew runProductionAutoTestClient --stacktrace --warning-mode=fail
       - uses: actions/upload-artifact@v2
+        if: always()
         with:
           name: Test Screenshots
           path: run/screenshots

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,3 +34,19 @@ jobs:
         with:
           name: Maven Local
           path: /root/.m2/repository
+
+  client_test:
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'microsoft'
+          java-version: '17'
+      - run: ./gradlew runAutoTestClient--stacktrace --warning-mode=fail -Porg.gradle.parallel.threads=4
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Test Screenshots
+          path: run/screenshots

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           distribution: 'microsoft'
           java-version: '17'
-      - uses: openrndr/setup-opengl@v1.1
+      - uses: GabrielBB/xvfb-action@v1
       - run: ./gradlew runAutoTestClient --stacktrace --warning-mode=fail -Porg.gradle.parallel.threads=4
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,8 @@ jobs:
         with:
           distribution: 'microsoft'
           java-version: '17'
-      - uses: GabrielBB/xvfb-action@v1
+      - name: Run Auto test Client
+        uses: GabrielBB/xvfb-action@v1
         with:
           run: ./gradlew runAutoTestClient --stacktrace --warning-mode=fail
       - uses: actions/upload-artifact@v2

--- a/build.gradle
+++ b/build.gradle
@@ -351,9 +351,12 @@ loom {
 		}
 		autoTestServer {
 			inherit testmodServer
-
 			name "Auto Test Server"
-
+			vmArg "-Dfabric.autoTest"
+		}
+		autoTestClient {
+			inherit testmodClient
+			name "Auto Test Client"
 			vmArg "-Dfabric.autoTest"
 		}
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -378,7 +378,7 @@ dependencies {
 
 import net.fabricmc.loom.util.OperatingSystem
 
-// This is very far beyond loom's API if you copy this, your on your own.
+// This is very far beyond loom's API if you copy this, you're on your own.
 task runProductionAutoTestClient(type: JavaExec, dependsOn: [remapJar, remapTestmodJar]) {
 	classpath.from configurations.productionRuntime
 	mainClass = "net.fabricmc.loader.impl.launch.knot.KnotClient"

--- a/build.gradle
+++ b/build.gradle
@@ -363,6 +363,49 @@ loom {
 }
 test.dependsOn runGametest
 
+configurations {
+	productionRuntime {
+		extendsFrom configurations.minecraftLibraries
+		extendsFrom configurations.loaderLibraries
+		extendsFrom configurations.minecraftRuntimeOnlyLibraries
+	}
+}
+
+dependencies {
+	productionRuntime "net.fabricmc:fabric-loader:${project.loader_version}"
+	productionRuntime "net.fabricmc:intermediary:${project.minecraft_version}"
+}
+
+import net.fabricmc.loom.util.OperatingSystem
+
+// This is very far beyond loom's API if you copy this, your on your own.
+task runProductionAutoTestClient(type: JavaExec, dependsOn: [remapJar, remapTestmodJar]) {
+	classpath.from configurations.productionRuntime
+	mainClass = "net.fabricmc.loader.impl.launch.knot.KnotClient"
+	workingDir = file("run")
+
+	doFirst {
+		classpath.from loom.minecraftProvider.minecraftClientJar
+
+		args(
+			"--assetIndex", loom.minecraftProvider.versionInfo.assetIndex().fabricId(loom.minecraftProvider.minecraftVersion()),
+			"--assetsDir", new File(loom.files.userCache, "assets").absolutePath,
+			"--gameDir", workingDir.absolutePath
+		)
+
+		if (OperatingSystem.CURRENT_OS == OperatingSystem.MAC_OS) {
+			jvmArgs(
+				"-XstartOnFirstThread"
+			)
+		}
+
+		jvmArgs(
+			"-Dfabric.addMods=${remapJar.archiveFile.get().asFile.absolutePath}${File.pathSeparator}${remapTestmodJar.archiveFile.get().asFile.absolutePath}",
+			"-Dfabric.autoTest"
+		)
+	}
+}
+
 subprojects {
 	if (it.name == "deprecated") return
 

--- a/build.gradle
+++ b/build.gradle
@@ -386,6 +386,7 @@ task runProductionAutoTestClient(type: JavaExec, dependsOn: [remapJar, remapTest
 
 	doFirst {
 		classpath.from loom.minecraftProvider.minecraftClientJar
+		workingDir.mkdirs()
 
 		args(
 			"--assetIndex", loom.minecraftProvider.versionInfo.assetIndex().fabricId(loom.minecraftProvider.minecraftVersion()),

--- a/build.gradle
+++ b/build.gradle
@@ -384,6 +384,10 @@ task runProductionAutoTestClient(type: JavaExec, dependsOn: [remapJar, remapTest
 	mainClass = "net.fabricmc.loader.impl.launch.knot.KnotClient"
 	workingDir = file("run")
 
+	afterEvaluate {
+		dependsOn downloadAssets
+	}
+
 	doFirst {
 		classpath.from loom.minecraftProvider.minecraftClientJar
 		workingDir.mkdirs()

--- a/fabric-api-base/build.gradle
+++ b/fabric-api-base/build.gradle
@@ -3,5 +3,6 @@ version = getSubprojectVersion(project)
 
 testDependencies(project, [
 	':fabric-command-api-v2',
-	':fabric-lifecycle-events-v1'
+	':fabric-lifecycle-events-v1',
+	':fabric-screen-api-v1'
 ])

--- a/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiAutoTestClient.java
+++ b/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiAutoTestClient.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.test.base;
 
 import static net.fabricmc.fabric.test.base.FabricClientTestHelper.clickScreenButton;
+import static net.fabricmc.fabric.test.base.FabricClientTestHelper.enableDebugHud;
 import static net.fabricmc.fabric.test.base.FabricClientTestHelper.openGameMenu;
 import static net.fabricmc.fabric.test.base.FabricClientTestHelper.takeScreenshot;
 import static net.fabricmc.fabric.test.base.FabricClientTestHelper.waitForLoadingComplete;
@@ -88,6 +89,7 @@ public class FabricApiAutoTestClient implements ClientModInitializer {
 		}
 
 		{
+			enableDebugHud();
 			waitForWorldTicks(200);
 			takeScreenshot("in_game_overworld");
 		}

--- a/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiAutoTestClient.java
+++ b/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiAutoTestClient.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.base;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.Drawable;
+import net.minecraft.client.gui.Element;
+import net.minecraft.client.gui.screen.ConfirmScreen;
+import net.minecraft.client.gui.screen.GameMenuScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.TitleScreen;
+import net.minecraft.client.gui.screen.world.CreateWorldScreen;
+import net.minecraft.client.gui.screen.world.SelectWorldScreen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.GridWidget;
+import net.minecraft.client.util.ScreenshotRecorder;
+import net.minecraft.text.Text;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+import net.fabricmc.fabric.test.base.mixin.ScreenAccessor;
+import net.fabricmc.loader.api.FabricLoader;
+
+public class FabricApiAutoTestClient implements ClientModInitializer {
+	int ticks = 0;
+	boolean loaded = false;
+
+	@Override
+	public void onInitializeClient() {
+		if (System.getProperty("fabric.autoTest") == null) {
+			return;
+		}
+
+		ScreenEvents.AFTER_INIT.register((client, screen, scaledWidth, scaledHeight) -> {
+			if (!loaded && screen instanceof TitleScreen) {
+				after1s(screen, () -> clickButton(screen, "menu.singleplayer"));
+			}
+
+			if (screen instanceof SelectWorldScreen) {
+				after1s(screen, () -> clickButton(screen, "selectWorld.create"));
+			}
+
+			if (screen instanceof CreateWorldScreen) {
+				after1s(screen, () -> clickButton(screen, "selectWorld.create"));
+			}
+
+			if (screen instanceof ConfirmScreen) {
+				after1s(screen, () -> clickButton(screen, "gui.yes"));
+			}
+
+			if (screen instanceof GameMenuScreen) {
+				after1s(screen, () -> clickButton(screen, "menu.returnToMenu"));
+			}
+
+			// See server tick event bellow
+
+			if (loaded && screen instanceof TitleScreen) {
+				after1s(screen, () -> clickButton(screen, "menu.quit"));
+			}
+		});
+
+		ServerTickEvents.END_SERVER_TICK.register(server -> {
+			ticks++;
+
+			if (!loaded && ticks > 200) {
+				loaded = true;
+				MinecraftClient.getInstance().submit(() -> MinecraftClient.getInstance().setScreen(new GameMenuScreen(true)));
+			}
+		});
+	}
+
+	private void after1s(Screen screen, Runnable runnable) {
+		ScreenEvents.afterTick(screen).register(new ScreenEvents.AfterTick() {
+			LocalDateTime time = LocalDateTime.now();
+
+			@Override
+			public void afterTick(Screen screen) {
+				if (MinecraftClient.getInstance().getOverlay() != null) {
+					// The main menu is hidden behind the loading overlay, wait for it to go.
+					time = LocalDateTime.now();
+					return;
+				}
+
+				if (LocalDateTime.now().isAfter(time.plus(Duration.ofSeconds(1)))) {
+					runnable.run();
+				}
+			}
+		});
+	}
+
+	private void clickButton(Screen screen, String translationKey) {
+		final String expected = Text.translatable(translationKey).getString();
+		final ScreenAccessor screenAccessor = (ScreenAccessor) screen;
+
+		ScreenshotRecorder.saveScreenshot(FabricLoader.getInstance().getGameDir().toFile(), translationKey + ".png", MinecraftClient.getInstance().getFramebuffer(), (message) -> {
+		});
+
+		for (Drawable drawable : screenAccessor.getDrawables()) {
+			if (drawable instanceof ButtonWidget buttonWidget) {
+				if (expected.equals(buttonWidget.getMessage().getString())) {
+					buttonWidget.onPress();
+					break;
+				}
+			}
+
+			if (drawable instanceof GridWidget gridWidget) {
+				for (Element child : gridWidget.children()) {
+					if (child instanceof ButtonWidget buttonWidget) {
+						if (expected.equals(buttonWidget.getMessage().getString())) {
+							buttonWidget.onPress();
+							break;
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiAutoTestClient.java
+++ b/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiAutoTestClient.java
@@ -17,8 +17,11 @@
 package net.fabricmc.fabric.test.base;
 
 import static net.fabricmc.fabric.test.base.FabricClientTestHelper.clickScreenButton;
+import static net.fabricmc.fabric.test.base.FabricClientTestHelper.closeScreen;
 import static net.fabricmc.fabric.test.base.FabricClientTestHelper.enableDebugHud;
 import static net.fabricmc.fabric.test.base.FabricClientTestHelper.openGameMenu;
+import static net.fabricmc.fabric.test.base.FabricClientTestHelper.openInventory;
+import static net.fabricmc.fabric.test.base.FabricClientTestHelper.setPerspective;
 import static net.fabricmc.fabric.test.base.FabricClientTestHelper.takeScreenshot;
 import static net.fabricmc.fabric.test.base.FabricClientTestHelper.waitForLoadingComplete;
 import static net.fabricmc.fabric.test.base.FabricClientTestHelper.waitForScreen;
@@ -36,6 +39,7 @@ import net.minecraft.client.gui.screen.ConfirmScreen;
 import net.minecraft.client.gui.screen.TitleScreen;
 import net.minecraft.client.gui.screen.world.CreateWorldScreen;
 import net.minecraft.client.gui.screen.world.SelectWorldScreen;
+import net.minecraft.client.option.Perspective;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
@@ -95,6 +99,19 @@ public class FabricApiAutoTestClient implements ClientModInitializer {
 		}
 
 		MixinEnvironment.getCurrentEnvironment().audit();
+
+		{
+			// See if the player render events are working.
+			setPerspective(Perspective.THIRD_PERSON_BACK);
+			waitForWorldTicks(20);
+			takeScreenshot("in_game_overworld_third_person");
+		}
+
+		{
+			openInventory();
+			takeScreenshot("in_game_inventory");
+			closeScreen();
+		}
 
 		{
 			openGameMenu();

--- a/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiAutoTestClient.java
+++ b/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiAutoTestClient.java
@@ -103,7 +103,6 @@ public class FabricApiAutoTestClient implements ClientModInitializer {
 		{
 			// See if the player render events are working.
 			setPerspective(Perspective.THIRD_PERSON_BACK);
-			waitForWorldTicks(20);
 			takeScreenshot("in_game_overworld_third_person");
 		}
 

--- a/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiAutoTestServer.java
+++ b/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiAutoTestServer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.base;
+
+import org.spongepowered.asm.mixin.MixinEnvironment;
+
+import net.fabricmc.api.DedicatedServerModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+
+public class FabricApiAutoTestServer implements DedicatedServerModInitializer {
+	private int ticks = 0;
+
+	@Override
+	public void onInitializeServer() {
+		if (System.getProperty("fabric.autoTest") != null) {
+			ServerTickEvents.END_SERVER_TICK.register(server -> {
+				ticks++;
+
+				if (ticks == 50) {
+					MixinEnvironment.getCurrentEnvironment().audit();
+					server.stop(false);
+				}
+			});
+		}
+	}
+}

--- a/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiBaseTestInit.java
+++ b/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricApiBaseTestInit.java
@@ -24,24 +24,10 @@ import net.minecraft.text.Text;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 
 public class FabricApiBaseTestInit implements ModInitializer {
-	private int ticks = 0;
-
 	@Override
 	public void onInitialize() {
-		if (System.getProperty("fabric.autoTest") != null) {
-			ServerTickEvents.END_SERVER_TICK.register(server -> {
-				ticks++;
-
-				if (ticks == 50) {
-					MixinEnvironment.getCurrentEnvironment().audit();
-					server.stop(false);
-				}
-			});
-		}
-
 		// Command to call audit the mixin environment
 		CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
 			dispatcher.register(literal("audit_mixins").executes(context -> {

--- a/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricClientTestHelper.java
+++ b/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricClientTestHelper.java
@@ -27,6 +27,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.Drawable;
 import net.minecraft.client.gui.Element;
 import net.minecraft.client.gui.screen.GameMenuScreen;
+import net.minecraft.client.gui.screen.LevelLoadingScreen;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
 import net.minecraft.client.gui.screen.ingame.InventoryScreen;
@@ -139,7 +140,7 @@ public final class FabricClientTestHelper {
 
 	public static void waitForWorldTicks(long ticks) {
 		// Wait for the world to be loaded and get the start ticks
-		waitFor("World load", client -> client.world != null, Duration.ofMinutes(30));
+		waitFor("World load", client -> client.world != null && !(client.currentScreen instanceof LevelLoadingScreen), Duration.ofMinutes(30));
 		final long startTicks = submitAndWait(client -> client.world.getTime());
 		waitFor("World load", client -> Objects.requireNonNull(client.world).getTime() > startTicks + ticks, Duration.ofMinutes(10));
 	}

--- a/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricClientTestHelper.java
+++ b/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricClientTestHelper.java
@@ -28,10 +28,13 @@ import net.minecraft.client.gui.Drawable;
 import net.minecraft.client.gui.Element;
 import net.minecraft.client.gui.screen.GameMenuScreen;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
+import net.minecraft.client.gui.screen.ingame.InventoryScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.CyclingButtonWidget;
 import net.minecraft.client.gui.widget.GridWidget;
 import net.minecraft.client.gui.widget.PressableWidget;
+import net.minecraft.client.option.Perspective;
 import net.minecraft.client.util.ScreenshotRecorder;
 import net.minecraft.text.Text;
 
@@ -56,6 +59,23 @@ public final class FabricClientTestHelper {
 		});
 
 		waitForScreen(GameMenuScreen.class);
+	}
+
+	public static void openInventory() {
+		submit(client -> {
+			client.setScreen(new InventoryScreen(Objects.requireNonNull(client.player)));
+			return null;
+		});
+
+		boolean creative = submitAndWait(client -> Objects.requireNonNull(client.player).isCreative());
+		waitForScreen(creative ? CreativeInventoryScreen.class : InventoryScreen.class);
+	}
+
+	public static void closeScreen() {
+		submit(client -> {
+			client.setScreen(null);
+			return null;
+		});
 	}
 
 	public static void takeScreenshot(String name) {
@@ -127,6 +147,13 @@ public final class FabricClientTestHelper {
 	public static void enableDebugHud() {
 		submitAndWait(client -> {
 			client.options.debugEnabled = true;
+			return null;
+		});
+	}
+
+	public static void setPerspective(Perspective perspective) {
+		submitAndWait(client -> {
+			client.options.setPerspective(perspective);
 			return null;
 		});
 	}

--- a/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricClientTestHelper.java
+++ b/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricClientTestHelper.java
@@ -124,6 +124,13 @@ public final class FabricClientTestHelper {
 		waitFor("World load", client -> Objects.requireNonNull(client.world).getTime() > startTicks + ticks, Duration.ofMinutes(10));
 	}
 
+	public static void enableDebugHud() {
+		submitAndWait(client -> {
+			client.options.debugEnabled = true;
+			return null;
+		});
+	}
+
 	private static void waitFor(String what, Predicate<MinecraftClient> predicate) {
 		waitFor(what, predicate, Duration.ofSeconds(10));
 	}

--- a/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricClientTestHelper.java
+++ b/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricClientTestHelper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.test.base;
 
 import java.time.Duration;

--- a/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricClientTestHelper.java
+++ b/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricClientTestHelper.java
@@ -26,7 +26,7 @@ import net.fabricmc.loader.api.FabricLoader;
 // Provides thread safe utils for interacting with a running game.
 public final class FabricClientTestHelper {
 	public static void waitForLoadingComplete() {
-		waitFor("Loading to complete", client -> client.getOverlay() == null);
+		waitFor("Loading to complete", client -> client.getOverlay() == null, Duration.ofMinutes(5));
 	}
 
 	public static void waitForScreen(Class<? extends Screen> screenClass) {

--- a/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricClientTestHelper.java
+++ b/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricClientTestHelper.java
@@ -53,32 +53,32 @@ public final class FabricClientTestHelper {
 	}
 
 	public static void openGameMenu() {
-		submit(client -> {
-			client.setScreen(new GameMenuScreen(true));
-			return null;
-		});
-
+		setScreen((client) -> new GameMenuScreen(true));
 		waitForScreen(GameMenuScreen.class);
 	}
 
 	public static void openInventory() {
-		submit(client -> {
-			client.setScreen(new InventoryScreen(Objects.requireNonNull(client.player)));
-			return null;
-		});
+		setScreen((client) -> new InventoryScreen(Objects.requireNonNull(client.player)));
 
 		boolean creative = submitAndWait(client -> Objects.requireNonNull(client.player).isCreative());
 		waitForScreen(creative ? CreativeInventoryScreen.class : InventoryScreen.class);
 	}
 
 	public static void closeScreen() {
+		setScreen((client) -> null);
+	}
+
+	private static void setScreen(Function<MinecraftClient, Screen> screenSupplier) {
 		submit(client -> {
-			client.setScreen(null);
+			client.setScreen(screenSupplier.apply(client));
 			return null;
 		});
 	}
 
 	public static void takeScreenshot(String name) {
+		// Allow time for any screens to open
+		waitFor(Duration.ofSeconds(1));
+
 		submitAndWait(client -> {
 			ScreenshotRecorder.saveScreenshot(FabricLoader.getInstance().getGameDir().toFile(), name + ".png", client.getFramebuffer(), (message) -> {
 			});

--- a/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricClientTestHelper.java
+++ b/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/FabricClientTestHelper.java
@@ -1,0 +1,148 @@
+package net.fabricmc.fabric.test.base;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.Drawable;
+import net.minecraft.client.gui.Element;
+import net.minecraft.client.gui.screen.GameMenuScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.CyclingButtonWidget;
+import net.minecraft.client.gui.widget.GridWidget;
+import net.minecraft.client.gui.widget.PressableWidget;
+import net.minecraft.client.util.ScreenshotRecorder;
+import net.minecraft.text.Text;
+
+import net.fabricmc.fabric.test.base.mixin.CyclingButtonWidgetAccessor;
+import net.fabricmc.fabric.test.base.mixin.ScreenAccessor;
+import net.fabricmc.loader.api.FabricLoader;
+
+// Provides thread safe utils for interacting with a running game.
+public final class FabricClientTestHelper {
+	public static void waitForLoadingComplete() {
+		waitFor("Loading to complete", client -> client.getOverlay() == null);
+	}
+
+	public static void waitForScreen(Class<? extends Screen> screenClass) {
+		waitFor("Screen %s".formatted(screenClass.getName()), client -> client.currentScreen != null && client.currentScreen.getClass() == screenClass);
+	}
+
+	public static void openGameMenu() {
+		submit(client -> {
+			client.setScreen(new GameMenuScreen(true));
+			return null;
+		});
+
+		waitForScreen(GameMenuScreen.class);
+	}
+
+	public static void takeScreenshot(String name) {
+		submitAndWait(client -> {
+			ScreenshotRecorder.saveScreenshot(FabricLoader.getInstance().getGameDir().toFile(), name + ".png", client.getFramebuffer(), (message) -> {
+			});
+			return null;
+		});
+	}
+
+	public static void clickScreenButton(String translationKey) {
+		final String buttonText = Text.translatable(translationKey).getString();
+
+		waitFor("Click button" + buttonText, client -> {
+			final Screen screen = client.currentScreen;
+
+			if (screen == null) {
+				return false;
+			}
+
+			final ScreenAccessor screenAccessor = (ScreenAccessor) screen;
+
+			for (Drawable drawable : screenAccessor.getDrawables()) {
+				if (drawable instanceof PressableWidget pressableWidget && pressMatchingButton(pressableWidget, buttonText)) {
+					return true;
+				}
+
+				if (drawable instanceof GridWidget gridWidget) {
+					for (Element child : gridWidget.children()) {
+						if (child instanceof PressableWidget pressableWidget && pressMatchingButton(pressableWidget, buttonText)) {
+							return true;
+						}
+					}
+				}
+			}
+
+			// Was unable to find the button to press
+			return false;
+		});
+	}
+
+	private static boolean pressMatchingButton(PressableWidget widget, String text) {
+		if (widget instanceof ButtonWidget buttonWidget) {
+			if (text.equals(buttonWidget.getMessage().getString())) {
+				buttonWidget.onPress();
+				return true;
+			}
+		}
+
+		if (widget instanceof CyclingButtonWidget<?> buttonWidget) {
+			CyclingButtonWidgetAccessor accessor = (CyclingButtonWidgetAccessor) buttonWidget;
+
+			if (text.equals(accessor.getOptionText().getString())) {
+				buttonWidget.onPress();
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	public static void waitForWorldTicks(long ticks) {
+		// Wait for the world to be loaded and get the start ticks
+		waitFor("World load", client -> client.world != null, Duration.ofMinutes(30));
+		final long startTicks = submitAndWait(client -> client.world.getTime());
+		waitFor("World load", client -> Objects.requireNonNull(client.world).getTime() > startTicks + ticks, Duration.ofMinutes(10));
+	}
+
+	private static void waitFor(String what, Predicate<MinecraftClient> predicate) {
+		waitFor(what, predicate, Duration.ofSeconds(10));
+	}
+
+	private static void waitFor(String what, Predicate<MinecraftClient> predicate, Duration timeout) {
+		final LocalDateTime end = LocalDateTime.now().plus(timeout);
+
+		while (true) {
+			boolean result = submitAndWait(predicate::test);
+
+			if (result) {
+				break;
+			}
+
+			if (LocalDateTime.now().isAfter(end)) {
+				throw new RuntimeException("Timed out waiting for " + what);
+			}
+
+			waitFor(Duration.ofSeconds(1));
+		}
+	}
+
+	private static void waitFor(Duration duration) {
+		try {
+			Thread.sleep(duration.toMillis());
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private static <T> CompletableFuture<T> submit(Function<MinecraftClient, T> function) {
+		return MinecraftClient.getInstance().submit(() -> function.apply(MinecraftClient.getInstance()));
+	}
+
+	private static <T> T submitAndWait(Function<MinecraftClient, T> function) {
+		return submit(function).join();
+	}
+}

--- a/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/mixin/CyclingButtonWidgetAccessor.java
+++ b/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/mixin/CyclingButtonWidgetAccessor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.test.base.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;

--- a/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/mixin/CyclingButtonWidgetAccessor.java
+++ b/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/mixin/CyclingButtonWidgetAccessor.java
@@ -1,0 +1,13 @@
+package net.fabricmc.fabric.test.base.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.client.gui.widget.CyclingButtonWidget;
+import net.minecraft.text.Text;
+
+@Mixin(CyclingButtonWidget.class)
+public interface CyclingButtonWidgetAccessor {
+	@Accessor
+	Text getOptionText();
+}

--- a/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/mixin/ScreenAccessor.java
+++ b/fabric-api-base/src/testmod/java/net/fabricmc/fabric/test/base/mixin/ScreenAccessor.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.base.mixin;
+
+import java.util.List;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.client.gui.Drawable;
+import net.minecraft.client.gui.screen.Screen;
+
+@Mixin(Screen.class)
+public interface ScreenAccessor {
+	@Accessor
+	List<Drawable> getDrawables();
+}

--- a/fabric-api-base/src/testmod/resources/fabric-api-base-testmod.mixins.json
+++ b/fabric-api-base/src/testmod/resources/fabric-api-base-testmod.mixins.json
@@ -3,6 +3,7 @@
   "package": "net.fabricmc.fabric.test.base.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "CyclingButtonWidgetAccessor",
     "ScreenAccessor"
   ],
   "injectors": {

--- a/fabric-api-base/src/testmod/resources/fabric-api-base-testmod.mixins.json
+++ b/fabric-api-base/src/testmod/resources/fabric-api-base-testmod.mixins.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "package": "net.fabricmc.fabric.test.base.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "mixins": [
+    "ScreenAccessor"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/fabric-api-base/src/testmod/resources/fabric.mod.json
+++ b/fabric-api-base/src/testmod/resources/fabric.mod.json
@@ -9,8 +9,17 @@
     "main": [
       "net.fabricmc.fabric.test.base.FabricApiBaseTestInit"
     ],
+    "client": [
+      "net.fabricmc.fabric.test.base.FabricApiAutoTestClient"
+    ],
+    "server": [
+      "net.fabricmc.fabric.test.base.FabricApiAutoTestServer"
+    ],
     "fabric-gametest" : [
       "net.fabricmc.fabric.test.base.FabricApiBaseGameTest"
     ]
-  }
+  },
+  "mixins": [
+    "fabric-api-base-testmod.mixins.json"
+  ]
 }

--- a/fabric-transfer-api-v1/src/testmod/java/net/fabricmc/fabric/test/transfer/ingame/client/FluidVariantRenderTest.java
+++ b/fabric-transfer-api-v1/src/testmod/java/net/fabricmc/fabric/test/transfer/ingame/client/FluidVariantRenderTest.java
@@ -54,6 +54,8 @@ public class FluidVariantRenderTest implements ClientModInitializer {
 			PlayerEntity player = MinecraftClient.getInstance().player;
 			if (player == null) return;
 
+			if (MinecraftClient.getInstance().options.debugEnabled) return;
+
 			int renderY = 0;
 			List<FluidVariant> variants = List.of(FluidVariant.of(Fluids.WATER), FluidVariant.of(Fluids.LAVA));
 


### PR DESCRIPTION
Currently we have a number of automated tests that run on a server (auto test server and game tests), but we have no automated testing of the client. This PR is a proof of concept showing how we might be able to run the full client within github actions. This also runs the game with intermediary names, the same as a "production" client.

This PR is currently able to load the client, create a new creative world and gracefully save and exit. This is done by automating the UI. Screenshots are also generated and uploaded after the test completes.

I uploaded a short video showing the tests running on my local machine: https://www.youtube.com/watch?v=CdfCJUZNgo8

This isnt designed to be used by other mods and is only included in Fabric API's test mods.

