### PR TITLE
Add producation server test, publish testmod jar to maven.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,6 @@ jobs:
         with:
           reports: |
             **/build/reports/checkstyle/*.xml
-      - run: mkdir run && echo "eula=true" >> run/eula.txt
-      - run: ./gradlew runAutoTestServer --stacktrace --warning-mode=fail
       - uses: actions/upload-artifact@v2
         with:
           name: Artifacts
@@ -54,3 +52,16 @@ jobs:
         with:
           name: Test Screenshots
           path: run/screenshots
+
+  server_test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'microsoft'
+          java-version: '17'
+      - run: mkdir run && echo "eula=true" >> run/eula.txt
+      - run: ./gradlew runProductionAutoTestServer --stacktrace --warning-mode=fail

--- a/build.gradle
+++ b/build.gradle
@@ -423,11 +423,14 @@ configurations {
 		extendsFrom configurations.loaderLibraries
 		extendsFrom configurations.minecraftRuntimeOnlyLibraries
 	}
+	productionRuntimeServer
 }
 
 dependencies {
 	productionRuntime "net.fabricmc:fabric-loader:${project.loader_version}"
 	productionRuntime "net.fabricmc:intermediary:${project.minecraft_version}"
+
+	productionRuntimeServer "net.fabricmc:fabric-installer:${project.installer_version}:server"
 }
 
 import net.fabricmc.loom.util.OperatingSystem
@@ -462,6 +465,38 @@ task runProductionAutoTestClient(type: JavaExec, dependsOn: [remapJar, remapTest
 			"-Dfabric.addMods=${remapJar.archiveFile.get().asFile.absolutePath}${File.pathSeparator}${remapTestmodJar.archiveFile.get().asFile.absolutePath}",
 			"-Dfabric.autoTest"
 		)
+	}
+}
+
+task serverPropertiesJar(type: Jar) {
+	def propsFile = file("build/tmp/install.properties")
+
+	doFirst {
+		propsFile.text = """\
+						fabric-loader-version=${project.loader_version}
+						game-version=${project.minecraft_version}
+						""".stripMargin().stripIndent()
+	}
+
+	archiveName = "test-server-properties.jar"
+	destinationDirectory = file("build/tmp")
+	from(propsFile)
+}
+
+task runProductionAutoTestServer(type: JavaExec, dependsOn: [remapJar, remapTestmodJar, serverPropertiesJar]) {
+	classpath.from configurations.productionRuntimeServer, serverPropertiesJar
+	mainClass = "net.fabricmc.installer.ServerLauncher"
+	workingDir = file("run")
+
+	doFirst {
+		workingDir.mkdirs()
+
+		jvmArgs(
+			"-Dfabric.addMods=${remapJar.archiveFile.get().asFile.absolutePath}${File.pathSeparator}${remapTestmodJar.archiveFile.get().asFile.absolutePath}",
+			"-Dfabric.autoTest"
+		)
+
+		args("nogui")
 	}
 }
 
@@ -525,6 +560,7 @@ publishing {
 			}
 
 			artifact javadocJar
+			artifact remapTestmodJar
 
 			pom.withXml {
 				def depsNode = asNode().appendNode("dependencies")

--- a/build.gradle
+++ b/build.gradle
@@ -478,7 +478,7 @@ task serverPropertiesJar(type: Jar) {
 						""".stripMargin().stripIndent()
 	}
 
-	archiveName = "test-server-properties.jar"
+	archiveFileName = "test-server-properties.jar"
 	destinationDirectory = file("build/tmp")
 	from(propsFile)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,7 @@ version=0.68.0
 minecraft_version=1.19.3-pre3
 yarn_version=+build.1
 loader_version=0.14.10
+installer_version=0.11.1
 
 prerelease=true
 


### PR DESCRIPTION
Building on the success of the prod client test, this PR now uses the real installer to run the testmods against a real server.

The testmod jar is also published as I want to look at adding a client and server test similar to this to in loader.