### PR TITLE
Convert flowing fluids to still ones in fluid variants

### DIFF
--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariant.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariant.java
@@ -52,6 +52,10 @@ public interface FluidVariant extends TransferVariant<Fluid> {
 
 	/**
 	 * Retrieve a FluidVariant with a fluid, and a {@code null} tag.
+	 *
+	 * <p>The flowing and still variations of {@linkplain net.minecraft.fluid.FlowableFluid flowable fluids}
+	 * are normalized to always refer to the still variant. For example,
+	 * {@code FluidVariant.of(Fluids.FLOWING_WATER).getFluid() == Fluids.WATER}.
 	 */
 	static FluidVariant of(Fluid fluid) {
 		return of(fluid, null);
@@ -59,6 +63,10 @@ public interface FluidVariant extends TransferVariant<Fluid> {
 
 	/**
 	 * Retrieve a FluidVariant with a fluid, and an optional tag.
+	 *
+	 * <p>The flowing and still variations of {@linkplain net.minecraft.fluid.FlowableFluid flowable fluids}
+	 * are normalized to always refer to the still fluid. For example,
+	 * {@code FluidVariant.of(Fluids.FLOWING_WATER, nbt).getFluid() == Fluids.WATER}.
 	 */
 	static FluidVariant of(Fluid fluid, @Nullable NbtCompound nbt) {
 		return FluidVariantImpl.of(fluid, nbt);

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/FluidVariantImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/FluidVariantImpl.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
+import net.minecraft.fluid.FlowableFluid;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.nbt.NbtCompound;
@@ -37,7 +38,14 @@ public class FluidVariantImpl implements FluidVariant {
 
 		if (!fluid.isStill(fluid.getDefaultState()) && fluid != Fluids.EMPTY) {
 			// Note: the empty fluid is not still, that's why we check for it specifically.
-			throw new IllegalArgumentException("Fluid may not be flowing.");
+
+			if (fluid instanceof FlowableFluid flowable) {
+				// Normalize FlowableFluids to their still variants.
+				fluid = flowable.getStill();
+			} else {
+				// If not a FlowableFluid, we don't know how to convert -> crash.
+				throw new IllegalArgumentException("Fluid may not be flowing.");
+			}
 		}
 
 		if (nbt == null || fluid == Fluids.EMPTY) {

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/FluidVariantImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/FluidVariantImpl.java
@@ -44,7 +44,8 @@ public class FluidVariantImpl implements FluidVariant {
 				fluid = flowable.getStill();
 			} else {
 				// If not a FlowableFluid, we don't know how to convert -> crash.
-				throw new IllegalArgumentException("Fluid may not be flowing.");
+				Identifier id = Registry.FLUID.getId(fluid);
+				throw new IllegalArgumentException("Cannot convert flowing fluid %s (%s) into a still fluid.".formatted(id, fluid));
 			}
 		}
 

--- a/fabric-transfer-api-v1/src/testmod/java/net/fabricmc/fabric/test/transfer/unittests/FluidVariantTests.java
+++ b/fabric-transfer-api-v1/src/testmod/java/net/fabricmc/fabric/test/transfer/unittests/FluidVariantTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.transfer.unittests;
+
+import static net.fabricmc.fabric.test.transfer.unittests.TestUtil.assertEquals;
+
+import net.minecraft.fluid.Fluid;
+import net.minecraft.fluid.Fluids;
+
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
+
+class FluidVariantTests {
+	public static void run() {
+		testFlowing();
+	}
+
+	private static void testFlowing() {
+		assertFluidEquals(Fluids.WATER, FluidVariant.of(Fluids.WATER), FluidVariant.of(Fluids.FLOWING_WATER));
+		assertFluidEquals(Fluids.LAVA, FluidVariant.of(Fluids.LAVA), FluidVariant.of(Fluids.FLOWING_LAVA));
+		assertEquals(FluidVariant.of(Fluids.WATER), FluidVariant.of(Fluids.FLOWING_WATER));
+		assertEquals(FluidVariant.of(Fluids.LAVA), FluidVariant.of(Fluids.FLOWING_LAVA));
+	}
+
+	private static void assertFluidEquals(Fluid fluid, FluidVariant... variants) {
+		for (FluidVariant variant : variants) {
+			if (variant.getFluid() != fluid) {
+				throw new AssertionError("Variant %s expected to have fluid %s, but found %s".formatted(variant, fluid, variant.getFluid()));
+			}
+		}
+	}
+}

--- a/fabric-transfer-api-v1/src/testmod/java/net/fabricmc/fabric/test/transfer/unittests/UnitTestsInitializer.java
+++ b/fabric-transfer-api-v1/src/testmod/java/net/fabricmc/fabric/test/transfer/unittests/UnitTestsInitializer.java
@@ -27,6 +27,7 @@ public class UnitTestsInitializer implements ModInitializer {
 		BaseStorageTests.run();
 		FluidItemTests.run();
 		FluidTests.run();
+		FluidVariantTests.run();
 		ItemTests.run();
 		PlayerInventoryStorageTests.run();
 		SingleVariantItemStorageTests.run();


### PR DESCRIPTION
Closes #2665.

Also properly fixes Juuxel/Adorn#295 and similar issues where all the entries in a fluid tag like `#minecraft:water` or `#c:milk` are converted to fluid variants without manually checking for flowing fluids. (I'd also note that the crashing is undocumented and unexpected behaviour)