### PR TITLE
Fix selected common item groups deselecting when reopening or changing pages on creative inv screen

### DIFF
--- a/fabric-item-group-api-v1/src/client/java/net/fabricmc/fabric/mixin/itemgroup/client/CreativeInventoryScreenMixin.java
+++ b/fabric-item-group-api-v1/src/client/java/net/fabricmc/fabric/mixin/itemgroup/client/CreativeInventoryScreenMixin.java
@@ -91,10 +91,12 @@ public abstract class CreativeInventoryScreenMixin<T extends ScreenHandler> exte
 	}
 
 	private void fabric_updateSelection() {
-		ItemGroupHelper.sortedGroups.stream()
-				.filter(this::fabric_isGroupVisible)
-				.findFirst()
-				.ifPresent(this::setSelectedTab);
+		if (!fabric_isGroupVisible(selectedTab)) {
+			ItemGroupHelper.sortedGroups.stream()
+					.filter(this::fabric_isGroupVisible)
+					.findFirst()
+					.ifPresent(this::setSelectedTab);
+		}
 	}
 
 	@Inject(method = "init", at = @At("RETURN"))
@@ -137,14 +139,14 @@ public abstract class CreativeInventoryScreenMixin<T extends ScreenHandler> exte
 	}
 
 	private boolean fabric_isGroupVisible(ItemGroup itemGroup) {
-		if (FabricCreativeGuiComponents.COMMON_GROUPS.contains(itemGroup)) {
-			return true;
-		}
-
 		return fabric_currentPage == fabric_getPage(itemGroup);
 	}
 
 	private static int fabric_getPage(ItemGroup itemGroup) {
+		if (FabricCreativeGuiComponents.COMMON_GROUPS.contains(itemGroup)) {
+			return fabric_currentPage;
+		}
+
 		final FabricItemGroup fabricItemGroup = (FabricItemGroup) itemGroup;
 		return fabricItemGroup.getPage();
 	}


### PR DESCRIPTION
This fixes changing the creative inventory page or reopening the creative inventory screen resulting in the selected tab being reset to the first one on the page if the search, toolbar, or survival tab was selected.