### PR TITLE
AttackBlockCallback: creative fix and javadoc update

### DIFF
--- a/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/mixin/event/interaction/client/ClientPlayerInteractionManagerMixin.java
+++ b/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/mixin/event/interaction/client/ClientPlayerInteractionManagerMixin.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.mixin.event.interaction.client;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -64,33 +65,38 @@ public abstract class ClientPlayerInteractionManagerMixin {
 	private ClientPlayNetworkHandler networkHandler;
 	@Shadow
 	private GameMode gameMode;
+	@Shadow
+	private int blockBreakingCooldown;
 
 	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/GameMode;isCreative()Z", ordinal = 0), method = "attackBlock", cancellable = true)
 	public void attackBlock(BlockPos pos, Direction direction, CallbackInfoReturnable<Boolean> info) {
+		fabric_fireAttackBlockCallback(pos, direction, info);
+	}
+
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/GameMode;isCreative()Z", ordinal = 0), method = "updateBlockBreakingProgress", cancellable = true)
+	public void method_2902(BlockPos pos, Direction direction, CallbackInfoReturnable<Boolean> info) {
+		if (gameMode.isCreative()) {
+			fabric_fireAttackBlockCallback(pos, direction, info);
+		}
+	}
+
+	@Unique
+	private void fabric_fireAttackBlockCallback(BlockPos pos, Direction direction, CallbackInfoReturnable<Boolean> info) {
 		ActionResult result = AttackBlockCallback.EVENT.invoker().interact(client.player, client.world, Hand.MAIN_HAND, pos, direction);
 
 		if (result != ActionResult.PASS) {
-			// Returning true will spawn particles and trigger the animation of the hand -> only for SUCCESS.
-			info.setReturnValue(result == ActionResult.SUCCESS);
+			// Returning true will spawn particles and trigger the animation of the hand -> only for SUCCESS or CONSUME_PARTIAL.
+			info.setReturnValue(result == ActionResult.SUCCESS || result == ActionResult.CONSUME_PARTIAL);
+
+			// Set block break delay for CONSUME_PARTIAL
+			if (result == ActionResult.CONSUME_PARTIAL) {
+				blockBreakingCooldown = 5;
+			}
 
 			// We also need to let the server process the action if it's accepted.
 			if (result.isAccepted()) {
 				sendSequencedPacket(client.world, id -> new PlayerActionC2SPacket(PlayerActionC2SPacket.Action.START_DESTROY_BLOCK, pos, direction, id));
 			}
-		}
-	}
-
-	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/GameMode;isCreative()Z", ordinal = 0), method = "updateBlockBreakingProgress", cancellable = true)
-	public void method_2902(BlockPos pos, Direction direction, CallbackInfoReturnable<Boolean> info) {
-		if (!gameMode.isCreative()) {
-			return;
-		}
-
-		ActionResult result = AttackBlockCallback.EVENT.invoker().interact(client.player, client.world, Hand.MAIN_HAND, pos, direction);
-
-		if (result != ActionResult.PASS) {
-			// Returning true will spawn particles and trigger the animation of the hand -> only for SUCCESS.
-			info.setReturnValue(result == ActionResult.SUCCESS);
 		}
 	}
 

--- a/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/mixin/event/interaction/client/ClientPlayerInteractionManagerMixin.java
+++ b/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/mixin/event/interaction/client/ClientPlayerInteractionManagerMixin.java
@@ -65,8 +65,6 @@ public abstract class ClientPlayerInteractionManagerMixin {
 	private ClientPlayNetworkHandler networkHandler;
 	@Shadow
 	private GameMode gameMode;
-	@Shadow
-	private int blockBreakingCooldown;
 
 	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/GameMode;isCreative()Z", ordinal = 0), method = "attackBlock", cancellable = true)
 	public void attackBlock(BlockPos pos, Direction direction, CallbackInfoReturnable<Boolean> info) {
@@ -85,13 +83,8 @@ public abstract class ClientPlayerInteractionManagerMixin {
 		ActionResult result = AttackBlockCallback.EVENT.invoker().interact(client.player, client.world, Hand.MAIN_HAND, pos, direction);
 
 		if (result != ActionResult.PASS) {
-			// Returning true will spawn particles and trigger the animation of the hand -> only for SUCCESS or CONSUME_PARTIAL.
-			info.setReturnValue(result == ActionResult.SUCCESS || result == ActionResult.CONSUME_PARTIAL);
-
-			// Set block break delay for CONSUME_PARTIAL
-			if (result == ActionResult.CONSUME_PARTIAL) {
-				blockBreakingCooldown = 5;
-			}
+			// Returning true will spawn particles and trigger the animation of the hand -> only for SUCCESS.
+			info.setReturnValue(result == ActionResult.SUCCESS);
 
 			// We also need to let the server process the action if it's accepted.
 			if (result.isAccepted()) {

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/AttackBlockCallback.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/AttackBlockCallback.java
@@ -32,10 +32,13 @@ import net.fabricmc.fabric.api.event.EventFactory;
  *
  * <p>On the client-side, the return values have the following meaning:
  * <ul>
- *     <li>SUCCESS cancels further processing and sends a packet to the server.
+ *     <li>SUCCESS cancels further processing, causes a hand swing, and sends a packet to the server.
  *     <b>However, it does not set the cooldown for block breaking, allowing block breaking again in the next client tick.</b></li>
- *     <li>CONSUME_PARTIAL cancels further processing and sends a packet to the server.
- *     <b>Additionally, it sets the cooldown for block breaking on the client, preventing spamming.</b></li>
+ *     <li>CONSUME cancels further processing, and sends a packet to the server. It does NOT cause a hand swing.
+ *     <b>However, it does not set the cooldown for block breaking, allowing block breaking again in the next client tick.</b></li>
+ *     <li>CONSUME_PARTIAL cancels further processing, causes a hand swing, and sends a packet to the server.
+ *     <b>Additionally, it sets the cooldown for block breaking on the client, preventing spamming.</b>
+ *     Note that this behavior is different from the normal uses of CONSUME_PARTIAL.</li>
  *     <li>PASS falls back to further processing.</li>
  *     <li>FAIL cancels further processing and does not send a packet to the server.</li>
  * </ul>

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/AttackBlockCallback.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/AttackBlockCallback.java
@@ -30,12 +30,21 @@ import net.fabricmc.fabric.api.event.EventFactory;
  * Callback for left-clicking ("attacking") a block.
  * Is hooked in before the spectator check, so make sure to check for the player's game mode as well!
  *
- * <p>Upon return:
- * <ul><li>SUCCESS cancels further processing and, on the client, sends a packet to the server.
- * <li>PASS falls back to further processing.
- * <li>FAIL cancels further processing and does not send a packet to the server.</ul>
+ * <p>On the client-side, the return values have the following meaning:
+ * <ul>
+ *     <li>SUCCESS cancels further processing and sends a packet to the server.
+ *     <b>However, it does not set the cooldown for block breaking, allowing block breaking again in the next client tick.</b></li>
+ *     <li>CONSUME_PARTIAL cancels further processing and sends a packet to the server.
+ *     <b>Additionally, it sets the cooldown for block breaking on the client, preventing spamming.</b></li>
+ *     <li>PASS falls back to further processing.</li>
+ *     <li>FAIL cancels further processing and does not send a packet to the server.</li>
+ * </ul>
  *
- * <p>ATTACK_BLOCK does not let you control the packet sending process yet.
+ * <p>On the server-side, the return values have the following meaning:
+ * <ul>
+ *     <li>PASS falls back to further processing.</li>
+ *     <li>Any other value cancels further processing.</li>
+ * </ul>
  */
 public interface AttackBlockCallback {
 	Event<AttackBlockCallback> EVENT = EventFactory.createArrayBacked(AttackBlockCallback.class,

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/AttackBlockCallback.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/AttackBlockCallback.java
@@ -30,7 +30,7 @@ import net.fabricmc.fabric.api.event.EventFactory;
  * Callback for left-clicking ("attacking") a block.
  * Is hooked in before the spectator check, so make sure to check for the player's game mode as well!
  *
- * <p>On the client-side, the return values have the following meaning:
+ * <p>On the logical client, the return values have the following meaning:
  * <ul>
  *     <li>SUCCESS cancels further processing, causes a hand swing, and sends a packet to the server.</li>
  *     <li>CONSUME cancels further processing, and sends a packet to the server. It does NOT cause a hand swing.</li>
@@ -38,7 +38,7 @@ import net.fabricmc.fabric.api.event.EventFactory;
  *     <li>FAIL cancels further processing and does not send a packet to the server.</li>
  * </ul>
  *
- * <p>On the server-side, the return values have the following meaning:
+ * <p>On the logical server, the return values have the following meaning:
  * <ul>
  *     <li>PASS falls back to further processing.</li>
  *     <li>Any other value cancels further processing.</li>

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/AttackBlockCallback.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/AttackBlockCallback.java
@@ -32,13 +32,8 @@ import net.fabricmc.fabric.api.event.EventFactory;
  *
  * <p>On the client-side, the return values have the following meaning:
  * <ul>
- *     <li>SUCCESS cancels further processing, causes a hand swing, and sends a packet to the server.
- *     <b>However, it does not set the cooldown for block breaking, allowing block breaking again in the next client tick.</b></li>
- *     <li>CONSUME cancels further processing, and sends a packet to the server. It does NOT cause a hand swing.
- *     <b>However, it does not set the cooldown for block breaking, allowing block breaking again in the next client tick.</b></li>
- *     <li>CONSUME_PARTIAL cancels further processing, causes a hand swing, and sends a packet to the server.
- *     <b>Additionally, it sets the cooldown for block breaking on the client, preventing spamming.</b>
- *     Note that this behavior is different from the normal uses of CONSUME_PARTIAL.</li>
+ *     <li>SUCCESS cancels further processing, causes a hand swing, and sends a packet to the server.</li>
+ *     <li>CONSUME cancels further processing, and sends a packet to the server. It does NOT cause a hand swing.</li>
  *     <li>PASS falls back to further processing.</li>
  *     <li>FAIL cancels further processing and does not send a packet to the server.</li>
  * </ul>

--- a/fabric-events-interaction-v0/src/testmod/java/net/fabricmc/fabric/test/event/interaction/AttackBlockTests.java
+++ b/fabric-events-interaction-v0/src/testmod/java/net/fabricmc/fabric/test/event/interaction/AttackBlockTests.java
@@ -41,7 +41,7 @@ public class AttackBlockTests implements ModInitializer {
 				if (world.getBlockState(pos).isOf(Blocks.CHEST)) {
 					if (player.getStackInHand(hand).isOf(Items.LAVA_BUCKET)) {
 						world.setBlockState(pos, Blocks.AIR.getDefaultState());
-						return ActionResult.success(world.isClient);
+						return ActionResult.CONSUME_PARTIAL;
 					}
 				}
 			}

--- a/fabric-events-interaction-v0/src/testmod/java/net/fabricmc/fabric/test/event/interaction/AttackBlockTests.java
+++ b/fabric-events-interaction-v0/src/testmod/java/net/fabricmc/fabric/test/event/interaction/AttackBlockTests.java
@@ -41,7 +41,7 @@ public class AttackBlockTests implements ModInitializer {
 				if (world.getBlockState(pos).isOf(Blocks.CHEST)) {
 					if (player.getStackInHand(hand).isOf(Items.LAVA_BUCKET)) {
 						world.setBlockState(pos, Blocks.AIR.getDefaultState());
-						return ActionResult.CONSUME_PARTIAL;
+						return ActionResult.success(world.isClient);
 					}
 				}
 			}


### PR DESCRIPTION
Fix `AttackBlockCallback` not properly sending a packet to the server in creative mode when left click is being held. This expands upon the #1872 patch, which missed this edge case. Thanks to @marchermans who spotted the issue, and insisted enough for me to find it!

I also edited the javadoc to clarify the meaning of the various return values for the event. FYI, here is what the rendered javadoc looks like now:
![image](https://user-images.githubusercontent.com/13494793/203938593-f604ea84-4c9e-462d-83ee-113519c03522.png)
