### PR TITLE
Fixed blocks with vanilla loot tables making strict validation of datagen fail

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricBlockLootTableProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricBlockLootTableProvider.java
@@ -95,8 +95,12 @@ public abstract class FabricBlockLootTableProvider extends BlockLootTableGenerat
 
 			for (Identifier blockId : Registries.BLOCK.getIds()) {
 				if (blockId.getNamespace().equals(output.getModId())) {
-					if (!lootTables.containsKey(Registries.BLOCK.get(blockId).getLootTableId())) {
-						missing.add(blockId);
+					Identifier blockLootTableId = Registries.BLOCK.get(blockId).getLootTableId();
+
+					if (blockLootTableId.getNamespace().equals(output.getModId())) {
+						if (!lootTables.containsKey(blockLootTableId)) {
+							missing.add(blockId);
+						}
 					}
 				}
 			}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricBlockLootTableProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricBlockLootTableProvider.java
@@ -95,8 +95,11 @@ public abstract class FabricBlockLootTableProvider extends BlockLootTableGenerat
 
 			for (Identifier blockId : Registries.BLOCK.getIds()) {
 				if (blockId.getNamespace().equals(output.getModId())) {
-					if (!lootTables.containsKey(Registries.BLOCK.get(blockId).getLootTableId())) {
-						missing.add(blockId);
+					Identifier blockLootTableId = Registries.BLOCK.get(blockId).getLootTableId();
+					if (blockLootTableId.getNamespace().equals(output.getModId())) {
+						if (!lootTables.containsKey(blockLootTableId)) {
+							missing.add(blockId);
+						}
 					}
 				}
 			}

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestContent.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestContent.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.test.datagen;
 
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
 import net.minecraft.block.Material;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
@@ -39,6 +40,8 @@ public class DataGeneratorTestContent implements ModInitializer {
 	public static Block SIMPLE_BLOCK;
 	public static Block BLOCK_WITHOUT_ITEM;
 	public static Block BLOCK_WITHOUT_LOOT_TABLE;
+	public static Block BLOCK_WITH_VANILLA_LOOT_TABLE;
+	public static Block BLOCK_THAT_DROPS_NOTHING;
 
 	public static final ItemGroup SIMPLE_ITEM_GROUP = FabricItemGroup.builder(new Identifier(MOD_ID, "simple"))
 			.icon(() -> new ItemStack(Items.DIAMOND_PICKAXE))
@@ -47,16 +50,18 @@ public class DataGeneratorTestContent implements ModInitializer {
 
 	@Override
 	public void onInitialize() {
-		SIMPLE_BLOCK = createBlock("simple_block", true);
-		BLOCK_WITHOUT_ITEM = createBlock("block_without_item", false);
-		BLOCK_WITHOUT_LOOT_TABLE = createBlock("block_without_loot_table", false);
+		SIMPLE_BLOCK = createBlock("simple_block", true, AbstractBlock.Settings.of(Material.STONE));
+		BLOCK_WITHOUT_ITEM = createBlock("block_without_item", false, AbstractBlock.Settings.of(Material.STONE));
+		BLOCK_WITHOUT_LOOT_TABLE = createBlock("block_without_loot_table", false, AbstractBlock.Settings.of(Material.STONE));
+		BLOCK_WITH_VANILLA_LOOT_TABLE = createBlock("block_with_vanilla_loot_table", false, AbstractBlock.Settings.of(Material.STONE).dropsLike(Blocks.STONE));
+		BLOCK_THAT_DROPS_NOTHING = createBlock("block_that_drops_nothing", false, AbstractBlock.Settings.of(Material.STONE).dropsNothing());
 
 		ItemGroupEvents.modifyEntriesEvent(SIMPLE_ITEM_GROUP).register(entries -> entries.add(SIMPLE_BLOCK));
 	}
 
-	private static Block createBlock(String name, boolean hasItem) {
+	private static Block createBlock(String name, boolean hasItem, AbstractBlock.Settings settings) {
 		Identifier identifier = new Identifier(MOD_ID, name);
-		Block block = Registry.register(Registries.BLOCK, identifier, new Block(AbstractBlock.Settings.of(Material.STONE)));
+		Block block = Registry.register(Registries.BLOCK, identifier, new Block(settings));
 
 		if (hasItem) {
 			Registry.register(Registries.ITEM, identifier, new BlockItem(block, new Item.Settings()));

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
@@ -16,8 +16,10 @@
 
 package net.fabricmc.fabric.test.datagen;
 
+import static net.fabricmc.fabric.test.datagen.DataGeneratorTestContent.BLOCK_THAT_DROPS_NOTHING;
 import static net.fabricmc.fabric.test.datagen.DataGeneratorTestContent.BLOCK_WITHOUT_ITEM;
 import static net.fabricmc.fabric.test.datagen.DataGeneratorTestContent.BLOCK_WITHOUT_LOOT_TABLE;
+import static net.fabricmc.fabric.test.datagen.DataGeneratorTestContent.BLOCK_WITH_VANILLA_LOOT_TABLE;
 import static net.fabricmc.fabric.test.datagen.DataGeneratorTestContent.MOD_ID;
 import static net.fabricmc.fabric.test.datagen.DataGeneratorTestContent.SIMPLE_BLOCK;
 import static net.fabricmc.fabric.test.datagen.DataGeneratorTestContent.SIMPLE_ITEM_GROUP;
@@ -163,6 +165,8 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 			blockStateModelGenerator.registerSimpleCubeAll(SIMPLE_BLOCK);
 			blockStateModelGenerator.registerSimpleCubeAll(BLOCK_WITHOUT_ITEM);
 			blockStateModelGenerator.registerSimpleCubeAll(BLOCK_WITHOUT_LOOT_TABLE);
+			blockStateModelGenerator.registerSimpleCubeAll(BLOCK_WITH_VANILLA_LOOT_TABLE);
+			blockStateModelGenerator.registerSimpleCubeAll(BLOCK_THAT_DROPS_NOTHING);
 		}
 
 		@Override


### PR DESCRIPTION
Previously, blocks that used `.dropsLike(block)` in their block settings to use a vanilla block's loot table, or `.dropsNothing()` to use the `minecraft:empty` loot table, would cause strict validation in data generation to fail as the vanilla loot tables wouldn't be present in the mod's own block loot table generator.

This fixes that by ensuring that the block's loot table IDhas a namespace that matches the loot table generator before adding it to the missing IDs list. This is in addition to the same check being done on the block's own ID, as previous.

Two test blocks were added to the testmod, one which uses `.dropsLike(Blocks.STONE)` to use the same loot table as Stone, and one that uses `.dropsNothing()`. Previously, these would have caused strict validation to fail as the `minecraft:stone` and `minecraft:empty` loot tables aren't generated by the testmod's generator. Now they pass just fine.