### PR TITLE
Disable the gametest command on the server by default.

### DIFF
--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/FabricGameTestHelper.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/FabricGameTestHelper.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import net.minecraft.resource.ResourcePackManager;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.command.TestCommand;
 import net.minecraft.test.GameTestBatch;
 import net.minecraft.test.TestContext;
 import net.minecraft.test.TestFailureLogger;
@@ -40,10 +41,21 @@ import net.minecraft.test.TestUtil;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.level.storage.LevelStorage;
 
+import net.fabricmc.api.EnvType;
 import net.fabricmc.fabric.api.gametest.v1.FabricGameTest;
+import net.fabricmc.loader.api.FabricLoader;
 
 public final class FabricGameTestHelper {
 	public static final boolean ENABLED = System.getProperty("fabric-api.gametest") != null;
+
+	/**
+	 * When enabled the {@link TestCommand} and related arguments will be registered.
+	 *
+	 * <p>When {@link EnvType#CLIENT} the default value is true.
+	 *
+	 * <p>When {@link EnvType#SERVER} the default value is false.
+	 */
+	public static final boolean COMMAND_ENABLED = Boolean.parseBoolean(System.getProperty("fabric-api.gametest.command", FabricLoader.getInstance().getEnvironmentType() == EnvType.CLIENT ? "true" : "false"));
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(FabricGameTestHelper.class);
 

--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/mixin/gametest/ArgumentTypesMixin.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/mixin/gametest/ArgumentTypesMixin.java
@@ -31,6 +31,8 @@ import net.minecraft.command.argument.serialize.ArgumentSerializer;
 import net.minecraft.command.argument.serialize.ConstantArgumentSerializer;
 import net.minecraft.registry.Registry;
 
+import net.fabricmc.fabric.impl.gametest.FabricGameTestHelper;
+
 @Mixin(ArgumentTypes.class)
 public abstract class ArgumentTypesMixin {
 	@Shadow
@@ -41,7 +43,7 @@ public abstract class ArgumentTypesMixin {
 	@Inject(method = "register(Lnet/minecraft/registry/Registry;)Lnet/minecraft/command/argument/serialize/ArgumentSerializer;", at = @At("RETURN"))
 	private static void register(Registry<ArgumentSerializer<?, ?>> registry, CallbackInfoReturnable<ArgumentSerializer<?, ?>> ci) {
 		// Registered by vanilla when isDevelopment is enabled.
-		if (!SharedConstants.isDevelopment) {
+		if (FabricGameTestHelper.COMMAND_ENABLED && !SharedConstants.isDevelopment) {
 			register(registry, "test_argument", TestFunctionArgumentType.class, ConstantArgumentSerializer.of(TestFunctionArgumentType::testFunction));
 			register(registry, "test_class", TestClassArgumentType.class, ConstantArgumentSerializer.of(TestClassArgumentType::testClass));
 		}

--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/mixin/gametest/CommandManagerMixin.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/mixin/gametest/CommandManagerMixin.java
@@ -30,6 +30,8 @@ import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.command.TestCommand;
 
+import net.fabricmc.fabric.impl.gametest.FabricGameTestHelper;
+
 @Mixin(CommandManager.class)
 public abstract class CommandManagerMixin {
 	@Shadow
@@ -39,7 +41,7 @@ public abstract class CommandManagerMixin {
 	@Inject(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/command/WorldBorderCommand;register(Lcom/mojang/brigadier/CommandDispatcher;)V", shift = At.Shift.AFTER))
 	private void construct(CommandManager.RegistrationEnvironment environment, CommandRegistryAccess registryAccess, CallbackInfo info) {
 		// Registered by vanilla when isDevelopment is enabled.
-		if (!SharedConstants.isDevelopment) {
+		if (FabricGameTestHelper.COMMAND_ENABLED && !SharedConstants.isDevelopment) {
 			TestCommand.register(this.dispatcher);
 		}
 	}


### PR DESCRIPTION
Adds the "fabric-api.gametest.command" system property to enable/disable.
Fixes #2315