### PR TITLE
Fix #1145: Long enum gamerule name hidden by button

### DIFF
--- a/fabric-game-rule-api-v1/src/client/java/net/fabricmc/fabric/impl/gamerule/widget/EnumRuleWidget.java
+++ b/fabric-game-rule-api-v1/src/client/java/net/fabricmc/fabric/impl/gamerule/widget/EnumRuleWidget.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.impl.gamerule.widget;
 import java.util.List;
 import java.util.Locale;
 
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.world.EditGameRulesScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.resource.language.I18n;
@@ -37,6 +38,9 @@ public final class EnumRuleWidget<E extends Enum<E>> extends EditGameRulesScreen
 
 	public EnumRuleWidget(EditGameRulesScreen gameRuleScreen, Text name, List<OrderedText> description, final String ruleName, EnumRule<E> rule, String translationKey) {
 		gameRuleScreen.super(description, name);
+
+		// Overwrite line wrapping to account for button larger than vanilla's by 44 pixels.
+		this.name = MinecraftClient.getInstance().textRenderer.wrapLines(name, 175 - 44);
 
 		// Base translation key needs to be set before the button widget is created.
 		this.rootTranslationKey = translationKey;

--- a/fabric-game-rule-api-v1/src/main/resources/fabric-game-rule-api-v1.accesswidener
+++ b/fabric-game-rule-api-v1/src/main/resources/fabric-game-rule-api-v1.accesswidener
@@ -3,3 +3,5 @@ accessible  method  net/minecraft/world/GameRules$Type <init>  (Ljava/util/funct
 extendable  method  net/minecraft/world/GameRules$Type <init>  (Ljava/util/function/Supplier;Ljava/util/function/Function;Ljava/util/function/BiConsumer;Lnet/minecraft/world/GameRules$Acceptor;)V
 accessible  class   net/minecraft/world/GameRules$Acceptor
 accessible  class   net/minecraft/client/gui/screen/world/EditGameRulesScreen$RuleWidgetFactory
+accessible  field   net/minecraft/client/gui/screen/world/EditGameRulesScreen$NamedRuleWidget name  Ljava/util/List;
+mutable  field   net/minecraft/client/gui/screen/world/EditGameRulesScreen$NamedRuleWidget name  Ljava/util/List;

--- a/fabric-game-rule-api-v1/src/testmod/resources/assets/fabric-gamerule-test/lang/en_us.json
+++ b/fabric-game-rule-api-v1/src/testmod/resources/assets/fabric-gamerule-test/lang/en_us.json
@@ -1,5 +1,5 @@
 {
-  "gamerule.cardinalDirection": "Random Cardinal Direction",
+  "gamerule.cardinalDirection": "Random Cardinal Direction Very Long Title",
   "gamerule.cardinalDirection.description": "A cardinal direction. Should never be up or down",
   "gamerule.cardinalDirection.north": "Northbound",
   "gamerule.cardinalDirection.south": "Southbound",


### PR DESCRIPTION
Simple overwrite the result of `this.name = EditGameRulesScreen.this.client.textRenderer.wrapLines(name, 175);` to account for fabric's button being 44 pixels larger.

Fixes #1145.