### PR TITLE
Add getters for equipment slot providers and damage handlers

### DIFF
--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/CustomDamageHandler.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/CustomDamageHandler.java
@@ -46,7 +46,7 @@ public interface CustomDamageHandler {
 	int damage(ItemStack stack, int amount, LivingEntity entity, Consumer<LivingEntity> breakCallback);
 
 	/**
-	 * {@return the custom damage handler of the specified item, or {@code null} if it doesn't have one}
+	 * {@return the custom damage handler of the specified item, or {@code null} if it doesn't have one}.
 	 *
 	 * @param item the item to query
 	 */

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/CustomDamageHandler.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/CustomDamageHandler.java
@@ -16,10 +16,16 @@
 
 package net.fabricmc.fabric.api.item.v1;
 
+import java.util.Objects;
 import java.util.function.Consumer;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+
+import net.fabricmc.fabric.impl.item.ItemExtensions;
 
 /**
  * Allows an item to run custom logic when {@link ItemStack#damage(int, LivingEntity, Consumer)} is called.
@@ -38,4 +44,14 @@ public interface CustomDamageHandler {
 	 * @return The amount of damage to pass to vanilla's logic
 	 */
 	int damage(ItemStack stack, int amount, LivingEntity entity, Consumer<LivingEntity> breakCallback);
+
+	/**
+	 * {@return the custom damage handler of the specified item, or {@code null} if it doesn't have one}
+	 *
+	 * @param item the item to query
+	 */
+	static @Nullable CustomDamageHandler get(Item item) {
+		Objects.requireNonNull(item, "Item cannot be null");
+		return ((ItemExtensions) item).fabric_getCustomDamageHandler();
+	}
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/EquipmentSlotProvider.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/EquipmentSlotProvider.java
@@ -50,7 +50,7 @@ public interface EquipmentSlotProvider {
 	EquipmentSlot getPreferredEquipmentSlot(ItemStack stack);
 
 	/**
-	 * {@return the equipment slot provider of the specified item, or {@code null} if it doesn't have one}
+	 * {@return the equipment slot provider of the specified item, or {@code null} if it doesn't have one}.
 	 *
 	 * @param item the item to query
 	 */

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/EquipmentSlotProvider.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/EquipmentSlotProvider.java
@@ -16,8 +16,15 @@
 
 package net.fabricmc.fabric.api.item.v1;
 
+import java.util.Objects;
+
+import org.jetbrains.annotations.Nullable;
+
 import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+
+import net.fabricmc.fabric.impl.item.ItemExtensions;
 
 /**
  * A provider for the preferred equipment slot of an item.
@@ -41,4 +48,14 @@ public interface EquipmentSlotProvider {
 	 * @return the preferred equipment slot
 	 */
 	EquipmentSlot getPreferredEquipmentSlot(ItemStack stack);
+
+	/**
+	 * {@return the equipment slot provider of the specified item, or {@code null} if it doesn't have one}
+	 *
+	 * @param item the item to query
+	 */
+	static @Nullable EquipmentSlotProvider get(Item item) {
+		Objects.requireNonNull(item, "Item cannot be null");
+		return ((ItemExtensions) item).fabric_getEquipmentSlotProvider();
+	}
 }

--- a/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/FabricItemSettingsTests.java
+++ b/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/FabricItemSettingsTests.java
@@ -16,20 +16,44 @@
 
 package net.fabricmc.fabric.test.item;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.item.Item;
-import net.minecraft.util.Identifier;
+import net.minecraft.item.Items;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
+import net.minecraft.util.Identifier;
 
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.item.v1.CustomDamageHandler;
+import net.fabricmc.fabric.api.item.v1.EquipmentSlotProvider;
 import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
 
 public class FabricItemSettingsTests implements ModInitializer {
+	private static final Logger LOGGER = LoggerFactory.getLogger(FabricItemSettingsTests.class);
+
 	@Override
 	public void onInitialize() {
-		// Registers an item with a custom equipment slot.
-		Item testItem = new Item(new FabricItemSettings().equipmentSlot(stack -> EquipmentSlot.CHEST));
+		EquipmentSlotProvider equipmentSlotProvider = stack -> EquipmentSlot.CHEST;
+		CustomDamageHandler damageHandler = (stack, amount, entity, breakCallback) -> amount;
+
+		// Registers an item with a custom equipment slot and a no-op custom damage handler.
+		Item testItem = new Item(new FabricItemSettings().equipmentSlot(equipmentSlotProvider).customDamage(damageHandler));
 		Registry.register(Registries.ITEM, new Identifier("fabric-item-api-v1-testmod", "test_item"), testItem);
+
+		// Test getters
+		assertIdentical(EquipmentSlotProvider.get(testItem), equipmentSlotProvider, "equipment slot provider");
+		assertIdentical(EquipmentSlotProvider.get(Items.APPLE), null, "equipment slot provider");
+		assertIdentical(CustomDamageHandler.get(testItem), damageHandler, "damage handler");
+		assertIdentical(CustomDamageHandler.get(Items.APPLE), null, "damage handler");
+		LOGGER.info("FabricItemSettings tests passed!");
+	}
+
+	private static void assertIdentical(Object found, Object expected, String message) {
+		if (found != expected) {
+			throw new AssertionError("Expected " + expected + " for " + message + ", but was " + found);
+		}
 	}
 }


### PR DESCRIPTION
Some mods need to access these and there's also no reason to "hide" them from mod devs.