### PR TITLE
Add EventSpy to make it easier to test events within a gametest.

### DIFF
--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/api/gametest/v1/EventSpy.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/api/gametest/v1/EventSpy.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.gametest.v1;
+
+import net.minecraft.test.GameTestException;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public interface EventSpy<T> {
+	/**
+	 * Verify that the event was invoked at least once.
+	 *
+	 * @throws GameTestException when the event has not been invoked.
+	 */
+	void verifyCalled();
+
+	/**
+	 * Verify that the event was invoked an exact number of times.
+	 *
+	 * @param expectedInvocations The expected number of event invocations.
+	 * @throws GameTestException when the event has not been invoked the expected number of times.
+	 */
+	void verifyCalledTimes(int expectedInvocations);
+
+	/**
+	 * Verify that the event was never invoked.
+	 *
+	 * @throws GameTestException when the event has been invoked at least once.
+	 */
+	default void verifyNotCalled() {
+		verifyCalledTimes(0);
+	}
+
+	/**
+	 * Verify that the event was called once.
+	 *
+	 * @throws GameTestException when the event was not called once.
+	 */
+	default void verifyCalledOnce() {
+		verifyCalledTimes(1);
+	}
+
+	/**
+	 * @return the number of event invocations.
+	 */
+	int getInvocations();
+
+	interface Context {
+		/**
+		 * Notify the {@link EventSpy} that the event was invoked.
+		 *
+		 * <p>The return value of this method should be used to determine whether the event should act upon the event.
+		 * This method will return false after the test has completed or failed.
+		 *
+		 * <p>Any positional event should use {@link Context#invoke(BlockPos)} to ensure that the event is relevant to the current test.
+		 *
+		 * @return true when the test event handler should consume the event.
+		 */
+		boolean invoke();
+
+		/**
+		 * Notify the {@link EventSpy} that the event was invoked.
+		 *
+		 * <p>The return value of this method should be used to determine whether the event should act upon the event.
+		 * This method will return false after the test has completed or failed.
+		 * This method will return false when the {@link BlockPos} is not within the current test structure.
+		 *
+		 * @param blockPos the position in a {@link World}, used to determine if the event is related to the current test.
+		 * @return true when the test event handler should consume the event.
+		 */
+		boolean invoke(BlockPos blockPos);
+	}
+}

--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/api/gametest/v1/FabricTestContext.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/api/gametest/v1/FabricTestContext.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.gametest.v1;
+
+import java.util.function.Function;
+
+import net.minecraft.test.GameTestState;
+import net.minecraft.test.TestContext;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
+
+import net.fabricmc.fabric.api.event.Event;
+
+/**
+ * Extensions to {@link FabricTestContext}
+ * for adding additional gametest functionality.
+ *
+ * <p>This interface is automatically injected to {@link TestContext}.
+ */
+public interface FabricTestContext {
+	/**
+	 * Creates an {@link EventSpy} instance that can be used to test {@link Event} invocations in a game test.
+	 *
+	 * <p><h3>Usage Example</h3>
+	 * The following example shows how to spy on a test and ensure that it was called once.
+	 * {@link EventSpy.Context#invoke(BlockPos)} must always be called to ensure that the event invocations are counted.
+	 *
+	 * <pre>{@code
+	 * final EventSpy<TestEvent> spy = context.eventSpy(TEST_EVENT, spyCtx -> (blockPos -> {
+	 *    if (spyCtx.invoke(blockPos)) {
+	 *       // Handle event while test is running.
+	 *    }
+	 * }));
+	 *
+	 * // Regular test code goes here
+	 * // Ensure that the event was called once
+	 *  context.addFinalTask(spy::verifyCalledOnce);}</pre>
+	 *
+	 * @param event The {@link Event} instance to spy
+	 * @param listenerFunction An {@link Function} implementation of that accepts a {@link EventSpy.Context} and returns an event listener.
+	 * @return A {@link EventSpy} instance
+	 */
+	default <T> EventSpy<T> eventSpy(Event<T> event, Function<EventSpy.Context, T> listenerFunction) {
+		throw new UnsupportedOperationException("Implemented via mixin");
+	}
+
+	default <T> EventSpy<T> eventSpy(Event<T> event, Identifier eventPhase, Function<EventSpy.Context, T> listenerFunction) {
+		throw new UnsupportedOperationException("Implemented via mixin");
+	}
+
+	/**
+	 * @return The {@link GameTestState} for the current test
+	 */
+	default GameTestState getGameTestState() {
+		throw new UnsupportedOperationException("Implemented via mixin");
+	}
+}

--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/EventSpyImpl.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/EventSpyImpl.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.gametest;
+
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import net.minecraft.test.GameTestException;
+import net.minecraft.test.TestContext;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.Vec3d;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.gametest.v1.EventSpy;
+
+public final class EventSpyImpl<T> implements EventSpy<T> {
+	private final TestContext testContext;
+	private final AtomicInteger invocationCount = new AtomicInteger();
+
+	public EventSpyImpl(Event<T> event, Identifier eventPhase, Function<EventSpy.Context, T> listenerFunction, TestContext testContext) {
+		this.testContext = testContext;
+		event.register(eventPhase, listenerFunction.apply(new SpyContextImpl()));
+	}
+
+	public EventSpyImpl(Event<T> event, Function<EventSpy.Context, T> listenerFunction, TestContext testContext) {
+		this.testContext = testContext;
+		event.register(listenerFunction.apply(new SpyContextImpl()));
+	}
+
+	@Override
+	public void verifyCalled() {
+		final int callCount = getInvocations();
+
+		if (callCount < 1) {
+			throw new GameTestException("Expected event to be called, but was never called");
+		}
+	}
+
+	public void verifyCalledTimes(int expectedInvocations) {
+		final int actualInvocations = getInvocations();
+
+		if (actualInvocations != expectedInvocations) {
+			if (actualInvocations == 0) {
+				throw new GameTestException(String.format(Locale.ROOT, "Expected event to be called %d times, but was never called", expectedInvocations));
+			}
+
+			throw new GameTestException(String.format(Locale.ROOT, "Expected event to be called %d times, but was called %s times", expectedInvocations, actualInvocations));
+		}
+	}
+
+	@Override
+	public int getInvocations() {
+		return invocationCount.get();
+	}
+
+	private class SpyContextImpl implements EventSpy.Context {
+		@Override
+		public boolean invoke() {
+			if (testContext.getGameTestState().isCompleted()) {
+				// Test has finished
+				return false;
+			}
+
+			invocationCount.getAndIncrement();
+
+			return true;
+		}
+
+		@Override
+		public boolean invoke(BlockPos blockPos) {
+			final Box testBoundingBox = testContext.getGameTestState().getBoundingBox();
+
+			if (testBoundingBox == null || !testBoundingBox.contains(Vec3d.of(blockPos))) {
+				return false;
+			}
+
+			return invoke();
+		}
+	}
+}

--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/mixin/gametest/TestContextMixin.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/mixin/gametest/TestContextMixin.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.gametest;
+
+import java.util.function.Function;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.test.GameTestState;
+import net.minecraft.test.TestContext;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.gametest.v1.EventSpy;
+import net.fabricmc.fabric.api.gametest.v1.FabricTestContext;
+import net.fabricmc.fabric.impl.gametest.EventSpyImpl;
+
+@Mixin(TestContext.class)
+public class TestContextMixin implements FabricTestContext {
+	@Shadow
+	@Final
+	private GameTestState test;
+
+	@Override
+	public <T> EventSpy<T> eventSpy(Event<T> event, Function<EventSpy.Context, T> listenerFunction) {
+		return new EventSpyImpl<>(event, listenerFunction, (TestContext) (Object) this);
+	}
+
+	@Override
+	public <T> EventSpy<T> eventSpy(Event<T> event, Identifier eventPhase, Function<EventSpy.Context, T> listenerFunction) {
+		return new EventSpyImpl<>(event, eventPhase, listenerFunction, (TestContext) (Object) this);
+	}
+
+	@Override
+	public GameTestState getGameTestState() {
+		return test;
+	}
+}

--- a/fabric-gametest-api-v1/src/main/resources/fabric-gametest-api-v1.mixins.json
+++ b/fabric-gametest-api-v1/src/main/resources/fabric-gametest-api-v1.mixins.json
@@ -7,6 +7,7 @@
     "CommandManagerMixin",
     "MinecraftServerMixin",
     "StructureTestUtilMixin",
+    "TestContextMixin",
     "TestFunctionsMixin",
     "TestServerMixin"
   ],

--- a/fabric-gametest-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-gametest-api-v1/src/main/resources/fabric.mod.json
@@ -28,6 +28,9 @@
     "fabric-gametest-api-v1.mixins.json"
   ],
   "custom": {
-    "fabric-api:module-lifecycle": "stable"
+    "fabric-api:module-lifecycle": "stable",
+    "loom:injected_interfaces": {
+      "net/minecraft/class_4516": ["net/fabricmc/fabric/api/gametest/v1/FabricTestContext"]
+    }
   }
 }

--- a/fabric-gametest-api-v1/src/testmod/java/net/fabricmc/fabric/test/gametest/EventSpyTestSuite.java
+++ b/fabric-gametest-api-v1/src/testmod/java/net/fabricmc/fabric/test/gametest/EventSpyTestSuite.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.gametest;
+
+import java.util.function.Consumer;
+
+import net.minecraft.test.GameTest;
+import net.minecraft.test.TestContext;
+import net.minecraft.util.math.BlockPos;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.fabricmc.fabric.api.gametest.v1.EventSpy;
+import net.fabricmc.fabric.api.gametest.v1.FabricGameTest;
+
+public class EventSpyTestSuite implements FabricGameTest {
+	@GameTest(templateName = EMPTY_STRUCTURE)
+	public void eventSpyCalledOnce(TestContext context) {
+		final EventSpy<TestEvent> spy = context.eventSpy(TEST_EVENT, spyCtx -> (spyCtx::invoke));
+
+		TEST_EVENT.invoker().accept(context.getAbsolutePos(BlockPos.ORIGIN));
+
+		context.addFinalTask(spy::verifyCalledOnce);
+	}
+
+	@GameTest(templateName = EMPTY_STRUCTURE)
+	public void eventSpyCalledExactly(TestContext context) {
+		final EventSpy<TestEvent> spy = context.eventSpy(TEST_EVENT, spyCtx -> (spyCtx::invoke));
+
+		for (int i = 0; i < 10; i++) {
+			TEST_EVENT.invoker().accept(context.getAbsolutePos(BlockPos.ORIGIN));
+		}
+
+		context.addFinalTask(() -> spy.verifyCalledTimes(10));
+	}
+
+	@GameTest(templateName = EMPTY_STRUCTURE)
+	public void eventSpyCalledMultiple(TestContext context) {
+		final EventSpy<TestEvent> spy = context.eventSpy(TEST_EVENT, spyCtx -> (spyCtx::invoke));
+
+		for (int i = 0; i < 10; i++) {
+			TEST_EVENT.invoker().accept(context.getAbsolutePos(BlockPos.ORIGIN));
+		}
+
+		context.addFinalTask(spy::verifyCalled);
+	}
+
+	@GameTest(templateName = EMPTY_STRUCTURE)
+	public void eventSpyNotCalled(TestContext context) {
+		final EventSpy<TestEvent> spy = context.eventSpy(TEST_EVENT, spyCtx -> (spyCtx::invoke));
+		context.addFinalTask(spy::verifyNotCalled);
+	}
+
+	@GameTest(templateName = EMPTY_STRUCTURE)
+	public void eventSpyNotCalledOutOfBounds(TestContext context) {
+		final EventSpy<TestEvent> spy = context.eventSpy(TEST_EVENT, spyCtx -> (spyCtx::invoke));
+
+		TEST_EVENT.invoker().accept(new BlockPos(0, 512, 0));
+
+		context.addFinalTask(spy::verifyNotCalled);
+	}
+
+	private static final Event<TestEvent> TEST_EVENT = EventFactory.createArrayBacked(TestEvent.class, callbacks -> (blockPos) -> {
+		for (TestEvent callback : callbacks) {
+			callback.accept(blockPos);
+		}
+	});
+
+	@FunctionalInterface
+	private interface TestEvent extends Consumer<BlockPos> {
+	}
+}

--- a/fabric-gametest-api-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-gametest-api-v1/src/testmod/resources/fabric.mod.json
@@ -7,6 +7,7 @@
   "license": "Apache-2.0",
   "entrypoints": {
     "fabric-gametest" : [
+      "net.fabricmc.fabric.test.gametest.EventSpyTestSuite",
       "net.fabricmc.fabric.test.gametest.ExampleFabricTestSuite",
       "net.fabricmc.fabric.test.gametest.ExampleTestSuite"
     ]

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/gametest/ServerBlockEntityEventsGameTest.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/gametest/ServerBlockEntityEventsGameTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.event.lifecycle.gametest;
+
+import net.minecraft.block.Blocks;
+import net.minecraft.block.entity.FurnaceBlockEntity;
+import net.minecraft.test.GameTest;
+import net.minecraft.test.GameTestException;
+import net.minecraft.test.TestContext;
+import net.minecraft.util.math.BlockPos;
+
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerBlockEntityEvents;
+import net.fabricmc.fabric.api.gametest.v1.EventSpy;
+import net.fabricmc.fabric.api.gametest.v1.FabricGameTest;
+import net.fabricmc.fabric.api.gametest.v1.FabricTestContext;
+
+public class ServerBlockEntityEventsGameTest implements FabricGameTest {
+	@GameTest(templateName = EMPTY_STRUCTURE)
+	public void loadBlockEntity(TestContext context) {
+		// Cast not needed in a normal mod due to interface injection
+		final FabricTestContext ctx = (FabricTestContext) context;
+
+		EventSpy<ServerBlockEntityEvents.Load> spy = ctx.eventSpy(ServerBlockEntityEvents.BLOCK_ENTITY_LOAD, spyCtx -> (blockEntity, world) -> {
+			// Call invoke to increment the call count
+			// Returns true when this test is running, false once this test has completed
+			// Passing a blockpos to ensure that we only count events triggered from within the test structure
+			if (spyCtx.invoke(blockEntity.getPos())) {
+				// Test is running can expect inputs
+				if (!(blockEntity instanceof FurnaceBlockEntity)) {
+					throw new GameTestException("Expected FurnaceBlockEntity but got %s".formatted(blockEntity.getClass().getName()));
+				}
+			}
+		});
+
+		context.setBlockState(BlockPos.ORIGIN.up(), Blocks.FURNACE);
+
+		context.addFinalTask(() -> {
+			// Verify that the event was called once while the test is running.
+			spy.verifyCalledTimes(1);
+		});
+	}
+}

--- a/fabric-lifecycle-events-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-lifecycle-events-v1/src/testmod/resources/fabric.mod.json
@@ -22,6 +22,9 @@
       "net.fabricmc.fabric.test.event.lifecycle.client.ClientEntityLifecycleTests",
       "net.fabricmc.fabric.test.event.lifecycle.client.ClientLifecycleTests",
       "net.fabricmc.fabric.test.event.lifecycle.client.ClientTickTests"
+    ],
+    "fabric-gametest" : [
+      "net.fabricmc.fabric.test.event.lifecycle.gametest.ServerBlockEntityEventsGameTest"
     ]
   }
 }


### PR DESCRIPTION
Adds the following API to ease testing events within a game test:

```java
public class ServerBlockEntityEventsGameTest implements FabricGameTest {
	@GameTest(templateName = EMPTY_STRUCTURE)
	public void loadBlockEntity(TestContext context) {
		var spy = context.eventSpy(ServerBlockEntityEvents.BLOCK_ENTITY_LOAD, spyCtx -> (blockEntity, world) -> {
			// Call invoke to increment the call count
			// Returns true when this test is running, false once this test has completed
			// Passing a blockpos to ensure that we only count events triggered from within the test structure
			if (spyCtx.invoke(blockEntity.getPos())) {
				// Test is running can expect inputs
				if (!(blockEntity instanceof FurnaceBlockEntity)) {
					throw new GameTestException("Expected FurnaceBlockEntity but got %s".formatted(blockEntity.getClass().getName()));
				}
			}
		});

		context.setBlockState(BlockPos.ORIGIN.up(), Blocks.FURNACE);

		context.addFinalTask(() -> {
			// Verify that the event was called once while the test is running.
			spy.verifyCalledOnce();
		});
	}
}
```

`FabricTestContext` is interface injected onto `TestContext` adding two new apis: `eventSpy` and `getGameTestState`.

I am a little unsure if this in scope or not, If we add a client testing module I think it may become more useful, maybe hold off until that happens? Let me know what you think.

This does create a new event listener for each test, technically leaking, it could possibly be reworked to have a static instance of `EventSpy` that can be reused between tests? 🤔 

Another option would be to keep this internal to fabric API (similar to the existing client tests) as I expect it might be seldom used by other mods?