### PR TITLE
Add FabricDataGenerator.createBuiltinResourcePack to support data gen for builtin resource packs.

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricDataGenerator.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricDataGenerator.java
@@ -24,9 +24,9 @@ import org.jetbrains.annotations.ApiStatus;
 
 import net.minecraft.SharedConstants;
 import net.minecraft.data.DataGenerator;
-import net.minecraft.data.DataOutput;
 import net.minecraft.data.DataProvider;
 import net.minecraft.registry.RegistryWrapper;
+import net.minecraft.util.Identifier;
 
 import net.fabricmc.loader.api.ModContainer;
 
@@ -48,13 +48,24 @@ public final class FabricDataGenerator extends DataGenerator {
 		this.registriesFuture = registriesFuture;
 	}
 
+	/**
+	 * Create a default {@link Pack} instance for generating a mod's data.
+	 */
 	public Pack createPack() {
 		return new Pack(true, modContainer.getMetadata().getName(), this.fabricOutput);
 	}
 
-	public Pack createSubPack(String packName) {
-		Path path = this.output.resolvePath(DataOutput.OutputType.DATA_PACK).resolve(getModId()).resolve("datapacks").resolve(packName);
-		return new Pack(true, packName, new FabricDataOutput(modContainer, path, strictValidation));
+	/**
+	 * Create a new {@link Pack} instance for generating a builtin resource pack.
+	 *
+	 * <p>To be used in conjunction with {@link net.fabricmc.fabric.api.resource.ResourceManagerHelper#registerBuiltinResourcePack}
+	 *
+	 * <p>The path in which the resource pack is generated is {@code "resourcepacks/<id path>"}. {@code id path} being the path specified
+	 * in the identifier.
+	 */
+	public Pack createBuiltinResourcePack(Identifier id) {
+		Path path = this.output.getPath().resolve("resourcepacks").resolve(id.getPath());
+		return new Pack(true, id.toString(), new FabricDataOutput(modContainer, path, strictValidation));
 	}
 
 	/**
@@ -94,7 +105,7 @@ public final class FabricDataGenerator extends DataGenerator {
 	}
 
 	/**
-	 * @deprecated Please use {@link FabricDataGenerator#createSubPack(String)}
+	 * @deprecated Please use {@link FabricDataGenerator#createBuiltinResourcePack(Identifier)}
 	 */
 	@Override
 	@Deprecated


### PR DESCRIPTION
Replaces the useless `createSubPack` method