### PR TITLE
Autogenerate Item constructor TAWs

### DIFF
--- a/fabric-transitive-access-wideners-v1/build.gradle
+++ b/fabric-transitive-access-wideners-v1/build.gradle
@@ -37,6 +37,8 @@ task generateAccessWidener {
 		try (def fs = FileSystems.newFileSystem(URI.create("jar:${commonJar.toUri()}"), [create: false])) {
 			generateBlockConstructors(lines, fs)
 			lines.add("")
+			generateItemConstructors(lines, fs)
+			lines.add("")
 		}
 
 		Path clientJar = loom.namedMinecraftProvider.parentMinecraftProvider.clientOnlyJar
@@ -58,7 +60,7 @@ def generateBlockConstructors(List<String> lines, FileSystem fs) {
 		.filter { (it.access & Opcodes.ACC_ABSTRACT) == 0 }
 		.forEach { node ->
 			for (def method : node.methods) {
-				// Checklist for finding block constructors as of 1.18.2:
+				// Checklist for finding block constructors as of 1.19.3:
 				//  - class directly in net.minecraft.block (excluding subpackages)
 				//  - method name == <init> (by definition)
 				//  - contains an AbstractBlock$Settings parameter
@@ -73,6 +75,32 @@ def generateBlockConstructors(List<String> lines, FileSystem fs) {
 				}
 			}
 		}
+}
+
+def generateItemConstructors(List<String> lines, FileSystem fs) {
+	lines.add("# Constructors of non-abstract item classes")
+	Files.list(fs.getPath("net/minecraft/item"))
+			.filter { Files.isRegularFile(it) && it.toString().endsWith(".class") }
+			.map { loadClass(it) }
+			.sorted(Comparator.comparing { it.name })
+			.filter { (it.access & Opcodes.ACC_ABSTRACT) == 0 }
+			.forEach { node ->
+				for (def method : node.methods) {
+					// Checklist for finding item constructors as of 1.19.3:
+					//  - class directly in net.minecraft.item (excluding subpackages)
+					//  - method name == <init> (by definition)
+					//  - contains an Item$Settings parameter
+					//  - only taking into account non-abstract classes and non-public constructors
+
+					// Item constructor...
+					if (method.name == "<init>" && Type.getArgumentTypes(method.desc).any { it.internalName == 'net/minecraft/item/Item$Settings' }) {
+						// ...and non-public
+						if ((method.access & Opcodes.ACC_PUBLIC) == 0) {
+							lines.add("transitive-accessible method $node.name <init> $method.desc")
+						}
+					}
+				}
+			}
 }
 
 def generateRenderPhaseFields(List<String> lines, FileSystem fs) {

--- a/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.accesswidener
+++ b/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.accesswidener
@@ -57,11 +57,6 @@ transitive-accessible method net/minecraft/block/Material$Builder burnable ()Lne
 transitive-accessible method net/minecraft/block/Material$Builder destroyedByPiston ()Lnet/minecraft/block/Material$Builder;
 transitive-accessible method net/minecraft/block/Material$Builder blocksPistons ()Lnet/minecraft/block/Material$Builder;
 
-# Item constructors
-transitive-accessible method net/minecraft/item/AxeItem <init> (Lnet/minecraft/item/ToolMaterial;FFLnet/minecraft/item/Item$Settings;)V
-transitive-accessible method net/minecraft/item/MusicDiscItem <init> (ILnet/minecraft/sound/SoundEvent;Lnet/minecraft/item/Item$Settings;I)V
-transitive-accessible method net/minecraft/item/PickaxeItem <init> (Lnet/minecraft/item/ToolMaterial;IFLnet/minecraft/item/Item$Settings;)V
-
 # Item usage context constructors
 transitive-accessible method net/minecraft/item/ItemUsageContext <init> (Lnet/minecraft/world/World;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/item/ItemStack;Lnet/minecraft/util/hit/BlockHitResult;)V
 transitive-accessible method net/minecraft/item/ItemPlacementContext <init> (Lnet/minecraft/world/World;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/item/ItemStack;Lnet/minecraft/util/hit/BlockHitResult;)V
@@ -230,6 +225,13 @@ transitive-accessible method net/minecraft/block/WallWitherSkullBlock <init> (Ln
 transitive-accessible method net/minecraft/block/WeightedPressurePlateBlock <init> (ILnet/minecraft/block/AbstractBlock$Settings;Lnet/minecraft/sound/SoundEvent;Lnet/minecraft/sound/SoundEvent;)V
 transitive-accessible method net/minecraft/block/WetSpongeBlock <init> (Lnet/minecraft/block/AbstractBlock$Settings;)V
 transitive-accessible method net/minecraft/block/WitherSkullBlock <init> (Lnet/minecraft/block/AbstractBlock$Settings;)V
+
+# Constructors of non-abstract item classes
+transitive-accessible method net/minecraft/item/AxeItem <init> (Lnet/minecraft/item/ToolMaterial;FFLnet/minecraft/item/Item$Settings;)V
+transitive-accessible method net/minecraft/item/HoeItem <init> (Lnet/minecraft/item/ToolMaterial;IFLnet/minecraft/item/Item$Settings;)V
+transitive-accessible method net/minecraft/item/MiningToolItem <init> (FFLnet/minecraft/item/ToolMaterial;Lnet/minecraft/registry/tag/TagKey;Lnet/minecraft/item/Item$Settings;)V
+transitive-accessible method net/minecraft/item/MusicDiscItem <init> (ILnet/minecraft/sound/SoundEvent;Lnet/minecraft/item/Item$Settings;I)V
+transitive-accessible method net/minecraft/item/PickaxeItem <init> (Lnet/minecraft/item/ToolMaterial;IFLnet/minecraft/item/Item$Settings;)V
 
 # Protected static fields of RenderPhase
 transitive-accessible field net/minecraft/client/render/RenderPhase NO_TRANSPARENCY Lnet/minecraft/client/render/RenderPhase$Transparency;

--- a/fabric-transitive-access-wideners-v1/template.accesswidener
+++ b/fabric-transitive-access-wideners-v1/template.accesswidener
@@ -52,11 +52,6 @@ transitive-accessible method net/minecraft/block/Material$Builder burnable ()Lne
 transitive-accessible method net/minecraft/block/Material$Builder destroyedByPiston ()Lnet/minecraft/block/Material$Builder;
 transitive-accessible method net/minecraft/block/Material$Builder blocksPistons ()Lnet/minecraft/block/Material$Builder;
 
-# Item constructors
-transitive-accessible method net/minecraft/item/AxeItem <init> (Lnet/minecraft/item/ToolMaterial;FFLnet/minecraft/item/Item$Settings;)V
-transitive-accessible method net/minecraft/item/MusicDiscItem <init> (ILnet/minecraft/sound/SoundEvent;Lnet/minecraft/item/Item$Settings;I)V
-transitive-accessible method net/minecraft/item/PickaxeItem <init> (Lnet/minecraft/item/ToolMaterial;IFLnet/minecraft/item/Item$Settings;)V
-
 # Item usage context constructors
 transitive-accessible method net/minecraft/item/ItemUsageContext <init> (Lnet/minecraft/world/World;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/item/ItemStack;Lnet/minecraft/util/hit/BlockHitResult;)V
 transitive-accessible method net/minecraft/item/ItemPlacementContext <init> (Lnet/minecraft/world/World;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/item/ItemStack;Lnet/minecraft/util/hit/BlockHitResult;)V


### PR DESCRIPTION
`generateAccessWidener` task in TAW module will now automatically generate TAWs for the constructors of non-abstract item classes, similar to how it already did so for blocks. As such, previously manually added item constructor TAWs have been removed from the template. This also means that `HoeItem` is now TAW'd. (I totally overlooked it earlier... whoops!)