### PR TITLE
Screen API: Fix MinecraftClientMixin overwriting the vanilla logger

### DIFF
--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/MinecraftClientMixin.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/MinecraftClientMixin.java
@@ -34,7 +34,9 @@ import net.fabricmc.loader.api.FabricLoader;
 
 @Mixin(MinecraftClient.class)
 abstract class MinecraftClientMixin {
+	@Unique
 	private static final Logger LOGGER = LoggerFactory.getLogger("fabric-screen-api-v1");
+	@Unique
 	private static final boolean DEBUG_SCREEN = FabricLoader.getInstance().isDevelopmentEnvironment() || Boolean.getBoolean("fabric.debugScreen");
 
 	@Shadow


### PR DESCRIPTION
Without `@Unique`, it's treated as some sort of an overwrite for the `LOGGER` field.

I also `@Unique`d the other field just in case vanilla adds that field in the future :smile: