### PR TITLE
TAW: Check that generated access widener matches expected output

### DIFF
--- a/fabric-transitive-access-wideners-v1/build.gradle
+++ b/fabric-transitive-access-wideners-v1/build.gradle
@@ -14,19 +14,44 @@ import java.nio.file.FileSystem
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
-import java.util.stream.Collectors
+
+File generatedAccessWidener = file('src/main/resources/fabric-transitive-access-wideners-v1.accesswidener')
 
 task generateAccessWidener {
 	doLast {
-		List<String> lines = file("template.accesswidener").text.lines().collect(Collectors.toCollection { [] })
-		Path inputJar = loom.namedMinecraftProvider.parentMinecraftProvider.commonJar
-
-		try (def fs = FileSystems.newFileSystem(URI.create("jar:${inputJar.toUri()}"), [create: false])) {
-			generateBlockConstructors(lines, fs)
-		}
-
-		file('src/main/resources/fabric-transitive-access-wideners-v1.accesswidener').text = String.join('\n', lines) + '\n'
+		List<String> lines = generateAccessWidener()
+		generatedAccessWidener.text = String.join('\n', lines) + '\n'
 	}
+}
+
+task validateGeneratedAccessWidener {
+	inputs.file file('template.accesswidener')
+	inputs.file generatedAccessWidener
+
+	// Ignore outputs for up-to-date checks as there aren't any (so only inputs are checked)
+	outputs.upToDateWhen { true }
+
+	doLast {
+		def expectedLines = generateAccessWidener()
+		def actualLines = generatedAccessWidener.readLines()
+
+		if (expectedLines != actualLines) {
+			throw new AssertionError("Generated access widener does not match the current output! Rerun $project.path:generateAccessWidener.")
+		}
+	}
+}
+
+check.dependsOn validateGeneratedAccessWidener
+
+List<String> generateAccessWidener() {
+	List<String> lines = new ArrayList<>(file('template.accesswidener').readLines())
+	Path inputJar = loom.namedMinecraftProvider.parentMinecraftProvider.commonJar
+
+	try (def fs = FileSystems.newFileSystem(URI.create("jar:${inputJar.toUri()}"), [create: false])) {
+		generateBlockConstructors(lines, fs)
+	}
+
+	return lines
 }
 
 def generateBlockConstructors(List<String> lines, FileSystem fs) {


### PR DESCRIPTION
See https://github.com/FabricMC/fabric/pull/2695#discussion_r1032199744.

This prevents builds with outdated access wideners when the MC version changes, or when template.accesswidener is modified.

Also simplifies the code a bit - `text.lines().collect(Collectors.toCollection { [] })` for getting a mutable list of the lines in a file was replaced with Groovy's `readLines` extension method wrapped in a new `ArrayList` for safety.