### PR TITLE
Fix modded item groups not having id's assigned

### DIFF
--- a/fabric-item-group-api-v1/src/main/java/net/fabricmc/fabric/impl/itemgroup/FabricItemGroupBuilderImpl.java
+++ b/fabric-item-group-api-v1/src/main/java/net/fabricmc/fabric/impl/itemgroup/FabricItemGroupBuilderImpl.java
@@ -23,15 +23,19 @@ import net.minecraft.util.Identifier;
 
 @ApiStatus.Internal
 public final class FabricItemGroupBuilderImpl extends ItemGroup.Builder {
+	private final Identifier identifier;
+
 	public FabricItemGroupBuilderImpl(Identifier identifier) {
 		// Set when building.
 		super(null, -1);
+		this.identifier = identifier;
 	}
 
 	@Override
 	public ItemGroup build() {
 		final ItemGroup itemGroup = super.build();
 		ItemGroupHelper.appendItemGroup(itemGroup);
+		MinecraftItemGroups.GROUP_ID_MAP.put(itemGroup, identifier);
 		return itemGroup;
 	}
 }

--- a/fabric-item-group-api-v1/src/main/java/net/fabricmc/fabric/impl/itemgroup/MinecraftItemGroups.java
+++ b/fabric-item-group-api-v1/src/main/java/net/fabricmc/fabric/impl/itemgroup/MinecraftItemGroups.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.impl.itemgroup;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
@@ -42,7 +43,7 @@ public final class MinecraftItemGroups {
 	public static final Identifier OP_ID = new Identifier("minecraft:op");
 	public static final Identifier INVENTORY_ID = new Identifier("minecraft:inventory");
 
-	public static final Map<ItemGroup, Identifier> GROUP_ID_MAP = new ImmutableMap.Builder<ItemGroup, Identifier>()
+	public static final Map<ItemGroup, Identifier> GROUP_ID_MAP = new HashMap<>(new ImmutableMap.Builder<ItemGroup, Identifier>()
 			.put(ItemGroups.BUILDING_BLOCKS, MinecraftItemGroups.BUILDING_BLOCKS_ID)
 			.put(ItemGroups.COLORED_BLOCKS, MinecraftItemGroups.COLOURED_BLOCKS_ID)
 			.put(ItemGroups.NATURAL, MinecraftItemGroups.NATURAL_ID)
@@ -57,7 +58,7 @@ public final class MinecraftItemGroups {
 			.put(ItemGroups.SPAWN_EGGS, MinecraftItemGroups.SPAWN_EGGS_ID)
 			.put(ItemGroups.OPERATOR, MinecraftItemGroups.OP_ID)
 			.put(ItemGroups.INVENTORY, MinecraftItemGroups.INVENTORY_ID)
-			.build();
+			.build());
 
 	private MinecraftItemGroups() {
 	}


### PR DESCRIPTION
Currently FabricItemGroupBuilderImpl doesn't do anything with the id. I assume this is a oversight and made a pr to fix it.
Currently I just GROUP_ID_MAP mutable and append the group and id to that. other solutions are possible. but I think this one has the smallest impact.