### PR TITLE
Catch exception inside client-side JOIN event

### DIFF
--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientPlayNetworkAddon.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientPlayNetworkAddon.java
@@ -69,7 +69,7 @@ public final class ClientPlayNetworkAddon extends AbstractChanneledNetworkAddon<
 		try {
 			ClientPlayConnectionEvents.JOIN.invoker().onPlayReady(this.handler, this, this.client);
 		} catch (RuntimeException e) {
-			LOGGER.error("Exception raised while invoking ClientPlayConnectionEvents.JOIN", e);
+			LOGGER.error("Exception thrown while invoking ClientPlayConnectionEvents.JOIN", e);
 		}
 
 		// The client cannot send any packets, including `minecraft:register` until after GameJoinS2CPacket is received.

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientPlayNetworkAddon.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientPlayNetworkAddon.java
@@ -20,6 +20,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import com.mojang.logging.LogUtils;
+import org.slf4j.Logger;
+
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.network.Packet;
@@ -38,6 +41,8 @@ public final class ClientPlayNetworkAddon extends AbstractChanneledNetworkAddon<
 	private final ClientPlayNetworkHandler handler;
 	private final MinecraftClient client;
 	private boolean sentInitialRegisterPacket;
+
+	private static final Logger LOGGER = LogUtils.getLogger();
 
 	public ClientPlayNetworkAddon(ClientPlayNetworkHandler handler, MinecraftClient client) {
 		super(ClientNetworkingImpl.PLAY, handler.getConnection(), "ClientPlayNetworkAddon for " + handler.getProfile().getName());
@@ -61,7 +66,11 @@ public final class ClientPlayNetworkAddon extends AbstractChanneledNetworkAddon<
 	}
 
 	public void onServerReady() {
-		ClientPlayConnectionEvents.JOIN.invoker().onPlayReady(this.handler, this, this.client);
+		try {
+			ClientPlayConnectionEvents.JOIN.invoker().onPlayReady(this.handler, this, this.client);
+		} catch (RuntimeException e) {
+			LOGGER.error("Exception raised while invoking ClientPlayConnectionEvents.JOIN", e);
+		}
 
 		// The client cannot send any packets, including `minecraft:register` until after GameJoinS2CPacket is received.
 		this.sendInitialChannelRegistrationPacket();


### PR DESCRIPTION
See #2812
Crashes inside `ClientPlayConnectionEvents.JOIN` previously interrupted the normal join cycle without logging exceptions. This now adds the logging.

Server-side event is not in this PR; I believe it is covered by vanilla logging.

Requesting backport to 1.19.2.