### PR TITLE
Improved error handling in FabricGameTestHelper

### DIFF
--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/FabricGameTestHelper.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/FabricGameTestHelper.java
@@ -101,6 +101,8 @@ public final class FabricGameTestHelper {
 		} catch (IllegalAccessException e) {
 			throw new RuntimeException("Failed to invoke test method (%s) in (%s) because %s".formatted(method.getName(), method.getDeclaringClass().getCanonicalName(), e.getMessage()), e);
 		} catch (InvocationTargetException e) {
+			LOGGER.error("Exception occurred when invoking test method {} in ({})", method.getName(), method.getDeclaringClass().getCanonicalName(), e);
+
 			if (e.getCause() instanceof RuntimeException runtimeException) {
 				throw runtimeException;
 			} else {


### PR DESCRIPTION
We had a test failing as a mixin it was using failed to apply, there was no indication of this in the log. This change just makes sure that any exeption thown in a test method is logged.