### PR TITLE
Block Entity Lifecycle fixes

### DIFF
--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientBlockEntityEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientBlockEntityEvents.java
@@ -31,6 +31,7 @@ public final class ClientBlockEntityEvents {
 	 * Called when a BlockEntity is loaded into a ClientWorld.
 	 *
 	 * <p>When this event is called, the block entity is already in the world.
+	 * However, its data might not be loaded yet, so don't rely on it.
 	 */
 	public static final Event<ClientBlockEntityEvents.Load> BLOCK_ENTITY_LOAD = EventFactory.createArrayBacked(ClientBlockEntityEvents.Load.class, callbacks -> (blockEntity, world) -> {
 		if (EventFactory.isProfilingEnabled()) {

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/ClientChunkManagerMixin.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/ClientChunkManagerMixin.java
@@ -55,8 +55,22 @@ public abstract class ClientChunkManagerMixin {
 		}
 	}
 
-	@Inject(method = "unload", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/world/ClientChunkManager$ClientChunkMap;compareAndSet(ILnet/minecraft/world/chunk/WorldChunk;Lnet/minecraft/world/chunk/WorldChunk;)Lnet/minecraft/world/chunk/WorldChunk;", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILEXCEPTION)
+	@Inject(method = "unload", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/world/ClientChunkManager$ClientChunkMap;compareAndSet(ILnet/minecraft/world/chunk/WorldChunk;Lnet/minecraft/world/chunk/WorldChunk;)Lnet/minecraft/world/chunk/WorldChunk;"), locals = LocalCapture.CAPTURE_FAILEXCEPTION)
 	private void onChunkUnload(int chunkX, int chunkZ, CallbackInfo ci, int i, WorldChunk chunk) {
 		ClientChunkEvents.CHUNK_UNLOAD.invoker().onChunkUnload(this.world, chunk);
+	}
+
+	@Inject(
+			method = "updateLoadDistance",
+			at = @At(
+					value = "INVOKE",
+					target = "net/minecraft/client/world/ClientChunkManager$ClientChunkMap.isInRadius(II)Z"
+			),
+			locals = LocalCapture.CAPTURE_FAILHARD
+	)
+	private void onUpdateLoadDistance(int loadDistance, CallbackInfo ci, int oldRadius, int newRadius, ClientChunkManager.ClientChunkMap clientChunkMap, int k, WorldChunk oldChunk, ChunkPos chunkPos) {
+		if (!clientChunkMap.isInRadius(chunkPos.x, chunkPos.z)) {
+			ClientChunkEvents.CHUNK_UNLOAD.invoker().onChunkUnload(this.world, oldChunk);
+		}
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerBlockEntityEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerBlockEntityEvents.java
@@ -31,6 +31,7 @@ public final class ServerBlockEntityEvents {
 	 * Called when an BlockEntity is loaded into a ServerWorld.
 	 *
 	 * <p>When this is event is called, the block entity is already in the world.
+	 * However, its data might not be loaded yet, so don't rely on it.
 	 */
 	public static final Event<ServerBlockEntityEvents.Load> BLOCK_ENTITY_LOAD = EventFactory.createArrayBacked(ServerBlockEntityEvents.Load.class, callbacks -> (blockEntity, world) -> {
 		if (EventFactory.isProfilingEnabled()) {

--- a/fabric-lifecycle-events-v1/src/main/resources/fabric-lifecycle-events-v1.accesswidener
+++ b/fabric-lifecycle-events-v1/src/main/resources/fabric-lifecycle-events-v1.accesswidener
@@ -1,3 +1,5 @@
 accessWidener	v2	named
 
 accessible    class    net/minecraft/server/MinecraftServer$ResourceManagerHolder
+accessible    class    net/minecraft/client/world/ClientChunkManager$ClientChunkMap
+accessible    method    net/minecraft/client/world/ClientChunkManager$ClientChunkMap    isInRadius    (II)Z


### PR DESCRIPTION
- Fire client chunk unload event when the load distance is decreased. Fixes #1821.
- Fire client chunk unload event before entities are cleared from the chunk to fix block entity unload event not firing. Clarify that block entity data is unreliable in the block entity load events. Fixes #2423.