### PR TITLE
Indigo and Renderer API fixes related to fallback consumers

### DIFF
--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/FabricBakedModel.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/FabricBakedModel.java
@@ -36,6 +36,8 @@ import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
  * Can also be used to generate or customize outputs based on world state instead of
  * or in addition to block state when render chunks are rebuilt.
  *
+ * <p>Implementors should have a look at {@link ModelHelper} as it contains many useful functions.
+ *
  * <p>Note for {@link Renderer} implementors: Fabric causes BakedModel to extend this
  * interface with {@link #isVanillaAdapter()} == true and to produce standard vertex data.
  * This means any BakedModel instance can be safely cast to this interface without an instanceof check.

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/FabricBakedModel.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/FabricBakedModel.java
@@ -82,7 +82,7 @@ public interface FabricBakedModel {
 	 * parameter is normally initialized with the same seed prior to each face layer.
 	 * Model authors should note this method is called only once per block, and call the provided
 	 * Random supplier multiple times if re-seeding is necessary. For wrapped vanilla baked models,
-	 * it will probably be easier to use {@link RenderContext#fallbackConsumer} which handles
+	 * it will probably be easier to use {@link RenderContext#bakedModelConsumer()} which handles
 	 * re-seeding per face automatically.
 	 *
 	 * @param blockView Access to world state. Cast to {@code RenderAttachedBlockView} to

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/RenderContext.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/RenderContext.java
@@ -47,7 +47,7 @@ public interface RenderContext {
 	 * via this interface. Can also be used by compound models that contain a mix
 	 * of vanilla baked models, packaged quads and/or dynamic elements.
 	 *
-	 * <p>For block contexts, this will use the block state of the block being rendered to get the quads.
+	 * <p>For block contexts, this will pass the block state being rendered to {@link BakedModel#getQuads}.
 	 * For item contexts, this will pass a {@code null} block state to {@link BakedModel#getQuads}.
 	 * {@link #blockFallbackConsumer()} can be used instead to pass the block state explicitly.
 	 */

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/RenderContext.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/RenderContext.java
@@ -16,8 +16,12 @@
 
 package net.fabricmc.fabric.api.renderer.v1.render;
 
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.block.BlockState;
 import net.minecraft.client.render.model.BakedModel;
 
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
@@ -42,8 +46,32 @@ public interface RenderContext {
 	 * Fabric causes vanilla baked models to send themselves
 	 * via this interface. Can also be used by compound models that contain a mix
 	 * of vanilla baked models, packaged quads and/or dynamic elements.
+	 *
+	 * <p>For block contexts, this will use the block state of the block being rendered to get the quads.
+	 * For item contexts, this will pass a {@code null} block state to {@link BakedModel#getQuads}.
+	 * {@link #blockFallbackConsumer()} can be used instead to pass the block state explicitly.
 	 */
 	Consumer<BakedModel> fallbackConsumer();
+
+	/**
+	 * Fallback consumer that can process a vanilla {@link BakedModel}.
+	 * Fabric causes vanilla baked models to send themselves
+	 * via this interface. Can also be used by compound models that contain a mix
+	 * of vanilla baked models, packaged quads and/or dynamic elements.
+	 *
+	 * <p>This overload allows passing the block state (or {@code null} to query the item quads).
+	 * This is useful when a model is being wrapped, and expects a different
+	 * block state than the one of the block being rendered.
+	 *
+	 * <p>For item render contexts, you can use this function if you want to render the model with a specific block state.
+	 * Otherwise, use {@link #fallbackConsumer()} to render the usual item quads.
+	 */
+	default BiConsumer<BakedModel, @Nullable BlockState> blockFallbackConsumer() {
+		// Default implementation is provided for compat with older renderer implementations,
+		// but they should always override this function.
+		Consumer<BakedModel> fallback = fallbackConsumer();
+		return (model, state) -> fallback.accept(model);
+	}
 
 	/**
 	 * Returns a {@link QuadEmitter} instance that emits directly to the render buffer.

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/BakedModelMixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/BakedModelMixin.java
@@ -47,6 +47,6 @@ public interface BakedModelMixin extends FabricBakedModel {
 
 	@Override
 	default void emitItemQuads(ItemStack stack, Supplier<Random> randomSupplier, RenderContext context) {
-		context.fallbackConsumer().accept((BakedModel) this);
+		context.blockFallbackConsumer().accept((BakedModel) this, null); // Pass null to enforce item quads in block render contexts
 	}
 }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/BakedModelMixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/BakedModelMixin.java
@@ -42,11 +42,12 @@ public interface BakedModelMixin extends FabricBakedModel {
 
 	@Override
 	default void emitBlockQuads(BlockRenderView blockView, BlockState state, BlockPos pos, Supplier<Random> randomSupplier, RenderContext context) {
-		context.blockFallbackConsumer().accept((BakedModel) this, state);
+		context.bakedModelConsumer().accept((BakedModel) this, state);
 	}
 
 	@Override
 	default void emitItemQuads(ItemStack stack, Supplier<Random> randomSupplier, RenderContext context) {
-		context.blockFallbackConsumer().accept((BakedModel) this, null); // Pass null to enforce item quads in block render contexts
+		// Pass null state to enforce item quads in block render contexts
+		context.bakedModelConsumer().accept((BakedModel) this, null);
 	}
 }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/BakedModelMixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/BakedModelMixin.java
@@ -42,7 +42,7 @@ public interface BakedModelMixin extends FabricBakedModel {
 
 	@Override
 	default void emitBlockQuads(BlockRenderView blockView, BlockState state, BlockPos pos, Supplier<Random> randomSupplier, RenderContext context) {
-		context.fallbackConsumer().accept((BakedModel) this);
+		context.blockFallbackConsumer().accept((BakedModel) this, state);
 	}
 
 	@Override

--- a/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/client/FrameBakedModel.java
+++ b/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/client/FrameBakedModel.java
@@ -152,7 +152,7 @@ final class FrameBakedModel implements BakedModel, FabricBakedModel {
 		});
 
 		// Emit the inner block model
-		context.fallbackConsumer().accept(MinecraftClient.getInstance().getBlockRenderManager().getModel(data.getDefaultState()));
+		((FabricBakedModel) MinecraftClient.getInstance().getBlockRenderManager().getModel(data.getDefaultState())).emitBlockQuads(blockView, data.getDefaultState(), pos, randomSupplier, context);
 
 		// Let's not forget to pop the transform!
 		context.popTransform();

--- a/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/client/FrameBakedModel.java
+++ b/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/client/FrameBakedModel.java
@@ -148,7 +148,7 @@ final class FrameBakedModel implements BakedModel, FabricBakedModel {
 			// Need to use the fallback consumer directly:
 			// - we can't use emitBlockQuads because we don't have a blockView
 			// - we can't use emitItemQuads because multipart models don't have item quads
-			context.blockFallbackConsumer().accept(MinecraftClient.getInstance().getBlockRenderManager().getModel(innerState), innerState);
+			context.bakedModelConsumer().accept(MinecraftClient.getInstance().getBlockRenderManager().getModel(innerState), innerState);
 		});
 	}
 

--- a/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/client/FrameModelResourceProvider.java
+++ b/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/client/FrameModelResourceProvider.java
@@ -16,6 +16,9 @@
 
 package net.fabricmc.fabric.test.renderer.simple.client;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.client.render.model.UnbakedModel;
@@ -28,12 +31,12 @@ import net.fabricmc.fabric.api.client.model.ModelResourceProvider;
  * Provides the unbaked model for use with the frame block.
  */
 final class FrameModelResourceProvider implements ModelResourceProvider {
-	private static final Identifier FRAME_MODEL_ID = new Identifier("fabric-renderer-api-v1-testmod", "block/frame");
+	static final Set<Identifier> FRAME_MODELS = new HashSet<>();
 
 	@Nullable
 	@Override
 	public UnbakedModel loadModelResource(Identifier resourceId, ModelProviderContext context) {
-		if (resourceId.equals(FRAME_MODEL_ID)) {
+		if (FRAME_MODELS.contains(resourceId)) {
 			return new FrameUnbakedModel();
 		}
 

--- a/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/client/RendererClientTest.java
+++ b/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/client/RendererClientTest.java
@@ -16,7 +16,10 @@
 
 package net.fabricmc.fabric.test.renderer.simple.client;
 
+import static net.fabricmc.fabric.test.renderer.simple.RendererTest.id;
+
 import net.minecraft.client.render.RenderLayer;
+import net.minecraft.registry.Registries;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
@@ -31,7 +34,15 @@ public final class RendererClientTest implements ClientModInitializer {
 		ModelLoadingRegistry.INSTANCE.registerVariantProvider(manager -> new PillarModelVariantProvider());
 
 		for (FrameBlock frameBlock : RendererTest.FRAMES) {
+			// We don't specify a material for the frame mesh,
+			// so it will use the default material, i.e. the one from BlockRenderLayerMap.
 			BlockRenderLayerMap.INSTANCE.putBlock(frameBlock, RenderLayer.getCutoutMipped());
+			BlockRenderLayerMap.INSTANCE.putItem(frameBlock.asItem(), RenderLayer.getCutoutMipped());
+
+			String itemPath = Registries.ITEM.getId(frameBlock.asItem()).getPath();
+			FrameModelResourceProvider.FRAME_MODELS.add(id("item/" + itemPath));
 		}
+
+		FrameModelResourceProvider.FRAME_MODELS.add(id("block/frame"));
 	}
 }

--- a/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/client/RendererClientTest.java
+++ b/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/client/RendererClientTest.java
@@ -37,7 +37,6 @@ public final class RendererClientTest implements ClientModInitializer {
 			// We don't specify a material for the frame mesh,
 			// so it will use the default material, i.e. the one from BlockRenderLayerMap.
 			BlockRenderLayerMap.INSTANCE.putBlock(frameBlock, RenderLayer.getCutoutMipped());
-			BlockRenderLayerMap.INSTANCE.putItem(frameBlock.asItem(), RenderLayer.getCutoutMipped());
 
 			String itemPath = Registries.ITEM.getId(frameBlock.asItem()).getPath();
 			FrameModelResourceProvider.FRAME_MODELS.add(id("item/" + itemPath));

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AbstractMeshConsumer.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AbstractMeshConsumer.java
@@ -26,7 +26,6 @@ import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext.QuadTransform;
 import net.fabricmc.fabric.impl.client.indigo.renderer.IndigoRenderer;
-import net.fabricmc.fabric.impl.client.indigo.renderer.RenderMaterialImpl;
 import net.fabricmc.fabric.impl.client.indigo.renderer.aocalc.AoCalculator;
 import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.EncodingFormat;
 import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.MeshImpl;
@@ -55,7 +54,7 @@ public abstract class AbstractMeshConsumer extends AbstractQuadRenderer implemen
 		@Override
 		public Maker emit() {
 			computeGeometry();
-			renderQuad(this);
+			renderQuad(this, false);
 			clear();
 			return this;
 		}
@@ -74,51 +73,12 @@ public abstract class AbstractMeshConsumer extends AbstractQuadRenderer implemen
 			System.arraycopy(data, index, editorQuad.data(), 0, EncodingFormat.TOTAL_STRIDE);
 			editorQuad.load();
 			index += EncodingFormat.TOTAL_STRIDE;
-			renderQuad(editorQuad);
+			renderQuad(editorQuad, false);
 		}
 	}
 
 	public QuadEmitter getEmitter() {
 		editorQuad.clear();
 		return editorQuad;
-	}
-
-	private void renderQuad(MutableQuadViewImpl quad) {
-		if (!transform.transform(quad)) {
-			return;
-		}
-
-		if (!blockInfo.shouldDrawFace(quad.cullFace())) {
-			return;
-		}
-
-		tessellateQuad(quad, 0);
-	}
-
-	/**
-	 * Determines color index and render layer, then routes to appropriate
-	 * tessellate routine based on material properties.
-	 */
-	private void tessellateQuad(MutableQuadViewImpl quad, int textureIndex) {
-		final RenderMaterialImpl.Value mat = quad.material();
-		final int colorIndex = mat.disableColorIndex(textureIndex) ? -1 : quad.colorIndex();
-		final RenderLayer renderLayer = blockInfo.effectiveRenderLayer(mat.blendMode(textureIndex));
-
-		if (blockInfo.defaultAo && !mat.disableAo(textureIndex)) {
-			// needs to happen before offsets are applied
-			aoCalc.compute(quad, false);
-
-			if (mat.emissive(textureIndex)) {
-				tessellateSmoothEmissive(quad, renderLayer, colorIndex);
-			} else {
-				tessellateSmooth(quad, renderLayer, colorIndex);
-			}
-		} else {
-			if (mat.emissive(textureIndex)) {
-				tessellateFlatEmissive(quad, renderLayer, colorIndex);
-			} else {
-				tessellateFlat(quad, renderLayer, colorIndex);
-			}
-		}
 	}
 }

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AbstractQuadRenderer.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AbstractQuadRenderer.java
@@ -34,6 +34,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext.QuadTransform;
+import net.fabricmc.fabric.impl.client.indigo.renderer.RenderMaterialImpl;
 import net.fabricmc.fabric.impl.client.indigo.renderer.aocalc.AoCalculator;
 import net.fabricmc.fabric.impl.client.indigo.renderer.helper.ColorHelper;
 import net.fabricmc.fabric.impl.client.indigo.renderer.helper.GeometryHelper;
@@ -61,6 +62,55 @@ public abstract class AbstractQuadRenderer {
 		this.bufferFunc = bufferFunc;
 		this.aoCalc = aoCalc;
 		this.transform = transform;
+	}
+
+	protected void renderQuad(MutableQuadViewImpl quad, boolean isVanilla) {
+		if (!transform.transform(quad)) {
+			return;
+		}
+
+		if (!blockInfo.shouldDrawFace(quad.cullFace())) {
+			return;
+		}
+
+		tessellateQuad(quad, 0, isVanilla);
+	}
+
+	/**
+	 * Determines color index and render layer, then routes to appropriate
+	 * tessellate routine based on material properties.
+	 */
+	private void tessellateQuad(MutableQuadViewImpl quad, int textureIndex, boolean isVanilla) {
+		final RenderMaterialImpl.Value mat = quad.material();
+		final int colorIndex = mat.disableColorIndex(textureIndex) ? -1 : quad.colorIndex();
+		final RenderLayer renderLayer = blockInfo.effectiveRenderLayer(mat.blendMode(textureIndex));
+
+		if (blockInfo.defaultAo && !mat.disableAo(textureIndex)) {
+			// needs to happen before offsets are applied
+			aoCalc.compute(quad, isVanilla);
+
+			if (mat.emissive(textureIndex)) {
+				tessellateSmoothEmissive(quad, renderLayer, colorIndex);
+			} else {
+				tessellateSmooth(quad, renderLayer, colorIndex);
+			}
+		} else {
+			if (isVanilla) {
+				// TODO: this is probably not needed?
+				// Recomputing whether the quad has a light face is only needed if it doesn't also have a cull face,
+				// as in those cases, the cull face will always be used to offset the light sampling position
+				if (quad.cullFace() == null) {
+					// Can't rely on lazy computation in tessellateFlat() because needs to happen before offsets are applied
+					quad.geometryFlags();
+				}
+			}
+
+			if (mat.emissive(textureIndex)) {
+				tessellateFlatEmissive(quad, renderLayer, colorIndex);
+			} else {
+				tessellateFlat(quad, renderLayer, colorIndex);
+			}
+		}
 	}
 
 	/** handles block color and red-blue swizzle, common to all renders. */

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AbstractQuadRenderer.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AbstractQuadRenderer.java
@@ -95,16 +95,6 @@ public abstract class AbstractQuadRenderer {
 				tessellateSmooth(quad, renderLayer, colorIndex);
 			}
 		} else {
-			if (isVanilla) {
-				// TODO: this is probably not needed?
-				// Recomputing whether the quad has a light face is only needed if it doesn't also have a cull face,
-				// as in those cases, the cull face will always be used to offset the light sampling position
-				if (quad.cullFace() == null) {
-					// Can't rely on lazy computation in tessellateFlat() because needs to happen before offsets are applied
-					quad.geometryFlags();
-				}
-			}
-
 			if (mat.emissive(textureIndex)) {
 				tessellateFlatEmissive(quad, renderLayer, colorIndex);
 			} else {

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/BlockRenderContext.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/BlockRenderContext.java
@@ -16,9 +16,11 @@
 
 package net.fabricmc.fabric.impl.client.indigo.renderer.render;
 
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix3f;
 import org.joml.Matrix4f;
 
@@ -143,6 +145,11 @@ public class BlockRenderContext extends AbstractRenderContext {
 
 	@Override
 	public Consumer<BakedModel> fallbackConsumer() {
+		return fallbackConsumer;
+	}
+
+	@Override
+	public BiConsumer<BakedModel, @Nullable BlockState> blockFallbackConsumer() {
 		return fallbackConsumer;
 	}
 

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/BlockRenderContext.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/BlockRenderContext.java
@@ -16,11 +16,9 @@
 
 package net.fabricmc.fabric.impl.client.indigo.renderer.render;
 
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix3f;
 import org.joml.Matrix4f;
 
@@ -144,12 +142,7 @@ public class BlockRenderContext extends AbstractRenderContext {
 	}
 
 	@Override
-	public Consumer<BakedModel> fallbackConsumer() {
-		return fallbackConsumer;
-	}
-
-	@Override
-	public BiConsumer<BakedModel, @Nullable BlockState> blockFallbackConsumer() {
+	public BakedModelConsumer bakedModelConsumer() {
 		return fallbackConsumer;
 	}
 

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
@@ -268,7 +268,7 @@ public class ItemRenderContext extends AbstractRenderContext {
 		}
 	}
 
-	private class FallbackConsumer implements Consumer<BakedModel>, BiConsumer<BakedModel, BlockState> {
+	private class FallbackConsumer implements Consumer<BakedModel>, BiConsumer<BakedModel, @Nullable BlockState> {
 		@Override
 		public void accept(BakedModel model) {
 			accept(model, null);

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
@@ -287,24 +287,14 @@ public class ItemRenderContext extends AbstractRenderContext {
 					if (count != 0) {
 						for (int j = 0; j < count; j++) {
 							final BakedQuad q = quads.get(j);
-							renderQuadWithTransform(q, cullFace);
+							editorQuad.fromVanilla(q, IndigoRenderer.MATERIAL_STANDARD, cullFace);
+							renderMeshQuad(editorQuad);
 						}
 					}
 				}
 			} else {
 				vanillaHandler.accept(model, itemStack, lightmap, overlay, matrixStack, modelVertexConsumer);
 			}
-		}
-
-		private void renderQuadWithTransform(BakedQuad quad, Direction cullFace) {
-			final Maker editorQuad = ItemRenderContext.this.editorQuad;
-			editorQuad.fromVanilla(quad, IndigoRenderer.MATERIAL_STANDARD, cullFace);
-
-			if (!transform(editorQuad)) {
-				return;
-			}
-
-			renderQuad(editorQuad, BlendMode.DEFAULT, editorQuad.colorIndex());
 		}
 	}
 

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
@@ -17,7 +17,6 @@
 package net.fabricmc.fabric.impl.client.indigo.renderer.render;
 
 import java.util.List;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -268,7 +267,7 @@ public class ItemRenderContext extends AbstractRenderContext {
 		}
 	}
 
-	private class FallbackConsumer implements Consumer<BakedModel>, BiConsumer<BakedModel, @Nullable BlockState> {
+	private class FallbackConsumer implements BakedModelConsumer {
 		@Override
 		public void accept(BakedModel model) {
 			accept(model, null);
@@ -304,12 +303,7 @@ public class ItemRenderContext extends AbstractRenderContext {
 	}
 
 	@Override
-	public Consumer<BakedModel> fallbackConsumer() {
-		return fallbackConsumer;
-	}
-
-	@Override
-	public BiConsumer<BakedModel, @Nullable BlockState> blockFallbackConsumer() {
+	public BakedModelConsumer bakedModelConsumer() {
 		return fallbackConsumer;
 	}
 

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
@@ -17,9 +17,11 @@
 package net.fabricmc.fabric.impl.client.indigo.renderer.render;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import org.jetbrains.annotations.Nullable;
 import org.joml.Vector3f;
 
 import net.minecraft.block.BlockState;
@@ -266,15 +268,20 @@ public class ItemRenderContext extends AbstractRenderContext {
 		}
 	}
 
-	private class FallbackConsumer implements Consumer<BakedModel> {
+	private class FallbackConsumer implements Consumer<BakedModel>, BiConsumer<BakedModel, BlockState> {
 		@Override
 		public void accept(BakedModel model) {
+			accept(model, null);
+		}
+
+		@Override
+		public void accept(BakedModel model, @Nullable BlockState state) {
 			if (hasTransform()) {
 				// if there's a transform in effect, convert to mesh-based quads so that we can apply it
 				for (int i = 0; i <= ModelHelper.NULL_FACE_ID; i++) {
 					final Direction cullFace = ModelHelper.faceFromIndex(i);
 					random.setSeed(ITEM_RANDOM_SEED);
-					final List<BakedQuad> quads = model.getQuads(null, cullFace, random);
+					final List<BakedQuad> quads = model.getQuads(state, cullFace, random);
 					final int count = quads.size();
 
 					if (count != 0) {
@@ -308,6 +315,11 @@ public class ItemRenderContext extends AbstractRenderContext {
 
 	@Override
 	public Consumer<BakedModel> fallbackConsumer() {
+		return fallbackConsumer;
+	}
+
+	@Override
+	public BiConsumer<BakedModel, @Nullable BlockState> blockFallbackConsumer() {
 		return fallbackConsumer;
 	}
 

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainFallbackConsumer.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainFallbackConsumer.java
@@ -102,29 +102,6 @@ public abstract class TerrainFallbackConsumer extends AbstractQuadRenderer imple
 		final MutableQuadViewImpl editorQuad = this.editorQuad;
 		editorQuad.fromVanilla(quad, defaultMaterial, cullFace);
 
-		if (!transform.transform(editorQuad)) {
-			return;
-		}
-
-		cullFace = editorQuad.cullFace();
-
-		if (cullFace != null && !blockInfo.shouldDrawFace(cullFace)) {
-			return;
-		}
-
-		if (!editorQuad.material().disableAo(0)) {
-			// needs to happen before offsets are applied
-			aoCalc.compute(editorQuad, true);
-			tessellateSmooth(editorQuad, blockInfo.defaultLayer, editorQuad.colorIndex());
-		} else {
-			// Recomputing whether the quad has a light face is only needed if it doesn't also have a cull face,
-			// as in those cases, the cull face will always be used to offset the light sampling position
-			if (cullFace == null) {
-				// Can't rely on lazy computation in tessellateFlat() because needs to happen before offsets are applied
-				editorQuad.geometryFlags();
-			}
-
-			tessellateFlat(editorQuad, blockInfo.defaultLayer, editorQuad.colorIndex());
-		}
+		renderQuad(editorQuad, true);
 	}
 }

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainFallbackConsumer.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainFallbackConsumer.java
@@ -17,8 +17,6 @@
 package net.fabricmc.fabric.impl.client.indigo.renderer.render;
 
 import java.util.List;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -34,6 +32,7 @@ import net.minecraft.util.math.random.Random;
 
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.renderer.v1.model.ModelHelper;
+import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext.QuadTransform;
 import net.fabricmc.fabric.impl.client.indigo.renderer.IndigoRenderer;
 import net.fabricmc.fabric.impl.client.indigo.renderer.RenderMaterialImpl.Value;
@@ -60,7 +59,7 @@ import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.MutableQuadViewImpl;
  *  vertex data is sent to the byte buffer.  Generally POJO array access will be faster than
  *  manipulating the data via NIO.
  */
-public abstract class TerrainFallbackConsumer extends AbstractQuadRenderer implements Consumer<BakedModel>, BiConsumer<BakedModel, @Nullable BlockState> {
+public abstract class TerrainFallbackConsumer extends AbstractQuadRenderer implements RenderContext.BakedModelConsumer {
 	private static final Value MATERIAL_FLAT = (Value) IndigoRenderer.INSTANCE.materialFinder().disableAo(0, true).find();
 	private static final Value MATERIAL_SHADED = (Value) IndigoRenderer.INSTANCE.materialFinder().find();
 

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainFallbackConsumer.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainFallbackConsumer.java
@@ -17,9 +17,12 @@
 package net.fabricmc.fabric.impl.client.indigo.renderer.render;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+
+import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.client.render.RenderLayer;
@@ -57,7 +60,7 @@ import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.MutableQuadViewImpl;
  *  vertex data is sent to the byte buffer.  Generally POJO array access will be faster than
  *  manipulating the data via NIO.
  */
-public abstract class TerrainFallbackConsumer extends AbstractQuadRenderer implements Consumer<BakedModel> {
+public abstract class TerrainFallbackConsumer extends AbstractQuadRenderer implements Consumer<BakedModel>, BiConsumer<BakedModel, @Nullable BlockState> {
 	private static final Value MATERIAL_FLAT = (Value) IndigoRenderer.INSTANCE.materialFinder().disableAo(0, true).find();
 	private static final Value MATERIAL_SHADED = (Value) IndigoRenderer.INSTANCE.materialFinder().find();
 
@@ -79,10 +82,14 @@ public abstract class TerrainFallbackConsumer extends AbstractQuadRenderer imple
 	};
 
 	@Override
-	public void accept(BakedModel model) {
+	public void accept(BakedModel bakedModel) {
+		accept(bakedModel, blockInfo.blockState);
+	}
+
+	@Override
+	public void accept(BakedModel model, @Nullable BlockState blockState) {
 		final Supplier<Random> random = blockInfo.randomSupplier;
 		final Value defaultMaterial = blockInfo.defaultAo && model.useAmbientOcclusion() ? MATERIAL_SHADED : MATERIAL_FLAT;
-		final BlockState blockState = blockInfo.blockState;
 
 		for (int i = 0; i <= ModelHelper.NULL_FACE_ID; i++) {
 			final Direction cullFace = ModelHelper.faceFromIndex(i);

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainRenderContext.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainRenderContext.java
@@ -17,10 +17,8 @@
 package net.fabricmc.fabric.impl.client.indigo.renderer.render;
 
 import java.util.Set;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix3f;
 import org.joml.Matrix4f;
 
@@ -124,12 +122,7 @@ public class TerrainRenderContext extends AbstractRenderContext {
 	}
 
 	@Override
-	public Consumer<BakedModel> fallbackConsumer() {
-		return fallbackConsumer;
-	}
-
-	@Override
-	public BiConsumer<BakedModel, @Nullable BlockState> blockFallbackConsumer() {
+	public BakedModelConsumer bakedModelConsumer() {
 		return fallbackConsumer;
 	}
 

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainRenderContext.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainRenderContext.java
@@ -17,8 +17,10 @@
 package net.fabricmc.fabric.impl.client.indigo.renderer.render;
 
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
+import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix3f;
 import org.joml.Matrix4f;
 
@@ -123,6 +125,11 @@ public class TerrainRenderContext extends AbstractRenderContext {
 
 	@Override
 	public Consumer<BakedModel> fallbackConsumer() {
+		return fallbackConsumer;
+	}
+
+	@Override
+	public BiConsumer<BakedModel, @Nullable BlockState> blockFallbackConsumer() {
 		return fallbackConsumer;
 	}
 


### PR DESCRIPTION
- Fix #2639: Rewire fallback consumers a bit so they go through the same logic as the other ways to emit a mesh.
- Fix #1871: Allow passing the block state explicitly to the fallback consumer by adding a `bakedModelConsumer`.
- Expand testmod to test these behaviors.