### PR TITLE
Remove 3rd party JavaDoc links

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -312,18 +312,6 @@ javadoc {
 		charSet = "UTF-8"
 		memberLevel = JavadocMemberLevel.PACKAGE
 		links(
-				"https://guava.dev/releases/31.1-jre/api/docs/",
-				"https://asm.ow2.io/javadoc/",
-				"https://docs.oracle.com/en/java/javase/17/docs/api/",
-				"https://jenkins.liteloader.com/job/Mixin/javadoc/",
-				"https://logging.apache.org/log4j/2.x/log4j-api/apidocs/",
-				"https://www.slf4j.org/apidocs/",
-				"https://netty.io/4.1/api/",
-				"https://javadoc.lwjgl.org/",
-				"https://www.javadoc.io/doc/com.google.code.gson/gson/2.10/",
-				"https://javadoc.io/doc/org.jetbrains/annotations/latest/",
-				"https://javadoc.io/doc/it.unimi.dsi/fastutil/",
-				"https://javadoc.scijava.org/JOML/",
 				"https://maven.fabricmc.net/docs/yarn-${rootProject.minecraft_version}${project.yarn_version}/"
 		)
 		// Disable the crazy super-strict doclint tool in Java 8


### PR DESCRIPTION
- They are unstable, when any one of these sites goes down it fails the whole build. And leads to dead links in our javadoc's
- A lot of them are not for the specific version being used.

I think we need to rehost the specific version, possibly driven by yarn?