### PR TITLE
Replace useless nullability comments with jetbrains annotation

### DIFF
--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/PlayerBlockBreakEvents.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/PlayerBlockBreakEvents.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.event.player;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -24,8 +26,6 @@ import net.minecraft.world.World;
 
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
-
-import org.jetbrains.annotations.Nullable;
 
 public final class PlayerBlockBreakEvents {
 	private PlayerBlockBreakEvents() { }

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/PlayerBlockBreakEvents.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/PlayerBlockBreakEvents.java
@@ -25,6 +25,8 @@ import net.minecraft.world.World;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
+import org.jetbrains.annotations.Nullable;
+
 public final class PlayerBlockBreakEvents {
 	private PlayerBlockBreakEvents() { }
 
@@ -90,7 +92,7 @@ public final class PlayerBlockBreakEvents {
 		 * @param blockEntity the block entity <strong>before</strong> the block is broken, can be {@code null}
 		 * @return {@code false} to cancel block breaking action, or {@code true} to pass to next listener
 		 */
-		boolean beforeBlockBreak(World world, PlayerEntity player, BlockPos pos, BlockState state, /* Nullable */ BlockEntity blockEntity);
+		boolean beforeBlockBreak(World world, PlayerEntity player, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity);
 	}
 
 	@FunctionalInterface
@@ -104,7 +106,7 @@ public final class PlayerBlockBreakEvents {
 		 * @param state the block state <strong>before</strong> the block was broken
 		 * @param blockEntity the block entity of the broken block, can be {@code null}
 		 */
-		void afterBlockBreak(World world, PlayerEntity player, BlockPos pos, BlockState state, /* Nullable */ BlockEntity blockEntity);
+		void afterBlockBreak(World world, PlayerEntity player, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity);
 	}
 
 	@FunctionalInterface
@@ -118,6 +120,6 @@ public final class PlayerBlockBreakEvents {
 		 * @param state the block state of the block that was going to be broken
 		 * @param blockEntity the block entity of the block that was going to be broken, can be {@code null}
 		 */
-		void onBlockBreakCanceled(World world, PlayerEntity player, BlockPos pos, BlockState state, /* Nullable */ BlockEntity blockEntity);
+		void onBlockBreakCanceled(World world, PlayerEntity player, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity);
 	}
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/FabricItemInternals.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/FabricItemInternals.java
@@ -18,12 +18,12 @@ package net.fabricmc.fabric.impl.item;
 
 import java.util.WeakHashMap;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.minecraft.item.Item;
 
 import net.fabricmc.fabric.api.item.v1.CustomDamageHandler;
 import net.fabricmc.fabric.api.item.v1.EquipmentSlotProvider;
-
-import org.jetbrains.annotations.Nullable;
 
 public final class FabricItemInternals {
 	private static final WeakHashMap<Item.Settings, ExtraData> extraData = new WeakHashMap<>();

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/FabricItemInternals.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/FabricItemInternals.java
@@ -45,8 +45,8 @@ public final class FabricItemInternals {
 	}
 
 	public static final class ExtraData {
-		private EquipmentSlotProvider equipmentSlotProvider;
-		private CustomDamageHandler customDamageHandler;
+		private @Nullable EquipmentSlotProvider equipmentSlotProvider;
+		private @Nullable CustomDamageHandler customDamageHandler;
 
 		public void equipmentSlot(EquipmentSlotProvider equipmentSlotProvider) {
 			this.equipmentSlotProvider = equipmentSlotProvider;

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/FabricItemInternals.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/FabricItemInternals.java
@@ -45,8 +45,8 @@ public final class FabricItemInternals {
 	}
 
 	public static final class ExtraData {
-		private @Nullable EquipmentSlotProvider equipmentSlotProvider;
-		private @Nullable CustomDamageHandler customDamageHandler;
+		private EquipmentSlotProvider equipmentSlotProvider;
+		private CustomDamageHandler customDamageHandler;
 
 		public void equipmentSlot(EquipmentSlotProvider equipmentSlotProvider) {
 			this.equipmentSlotProvider = equipmentSlotProvider;

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/FabricItemInternals.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/FabricItemInternals.java
@@ -23,6 +23,8 @@ import net.minecraft.item.Item;
 import net.fabricmc.fabric.api.item.v1.CustomDamageHandler;
 import net.fabricmc.fabric.api.item.v1.EquipmentSlotProvider;
 
+import org.jetbrains.annotations.Nullable;
+
 public final class FabricItemInternals {
 	private static final WeakHashMap<Item.Settings, ExtraData> extraData = new WeakHashMap<>();
 
@@ -43,8 +45,8 @@ public final class FabricItemInternals {
 	}
 
 	public static final class ExtraData {
-		private /* @Nullable */ EquipmentSlotProvider equipmentSlotProvider;
-		private /* @Nullable */ CustomDamageHandler customDamageHandler;
+		private @Nullable EquipmentSlotProvider equipmentSlotProvider;
+		private @Nullable CustomDamageHandler customDamageHandler;
 
 		public void equipmentSlot(EquipmentSlotProvider equipmentSlotProvider) {
 			this.equipmentSlotProvider = equipmentSlotProvider;

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/ItemExtensions.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/ItemExtensions.java
@@ -19,9 +19,11 @@ package net.fabricmc.fabric.impl.item;
 import net.fabricmc.fabric.api.item.v1.CustomDamageHandler;
 import net.fabricmc.fabric.api.item.v1.EquipmentSlotProvider;
 
+import org.jetbrains.annotations.Nullable;
+
 public interface ItemExtensions {
-	/* @Nullable */ EquipmentSlotProvider fabric_getEquipmentSlotProvider();
+	@Nullable EquipmentSlotProvider fabric_getEquipmentSlotProvider();
 	void fabric_setEquipmentSlotProvider(EquipmentSlotProvider equipmentSlotProvider);
-	/* @Nullable */ CustomDamageHandler fabric_getCustomDamageHandler();
+	@Nullable CustomDamageHandler fabric_getCustomDamageHandler();
 	void fabric_setCustomDamageHandler(CustomDamageHandler handler);
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/ItemExtensions.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/ItemExtensions.java
@@ -22,8 +22,8 @@ import net.fabricmc.fabric.api.item.v1.EquipmentSlotProvider;
 import org.jetbrains.annotations.Nullable;
 
 public interface ItemExtensions {
-	EquipmentSlotProvider fabric_getEquipmentSlotProvider();
+	@Nullable EquipmentSlotProvider fabric_getEquipmentSlotProvider();
 	void fabric_setEquipmentSlotProvider(EquipmentSlotProvider equipmentSlotProvider);
-	CustomDamageHandler fabric_getCustomDamageHandler();
+	@Nullable CustomDamageHandler fabric_getCustomDamageHandler();
 	void fabric_setCustomDamageHandler(CustomDamageHandler handler);
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/ItemExtensions.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/ItemExtensions.java
@@ -16,10 +16,10 @@
 
 package net.fabricmc.fabric.impl.item;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.fabricmc.fabric.api.item.v1.CustomDamageHandler;
 import net.fabricmc.fabric.api.item.v1.EquipmentSlotProvider;
-
-import org.jetbrains.annotations.Nullable;
 
 public interface ItemExtensions {
 	@Nullable EquipmentSlotProvider fabric_getEquipmentSlotProvider();

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/ItemExtensions.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/ItemExtensions.java
@@ -22,8 +22,8 @@ import net.fabricmc.fabric.api.item.v1.EquipmentSlotProvider;
 import org.jetbrains.annotations.Nullable;
 
 public interface ItemExtensions {
-	@Nullable EquipmentSlotProvider fabric_getEquipmentSlotProvider();
+	EquipmentSlotProvider fabric_getEquipmentSlotProvider();
 	void fabric_setEquipmentSlotProvider(EquipmentSlotProvider equipmentSlotProvider);
-	@Nullable CustomDamageHandler fabric_getCustomDamageHandler();
+	CustomDamageHandler fabric_getCustomDamageHandler();
 	void fabric_setCustomDamageHandler(CustomDamageHandler handler);
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemMixin.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.mixin.item;
 
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -33,9 +34,11 @@ import net.fabricmc.fabric.impl.item.ItemExtensions;
 @Mixin(Item.class)
 abstract class ItemMixin implements ItemExtensions, FabricItem {
 	@Unique
+	@Nullable
 	private EquipmentSlotProvider equipmentSlotProvider;
 
 	@Unique
+	@Nullable
 	private CustomDamageHandler customDamageHandler;
 
 	@Inject(method = "<init>", at = @At("RETURN"))
@@ -44,22 +47,24 @@ abstract class ItemMixin implements ItemExtensions, FabricItem {
 	}
 
 	@Override
+	@Nullable
 	public EquipmentSlotProvider fabric_getEquipmentSlotProvider() {
 		return equipmentSlotProvider;
 	}
 
 	@Override
-	public void fabric_setEquipmentSlotProvider(EquipmentSlotProvider equipmentSlotProvider) {
+	public void fabric_setEquipmentSlotProvider(@Nullable EquipmentSlotProvider equipmentSlotProvider) {
 		this.equipmentSlotProvider = equipmentSlotProvider;
 	}
 
 	@Override
+	@Nullable
 	public CustomDamageHandler fabric_getCustomDamageHandler() {
 		return customDamageHandler;
 	}
 
 	@Override
-	public void fabric_setCustomDamageHandler(CustomDamageHandler handler) {
+	public void fabric_setCustomDamageHandler(@Nullable CustomDamageHandler handler) {
 		this.customDamageHandler = handler;
 	}
 }

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/entity/FabricEntityTypeBuilder.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/entity/FabricEntityTypeBuilder.java
@@ -36,6 +36,8 @@ import net.minecraft.world.World;
 
 import net.fabricmc.fabric.impl.object.builder.FabricEntityType;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Extended version of {@link EntityType.Builder} with added registration for
  * server-&gt;client entity tracking values.
@@ -272,7 +274,7 @@ public class FabricEntityTypeBuilder<T extends Entity> {
 	 * @param <T> Entity class.
 	 */
 	public static class Living<T extends LivingEntity> extends FabricEntityTypeBuilder<T> {
-		/* @Nullable */
+		@Nullable
 		private Supplier<DefaultAttributeContainer.Builder> defaultAttributeBuilder;
 
 		protected Living(SpawnGroup spawnGroup, EntityType.EntityFactory<T> function) {

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/entity/FabricEntityTypeBuilder.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/entity/FabricEntityTypeBuilder.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 import com.google.common.collect.ImmutableSet;
+import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
@@ -35,8 +36,6 @@ import net.minecraft.world.Heightmap;
 import net.minecraft.world.World;
 
 import net.fabricmc.fabric.impl.object.builder.FabricEntityType;
-
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Extended version of {@link EntityType.Builder} with added registration for


### PR DESCRIPTION
This broke my automated tooling which relies on knowing nullability (specifically the block break events fucked it up). I very much hope you aren't planning to add more of these into the codebase because these are tremendously annoying and I assumed it was some "smart view" mode in my IDE hiding the actual annotation.