### PR TITLE
Transfer API: Add slotted storage and non-empty iterator

### DIFF
--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/context/ContainerItemContext.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/context/ContainerItemContext.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
 
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
@@ -293,5 +294,6 @@ public interface ContainerItemContext {
 	 *
 	 * @return An unmodifiable list containing additional slots of this context. If no additional slot is available, the list is empty.
 	 */
+	@UnmodifiableView
 	List<SingleSlotStorage<ItemVariant>> getAdditionalSlots();
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/context/ContainerItemContext.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/context/ContainerItemContext.java
@@ -169,22 +169,26 @@ public interface ContainerItemContext {
 
 	/**
 	 * Return a context that can accept anything, and will accept (and destroy) any overflow items, with some initial content.
-	 * The context is backed by a single slot storage that can be freely mutated.
 	 * This can typically be used to check if a stack provides an API, or simulate operations on the returned API,
 	 * for example to simulate how much fluid could be extracted from the stack.
 	 *
 	 * <p>Note that the stack can never be mutated by this function: its contents are copied directly.
+	 *
+	 * @deprecated Use {@link #withConstant(ItemStack)} instead.
 	 */
+	@Deprecated(forRemoval = true)
 	static ContainerItemContext withInitial(ItemStack initialContent) {
 		return withInitial(ItemVariant.of(initialContent), initialContent.getCount());
 	}
 
 	/**
 	 * Return a context that can accept anything, and will accept (and destroy) any overflow items, with some initial variant and amount.
-	 * The context is backed by a single slot storage that can be freely mutated.
 	 * This can typically be used to check if a variant provides an API, or simulate operations on the returned API,
 	 * for example to simulate how much fluid could be extracted from the variant and amount.
+	 *
+	 * @deprecated Use {@link #withConstant(ItemVariant, long)} instead.
 	 */
+	@Deprecated(forRemoval = true)
 	static ContainerItemContext withInitial(ItemVariant initialVariant, long initialAmount) {
 		StoragePreconditions.notNegative(initialAmount);
 		return new InitialContentsContainerItemContext(initialVariant, initialAmount);

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/context/ContainerItemContext.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/context/ContainerItemContext.java
@@ -169,26 +169,22 @@ public interface ContainerItemContext {
 
 	/**
 	 * Return a context that can accept anything, and will accept (and destroy) any overflow items, with some initial content.
+	 * The context is backed by a single slot storage that can be freely mutated.
 	 * This can typically be used to check if a stack provides an API, or simulate operations on the returned API,
 	 * for example to simulate how much fluid could be extracted from the stack.
 	 *
 	 * <p>Note that the stack can never be mutated by this function: its contents are copied directly.
-	 *
-	 * @deprecated Use {@link #withConstant(ItemStack)} instead.
 	 */
-	@Deprecated(forRemoval = true)
 	static ContainerItemContext withInitial(ItemStack initialContent) {
 		return withInitial(ItemVariant.of(initialContent), initialContent.getCount());
 	}
 
 	/**
 	 * Return a context that can accept anything, and will accept (and destroy) any overflow items, with some initial variant and amount.
+	 * The context is backed by a single slot storage that can be freely mutated.
 	 * This can typically be used to check if a variant provides an API, or simulate operations on the returned API,
 	 * for example to simulate how much fluid could be extracted from the variant and amount.
-	 *
-	 * @deprecated Use {@link #withConstant(ItemVariant, long)} instead.
 	 */
-	@Deprecated(forRemoval = true)
 	static ContainerItemContext withInitial(ItemVariant initialVariant, long initialAmount) {
 		StoragePreconditions.notNegative(initialAmount);
 		return new InitialContentsContainerItemContext(initialVariant, initialAmount);

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/InventoryStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/InventoryStorage.java
@@ -74,17 +74,11 @@ public interface InventoryStorage extends SlottedStorage<ItemVariant> {
 	@UnmodifiableView
 	List<SingleSlotStorage<ItemVariant>> getSlots();
 
-	/**
-	 * {@inheritDoc}
-	 */
 	@Override
 	default int getSlotCount() {
 		return getSlots().size();
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	@Override
 	default SingleSlotStorage<ItemVariant> getSlot(int slot) {
 		return getSlots().get(slot);

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/InventoryStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/InventoryStorage.java
@@ -28,7 +28,7 @@ import net.minecraft.inventory.SidedInventory;
 import net.minecraft.inventory.SimpleInventory;
 import net.minecraft.util.math.Direction;
 
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
+import net.fabricmc.fabric.api.transfer.v1.storage.SlottedStorage;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.CombinedStorage;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleSlotStorage;
 import net.fabricmc.fabric.impl.transfer.item.InventoryStorageImpl;
@@ -50,7 +50,7 @@ import net.fabricmc.fabric.impl.transfer.item.InventoryStorageImpl;
  */
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface InventoryStorage extends Storage<ItemVariant> {
+public interface InventoryStorage extends SlottedStorage<ItemVariant> {
 	/**
 	 * Return a wrapper around an {@link Inventory}.
 	 *
@@ -69,11 +69,21 @@ public interface InventoryStorage extends Storage<ItemVariant> {
 	 * Retrieve an unmodifiable list of the wrappers for the slots in this inventory.
 	 * Each wrapper corresponds to a single slot in the inventory.
 	 */
+	@Override
 	List<SingleSlotStorage<ItemVariant>> getSlots();
 
 	/**
-	 * Retrieve a wrapper around a specific slot of the inventory.
+	 * {@inheritDoc}
 	 */
+	@Override
+	default int getSlotCount() {
+		return getSlots().size();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	default SingleSlotStorage<ItemVariant> getSlot(int slot) {
 		return getSlots().get(slot);
 	}

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/InventoryStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/InventoryStorage.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
 
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.Inventory;
@@ -70,6 +71,7 @@ public interface InventoryStorage extends SlottedStorage<ItemVariant> {
 	 * Each wrapper corresponds to a single slot in the inventory.
 	 */
 	@Override
+	@UnmodifiableView
 	List<SingleSlotStorage<ItemVariant>> getSlots();
 
 	/**

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/ItemStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/ItemStorage.java
@@ -32,10 +32,12 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Direction;
 
 import net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup;
-import net.fabricmc.fabric.api.transfer.v1.storage.base.SidedStorageBlockEntity;
 import net.fabricmc.fabric.api.transfer.v1.item.base.SingleStackStorage;
+import net.fabricmc.fabric.api.transfer.v1.storage.SlottedStorage;
 import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
+import net.fabricmc.fabric.api.transfer.v1.storage.base.CombinedSlottedStorage;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.CombinedStorage;
+import net.fabricmc.fabric.api.transfer.v1.storage.base.SidedStorageBlockEntity;
 import net.fabricmc.fabric.impl.transfer.item.ComposterWrapper;
 import net.fabricmc.fabric.mixin.transfer.DoubleInventoryAccessor;
 
@@ -119,10 +121,10 @@ public final class ItemStorage {
 
 					// For double chests, we need to retrieve a wrapper for each part separately.
 					if (inventoryToWrap instanceof DoubleInventoryAccessor accessor) {
-						Storage<ItemVariant> first = InventoryStorage.of(accessor.fabric_getFirst(), direction);
-						Storage<ItemVariant> second = InventoryStorage.of(accessor.fabric_getSecond(), direction);
+						SlottedStorage<ItemVariant> first = InventoryStorage.of(accessor.fabric_getFirst(), direction);
+						SlottedStorage<ItemVariant> second = InventoryStorage.of(accessor.fabric_getSecond(), direction);
 
-						return new CombinedStorage<>(List.of(first, second));
+						return new CombinedSlottedStorage<>(List.of(first, second));
 					}
 				} else {
 					inventoryToWrap = inventory;

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/SlottedStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/SlottedStorage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.api.transfer.v1.storage;
 
 import java.util.List;

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/SlottedStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/SlottedStorage.java
@@ -19,8 +19,11 @@ package net.fabricmc.fabric.api.transfer.v1.storage;
 import java.util.List;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.UnmodifiableView;
 
 import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleSlotStorage;
+import net.fabricmc.fabric.api.transfer.v1.context.ContainerItemContext;
+import net.fabricmc.fabric.impl.transfer.TransferApiImpl;
 
 /**
  * A {@link Storage} implementation made of indexed slots.
@@ -49,16 +52,16 @@ public interface SlottedStorage<T> extends Storage<T> {
 	SingleSlotStorage<T> getSlot(int slot);
 
 	/**
-	 * Retrieve all the slots of this storage. <b>The list must not be modified.</b>
+	 * Retrieve a list containing all the slots of this storage. <b>The list must not be modified.</b>
+	 *
+	 * <p>This function can be used to interface with code that requires a slot list,
+	 * for example {@link StorageUtil#insertStacking} or {@link ContainerItemContext#getAdditionalSlots()}.
+	 *
+	 * <p>It is guaranteed that calling this function is fast.
+	 * The default implementation returns a view over the storage that delegates to {@link #getSlotCount} and {@link #getSlot}.
 	 */
+	@UnmodifiableView
 	default List<SingleSlotStorage<T>> getSlots() {
-		int slotCount = getSlotCount();
-		SingleSlotStorage<T>[] slots = new SingleSlotStorage[slotCount];
-
-		for (int i = 0; i < slotCount; i++) {
-			slots[i] = getSlot(i);
-		}
-
-		return List.of(slots);
+		return TransferApiImpl.makeListView(this);
 	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/SlottedStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/SlottedStorage.java
@@ -1,0 +1,46 @@
+package net.fabricmc.fabric.api.transfer.v1.storage;
+
+import java.util.List;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleSlotStorage;
+
+/**
+ * A {@link Storage} implementation made of indexed slots.
+ * Please note that some storages may not implement this interface:
+ * checking whether a storage is slotted can be done using {@code instanceof}.
+ *
+ * @param <T> The type of the stored resources.
+ *
+ * <b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
+ * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
+ */
+@ApiStatus.Experimental
+public interface SlottedStorage<T> extends Storage<T> {
+	/**
+	 * Retrieve the number of slots in this storage.
+	 */
+	int getSlotCount();
+
+	/**
+	 * Retrieve a specific slot of this storage.
+	 *
+	 * @throws IndexOutOfBoundsException If the slot index is out of bounds.
+	 */
+	SingleSlotStorage<T> getSlot(int slot);
+
+	/**
+	 * Retrieve all the slots of this storage. <b>The list must not be modified.</b>
+	 */
+	default List<SingleSlotStorage<T>> getSlots() {
+		int slotCount = getSlotCount();
+		SingleSlotStorage<T>[] slots = new SingleSlotStorage[slotCount];
+
+		for (int i = 0; i < slotCount; i++) {
+			slots[i] = getSlot(i);
+		}
+
+		return List.of(slots);
+	}
+}

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/SlottedStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/SlottedStorage.java
@@ -24,8 +24,10 @@ import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleSlotStorage;
 
 /**
  * A {@link Storage} implementation made of indexed slots.
- * Please note that some storages may not implement this interface:
- * checking whether a storage is slotted can be done using {@code instanceof}.
+ *
+ * <p>Please note that some storages may not implement this interface.
+ * It is up to the storage implementation to decide whether to implement this interface or not.
+ * Checking whether a storage is slotted can be done using {@code instanceof}.
  *
  * @param <T> The type of the stored resources.
  *

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/Storage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/Storage.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.api.transfer.v1.storage;
 
 import java.util.Iterator;
 
+import com.google.common.collect.Iterators;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
@@ -150,6 +151,32 @@ public interface Storage<T> extends Iterable<StorageView<T>> {
 	 */
 	@Override
 	Iterator<StorageView<T>> iterator();
+
+	/**
+	 * Same as {@link #iterator()}, but the iterator is guaranteed to skip over empty views,
+	 * i.e. views that {@linkplain StorageView#isResourceBlank() contain blank resources} or have a zero {@linkplain StorageView#getAmount() amount}.
+	 *
+	 * <p>This can provide a large performance benefit over {@link #iterator()} if the caller is only interested in non-empty views,
+	 * for example because it is trying to extract resources from the storage.
+	 *
+	 * @return An iterator over the non-empty views of this storage. Calling remove on the iterator is not allowed.
+	 */
+	default Iterator<StorageView<T>> nonEmptyIterator() {
+		return Iterators.filter(iterator(), view -> view.getAmount() > 0 && !view.isResourceBlank());
+	}
+
+	/**
+	 * Convenient helper to get an {@link Iterable} over the {@linkplain #nonEmptyIterator() non-empty views} of this storage, for use in for-each loops.
+	 *
+	 * <p><pre>{@code
+	 * for (StorageView<T> view : storage.nonEmptyViews()) {
+	 *     // Do something with the view
+	 * }
+	 * }</pre>
+	 */
+	default Iterable<StorageView<T>> nonEmptyViews() {
+		return this::nonEmptyIterator;
+	}
 
 	/**
 	 * Return a view over this storage, for a specific resource, or {@code null} if none is quickly available.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/Storage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/Storage.java
@@ -18,7 +18,6 @@ package net.fabricmc.fabric.api.transfer.v1.storage;
 
 import java.util.Iterator;
 
-import com.google.common.collect.Iterators;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
@@ -159,10 +158,17 @@ public interface Storage<T> extends Iterable<StorageView<T>> {
 	 * <p>This can provide a large performance benefit over {@link #iterator()} if the caller is only interested in non-empty views,
 	 * for example because it is trying to extract resources from the storage.
 	 *
+	 * <p>This function should only be overridden if the storage is able to provide an optimized iterator over non-empty views,
+	 * for example because it is keeping an index of non-empty views.
+	 * Otherwise, the default implementation simply calls {@link #iterator()} and filters out empty views.
+	 *
+	 * <p>When implementing this function, note that the guarantees of {@link #iterator()} still apply.
+	 * In particular, {@link #insert} and {@link #extract} may be called safely during iteration.
+	 *
 	 * @return An iterator over the non-empty views of this storage. Calling remove on the iterator is not allowed.
 	 */
 	default Iterator<StorageView<T>> nonEmptyIterator() {
-		return Iterators.filter(iterator(), view -> view.getAmount() > 0 && !view.isResourceBlank());
+		return TransferApiImpl.filterEmptyViews(iterator());
 	}
 
 	/**

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StorageUtil.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StorageUtil.java
@@ -88,8 +88,7 @@ public final class StorageUtil {
 		long totalMoved = 0;
 
 		try (Transaction iterationTransaction = Transaction.openNested(transaction)) {
-			for (StorageView<T> view : from) {
-				if (view.isResourceBlank()) continue;
+			for (StorageView<T> view : from.nonEmptyViews()) {
 				T resource = view.getResource();
 				if (!filter.test(resource)) continue;
 				long maxExtracted;
@@ -174,8 +173,8 @@ public final class StorageUtil {
 		Objects.requireNonNull(filter, "Filter may not be null");
 		if (storage == null) return null;
 
-		for (StorageView<T> view : storage) {
-			if (!view.isResourceBlank() && filter.test(view.getResource())) {
+		for (StorageView<T> view : storage.nonEmptyViews()) {
+			if (filter.test(view.getResource())) {
 				return view.getResource();
 			}
 		}
@@ -209,11 +208,11 @@ public final class StorageUtil {
 		if (storage == null) return null;
 
 		try (Transaction nested = Transaction.openNested(transaction)) {
-			for (StorageView<T> view : storage) {
+			for (StorageView<T> view : storage.nonEmptyViews()) {
 				// Extract below could change the resource, so we have to query it before extracting.
 				T resource = view.getResource();
 
-				if (!view.isResourceBlank() && filter.test(resource) && view.extract(resource, Long.MAX_VALUE, nested) > 0) {
+				if (filter.test(resource) && view.extract(resource, Long.MAX_VALUE, nested) > 0) {
 					// Will abort the extraction.
 					return resource;
 				}

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StorageUtil.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StorageUtil.java
@@ -130,7 +130,7 @@ public final class StorageUtil {
 	 * @return How much was inserted.
 	 * @see Storage#insert
 	 */
-	public static <T> long insertStacking(List<SingleSlotStorage<T>> slots, T resource, long maxAmount, TransactionContext transaction) {
+	public static <T> long insertStacking(List<? extends SingleSlotStorage<T>> slots, T resource, long maxAmount, TransactionContext transaction) {
 		StoragePreconditions.notNegative(maxAmount);
 		long amount = 0;
 
@@ -147,6 +147,27 @@ public final class StorageUtil {
 		}
 
 		return amount;
+	}
+
+	/**
+	 * Insert resources in a storage, attempting to stack them with existing resources first if possible.
+	 *
+	 * @param storage The storage, may be null.
+	 * @param resource The resource to insert. May not be blank.
+	 * @param maxAmount The maximum amount of resource to insert. May not be negative.
+	 * @param transaction The transaction this operation is part of.
+	 * @return A nonnegative integer not greater than maxAmount: the amount that was inserted.
+	 */
+	public static <T> long tryInsertStacking(@Nullable Storage<T> storage, T resource, long maxAmount, TransactionContext transaction) {
+		StoragePreconditions.notNegative(maxAmount);
+
+		if (storage instanceof SlottedStorage<T> slottedStorage) {
+			return insertStacking(slottedStorage.getSlots(), resource, maxAmount, transaction);
+		} else if (storage != null) {
+			return storage.insert(resource, maxAmount, transaction);
+		} else {
+			return 0;
+		}
 	}
 
 	/**

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StorageUtil.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StorageUtil.java
@@ -124,6 +124,32 @@ public final class StorageUtil {
 	}
 
 	/**
+	 * Try to extract any resource from a storage, up to a maximum amount.
+	 *
+	 * <p>This function will only ever pull from one storage view of the storage, even if multiple storage views contain the same resource.
+	 *
+	 * @param storage The storage, may be null.
+	 * @param maxAmount The maximum to extract.
+	 * @param transaction The transaction this operation is part of.
+	 * @return A non-blank resource and the strictly positive amount of it that was extracted from the storage,
+	 * or {@code null} if none could be found.
+	 */
+	@Nullable
+	public static <T> ResourceAmount<T> extractAny(@Nullable Storage<T> storage, long maxAmount, TransactionContext transaction) {
+		StoragePreconditions.notNegative(maxAmount);
+
+		if (storage == null) return null;
+
+		for (StorageView<T> view : storage.nonEmptyViews()) {
+			T resource = view.getResource();
+			long amount = view.extract(resource, maxAmount, transaction);
+			if (amount > 0) return new ResourceAmount<>(resource, amount);
+		}
+
+		return null;
+	}
+
+	/**
 	 * Try to insert up to some amount of a resource into a list of storage slots, trying to "stack" first,
 	 * i.e. prioritizing slots that already contain the resource.
 	 *

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/CombinedSlottedStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/CombinedSlottedStorage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.api.transfer.v1.storage.base;
 
 import java.util.List;

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/CombinedSlottedStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/CombinedSlottedStorage.java
@@ -1,0 +1,51 @@
+package net.fabricmc.fabric.api.transfer.v1.storage.base;
+
+import java.util.List;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import net.fabricmc.fabric.api.transfer.v1.storage.SlottedStorage;
+import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
+
+/**
+ * A {@link Storage} wrapping multiple slotted storages.
+ * Same as {@link CombinedStorage}, but for {@link SlottedStorage}s.
+ *
+ * @param <T> The type of the stored resources.
+ * @param <S> The class of every part. {@code ? extends Storage<T>} can be used if the parts are of different types.
+ *
+ * <b>Experimental feature</b>, we reserve the right to remove or change it without further notice.
+ * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
+ */
+@ApiStatus.Experimental
+public class CombinedSlottedStorage<T, S extends SlottedStorage<T>> extends CombinedStorage<T, S> implements SlottedStorage<T> {
+	public CombinedSlottedStorage(List<S> parts) {
+		super(parts);
+	}
+
+	@Override
+	public int getSlotCount() {
+		int count = 0;
+
+		for (S part : parts) {
+			count += part.getSlotCount();
+		}
+
+		return count;
+	}
+
+	@Override
+	public SingleSlotStorage<T> getSlot(int slot) {
+		int updatedSlot = slot;
+
+		for (SlottedStorage<T> part : parts) {
+			if (updatedSlot < part.getSlotCount()) {
+				return part.getSlot(updatedSlot);
+			}
+
+			updatedSlot -= part.getSlotCount();
+		}
+
+		throw new IndexOutOfBoundsException("Slot " + slot + " is out of bounds. This storage has size " + getSlotCount());
+	}
+}

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/SingleSlotStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/SingleSlotStorage.java
@@ -20,7 +20,7 @@ import java.util.Iterator;
 
 import org.jetbrains.annotations.ApiStatus;
 
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
+import net.fabricmc.fabric.api.transfer.v1.storage.SlottedStorage;
 import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
 import net.fabricmc.fabric.impl.transfer.TransferApiImpl;
 
@@ -34,9 +34,23 @@ import net.fabricmc.fabric.impl.transfer.TransferApiImpl;
  * The transfer API is a complex addition, and we want to be able to correct possible design mistakes.
  */
 @ApiStatus.Experimental
-public interface SingleSlotStorage<T> extends Storage<T>, StorageView<T> {
+public interface SingleSlotStorage<T> extends SlottedStorage<T>, StorageView<T> {
 	@Override
 	default Iterator<StorageView<T>> iterator() {
 		return TransferApiImpl.singletonIterator(this);
+	}
+
+	@Override
+	default int getSlotCount() {
+		return 1;
+	}
+
+	@Override
+	default SingleSlotStorage<T> getSlot(int slot) {
+		if (slot != 0) {
+			throw new IndexOutOfBoundsException("Slot " + slot + " does not exist in a single-slot storage.");
+		}
+
+		return this;
 	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/SingleVariantStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/SingleVariantStorage.java
@@ -47,6 +47,9 @@ public abstract class SingleVariantStorage<T extends TransferVariant<?>> extends
 
 	/**
 	 * Return the blank variant.
+	 *
+	 * <p>Note: this is called very early in the constructor.
+	 * If fields need to be accessed from this function, make sure to re-initialize {@link #variant} yourself.
 	 */
 	protected abstract T getBlankVariant();
 

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/TransferApiImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/TransferApiImpl.java
@@ -89,4 +89,40 @@ public class TransferApiImpl {
 			}
 		};
 	}
+
+	public static <T> Iterator<StorageView<T>> filterEmptyViews(Iterator<StorageView<T>> iterator) {
+		return new Iterator<>() {
+			StorageView<T> next;
+
+			{
+				findNext();
+			}
+
+			private void findNext() {
+				while (iterator.hasNext()) {
+					next = iterator.next();
+
+					if (next.getAmount() > 0 && !next.isResourceBlank()) {
+						return;
+					}
+				}
+
+				next = null;
+			}
+
+			@Override
+			public boolean hasNext() {
+				return next != null;
+			}
+
+			@Override
+			public StorageView<T> next() {
+				if (!hasNext()) {
+					throw new NoSuchElementException();
+				}
+
+				return next;
+			}
+		};
+	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/TransferApiImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/TransferApiImpl.java
@@ -16,16 +16,20 @@
 
 package net.fabricmc.fabric.impl.transfer;
 
+import java.util.AbstractList;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 
+import net.fabricmc.fabric.api.transfer.v1.storage.SlottedStorage;
 import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
 import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
+import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleSlotStorage;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 
 public class TransferApiImpl {
@@ -63,11 +67,6 @@ public class TransferApiImpl {
 			return 0;
 		}
 	};
-
-	/**
-	 * Not null when writing to an inventory in a transaction, null otherwise.
-	 */
-	public static final ThreadLocal<Object> SUPPRESS_SPECIAL_LOGIC = new ThreadLocal<>();
 
 	public static <T> Iterator<T> singletonIterator(T it) {
 		return new Iterator<T>() {
@@ -122,6 +121,20 @@ public class TransferApiImpl {
 				}
 
 				return next;
+			}
+		};
+	}
+
+	public static <T> List<SingleSlotStorage<T>> makeListView(SlottedStorage<T> storage) {
+		return new AbstractList<>() {
+			@Override
+			public SingleSlotStorage<T> get(int index) {
+				return storage.getSlot(index);
+			}
+
+			@Override
+			public int size() {
+				return storage.getSlotCount();
 			}
 		};
 	}

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/TransferApiImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/TransferApiImpl.java
@@ -120,7 +120,9 @@ public class TransferApiImpl {
 					throw new NoSuchElementException();
 				}
 
-				return next;
+				StorageView<T> ret = next;
+				findNext();
+				return ret;
 			}
 		};
 	}

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/context/InitialContentsContainerItemContext.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/context/InitialContentsContainerItemContext.java
@@ -26,7 +26,6 @@ import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleSlotStorage;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleVariantStorage;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 
-@Deprecated(forRemoval = true)
 public class InitialContentsContainerItemContext implements ContainerItemContext {
 	private final SingleVariantStorage<ItemVariant> backingSlot = new SingleVariantStorage<>() {
 		@Override

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/context/InitialContentsContainerItemContext.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/context/InitialContentsContainerItemContext.java
@@ -26,6 +26,7 @@ import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleSlotStorage;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleVariantStorage;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 
+@Deprecated(forRemoval = true)
 public class InitialContentsContainerItemContext implements ContainerItemContext {
 	private final SingleVariantStorage<ItemVariant> backingSlot = new SingleVariantStorage<>() {
 		@Override


### PR DESCRIPTION
- Add non-empty iterator system. This allows many slots to be skipped in large inventories provided a suitable tracking structure. Adds `StorageUtil.extractAny`.
- Add `SlottedStorage` that allows storages to optionally expose a slot list. This is optional, and is meant for usage by chest-like inventories.
- Clarify edge case in `SingleVariantStorage#getBlankVariant`.
- Remove unused field from `TransferApiImpl`.

None of these should be breaking changes.