### PR TITLE
Add some useful helper methods to FabricDynamicRegistryProvider.Entries

### DIFF
--- a/fabric-biome-api-v1/src/testmod/java/net/fabricmc/fabric/test/biome/WorldgenProvider.java
+++ b/fabric-biome-api-v1/src/testmod/java/net/fabricmc/fabric/test/biome/WorldgenProvider.java
@@ -19,7 +19,6 @@ package net.fabricmc.fabric.test.biome;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.registry.entry.RegistryEntry;
@@ -44,17 +43,7 @@ public class WorldgenProvider extends FabricDynamicRegistryProvider {
 	protected void configure(RegistryWrapper.WrapperLookup registries, Entries entries) {
 		final RegistryWrapper.Impl<Biome> biomeRegistry = registries.getWrapperOrThrow(RegistryKeys.BIOME);
 
-		List<RegistryKey<Biome>> allBiomes = List.of(
-				TestBiomes.TEST_CRIMSON_FOREST,
-				TestBiomes.CUSTOM_PLAINS,
-				TestBiomes.TEST_END_HIGHLANDS,
-				TestBiomes.TEST_END_MIDLANDS,
-				TestBiomes.TEST_END_BARRRENS
-		);
-
-		for (RegistryKey<Biome> biomeRegistryKey : allBiomes) {
-			entries.add(biomeRegistryKey, biomeRegistry.getOrThrow(biomeRegistryKey).value());
-		}
+		entries.addAll(biomeRegistry);
 
 		ConfiguredFeature<?, ?> COMMON_DESERT_WELL = new ConfiguredFeature<>(Feature.DESERT_WELL, DefaultFeatureConfig.INSTANCE);
 

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricDynamicRegistryProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricDynamicRegistryProvider.java
@@ -142,7 +142,7 @@ public abstract class FabricDynamicRegistryProvider implements DataProvider {
 		}
 
 		/**
-		 * All the registry entries matching the current effective modid will be data generated.
+		 * All the registry entries whose namespace matches the current effective mod ID will be data generated.
 		 */
 		public <T> List<RegistryEntry<T>> addAll(RegistryWrapper.Impl<T> registry) {
 			return registry.streamKeys()


### PR DESCRIPTION
Main one is `addAll` this data generates all registry entries where the namespace matches the current effective modid.

The usecase I can see is a lot of people will want to generate all of their registry entries.