### PR TITLE
Cleanup Environment annotation usage.

### DIFF
--- a/deprecated/fabric-renderer-registries-v1/src/client/java/net/fabricmc/fabric/api/client/rendereregistry/v1/EntityModelLayerRegistry.java
+++ b/deprecated/fabric-renderer-registries-v1/src/client/java/net/fabricmc/fabric/api/client/rendereregistry/v1/EntityModelLayerRegistry.java
@@ -19,16 +19,12 @@ package net.fabricmc.fabric.api.client.rendereregistry.v1;
 import net.minecraft.client.model.TexturedModelData;
 import net.minecraft.client.render.entity.model.EntityModelLayer;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
-
 /**
  * A helpers for registering entity model layers and providers for the layer's textured model data.
  *
  * @deprecated This module has been moved into fabric-rendering-v1. Use {@link net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry} instead.
  */
 @Deprecated
-@Environment(EnvType.CLIENT)
 public final class EntityModelLayerRegistry {
 	/**
 	 * Registers an entity model layer and registers a provider for a {@linkplain TexturedModelData}.
@@ -45,7 +41,6 @@ public final class EntityModelLayerRegistry {
 
 	@FunctionalInterface
 	@Deprecated
-	@Environment(EnvType.CLIENT)
 	public interface TexturedModelDataProvider {
 		/**
 		 * Creates the textured model data for use in a {@link EntityModelLayer}.

--- a/deprecated/fabric-renderer-registries-v1/src/client/java/net/fabricmc/fabric/api/client/rendereregistry/v1/LivingEntityFeatureRendererRegistrationCallback.java
+++ b/deprecated/fabric-renderer-registries-v1/src/client/java/net/fabricmc/fabric/api/client/rendereregistry/v1/LivingEntityFeatureRendererRegistrationCallback.java
@@ -24,8 +24,6 @@ import net.minecraft.client.render.entity.model.EntityModel;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
@@ -50,7 +48,6 @@ import net.fabricmc.fabric.api.event.EventFactory;
  */
 @FunctionalInterface
 @Deprecated
-@Environment(EnvType.CLIENT)
 public interface LivingEntityFeatureRendererRegistrationCallback {
 	Event<LivingEntityFeatureRendererRegistrationCallback> EVENT = createEvent();
 

--- a/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/api/tag/client/v1/ClientTags.java
+++ b/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/api/tag/client/v1/ClientTags.java
@@ -30,8 +30,6 @@ import net.minecraft.registry.Registry;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.registry.RegistryKey;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.impl.tag.client.ClientTagsLoader;
 
 /**
@@ -46,7 +44,6 @@ import net.fabricmc.fabric.impl.tag.client.ClientTagsLoader;
  * directly, allowing for mods to query tags such as {@link net.fabricmc.fabric.api.tag.convention.v1.ConventionalBlockTags}
  * even when connected to a vanilla server.
  */
-@Environment(EnvType.CLIENT)
 public final class ClientTags {
 	private static final Map<TagKey<?>, Set<Identifier>> LOCAL_TAG_CACHE = new ConcurrentHashMap<>();
 

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/api/client/command/v2/ClientCommandManager.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/api/client/command/v2/ClientCommandManager.java
@@ -22,8 +22,6 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import org.jetbrains.annotations.Nullable;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.impl.command.client.ClientCommandInternals;
 
 /**
@@ -62,7 +60,6 @@ import net.fabricmc.fabric.impl.command.client.ClientCommandInternals;
  * }
  * </pre>
  */
-@Environment(EnvType.CLIENT)
 public final class ClientCommandManager {
 	private ClientCommandManager() {
 	}

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/api/client/command/v2/FabricClientCommandSource.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/api/client/command/v2/FabricClientCommandSource.java
@@ -25,13 +25,9 @@ import net.minecraft.text.Text;
 import net.minecraft.util.math.Vec2f;
 import net.minecraft.util.math.Vec3d;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
-
 /**
  * Extensions to {@link CommandSource} for client-sided commands.
  */
-@Environment(EnvType.CLIENT)
 public interface FabricClientCommandSource extends CommandSource {
 	/**
 	 * Sends a feedback message to the player.

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/impl/command/client/ClientCommandInternals.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/impl/command/client/ClientCommandInternals.java
@@ -45,12 +45,9 @@ import net.minecraft.command.CommandException;
 import net.minecraft.text.Text;
 import net.minecraft.text.Texts;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.fabricmc.fabric.mixin.command.HelpCommandAccessor;
 
-@Environment(EnvType.CLIENT)
 public final class ClientCommandInternals {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ClientCommandInternals.class);
 	private static final String API_COMMAND_NAME = "fabric-command-api-v2:client";

--- a/fabric-game-rule-api-v1/src/client/java/net/fabricmc/fabric/impl/gamerule/widget/DoubleRuleWidget.java
+++ b/fabric-game-rule-api-v1/src/client/java/net/fabricmc/fabric/impl/gamerule/widget/DoubleRuleWidget.java
@@ -22,15 +22,12 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.world.EditGameRulesScreen;
 import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.text.Text;
 import net.minecraft.text.OrderedText;
+import net.minecraft.text.Text;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.gamerule.v1.rule.DoubleRule;
 import net.fabricmc.fabric.mixin.gamerule.client.EditGameRulesScreenAccessor;
 
-@Environment(EnvType.CLIENT)
 public final class DoubleRuleWidget extends EditGameRulesScreen.NamedRuleWidget {
 	private final TextFieldWidget textFieldWidget;
 

--- a/fabric-game-rule-api-v1/src/client/java/net/fabricmc/fabric/impl/gamerule/widget/EnumRuleWidget.java
+++ b/fabric-game-rule-api-v1/src/client/java/net/fabricmc/fabric/impl/gamerule/widget/EnumRuleWidget.java
@@ -26,11 +26,8 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.OrderedText;
 import net.minecraft.text.Text;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.gamerule.v1.rule.EnumRule;
 
-@Environment(EnvType.CLIENT)
 public final class EnumRuleWidget<E extends Enum<E>> extends EditGameRulesScreen.NamedRuleWidget {
 	private final ButtonWidget buttonWidget;
 	private final String rootTranslationKey;

--- a/fabric-game-rule-api-v1/src/client/java/net/fabricmc/fabric/mixin/gamerule/client/EditGameRulesScreenAccessor.java
+++ b/fabric-game-rule-api-v1/src/client/java/net/fabricmc/fabric/mixin/gamerule/client/EditGameRulesScreenAccessor.java
@@ -21,11 +21,7 @@ import org.spongepowered.asm.mixin.gen.Invoker;
 
 import net.minecraft.client.gui.screen.world.EditGameRulesScreen;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
-
 @Mixin(EditGameRulesScreen.class)
-@Environment(EnvType.CLIENT)
 public interface EditGameRulesScreenAccessor {
 	@Invoker("markValid")
 	void callMarkValid(EditGameRulesScreen.AbstractRuleWidget ruleWidget);

--- a/fabric-game-rule-api-v1/src/client/java/net/fabricmc/fabric/mixin/gamerule/client/RuleListWidgetVisitorMixin.java
+++ b/fabric-game-rule-api-v1/src/client/java/net/fabricmc/fabric/mixin/gamerule/client/RuleListWidgetVisitorMixin.java
@@ -28,15 +28,12 @@ import net.minecraft.client.gui.screen.world.EditGameRulesScreen;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.world.GameRules;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.gamerule.v1.FabricGameRuleVisitor;
 import net.fabricmc.fabric.api.gamerule.v1.rule.DoubleRule;
 import net.fabricmc.fabric.api.gamerule.v1.rule.EnumRule;
 import net.fabricmc.fabric.impl.gamerule.widget.DoubleRuleWidget;
 import net.fabricmc.fabric.impl.gamerule.widget.EnumRuleWidget;
 
-@Environment(EnvType.CLIENT)
 @Mixin(targets = "net/minecraft/client/gui/screen/world/EditGameRulesScreen$RuleListWidget$1")
 public abstract class RuleListWidgetVisitorMixin implements GameRules.Visitor, FabricGameRuleVisitor {
 	@Final

--- a/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/impl/gamerule/rule/BoundedIntRule.java
+++ b/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/impl/gamerule/rule/BoundedIntRule.java
@@ -16,13 +16,11 @@
 
 package net.fabricmc.fabric.impl.gamerule.rule;
 
-import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import net.minecraft.world.GameRules;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.gamerule.v1.GameRuleRegistry;
 import net.fabricmc.fabric.mixin.gamerule.GameRulesIntRuleAccessor;
 
@@ -51,7 +49,6 @@ public final class BoundedIntRule extends GameRules.IntRule {
 	}
 
 	@Override
-	@Environment(EnvType.CLIENT)
 	public boolean validate(String input) {
 		try {
 			int value = Integer.parseInt(input);

--- a/fabric-item-api-v1/src/client/java/net/fabricmc/fabric/api/client/item/v1/ItemTooltipCallback.java
+++ b/fabric-item-api-v1/src/client/java/net/fabricmc/fabric/api/client/item/v1/ItemTooltipCallback.java
@@ -22,12 +22,9 @@ import net.minecraft.client.item.TooltipContext;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
-@Environment(EnvType.CLIENT)
 public interface ItemTooltipCallback {
 	/**
 	 * Fired after the game has appended all base tooltip lines to the list.

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientBlockEntityEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientBlockEntityEvents.java
@@ -20,12 +20,9 @@ import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.profiler.Profiler;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
-@Environment(EnvType.CLIENT)
 public final class ClientBlockEntityEvents {
 	private ClientBlockEntityEvents() {
 	}

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientChunkEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientChunkEvents.java
@@ -20,12 +20,9 @@ import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.profiler.Profiler;
 import net.minecraft.world.chunk.WorldChunk;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
-@Environment(EnvType.CLIENT)
 public final class ClientChunkEvents {
 	private ClientChunkEvents() {
 	}

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientEntityEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientEntityEvents.java
@@ -20,12 +20,9 @@ import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.profiler.Profiler;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
-@Environment(EnvType.CLIENT)
 public final class ClientEntityEvents {
 	private ClientEntityEvents() {
 	}

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientLifecycleEvents.java
@@ -18,12 +18,9 @@ package net.fabricmc.fabric.api.client.event.lifecycle.v1;
 
 import net.minecraft.client.MinecraftClient;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
-@Environment(EnvType.CLIENT)
 public final class ClientLifecycleEvents {
 	private ClientLifecycleEvents() {
 	}

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientTickEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientTickEvents.java
@@ -20,12 +20,9 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.profiler.Profiler;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
-@Environment(EnvType.CLIENT)
 public final class ClientTickEvents {
 	private ClientTickEvents() {
 	}

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/impl/client/event/lifecycle/ClientLifecycleEventsImpl.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/impl/client/event/lifecycle/ClientLifecycleEventsImpl.java
@@ -19,13 +19,10 @@ package net.fabricmc.fabric.impl.client.event.lifecycle;
 import net.minecraft.block.entity.BlockEntity;
 
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientBlockEntityEvents;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientChunkEvents;
 import net.fabricmc.fabric.impl.event.lifecycle.LoadedChunksCache;
 
-@Environment(EnvType.CLIENT)
 public final class ClientLifecycleEventsImpl implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/ClientChunkManagerMixin.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/ClientChunkManagerMixin.java
@@ -27,19 +27,16 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-import net.minecraft.network.packet.s2c.play.ChunkData;
 import net.minecraft.client.world.ClientChunkManager;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.PacketByteBuf;
-import net.minecraft.world.chunk.WorldChunk;
+import net.minecraft.network.packet.s2c.play.ChunkData;
 import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.chunk.WorldChunk;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientChunkEvents;
 
-@Environment(EnvType.CLIENT)
 @Mixin(ClientChunkManager.class)
 public abstract class ClientChunkManagerMixin {
 	@Final

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/ClientPlayNetworkHandlerMixin.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/ClientPlayNetworkHandlerMixin.java
@@ -31,14 +31,11 @@ import net.minecraft.network.packet.s2c.play.PlayerRespawnS2CPacket;
 import net.minecraft.network.packet.s2c.play.SynchronizeTagsS2CPacket;
 import net.minecraft.world.chunk.WorldChunk;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientBlockEntityEvents;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientEntityEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.CommonLifecycleEvents;
 import net.fabricmc.fabric.impl.event.lifecycle.LoadedChunksCache;
 
-@Environment(EnvType.CLIENT)
 @Mixin(ClientPlayNetworkHandler.class)
 abstract class ClientPlayNetworkHandlerMixin {
 	@Shadow

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/ClientWorldClientEntityHandlerMixin.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/ClientWorldClientEntityHandlerMixin.java
@@ -26,11 +26,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.Entity;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientEntityEvents;
 
-@Environment(EnvType.CLIENT)
 @Mixin(targets = "net/minecraft/client/world/ClientWorld$ClientEntityHandler")
 abstract class ClientWorldClientEntityHandlerMixin {
 	// final synthetic Lnet/minecraft/client/world/ClientWorld; field_27735

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/ClientWorldMixin.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/ClientWorldMixin.java
@@ -23,11 +23,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.client.world.ClientWorld;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 
-@Environment(EnvType.CLIENT)
 @Mixin(ClientWorld.class)
 public abstract class ClientWorldMixin {
 	@Inject(method = "tickEntities", at = @At("TAIL"))

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/MinecraftClientMixin.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/MinecraftClientMixin.java
@@ -23,12 +23,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.client.MinecraftClient;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 
-@Environment(EnvType.CLIENT)
 @Mixin(MinecraftClient.class)
 public abstract class MinecraftClientMixin {
 	@Inject(at = @At("HEAD"), method = "tick")

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/WorldChunkMixin.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/WorldChunkMixin.java
@@ -35,12 +35,9 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.WorldChunk;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientBlockEntityEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerBlockEntityEvents;
 
-@Environment(EnvType.CLIENT)
 @Mixin(WorldChunk.class)
 abstract class WorldChunkMixin {
 	@Shadow

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/server/WorldChunkMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/server/WorldChunkMixin.java
@@ -34,8 +34,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.WorldChunk;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerBlockEntityEvents;
 
 /**
@@ -43,7 +41,6 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerBlockEntityEvents;
  * Since all block entity tracking is now on the world chunk, we inject into WorldChunk.
  * In order to prevent client logic from being loaded due to the mixin, we have a mixin for the client and this one for the server.
  */
-@Environment(EnvType.SERVER)
 @Mixin(WorldChunk.class)
 abstract class WorldChunkMixin {
 	@Shadow

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/C2SPlayChannelEvents.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/C2SPlayChannelEvents.java
@@ -22,8 +22,6 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.util.Identifier;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.fabricmc.fabric.api.networking.v1.PacketSender;
@@ -31,7 +29,6 @@ import net.fabricmc.fabric.api.networking.v1.PacketSender;
 /**
  * Offers access to events related to the indication of a connected server's ability to receive packets in certain channels.
  */
-@Environment(EnvType.CLIENT)
 public final class C2SPlayChannelEvents {
 	/**
 	 * An event for the client play network handler receiving an update indicating the connected server's ability to receive packets in certain channels.
@@ -59,7 +56,6 @@ public final class C2SPlayChannelEvents {
 	/**
 	 * @see C2SPlayChannelEvents#REGISTER
 	 */
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface Register {
 		void onChannelRegister(ClientPlayNetworkHandler handler, PacketSender sender, MinecraftClient client, List<Identifier> channels);
@@ -68,7 +64,6 @@ public final class C2SPlayChannelEvents {
 	/**
 	 * @see C2SPlayChannelEvents#UNREGISTER
 	 */
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface Unregister {
 		void onChannelUnregister(ClientPlayNetworkHandler handler, PacketSender sender, MinecraftClient client, List<Identifier> channels);

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientLoginConnectionEvents.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientLoginConnectionEvents.java
@@ -20,15 +20,12 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientLoginNetworkHandler;
 import net.minecraft.util.Identifier;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
 /**
  * Offers access to events related to the connection to a server on the client while the server is processing the client's login request.
  */
-@Environment(EnvType.CLIENT)
 public final class ClientLoginConnectionEvents {
 	/**
 	 * Event indicating a connection entered the LOGIN state, ready for registering query request handlers.
@@ -80,7 +77,6 @@ public final class ClientLoginConnectionEvents {
 	/**
 	 * @see ClientLoginConnectionEvents#INIT
 	 */
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface Init {
 		void onLoginStart(ClientLoginNetworkHandler handler, MinecraftClient client);
@@ -89,7 +85,6 @@ public final class ClientLoginConnectionEvents {
 	/**
 	 * @see ClientLoginConnectionEvents#QUERY_START
 	 */
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface QueryStart {
 		void onLoginQueryStart(ClientLoginNetworkHandler handler, MinecraftClient client);
@@ -98,7 +93,6 @@ public final class ClientLoginConnectionEvents {
 	/**
 	 * @see ClientLoginConnectionEvents#DISCONNECT
 	 */
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface Disconnect {
 		void onLoginDisconnect(ClientLoginNetworkHandler handler, MinecraftClient client);

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientLoginNetworking.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientLoginNetworking.java
@@ -31,8 +31,6 @@ import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.listener.PacketListener;
 import net.minecraft.util.Identifier;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.networking.v1.ServerLoginNetworking;
 import net.fabricmc.fabric.impl.networking.client.ClientNetworkingImpl;
 
@@ -44,7 +42,6 @@ import net.fabricmc.fabric.impl.networking.client.ClientNetworkingImpl;
  * @see ClientPlayNetworking
  * @see ServerLoginNetworking
  */
-@Environment(EnvType.CLIENT)
 public final class ClientLoginNetworking {
 	/**
 	 * Registers a handler to a query request channel.
@@ -141,7 +138,6 @@ public final class ClientLoginNetworking {
 	private ClientLoginNetworking() {
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface LoginQueryRequestHandler {
 		/**

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientPlayConnectionEvents.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientPlayConnectionEvents.java
@@ -20,8 +20,6 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.util.Identifier;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.fabricmc.fabric.api.networking.v1.PacketSender;
@@ -29,7 +27,6 @@ import net.fabricmc.fabric.api.networking.v1.PacketSender;
 /**
  * Offers access to events related to the connection to a server on a logical client.
  */
-@Environment(EnvType.CLIENT)
 public final class ClientPlayConnectionEvents {
 	/**
 	 * Event indicating a connection entered the PLAY state, ready for registering channel handlers.
@@ -68,19 +65,16 @@ public final class ClientPlayConnectionEvents {
 	private ClientPlayConnectionEvents() {
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface Init {
 		void onPlayInit(ClientPlayNetworkHandler handler, MinecraftClient client);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface Join {
 		void onPlayReady(ClientPlayNetworkHandler handler, PacketSender sender, MinecraftClient client);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface Disconnect {
 		void onPlayDisconnect(ClientPlayNetworkHandler handler, MinecraftClient client);

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientPlayNetworking.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientPlayNetworking.java
@@ -28,8 +28,6 @@ import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.listener.ServerPlayPacketListener;
 import net.minecraft.util.Identifier;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.networking.v1.PacketSender;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.impl.networking.client.ClientNetworkingImpl;
@@ -46,7 +44,6 @@ import net.fabricmc.fabric.impl.networking.client.ClientPlayNetworkAddon;
  * @see ClientLoginNetworking
  * @see ServerPlayNetworking
  */
-@Environment(EnvType.CLIENT)
 public final class ClientPlayNetworking {
 	/**
 	 * Registers a handler to a channel.
@@ -232,7 +229,6 @@ public final class ClientPlayNetworking {
 	private ClientPlayNetworking() {
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface PlayChannelHandler {
 		/**

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientLoginNetworkAddon.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientLoginNetworkAddon.java
@@ -32,8 +32,6 @@ import net.minecraft.network.packet.c2s.login.LoginQueryResponseC2SPacket;
 import net.minecraft.network.packet.s2c.login.LoginQueryRequestS2CPacket;
 import net.minecraft.util.Identifier;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.networking.v1.ClientLoginConnectionEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientLoginNetworking;
 import net.fabricmc.fabric.api.networking.v1.FutureListeners;
@@ -41,7 +39,6 @@ import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.impl.networking.AbstractNetworkAddon;
 import net.fabricmc.fabric.impl.networking.GenericFutureListenerHolder;
 
-@Environment(EnvType.CLIENT)
 public final class ClientLoginNetworkAddon extends AbstractNetworkAddon<ClientLoginNetworking.LoginQueryRequestHandler> {
 	private final ClientLoginNetworkHandler handler;
 	private final MinecraftClient client;

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientNetworkingImpl.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientNetworkingImpl.java
@@ -34,8 +34,6 @@ import net.minecraft.network.listener.ServerPlayPacketListener;
 import net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket;
 import net.minecraft.util.Identifier;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.networking.v1.ClientLoginNetworking;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
@@ -47,7 +45,6 @@ import net.fabricmc.fabric.impl.networking.NetworkingImpl;
 import net.fabricmc.fabric.mixin.networking.client.accessor.ConnectScreenAccessor;
 import net.fabricmc.fabric.mixin.networking.client.accessor.MinecraftClientAccessor;
 
-@Environment(EnvType.CLIENT)
 public final class ClientNetworkingImpl {
 	public static final GlobalReceiverRegistry<ClientLoginNetworking.LoginQueryRequestHandler> LOGIN = new GlobalReceiverRegistry<>();
 	public static final GlobalReceiverRegistry<ClientPlayNetworking.PlayChannelHandler> PLAY = new GlobalReceiverRegistry<>();

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientPlayNetworkAddon.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientPlayNetworkAddon.java
@@ -27,8 +27,6 @@ import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
 import net.minecraft.util.Identifier;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.networking.v1.C2SPlayChannelEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
@@ -36,7 +34,6 @@ import net.fabricmc.fabric.impl.networking.AbstractChanneledNetworkAddon;
 import net.fabricmc.fabric.impl.networking.ChannelInfoHolder;
 import net.fabricmc.fabric.impl.networking.NetworkingImpl;
 
-@Environment(EnvType.CLIENT)
 public final class ClientPlayNetworkAddon extends AbstractChanneledNetworkAddon<ClientPlayNetworking.PlayChannelHandler> {
 	private final ClientPlayNetworkHandler handler;
 	private final MinecraftClient client;

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/ClientLoginNetworkHandlerMixin.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/ClientLoginNetworkHandlerMixin.java
@@ -29,12 +29,9 @@ import net.minecraft.client.network.ClientLoginNetworkHandler;
 import net.minecraft.network.packet.s2c.login.LoginQueryRequestS2CPacket;
 import net.minecraft.text.Text;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.impl.networking.NetworkHandlerExtensions;
 import net.fabricmc.fabric.impl.networking.client.ClientLoginNetworkAddon;
 
-@Environment(EnvType.CLIENT)
 @Mixin(ClientLoginNetworkHandler.class)
 abstract class ClientLoginNetworkHandlerMixin implements NetworkHandlerExtensions {
 	@Shadow

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/ClientPlayNetworkHandlerMixin.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/ClientPlayNetworkHandlerMixin.java
@@ -30,14 +30,11 @@ import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
 import net.minecraft.network.packet.s2c.play.GameJoinS2CPacket;
 import net.minecraft.text.Text;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.impl.networking.NetworkHandlerExtensions;
 import net.fabricmc.fabric.impl.networking.client.ClientNetworkingImpl;
 import net.fabricmc.fabric.impl.networking.client.ClientPlayNetworkAddon;
 
 // We want to apply a bit earlier than other mods which may not use us in order to prevent refCount issues
-@Environment(EnvType.CLIENT)
 @Mixin(value = ClientPlayNetworkHandler.class, priority = 999)
 abstract class ClientPlayNetworkHandlerMixin implements NetworkHandlerExtensions {
 	@Final

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/accessor/ConnectScreenAccessor.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/accessor/ConnectScreenAccessor.java
@@ -22,10 +22,6 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 import net.minecraft.client.gui.screen.ConnectScreen;
 import net.minecraft.network.ClientConnection;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
-
-@Environment(EnvType.CLIENT)
 @Mixin(ConnectScreen.class)
 public interface ConnectScreenAccessor {
 	@Accessor

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/accessor/MinecraftClientAccessor.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/accessor/MinecraftClientAccessor.java
@@ -23,10 +23,6 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.network.ClientConnection;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
-
-@Environment(EnvType.CLIENT)
 @Mixin(MinecraftClient.class)
 public interface MinecraftClientAccessor {
 	@Nullable

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/aocalc/AoCalculator.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/aocalc/AoCalculator.java
@@ -40,8 +40,6 @@ import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.BlockRenderView;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.impl.client.indigo.Indigo;
 import net.fabricmc.fabric.impl.client.indigo.renderer.aocalc.AoFace.WeightFunction;
 import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.EncodingFormat;
@@ -52,7 +50,6 @@ import net.fabricmc.fabric.impl.client.indigo.renderer.render.BlockRenderInfo;
 /**
  * Adaptation of inner, non-static class in BlockModelRenderer that serves same purpose.
  */
-@Environment(EnvType.CLIENT)
 public class AoCalculator {
 	@FunctionalInterface
 	public interface BrightnessFunc {

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/aocalc/AoFace.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/aocalc/AoFace.java
@@ -27,14 +27,11 @@ import static net.minecraft.util.math.Direction.WEST;
 import net.minecraft.util.Util;
 import net.minecraft.util.math.Direction;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.QuadViewImpl;
 
 /**
  * Adapted from vanilla BlockModelRenderer.AoCalculator.
  */
-@Environment(EnvType.CLIENT)
 enum AoFace {
 	AOF_DOWN(new Direction[] { WEST, EAST, NORTH, SOUTH }, (q, i) -> CLAMP_FUNC.clamp(q.y(i)), (q, i, w) -> {
 		final float u = CLAMP_FUNC.clamp(q.x(i));

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/aocalc/AoVertexClampFunction.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/aocalc/AoVertexClampFunction.java
@@ -16,11 +16,8 @@
 
 package net.fabricmc.fabric.impl.client.indigo.renderer.aocalc;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.impl.client.indigo.Indigo;
 
-@Environment(EnvType.CLIENT)
 @FunctionalInterface
 interface AoVertexClampFunction {
 	float clamp(float x);

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/ArmorRenderer.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/ArmorRenderer.java
@@ -31,8 +31,6 @@ import net.minecraft.item.ItemConvertible;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.impl.client.rendering.ArmorRendererRegistryImpl;
 
 /**
@@ -41,7 +39,6 @@ import net.fabricmc.fabric.impl.client.rendering.ArmorRendererRegistryImpl;
  *
  * <p>The renderers are registered with {@link net.fabricmc.fabric.api.client.rendering.v1.ArmorRenderer#register(ArmorRenderer, ItemConvertible...)}.
  */
-@Environment(EnvType.CLIENT)
 @FunctionalInterface
 public interface ArmorRenderer {
 	/**

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockEntityRendererRegistry.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockEntityRendererRegistry.java
@@ -18,18 +18,15 @@ package net.fabricmc.fabric.api.client.rendering.v1;
 
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
-import net.minecraft.client.render.block.entity.BlockEntityRendererFactory;
 import net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher;
 import net.minecraft.client.render.block.entity.BlockEntityRenderer;
+import net.minecraft.client.render.block.entity.BlockEntityRendererFactory;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.impl.client.rendering.BlockEntityRendererRegistryImpl;
 
 /**
  * Helper class for registering BlockEntityRenderers.
  */
-@Environment(EnvType.CLIENT)
 public final class BlockEntityRendererRegistry {
 	/**
 	 * Register a BlockEntityRenderer for a BlockEntityType. Can be called clientside before the world is rendered.

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BuiltinItemRenderer.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BuiltinItemRenderer.java
@@ -21,9 +21,6 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
-
 /**
  * Builtin item renderers render items with custom code.
  * They allow using non-model rendering, such as BERs, for items.
@@ -34,7 +31,6 @@ import net.fabricmc.api.Environment;
  * @deprecated Please use {@link BuiltinItemRendererRegistry.DynamicItemRenderer} instead.
  */
 @Deprecated
-@Environment(EnvType.CLIENT)
 @FunctionalInterface
 public interface BuiltinItemRenderer {
 	/**

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BuiltinItemRendererRegistry.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BuiltinItemRendererRegistry.java
@@ -25,14 +25,11 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemConvertible;
 import net.minecraft.item.ItemStack;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.impl.client.rendering.BuiltinItemRendererRegistryImpl;
 
 /**
  * This registry holds {@linkplain DynamicItemRenderer builtin item renderers} for items.
  */
-@Environment(EnvType.CLIENT)
 public interface BuiltinItemRendererRegistry {
 	/**
 	 * The singleton instance of the renderer registry.
@@ -88,7 +85,6 @@ public interface BuiltinItemRendererRegistry {
 	 * The renderers are registered with {@link BuiltinItemRendererRegistry#register(ItemConvertible, DynamicItemRenderer)}.
 	 */
 	@FunctionalInterface
-	@Environment(EnvType.CLIENT)
 	interface DynamicItemRenderer {
 		/**
 		 * Renders an item stack.

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/DimensionRenderingRegistry.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/DimensionRenderingRegistry.java
@@ -19,12 +19,10 @@ package net.fabricmc.fabric.api.client.rendering.v1;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.client.render.DimensionEffects;
-import net.minecraft.util.Identifier;
 import net.minecraft.registry.RegistryKey;
+import net.minecraft.util.Identifier;
 import net.minecraft.world.World;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.impl.client.rendering.DimensionRenderingRegistryImpl;
 
 /**
@@ -32,7 +30,6 @@ import net.fabricmc.fabric.impl.client.rendering.DimensionRenderingRegistryImpl;
  * They may be used to render the sky, weather, or clouds.
  * The {@link DimensionEffects} is the vanilla dimensional renderer.
  */
-@Environment(EnvType.CLIENT)
 public interface DimensionRenderingRegistry {
 	/**
 	 * Registers the custom sky renderer for a {@link World}.

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/EntityModelLayerRegistry.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/EntityModelLayerRegistry.java
@@ -21,15 +21,12 @@ import java.util.Objects;
 import net.minecraft.client.model.TexturedModelData;
 import net.minecraft.client.render.entity.model.EntityModelLayer;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.impl.client.rendering.EntityModelLayerImpl;
 import net.fabricmc.fabric.mixin.client.rendering.EntityModelLayersAccessor;
 
 /**
  * A helpers for registering entity model layers and providers for the layer's textured model data.
  */
-@Environment(EnvType.CLIENT)
 public final class EntityModelLayerRegistry {
 	/**
 	 * Registers an entity model layer and registers a provider for a {@linkplain TexturedModelData}.
@@ -52,7 +49,6 @@ public final class EntityModelLayerRegistry {
 	}
 
 	@FunctionalInterface
-	@Environment(EnvType.CLIENT)
 	public interface TexturedModelDataProvider {
 		/**
 		 * Creates the textured model data for use in a {@link EntityModelLayer}.

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/EntityRendererRegistry.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/EntityRendererRegistry.java
@@ -22,14 +22,11 @@ import net.minecraft.client.render.entity.EntityRendererFactory;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.impl.client.rendering.EntityRendererRegistryImpl;
 
 /**
  * Helper class for registering EntityRenderers.
  */
-@Environment(EnvType.CLIENT)
 public final class EntityRendererRegistry {
 	/**
 	 * Register a BlockEntityRenderer for a BlockEntityType. Can be called clientside before the world is rendered.

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/LivingEntityFeatureRendererRegistrationCallback.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/LivingEntityFeatureRendererRegistrationCallback.java
@@ -26,8 +26,6 @@ import net.minecraft.client.render.entity.model.EntityModel;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
@@ -49,7 +47,6 @@ import net.fabricmc.fabric.api.event.EventFactory;
  * </pre></blockquote>
  */
 @FunctionalInterface
-@Environment(EnvType.CLIENT)
 public interface LivingEntityFeatureRendererRegistrationCallback {
 	Event<LivingEntityFeatureRendererRegistrationCallback> EVENT = EventFactory.createArrayBacked(LivingEntityFeatureRendererRegistrationCallback.class, callbacks -> (entityType, entityRenderer, registrationHelper, context) -> {
 		for (LivingEntityFeatureRendererRegistrationCallback callback : callbacks) {

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipComponentCallback.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipComponentCallback.java
@@ -19,11 +19,9 @@ package net.fabricmc.fabric.api.client.rendering.v1;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.client.gui.tooltip.TooltipComponent;
-import net.minecraft.item.Item;
 import net.minecraft.client.item.TooltipData;
+import net.minecraft.item.Item;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
@@ -35,7 +33,6 @@ import net.fabricmc.fabric.api.event.EventFactory;
  * <p>Note that failure to map some data to a component will throw an exception,
  * so make sure that any data you return in {@link Item#getTooltipData} will be handled by one of the callbacks.
  */
-@Environment(EnvType.CLIENT)
 public interface TooltipComponentCallback {
 	Event<TooltipComponentCallback> EVENT = EventFactory.createArrayBacked(TooltipComponentCallback.class, listeners -> data -> {
 		for (TooltipComponentCallback listener : listeners) {

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderContext.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderContext.java
@@ -33,14 +33,10 @@ import net.minecraft.entity.Entity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.profiler.Profiler;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
-
 /**
  * Except as noted below, the properties exposed here match the parameters passed to
  * {@link WorldRenderer#render(MatrixStack, float, long, boolean, Camera, GameRenderer, LightmapTextureManager, Matrix4f)}.
  */
-@Environment(EnvType.CLIENT)
 public interface WorldRenderContext {
 	/**
 	 * The world renderer instance doing the rendering and invoking the event.
@@ -119,7 +115,6 @@ public interface WorldRenderContext {
 	 * Used in {@code BLOCK_OUTLINE} to convey the parameters normally sent to
 	 * {@code WorldRenderer.drawBlockOutline}.
 	 */
-	@Environment(EnvType.CLIENT)
 	interface BlockOutlineContext {
 		/**
 		 * @deprecated Use {@link #consumers()} directly.

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderEvents.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderEvents.java
@@ -22,8 +22,6 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.util.hit.HitResult;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext.BlockOutlineContext;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
@@ -47,7 +45,6 @@ import net.fabricmc.fabric.api.event.EventFactory;
  *
  * <p>These events are not dependent on the Fabric rendering API or Indigo but work when those are present.
  */
-@Environment(EnvType.CLIENT)
 public final class WorldRenderEvents {
 	private WorldRenderEvents() { }
 
@@ -255,31 +252,26 @@ public final class WorldRenderEvents {
 		}
 	});
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface Start {
 		void onStart(WorldRenderContext context);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface AfterSetup {
 		void afterSetup(WorldRenderContext context);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface BeforeEntities {
 		void beforeEntities(WorldRenderContext context);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface AfterEntities {
 		void afterEntities(WorldRenderContext context);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface BeforeBlockOutline {
 		/**
@@ -295,31 +287,26 @@ public final class WorldRenderEvents {
 		boolean beforeBlockOutline(WorldRenderContext context, @Nullable HitResult hitResult);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface BlockOutline {
 		boolean onBlockOutline(WorldRenderContext worldRenderContext, BlockOutlineContext blockOutlineContext);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface DebugRender {
 		void beforeDebugRender(WorldRenderContext context);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface AfterTranslucent {
 		void afterTranslucent(WorldRenderContext context);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface Last {
 		void onLast(WorldRenderContext context);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface End {
 		void onEnd(WorldRenderContext context);

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/BuiltinItemRendererRegistryImpl.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/BuiltinItemRendererRegistryImpl.java
@@ -26,12 +26,9 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemConvertible;
 import net.minecraft.registry.Registries;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRenderer;
 import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRendererRegistry;
 
-@Environment(EnvType.CLIENT)
 public final class BuiltinItemRendererRegistryImpl implements BuiltinItemRendererRegistry {
 	private static final Map<Item, DynamicItemRenderer> RENDERERS = new HashMap<>();
 

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/EntityModelLayerImpl.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/EntityModelLayerImpl.java
@@ -21,11 +21,8 @@ import java.util.Map;
 
 import net.minecraft.client.render.entity.model.EntityModelLayer;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry;
 
-@Environment(EnvType.CLIENT)
 public final class EntityModelLayerImpl {
 	public static final Map<EntityModelLayer, EntityModelLayerRegistry.TexturedModelDataProvider> PROVIDERS = new HashMap<>();
 

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/WorldRenderContextImpl.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/WorldRenderContextImpl.java
@@ -33,11 +33,8 @@ import net.minecraft.entity.Entity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.profiler.Profiler;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 
-@Environment(EnvType.CLIENT)
 public final class WorldRenderContextImpl implements WorldRenderContext.BlockOutlineContext, WorldRenderContext {
 	private WorldRenderer worldRenderer;
 	private MatrixStack matrixStack;

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/DimensionEffectsAccessor.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/DimensionEffectsAccessor.java
@@ -23,10 +23,6 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 import net.minecraft.client.render.DimensionEffects;
 import net.minecraft.util.Identifier;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
-
-@Environment(EnvType.CLIENT)
 @Mixin(DimensionEffects.class)
 public interface DimensionEffectsAccessor {
 	@Accessor("BY_IDENTIFIER")

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenEvents.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenEvents.java
@@ -22,8 +22,6 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.util.math.MatrixStack;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.fabricmc.fabric.impl.client.screen.ScreenExtensions;
@@ -43,7 +41,7 @@ import net.fabricmc.fabric.impl.client.screen.ScreenExtensions;
  * @see ScreenKeyboardEvents
  * @see ScreenMouseEvents
  */
-@Environment(EnvType.CLIENT)
+
 public final class ScreenEvents {
 	/**
 	 * An event that is called before {@link Screen#init(MinecraftClient, int, int) a screen is initialized} to its default state.
@@ -161,43 +159,36 @@ public final class ScreenEvents {
 		return ScreenExtensions.getExtensions(screen).fabric_getAfterTickEvent();
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface BeforeInit {
 		void beforeInit(MinecraftClient client, Screen screen, int scaledWidth, int scaledHeight);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface AfterInit {
 		void afterInit(MinecraftClient client, Screen screen, int scaledWidth, int scaledHeight);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface Remove {
 		void onRemove(Screen screen);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface BeforeRender {
 		void beforeRender(Screen screen, MatrixStack matrices, int mouseX, int mouseY, float tickDelta);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface AfterRender {
 		void afterRender(Screen screen, MatrixStack matrices, int mouseX, int mouseY, float tickDelta);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface BeforeTick {
 		void beforeTick(Screen screen);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface AfterTick {
 		void afterTick(Screen screen);

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenKeyboardEvents.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenKeyboardEvents.java
@@ -20,8 +20,6 @@ import java.util.Objects;
 
 import net.minecraft.client.gui.screen.Screen;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.impl.client.screen.ScreenExtensions;
 
@@ -38,7 +36,6 @@ import net.fabricmc.fabric.impl.client.screen.ScreenExtensions;
  *
  * @see ScreenEvents
  */
-@Environment(EnvType.CLIENT)
 public final class ScreenKeyboardEvents {
 	/**
 	 * An event that checks if a key press should be allowed.
@@ -109,7 +106,6 @@ public final class ScreenKeyboardEvents {
 	private ScreenKeyboardEvents() {
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface AllowKeyPress {
 		/**
@@ -125,7 +121,6 @@ public final class ScreenKeyboardEvents {
 		boolean allowKeyPress(Screen screen, int key, int scancode, int modifiers);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface BeforeKeyPress {
 		/**
@@ -140,7 +135,6 @@ public final class ScreenKeyboardEvents {
 		void beforeKeyPress(Screen screen, int key, int scancode, int modifiers);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface AfterKeyPress {
 		/**
@@ -155,7 +149,6 @@ public final class ScreenKeyboardEvents {
 		void afterKeyPress(Screen screen, int key, int scancode, int modifiers);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface AllowKeyRelease {
 		/**
@@ -171,7 +164,6 @@ public final class ScreenKeyboardEvents {
 		boolean allowKeyRelease(Screen screen, int key, int scancode, int modifiers);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface BeforeKeyRelease {
 		/**
@@ -186,7 +178,6 @@ public final class ScreenKeyboardEvents {
 		void beforeKeyRelease(Screen screen, int key, int scancode, int modifiers);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface AfterKeyRelease {
 		/**

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenMouseEvents.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenMouseEvents.java
@@ -20,8 +20,6 @@ import java.util.Objects;
 
 import net.minecraft.client.gui.screen.Screen;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.impl.client.screen.ScreenExtensions;
 
@@ -38,7 +36,6 @@ import net.fabricmc.fabric.impl.client.screen.ScreenExtensions;
  *
  * @see ScreenEvents
  */
-@Environment(EnvType.CLIENT)
 public final class ScreenMouseEvents {
 	/**
 	 * An event that checks if the mouse click should be allowed.
@@ -148,7 +145,6 @@ public final class ScreenMouseEvents {
 	private ScreenMouseEvents() {
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface AllowMouseClick {
 		/**
@@ -160,7 +156,6 @@ public final class ScreenMouseEvents {
 		boolean allowMouseClick(Screen screen, double mouseX, double mouseY, int button);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface BeforeMouseClick {
 		/**
@@ -172,7 +167,6 @@ public final class ScreenMouseEvents {
 		void beforeMouseClick(Screen screen, double mouseX, double mouseY, int button);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface AfterMouseClick {
 		/**
@@ -184,7 +178,6 @@ public final class ScreenMouseEvents {
 		void afterMouseClick(Screen screen, double mouseX, double mouseY, int button);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface AllowMouseRelease {
 		/**
@@ -198,7 +191,6 @@ public final class ScreenMouseEvents {
 		boolean allowMouseRelease(Screen screen, double mouseX, double mouseY, int button);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface BeforeMouseRelease {
 		/**
@@ -212,7 +204,6 @@ public final class ScreenMouseEvents {
 		void beforeMouseRelease(Screen screen, double mouseX, double mouseY, int button);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface AfterMouseRelease {
 		/**
@@ -226,7 +217,6 @@ public final class ScreenMouseEvents {
 		void afterMouseRelease(Screen screen, double mouseX, double mouseY, int button);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface AllowMouseScroll {
 		/**
@@ -241,7 +231,6 @@ public final class ScreenMouseEvents {
 		boolean allowMouseScroll(Screen screen, double mouseX, double mouseY, double horizontalAmount, double verticalAmount);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface BeforeMouseScroll {
 		/**
@@ -255,7 +244,6 @@ public final class ScreenMouseEvents {
 		void beforeMouseScroll(Screen screen, double mouseX, double mouseY, double horizontalAmount, double verticalAmount);
 	}
 
-	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface AfterMouseScroll {
 		/**

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/Screens.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/Screens.java
@@ -25,8 +25,6 @@ import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.ClickableWidget;
 import net.minecraft.client.render.item.ItemRenderer;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.impl.client.screen.ScreenExtensions;
 import net.fabricmc.fabric.mixin.screen.ScreenAccessor;
 
@@ -35,7 +33,6 @@ import net.fabricmc.fabric.mixin.screen.ScreenAccessor;
  *
  * @see ScreenEvents
  */
-@Environment(EnvType.CLIENT)
 public final class Screens {
 	/**
 	 * Gets all of a screen's button widgets.

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ButtonList.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ButtonList.java
@@ -19,16 +19,12 @@ package net.fabricmc.fabric.impl.client.screen;
 import java.util.AbstractList;
 import java.util.List;
 
-import net.minecraft.client.gui.Selectable;
 import net.minecraft.client.gui.Drawable;
 import net.minecraft.client.gui.Element;
+import net.minecraft.client.gui.Selectable;
 import net.minecraft.client.gui.widget.ClickableWidget;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
-
 // TODO: When events for listening to addition of child elements are added, fire events from this list.
-@Environment(EnvType.CLIENT)
 public final class ButtonList extends AbstractList<ClickableWidget> {
 	private final List<Drawable> drawables;
 	private final List<Selectable> selectables;

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenEventFactory.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenEventFactory.java
@@ -16,8 +16,6 @@
 
 package net.fabricmc.fabric.impl.client.screen;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenKeyboardEvents;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenMouseEvents;
@@ -27,7 +25,6 @@ import net.fabricmc.fabric.api.event.EventFactory;
 /**
  * Factory methods for creating event instances used in {@link ScreenExtensions}.
  */
-@Environment(EnvType.CLIENT)
 public final class ScreenEventFactory {
 	public static Event<ScreenEvents.Remove> createRemoveEvent() {
 		return EventFactory.createArrayBacked(ScreenEvents.Remove.class, callbacks -> screen -> {

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenExtensions.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenExtensions.java
@@ -21,14 +21,11 @@ import java.util.List;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.ClickableWidget;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenKeyboardEvents;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenMouseEvents;
 import net.fabricmc.fabric.api.event.Event;
 
-@Environment(EnvType.CLIENT)
 public interface ScreenExtensions {
 	static ScreenExtensions getExtensions(Screen screen) {
 		return (ScreenExtensions) screen;

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/GameRendererMixin.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/GameRendererMixin.java
@@ -30,11 +30,8 @@ import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.render.GameRenderer;
 import net.minecraft.client.util.math.MatrixStack;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 
-@Environment(EnvType.CLIENT)
 @Mixin(GameRenderer.class)
 abstract class GameRendererMixin {
 	@Shadow

--- a/fabric-screen-handler-api-v1/src/client/java/net/fabricmc/fabric/api/client/screenhandler/v1/ScreenRegistry.java
+++ b/fabric-screen-handler-api-v1/src/client/java/net/fabricmc/fabric/api/client/screenhandler/v1/ScreenRegistry.java
@@ -24,9 +24,6 @@ import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.text.Text;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
-
 /**
  * An API for registering handled screens that represent screen handlers on the client.
  * Exposes vanilla's private {@link HandledScreens#register HandledScreens.register()} to modders as {@link #register ScreenRegistry.register()}.
@@ -50,7 +47,6 @@ import net.fabricmc.api.Environment;
  * @deprecated Replaced by access wideners for {@link HandledScreens#register(ScreenHandlerType, HandledScreens.Provider)}
  * and {@link HandledScreens.Provider} in Fabric Transitive Access Wideners (v1).
  */
-@Environment(EnvType.CLIENT)
 @Deprecated
 public final class ScreenRegistry {
 	private ScreenRegistry() {

--- a/fabric-screen-handler-api-v1/src/client/java/net/fabricmc/fabric/impl/screenhandler/client/ClientNetworking.java
+++ b/fabric-screen-handler-api-v1/src/client/java/net/fabricmc/fabric/impl/screenhandler/client/ClientNetworking.java
@@ -25,19 +25,16 @@ import net.minecraft.client.gui.screen.ingame.HandledScreens;
 import net.minecraft.client.gui.screen.ingame.ScreenHandlerProvider;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.PacketByteBuf;
+import net.minecraft.registry.Registries;
 import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
-import net.minecraft.registry.Registries;
 
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerType;
 import net.fabricmc.fabric.impl.screenhandler.Networking;
 
-@Environment(EnvType.CLIENT)
 public final class ClientNetworking implements ClientModInitializer {
 	private static final Logger LOGGER = LoggerFactory.getLogger("fabric-screen-handler-api-v1/client");
 

--- a/fabric-transfer-api-v1/src/client/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRenderHandler.java
+++ b/fabric-transfer-api-v1/src/client/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRenderHandler.java
@@ -27,8 +27,6 @@ import net.minecraft.text.Text;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockRenderView;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandler;
 import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandlerRegistry;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
@@ -41,7 +39,6 @@ import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Environment(EnvType.CLIENT)
 public interface FluidVariantRenderHandler {
 	/**
 	 * Append additional tooltips to the passed list if additional information is contained in the fluid variant.

--- a/fabric-transfer-api-v1/src/client/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRendering.java
+++ b/fabric-transfer-api-v1/src/client/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRendering.java
@@ -27,14 +27,12 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.fluid.Fluid;
+import net.minecraft.registry.Registries;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.registry.Registries;
 import net.minecraft.world.BlockRenderView;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.lookup.v1.custom.ApiProviderMap;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariantAttributes;
@@ -46,7 +44,6 @@ import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariantAttributes;
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-@Environment(EnvType.CLIENT)
 public final class FluidVariantRendering {
 	private static final ApiProviderMap<Fluid, FluidVariantRenderHandler> HANDLERS = ApiProviderMap.create();
 	private static final FluidVariantRenderHandler DEFAULT_HANDLER = new FluidVariantRenderHandler() { };


### PR DESCRIPTION
- Fix BoundedIntRule.validate being client only
- Move ItemTooltipCallback to client sourceset. (Was previously client only).
- Remove @Environment from all classes as it should **never** be used in a split sources setup. Loom automatically adds this to all client only classes in the output jar.

Splitting the testmods will follow pending some minor loom changes.