### PR TITLE
Allow passing the block state explicitly to the fallback consumer. Fixes #1871

### DIFF
--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/RenderContext.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/RenderContext.java
@@ -16,8 +16,10 @@
 
 package net.fabricmc.fabric.api.renderer.v1.render;
 
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
+import net.minecraft.block.BlockState;
 import net.minecraft.client.render.model.BakedModel;
 
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
@@ -42,8 +44,31 @@ public interface RenderContext {
 	 * Fabric causes vanilla baked models to send themselves
 	 * via this interface. Can also be used by compound models that contain a mix
 	 * of vanilla baked models, packaged quads and/or dynamic elements.
+	 *
+	 * <p>For block models, this will use the block state of the block being rendered to get the quads.
+	 * {@link #blockFallbackConsumer()} can be used instead to pass the block state explicitly.
 	 */
 	Consumer<BakedModel> fallbackConsumer();
+
+	/**
+	 * Fallback consumer that can process a vanilla {@link BakedModel}.
+	 * Fabric causes vanilla baked models to send themselves
+	 * via this interface. Can also be used by compound models that contain a mix
+	 * of vanilla baked models, packaged quads and/or dynamic elements.
+	 *
+	 * <p>This overload allows passing the block state.
+	 * This is useful when a model is being wrapped, and expects a different
+	 * block state than the one of the block being rendered.
+	 *
+	 * <p>For item render contexts, you can use this function if you want to render the model with a specific block state.
+	 * Otherwise, use {@link #fallbackConsumer()} to render the usual item quads.
+	 */
+	default BiConsumer<BakedModel, BlockState> blockFallbackConsumer() {
+		// Default implementation is provided for compat with older renderer implementations,
+		// but they should always override this function.
+		Consumer<BakedModel> fallback = fallbackConsumer();
+		return (model, state) -> fallback.accept(model);
+	}
 
 	/**
 	 * Returns a {@link QuadEmitter} instance that emits directly to the render buffer.

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/BakedModelMixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/BakedModelMixin.java
@@ -42,7 +42,7 @@ public interface BakedModelMixin extends FabricBakedModel {
 
 	@Override
 	default void emitBlockQuads(BlockRenderView blockView, BlockState state, BlockPos pos, Supplier<Random> randomSupplier, RenderContext context) {
-		context.fallbackConsumer().accept((BakedModel) this);
+		context.blockFallbackConsumer().accept((BakedModel) this, state);
 	}
 
 	@Override

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/BlockRenderContext.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/BlockRenderContext.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.impl.client.indigo.renderer.render;
 
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -143,6 +144,11 @@ public class BlockRenderContext extends AbstractRenderContext {
 
 	@Override
 	public Consumer<BakedModel> fallbackConsumer() {
+		return fallbackConsumer;
+	}
+
+	@Override
+	public BiConsumer<BakedModel, BlockState> blockFallbackConsumer() {
 		return fallbackConsumer;
 	}
 

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
@@ -17,9 +17,11 @@
 package net.fabricmc.fabric.impl.client.indigo.renderer.render;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import org.jetbrains.annotations.Nullable;
 import org.joml.Vector3f;
 
 import net.minecraft.block.BlockState;
@@ -266,15 +268,20 @@ public class ItemRenderContext extends AbstractRenderContext {
 		}
 	}
 
-	private class FallbackConsumer implements Consumer<BakedModel> {
+	private class FallbackConsumer implements Consumer<BakedModel>, BiConsumer<BakedModel, BlockState> {
 		@Override
 		public void accept(BakedModel model) {
+			accept(model, null);
+		}
+
+		@Override
+		public void accept(BakedModel model, @Nullable BlockState state) {
 			if (hasTransform()) {
 				// if there's a transform in effect, convert to mesh-based quads so that we can apply it
 				for (int i = 0; i <= ModelHelper.NULL_FACE_ID; i++) {
 					final Direction cullFace = ModelHelper.faceFromIndex(i);
 					random.setSeed(ITEM_RANDOM_SEED);
-					final List<BakedQuad> quads = model.getQuads(null, cullFace, random);
+					final List<BakedQuad> quads = model.getQuads(state, cullFace, random);
 					final int count = quads.size();
 
 					if (count != 0) {

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainFallbackConsumer.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainFallbackConsumer.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.impl.client.indigo.renderer.render;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -57,7 +58,7 @@ import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.MutableQuadViewImpl;
  *  vertex data is sent to the byte buffer.  Generally POJO array access will be faster than
  *  manipulating the data via NIO.
  */
-public abstract class TerrainFallbackConsumer extends AbstractQuadRenderer implements Consumer<BakedModel> {
+public abstract class TerrainFallbackConsumer extends AbstractQuadRenderer implements Consumer<BakedModel>, BiConsumer<BakedModel, BlockState> {
 	private static final Value MATERIAL_FLAT = (Value) IndigoRenderer.INSTANCE.materialFinder().disableAo(0, true).find();
 	private static final Value MATERIAL_SHADED = (Value) IndigoRenderer.INSTANCE.materialFinder().find();
 
@@ -79,10 +80,14 @@ public abstract class TerrainFallbackConsumer extends AbstractQuadRenderer imple
 	};
 
 	@Override
-	public void accept(BakedModel model) {
+	public void accept(BakedModel bakedModel) {
+		accept(bakedModel, blockInfo.blockState);
+	}
+
+	@Override
+	public void accept(BakedModel model, BlockState blockState) {
 		final Supplier<Random> random = blockInfo.randomSupplier;
 		final Value defaultMaterial = blockInfo.defaultAo && model.useAmbientOcclusion() ? MATERIAL_SHADED : MATERIAL_FLAT;
-		final BlockState blockState = blockInfo.blockState;
 
 		for (int i = 0; i <= ModelHelper.NULL_FACE_ID; i++) {
 			final Direction cullFace = ModelHelper.faceFromIndex(i);

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainRenderContext.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainRenderContext.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.impl.client.indigo.renderer.render;
 
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import org.joml.Matrix3f;
@@ -123,6 +124,11 @@ public class TerrainRenderContext extends AbstractRenderContext {
 
 	@Override
 	public Consumer<BakedModel> fallbackConsumer() {
+		return fallbackConsumer;
+	}
+
+	@Override
+	public BiConsumer<BakedModel, BlockState> blockFallbackConsumer() {
 		return fallbackConsumer;
 	}
 


### PR DESCRIPTION
Issue reproduced and fixed using the testmod from #2775.

The fix is rather straightforward: we need to pass the `BlockState` explicitly. There is a new API addition, but it is backwards-compatible.
