### PR TITLE
[1.19.4] Fail hard when unable to register key bindings.

### DIFF
--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import com.google.common.collect.Lists;
 import it.unimi.dsi.fastutil.objects.ReferenceArrayList;
 
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
 
 import net.fabricmc.fabric.mixin.client.keybinding.KeyBindingAccessor;
@@ -51,6 +52,10 @@ public final class KeyBindingRegistryImpl {
 	}
 
 	public static KeyBinding registerKeyBinding(KeyBinding binding) {
+		if (MinecraftClient.getInstance().options != null) {
+			throw new IllegalStateException("GameOptions has already been initialised");
+		}
+
 		for (KeyBinding existingKeyBindings : MODDED_KEY_BINDINGS) {
 			if (existingKeyBindings == binding) {
 				throw new IllegalArgumentException("Attempted to register a key binding twice: " + binding.getTranslationKey());

--- a/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/channeltest/NetworkingChannelClientTest.java
+++ b/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/channeltest/NetworkingChannelClientTest.java
@@ -34,7 +34,7 @@ import net.fabricmc.fabric.api.client.networking.v1.C2SPlayChannelEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 
 public final class NetworkingChannelClientTest implements ClientModInitializer {
-	public static final KeyBinding OPEN = KeyBindingHelper.registerKeyBinding(new KeyBinding("networking-v1-test", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_MENU, "fabric-networking-api-v1-testmod\""));
+	public static final KeyBinding OPEN = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-networking-api-v1-testmod.open", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_MENU, "key.category.fabric-networking-api-v1-testmod"));
 	static final Set<Identifier> SUPPORTED_C2S_CHANNELS = new HashSet<>();
 
 	@Override

--- a/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/keybindreciever/NetworkingKeybindClientPacketTest.java
+++ b/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/keybindreciever/NetworkingKeybindClientPacketTest.java
@@ -33,7 +33,7 @@ import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 // The server in response will send a chat message to the client.
 @Environment(EnvType.CLIENT)
 public class NetworkingKeybindClientPacketTest implements ClientModInitializer {
-	public static final KeyBinding TEST_BINDING = KeyBindingHelper.registerKeyBinding(new KeyBinding("fabric-networking-api-v1-testmod-keybind", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_RIGHT_BRACKET, "fabric-networking-api-v1-testmod"));
+	public static final KeyBinding TEST_BINDING = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-networking-api-v1-testmod.test", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_RIGHT_BRACKET, "key.category.fabric-networking-api-v1-testmod"));
 
 	@Override
 	public void onInitializeClient() {

--- a/fabric-networking-api-v1/src/testmod/resources/assets/fabric-networking-api-v1-testmod/lang/en_us.json
+++ b/fabric-networking-api-v1/src/testmod/resources/assets/fabric-networking-api-v1-testmod/lang/en_us.json
@@ -1,0 +1,5 @@
+{
+  "key.category.fabric-networking-api-v1-testmod": "Fabric Network Test",
+  "key.fabric-networking-api-v1-testmod.test": "Send test packet",
+  "key.fabric-networking-api-v1-testmod.open": "Open channel tester"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ fabric.loom.multiProjectOptimisation=true
 version=0.73.3
 minecraft_version=23w05a
 yarn_version=+build.2
-loader_version=0.14.13
+loader_version=0.14.14
 installer_version=0.11.1
 
 prerelease=true

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,7 +19,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.14.13",
+    "fabricloader": ">=0.14.14",
     "java": ">=17",
     "minecraft": ">=1.19.4- <1.19.5-"
   },


### PR DESCRIPTION
Related to: https://github.com/FabricMC/fabric/issues/2879
Depends on: https://github.com/FabricMC/fabric-loader/pull/764