### PR TITLE
Add coverage task

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,3 +54,26 @@ jobs:
         with:
           name: Test Screenshots
           path: run/screenshots
+
+  coverage:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'microsoft'
+          java-version: '17'
+      - name: Run coverage
+        uses: modmuss50/xvfb-action@v1
+        with:
+          run: ./gradlew coverage --stacktrace --warning-mode=fail
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Coverage Client Screenshots
+          path: run/screenshots
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Coverage Report
+          path: build/reports/jacoco/coverage/html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,26 +54,3 @@ jobs:
         with:
           name: Test Screenshots
           path: run/screenshots
-
-  coverage:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'microsoft'
-          java-version: '17'
-      - name: Run coverage
-        uses: modmuss50/xvfb-action@v1
-        with:
-          run: ./gradlew coverage --stacktrace --warning-mode=fail
-      - uses: actions/upload-artifact@v2
-        with:
-          name: Coverage Client Screenshots
-          path: run/screenshots
-      - uses: actions/upload-artifact@v2
-        with:
-          name: Coverage Report
-          path: build/reports/jacoco/coverage/html

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
 	id "eclipse"
 	id "idea"
 	id "maven-publish"
+	id 'jacoco'
 	id "fabric-loom" version "1.0.12" apply false
 	id "com.diffplug.spotless" version "6.11.0"
 	id "org.ajoberstar.grgit" version "3.1.0"
@@ -372,9 +373,49 @@ loom {
 			name "Auto Test Client"
 			vmArg "-Dfabric.autoTest"
 		}
+
+		// Create duplicate tasks for this, as jacoco slows things down a bit
+		gametestCoverage {
+			inherit gametest
+			name "Game Test Coverage"
+			ideConfigGenerated = false
+		}
+
+		autoTestClientCoverage {
+			inherit autoTestClient
+			name "Auto Test Client Coverage"
+			ideConfigGenerated = false
+		}
 	}
 }
 test.dependsOn runGametest
+
+def coverageTasks = [runGametestCoverage, runAutoTestClientCoverage]
+
+jacoco {
+	coverageTasks.forEach {
+		applyTo it
+	}
+}
+
+task coverage(type: JacocoReport, dependsOn: coverageTasks) {
+	coverageTasks.forEach {
+		executionData it
+	}
+
+	// Add all source as input
+	allprojects { p ->
+		if (p.path.startsWith(":deprecated")) return
+		sourceSets p.sourceSets.main, p.sourceSets.client, p.sourceSets.testmod
+	}
+
+	// Exclude mixins
+	afterEvaluate {
+		classDirectories.setFrom(files(classDirectories.files.collect {
+			fileTree(dir: it, exclude: '**/mixin/**')
+		}))
+	}
+}
 
 configurations {
 	productionRuntime {


### PR DESCRIPTION
Adds a coverage task used to genrate a JaCoCo coverage report (See build output). Datagen is not included, but this does include the client run, and gametests.

Im unsure if this is worth runing for every build as it can be a little slow. I think its worth adding even if it needs to be ran manually.