### PR TITLE
Add license to client only etries for client modules.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 	id "eclipse"
 	id "idea"
 	id "maven-publish"
-	id "fabric-loom" version "1.0.11" apply false
+	id "fabric-loom" version "1.0.12" apply false
 	id "com.diffplug.spotless" version "6.11.0"
 	id "org.ajoberstar.grgit" version "3.1.0"
 	id "com.matthewprenger.cursegradle" version "1.4.0"
@@ -248,9 +248,19 @@ allprojects {
 		archiveClassifier = "testmod"
 	}
 
-	[jar, testmodJar, sourcesJar].each {
+	[jar, sourcesJar].each {
 		it.from(rootProject.file("LICENSE")) {
 			rename { "${it}-${project.archivesBaseName}"}
+		}
+	}
+
+	if (file("src/client").exists() && !file("src/main").exists()) {
+		remapJar {
+			additionalClientOnlyEntries.add("LICENSE-${project.archivesBaseName}")
+		}
+
+		remapSourcesJar {
+			additionalClientOnlyEntries.add("LICENSE-${project.archivesBaseName}")
 		}
 	}
 


### PR DESCRIPTION
Requires all modules updating due to loom update.

Dont add testmod jars as it was causing testmod jars to be generated for mods without a testmod. We dont publish them anyway.