### PR TITLE
Generate a test datapack from the datagen testmod output.

### DIFF
--- a/fabric-data-generation-api-v1/build.gradle
+++ b/fabric-data-generation-api-v1/build.gradle
@@ -53,7 +53,7 @@ loom {
 test.dependsOn runDatagen
 
 task datapackZip(type: Zip, dependsOn: runDatagen) {
-	archiveFileName = "${archivesBaseName}-${version}-test-datapack.zip"
+	archiveFileName = "${archivesBaseName}-${project.version}-test-datapack.zip"
 	destinationDirectory = layout.buildDirectory.dir('libs')
 
 	from file("src/testmod/generated")

--- a/fabric-data-generation-api-v1/build.gradle
+++ b/fabric-data-generation-api-v1/build.gradle
@@ -52,6 +52,16 @@ loom {
 
 test.dependsOn runDatagen
 
+task datapackZip(type: Zip, dependsOn: runDatagen) {
+	archiveFileName = "${archivesBaseName}-${version}-test-datapack.zip"
+	destinationDirectory = layout.buildDirectory.dir('libs')
+
+	from file("src/testmod/generated")
+	from file("pack.mcmeta")
+}
+
+build.dependsOn datapackZip
+
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.tree.ClassNode

--- a/fabric-data-generation-api-v1/pack.mcmeta
+++ b/fabric-data-generation-api-v1/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 10,
+    "description": "Datagen test Data Pack"
+  }
+}


### PR DESCRIPTION
Useful if you want to test the datagened output from a PR. Not published to maven, only github actions or locally.