### PR TITLE
Transfer API v3: Allow null directions, remove deprecated exactView override

### DIFF
--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidStorage.java
@@ -55,7 +55,7 @@ public final class FluidStorage {
 	/**
 	 * Sided block access to fluid variant storages.
 	 * Fluid amounts are always expressed in {@linkplain FluidConstants droplets}.
-	 * The {@code Direction} parameter may never be null.
+	 * The {@code Direction} parameter may be null, meaning that the full inventory (ignoring side restrictions) should be queried.
 	 * Refer to {@link BlockApiLookup} for documentation on how to use this field.
 	 *
 	 * <p>A simple way to expose fluid variant storages for a block entity hierarchy is to extend {@link SidedStorageBlockEntity}.
@@ -68,7 +68,7 @@ public final class FluidStorage {
 	 * On the server thread (i.e. with a server world), all transfer functionality is always supported.
 	 * On the client thread (i.e. with a client world), contents of queried Storages are unreliable and should not be modified.
 	 */
-	public static final BlockApiLookup<Storage<FluidVariant>, Direction> SIDED =
+	public static final BlockApiLookup<Storage<FluidVariant>, @Nullable Direction> SIDED =
 			BlockApiLookup.get(new Identifier("fabric:sided_fluid_storage"), Storage.asClass(), Direction.class);
 
 	/**

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/ItemStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/ItemStorage.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.api.transfer.v1.item;
 import java.util.List;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Blocks;
 import net.minecraft.block.ChestBlock;
@@ -48,7 +49,7 @@ import net.fabricmc.fabric.mixin.transfer.DoubleInventoryAccessor;
 public final class ItemStorage {
 	/**
 	 * Sided block access to item variant storages.
-	 * The {@code Direction} parameter may never be null.
+	 * The {@code Direction} parameter may be null, meaning that the full inventory (ignoring side restrictions) should be queried.
 	 * Refer to {@link BlockApiLookup} for documentation on how to use this field.
 	 *
 	 * <p>When the operations supported by a storage change,
@@ -79,7 +80,7 @@ public final class ItemStorage {
 	 * On the server thread (i.e. with a server world), all transfer functionality is always supported.
 	 * On the client thread (i.e. with a client world), contents of queried Storages are unreliable and should not be modified.
 	 */
-	public static final BlockApiLookup<Storage<ItemVariant>, Direction> SIDED =
+	public static final BlockApiLookup<Storage<ItemVariant>, @Nullable Direction> SIDED =
 			BlockApiLookup.get(new Identifier("fabric:sided_item_storage"), Storage.asClass(), Direction.class);
 
 	private ItemStorage() {

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/Storage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/Storage.java
@@ -168,15 +168,6 @@ public interface Storage<T> extends Iterable<StorageView<T>> {
 	}
 
 	/**
-	 * @deprecated Use and implement the overload without the transaction parameter.
-	 */
-	@Deprecated(forRemoval = true)
-	@Nullable
-	default StorageView<T> exactView(TransactionContext transaction, T resource) {
-		return exactView(resource);
-	}
-
-	/**
 	 * Return an integer representing the current version of this storage instance to allow for fast change detection:
 	 * if the version hasn't changed since the last time, <b>and the storage instance is the same</b>, the storage has the same contents.
 	 * This can be used to avoid re-scanning the contents of the storage, which could be an expensive operation.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/FilteringStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/FilteringStorage.java
@@ -177,19 +177,6 @@ public abstract class FilteringStorage<T> implements Storage<T> {
 		}
 	}
 
-	@Deprecated(forRemoval = true)
-	@Override
-	@Nullable
-	public StorageView<T> exactView(TransactionContext transaction, T resource) {
-		StorageView<T> exact = backingStorage.get().exactView(transaction, resource);
-
-		if (exact != null) {
-			return new FilteringStorageView(exact);
-		} else {
-			return null;
-		}
-	}
-
 	@Override
 	public long getVersion() {
 		return backingStorage.get().getVersion();

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/ComposterWrapper.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/ComposterWrapper.java
@@ -19,7 +19,6 @@ package net.fabricmc.fabric.impl.transfer.item;
 import static net.minecraft.util.math.Direction.UP;
 
 import java.util.Map;
-import java.util.Objects;
 
 import com.google.common.collect.MapMaker;
 import org.jetbrains.annotations.Nullable;
@@ -63,10 +62,8 @@ public class ComposterWrapper extends SnapshotParticipant<Float> {
 	private static final Map<WorldLocation, ComposterWrapper> COMPOSTERS = new MapMaker().concurrencyLevel(1).weakValues().makeMap();
 
 	@Nullable
-	public static Storage<ItemVariant> get(World world, BlockPos pos, Direction direction) {
-		Objects.requireNonNull(direction);
-
-		if (direction.getAxis().isVertical()) {
+	public static Storage<ItemVariant> get(World world, BlockPos pos, @Nullable Direction direction) {
+		if (direction != null && direction.getAxis().isVertical()) {
 			WorldLocation location = new WorldLocation(world, pos.toImmutable());
 			ComposterWrapper composterWrapper = COMPOSTERS.computeIfAbsent(location, ComposterWrapper::new);
 			return direction == UP ? composterWrapper.upStorage : composterWrapper.downStorage;


### PR DESCRIPTION
Basically what the title says. These are "soft" breaking changes, so they're being PR'ed early on to 1.19.4.