### PR TITLE
Remove Texture Indices

### DIFF
--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/RendererAccess.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/RendererAccess.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.api.renderer.v1;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.fabric.impl.renderer.RendererAccessImpl;
@@ -23,6 +24,7 @@ import net.fabricmc.fabric.impl.renderer.RendererAccessImpl;
 /**
  * Registration and access for rendering extensions.
  */
+@ApiStatus.NonExtendable
 public interface RendererAccess {
 	RendererAccess INSTANCE = RendererAccessImpl.INSTANCE;
 

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/material/MaterialFinder.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/material/MaterialFinder.java
@@ -31,33 +31,23 @@ import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
 public interface MaterialFinder {
 	/**
 	 * Defines how sprite pixels will be blended with the scene.
-	 * Accepts {link @BlockRenderLayer} values and blending behavior
-	 * will emulate the way that Minecraft renders those instances. This does
-	 * NOT mean the sprite will be rendered in a specific render pass - some
-	 * implementations may not use the standard vanilla render passes.
 	 *
-	 * <p>CAN be null and is null by default. A null value means the renderer
-	 * will use the value normally associated with the block being rendered, or
-	 * {@code TRANSLUCENT} for item renders. (Normal Minecraft rendering)
+	 * <p>See {@link BlendMode} for more information.
 	 *
-	 * @deprecated Use {@code BlendMode} version instead.
+	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	@Deprecated
-	default MaterialFinder blendMode(int spriteIndex, RenderLayer renderLayer) {
-		return blendMode(spriteIndex, BlendMode.fromRenderLayer(renderLayer));
+	default MaterialFinder blendMode(BlendMode blendMode) {
+		return blendMode(0, blendMode);
 	}
 
 	/**
-	 * Defines how sprite pixels will be blended with the scene.
-	 *
-	 * <p>See {@link BlendMode} for more information.
-	 */
-	MaterialFinder blendMode(int spriteIndex, BlendMode blendMode);
-
-	/**
 	 * Vertex color(s) will be modified for quad color index unless disabled.
+	 *
+	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	MaterialFinder disableColorIndex(int spriteIndex, boolean disable);
+	default MaterialFinder disableColorIndex(boolean disable) {
+		return disableColorIndex(0, disable);
+	}
 
 	/**
 	 * When true, sprite texture and color will be rendered at full brightness.
@@ -69,24 +59,31 @@ public interface MaterialFinder {
 	 * allow per-sprite emissive lighting in future extensions that support overlay sprites.
 	 *
 	 * <p>Note that color will still be modified by diffuse shading and ambient occlusion,
-	 * unless disabled via {@link #disableAo(int, boolean)} and {@link #disableDiffuse(int, boolean)}.
+	 * unless disabled via {@link #disableAo(boolean)} and {@link #disableDiffuse(boolean)}.
+	 *
+	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	MaterialFinder emissive(int spriteIndex, boolean isEmissive);
+	default MaterialFinder emissive(boolean isEmissive) {
+		return emissive(0, isEmissive);
+	}
 
 	/**
 	 * Vertex color(s) will be modified for diffuse shading unless disabled.
+	 *
+	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	MaterialFinder disableDiffuse(int spriteIndex, boolean disable);
+	default MaterialFinder disableDiffuse(boolean disable) {
+		return disableDiffuse(0, disable);
+	}
 
 	/**
 	 * Vertex color(s) will be modified for ambient occlusion unless disabled.
+	 *
+	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	MaterialFinder disableAo(int spriteIndex, boolean disable);
-
-	/**
-	 * Reserved for future use.  Behavior for values &gt; 1 is currently undefined.
-	 */
-	MaterialFinder spriteDepth(int depth);
+	default MaterialFinder disableAo(boolean disable) {
+		return disableAo(0, disable);
+	}
 
 	/**
 	 * Resets this instance to default values. Values will match those
@@ -104,4 +101,60 @@ public interface MaterialFinder {
 	 * may or may not cache standard material instances.
 	 */
 	RenderMaterial find();
+
+	/**
+	 * @deprecated Use {@link #blendMode(BlendMode)} instead.
+	 */
+	@Deprecated
+	default MaterialFinder blendMode(int spriteIndex, RenderLayer renderLayer) {
+		return blendMode(BlendMode.fromRenderLayer(renderLayer));
+	}
+
+	/**
+	 * @deprecated Use {@link #blendMode(BlendMode)} instead.
+	 */
+	@Deprecated
+	default MaterialFinder blendMode(int spriteIndex, BlendMode blendMode) {
+		return blendMode(blendMode);
+	}
+
+	/**
+	 * @deprecated Use {@link #disableColorIndex(boolean)} instead.
+	 */
+	@Deprecated
+	default MaterialFinder disableColorIndex(int spriteIndex, boolean disable) {
+		return disableColorIndex(disable);
+	}
+
+	/**
+	 * @deprecated Use {@link #emissive(boolean)} instead.
+	 */
+	@Deprecated
+	default MaterialFinder emissive(int spriteIndex, boolean isEmissive) {
+		return emissive(isEmissive);
+	}
+
+	/**
+	 * @deprecated Use {@link #disableDiffuse(boolean)} instead.
+	 */
+	@Deprecated
+	default MaterialFinder disableDiffuse(int spriteIndex, boolean disable) {
+		return disableDiffuse(disable);
+	}
+
+	/**
+	 * @deprecated Use {@link #disableAo(boolean)} instead.
+	 */
+	@Deprecated
+	default MaterialFinder disableAo(int spriteIndex, boolean disable) {
+		return disableAo(disable);
+	}
+
+	/**
+	 * Do not use. Does nothing.
+	 */
+	@Deprecated
+	default MaterialFinder spriteDepth(int depth) {
+		return this;
+	}
 }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/material/MaterialFinder.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/material/MaterialFinder.java
@@ -30,28 +30,6 @@ import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
  */
 public interface MaterialFinder {
 	/**
-	 * Returns the standard material encoding all
-	 * of the current settings in this finder. The settings in
-	 * this finder are not changed.
-	 *
-	 * <p>Resulting instances can and should be re-used to prevent
-	 * needless memory allocation. {@link Renderer} implementations
-	 * may or may not cache standard material instances.
-	 */
-	RenderMaterial find();
-
-	/**
-	 * Resets this instance to default values. Values will match those
-	 * in effect when an instance is newly obtained via {@link Renderer#materialFinder()}.
-	 */
-	MaterialFinder clear();
-
-	/**
-	 * Reserved for future use.  Behavior for values &gt; 1 is currently undefined.
-	 */
-	MaterialFinder spriteDepth(int depth);
-
-	/**
 	 * Defines how sprite pixels will be blended with the scene.
 	 * Accepts {link @BlockRenderLayer} values and blending behavior
 	 * will emulate the way that Minecraft renders those instances. This does
@@ -82,16 +60,6 @@ public interface MaterialFinder {
 	MaterialFinder disableColorIndex(int spriteIndex, boolean disable);
 
 	/**
-	 * Vertex color(s) will be modified for diffuse shading unless disabled.
-	 */
-	MaterialFinder disableDiffuse(int spriteIndex, boolean disable);
-
-	/**
-	 * Vertex color(s) will be modified for ambient occlusion unless disabled.
-	 */
-	MaterialFinder disableAo(int spriteIndex, boolean disable);
-
-	/**
 	 * When true, sprite texture and color will be rendered at full brightness.
 	 * Lightmap values provided via {@link QuadEmitter#lightmap(int)} will be ignored.
 	 * False by default
@@ -104,4 +72,36 @@ public interface MaterialFinder {
 	 * unless disabled via {@link #disableAo(int, boolean)} and {@link #disableDiffuse(int, boolean)}.
 	 */
 	MaterialFinder emissive(int spriteIndex, boolean isEmissive);
+
+	/**
+	 * Vertex color(s) will be modified for diffuse shading unless disabled.
+	 */
+	MaterialFinder disableDiffuse(int spriteIndex, boolean disable);
+
+	/**
+	 * Vertex color(s) will be modified for ambient occlusion unless disabled.
+	 */
+	MaterialFinder disableAo(int spriteIndex, boolean disable);
+
+	/**
+	 * Reserved for future use.  Behavior for values &gt; 1 is currently undefined.
+	 */
+	MaterialFinder spriteDepth(int depth);
+
+	/**
+	 * Resets this instance to default values. Values will match those
+	 * in effect when an instance is newly obtained via {@link Renderer#materialFinder()}.
+	 */
+	MaterialFinder clear();
+
+	/**
+	 * Returns the standard material encoding all
+	 * of the current settings in this finder. The settings in
+	 * this finder are not changed.
+	 *
+	 * <p>Resulting instances can and should be re-used to prevent
+	 * needless memory allocation. {@link Renderer} implementations
+	 * may or may not cache standard material instances.
+	 */
+	RenderMaterial find();
 }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/material/RenderMaterial.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/material/RenderMaterial.java
@@ -76,9 +76,10 @@ public interface RenderMaterial {
 	Identifier MATERIAL_STANDARD = new Identifier("fabric", "standard");
 
 	/**
-	 * How many sprite color/uv coordinates are in the material.
-	 * Behavior for values &gt; 1 is currently undefined.
-	 * See {@link MaterialFinder#spriteDepth(int)}
+	 * Do not use. Always returns 1.
 	 */
-	int spriteDepth();
+	@Deprecated
+	default int spriteDepth() {
+		return 1;
+	}
 }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
@@ -98,79 +98,6 @@ public interface MutableQuadView extends QuadView {
 	int BAKE_NORMALIZED = 32;
 
 	/**
-	 * Assigns a different material to this quad. Useful for transformation of
-	 * existing meshes because lighting and texture blending are controlled by material.
-	 */
-	MutableQuadView material(RenderMaterial material);
-
-	/**
-	 * If non-null, quad is coplanar with a block face which, if known, simplifies
-	 * or shortcuts geometric analysis that might otherwise be needed.
-	 * Set to null if quad is not coplanar or if this is not known.
-	 * Also controls face culling during block rendering.
-	 *
-	 * <p>Null by default.
-	 *
-	 * <p>When called with a non-null value, also sets {@link #nominalFace(Direction)}
-	 * to the same value.
-	 *
-	 * <p>This is different from the value reported by {@link BakedQuad#getFace()}. That value
-	 * is computed based on face geometry and must be non-null in vanilla quads.
-	 * That computed value is returned by {@link #lightFace()}.
-	 */
-	@Nullable
-	MutableQuadView cullFace(@Nullable Direction face);
-
-	/**
-	 * Provides a hint to renderer about the facing of this quad. Not required,
-	 * but if provided can shortcut some geometric analysis if the quad is parallel to a block face.
-	 * Should be the expected value of {@link #lightFace()}. Value will be confirmed
-	 * and if invalid the correct light face will be calculated.
-	 *
-	 * <p>Null by default, and set automatically by {@link #cullFace()}.
-	 *
-	 * <p>Models may also find this useful as the face for texture UV locking and rotation semantics.
-	 *
-	 * <p>Note: This value is not persisted independently when the quad is encoded.
-	 * When reading encoded quads, this value will always be the same as {@link #lightFace()}.
-	 */
-	@Nullable
-	MutableQuadView nominalFace(Direction face);
-
-	/**
-	 * Value functions identically to {@link BakedQuad#getColorIndex()} and is
-	 * used by renderer / model builder in same way. Default value is -1.
-	 */
-	MutableQuadView colorIndex(int colorIndex);
-
-	/**
-	 * Enables bulk vertex data transfer using the standard Minecraft vertex formats.
-	 * This method should be performant whenever caller's vertex representation makes it feasible.
-	 *
-	 * <p>Calling this method does not emit the quad.
-	 *
-	 * @deprecated Use {@link #fromVanilla(BakedQuad, RenderMaterial, Direction)}
-	 * which has better encapsulation and removed outdated item flag
-	 */
-	@Deprecated
-	MutableQuadView fromVanilla(int[] quadData, int startIndex, boolean isItem);
-
-	/**
-	 * Enables bulk vertex data transfer using the standard Minecraft vertex formats.
-	 * This method should be performant whenever caller's vertex representation makes it feasible.
-	 *
-	 * <p>Calling this method does not emit the quad.
-	 */
-	MutableQuadView fromVanilla(BakedQuad quad, RenderMaterial material, Direction cullFace);
-
-	/**
-	 * Encodes an integer tag with this quad that can later be retrieved via
-	 * {@link QuadView#tag()}.  Useful for models that want to perform conditional
-	 * transformation or filtering on static meshes.
-	 */
-	MutableQuadView tag(int tag);
-
-	/**
 	 * Sets the geometric vertex position for the given vertex,
 	 * relative to block origin. (0,0,0).  Minecraft rendering is designed
 	 * for models that fit within a single block space and is recommended
@@ -184,47 +111,6 @@ public interface MutableQuadView extends QuadView {
 	 */
 	default MutableQuadView pos(int vertexIndex, Vector3f vec) {
 		return pos(vertexIndex, vec.x(), vec.y(), vec.z());
-	}
-
-	/**
-	 * Adds a vertex normal. Models that have per-vertex
-	 * normals should include them to get correct lighting when it matters.
-	 * Computed face normal is used when no vertex normal is provided.
-	 *
-	 * <p>{@link Renderer} implementations should honor vertex normals for
-	 * diffuse lighting - modifying vertex color(s) or packing normals in the vertex
-	 * buffer as appropriate for the rendering method/vertex format in effect.
-	 */
-	MutableQuadView normal(int vertexIndex, float x, float y, float z);
-
-	/**
-	 * Same as {@link #normal(int, float, float, float)} but accepts vector type.
-	 */
-	default MutableQuadView normal(int vertexIndex, Vector3f vec) {
-		return normal(vertexIndex, vec.x(), vec.y(), vec.z());
-	}
-
-	/**
-	 * Accept vanilla lightmap values.  Input values will override lightmap values
-	 * computed from world state if input values are higher. Exposed for completeness
-	 * but some rendering implementations with non-standard lighting model may not honor it.
-	 *
-	 * <p>For emissive rendering, it is better to use {@link MaterialFinder#emissive(int, boolean)}.
-	 */
-	MutableQuadView lightmap(int vertexIndex, int lightmap);
-
-	/**
-	 * Convenience: set lightmap for all vertices at once.
-	 *
-	 * <p>For emissive rendering, it is better to use {@link MaterialFinder#emissive(int, boolean)}.
-	 * See {@link #lightmap(int, int)}.
-	 */
-	default MutableQuadView lightmap(int b0, int b1, int b2, int b3) {
-		lightmap(0, b0);
-		lightmap(1, b1);
-		lightmap(2, b2);
-		lightmap(3, b3);
-		return this;
 	}
 
 	/**
@@ -265,4 +151,118 @@ public interface MutableQuadView extends QuadView {
 	 * Behavior for {@code spriteIndex > 0} is currently undefined.
 	 */
 	MutableQuadView spriteBake(int spriteIndex, Sprite sprite, int bakeFlags);
+
+	/**
+	 * Accept vanilla lightmap values.  Input values will override lightmap values
+	 * computed from world state if input values are higher. Exposed for completeness
+	 * but some rendering implementations with non-standard lighting model may not honor it.
+	 *
+	 * <p>For emissive rendering, it is better to use {@link MaterialFinder#emissive(int, boolean)}.
+	 */
+	MutableQuadView lightmap(int vertexIndex, int lightmap);
+
+	/**
+	 * Convenience: set lightmap for all vertices at once.
+	 *
+	 * <p>For emissive rendering, it is better to use {@link MaterialFinder#emissive(int, boolean)}.
+	 * See {@link #lightmap(int, int)}.
+	 */
+	default MutableQuadView lightmap(int b0, int b1, int b2, int b3) {
+		lightmap(0, b0);
+		lightmap(1, b1);
+		lightmap(2, b2);
+		lightmap(3, b3);
+		return this;
+	}
+
+	/**
+	 * Adds a vertex normal. Models that have per-vertex
+	 * normals should include them to get correct lighting when it matters.
+	 * Computed face normal is used when no vertex normal is provided.
+	 *
+	 * <p>{@link Renderer} implementations should honor vertex normals for
+	 * diffuse lighting - modifying vertex color(s) or packing normals in the vertex
+	 * buffer as appropriate for the rendering method/vertex format in effect.
+	 */
+	MutableQuadView normal(int vertexIndex, float x, float y, float z);
+
+	/**
+	 * Same as {@link #normal(int, float, float, float)} but accepts vector type.
+	 */
+	default MutableQuadView normal(int vertexIndex, Vector3f vec) {
+		return normal(vertexIndex, vec.x(), vec.y(), vec.z());
+	}
+
+	/**
+	 * If non-null, quad is coplanar with a block face which, if known, simplifies
+	 * or shortcuts geometric analysis that might otherwise be needed.
+	 * Set to null if quad is not coplanar or if this is not known.
+	 * Also controls face culling during block rendering.
+	 *
+	 * <p>Null by default.
+	 *
+	 * <p>When called with a non-null value, also sets {@link #nominalFace(Direction)}
+	 * to the same value.
+	 *
+	 * <p>This is different from the value reported by {@link BakedQuad#getFace()}. That value
+	 * is computed based on face geometry and must be non-null in vanilla quads.
+	 * That computed value is returned by {@link #lightFace()}.
+	 */
+	@Nullable
+	MutableQuadView cullFace(@Nullable Direction face);
+
+	/**
+	 * Provides a hint to renderer about the facing of this quad. Not required,
+	 * but if provided can shortcut some geometric analysis if the quad is parallel to a block face.
+	 * Should be the expected value of {@link #lightFace()}. Value will be confirmed
+	 * and if invalid the correct light face will be calculated.
+	 *
+	 * <p>Null by default, and set automatically by {@link #cullFace()}.
+	 *
+	 * <p>Models may also find this useful as the face for texture UV locking and rotation semantics.
+	 *
+	 * <p>Note: This value is not persisted independently when the quad is encoded.
+	 * When reading encoded quads, this value will always be the same as {@link #lightFace()}.
+	 */
+	@Nullable
+	MutableQuadView nominalFace(Direction face);
+
+	/**
+	 * Assigns a different material to this quad. Useful for transformation of
+	 * existing meshes because lighting and texture blending are controlled by material.
+	 */
+	MutableQuadView material(RenderMaterial material);
+
+	/**
+	 * Value functions identically to {@link BakedQuad#getColorIndex()} and is
+	 * used by renderer / model builder in same way. Default value is -1.
+	 */
+	MutableQuadView colorIndex(int colorIndex);
+
+	/**
+	 * Encodes an integer tag with this quad that can later be retrieved via
+	 * {@link QuadView#tag()}.  Useful for models that want to perform conditional
+	 * transformation or filtering on static meshes.
+	 */
+	MutableQuadView tag(int tag);
+
+	/**
+	 * Enables bulk vertex data transfer using the standard Minecraft vertex formats.
+	 * This method should be performant whenever caller's vertex representation makes it feasible.
+	 *
+	 * <p>Calling this method does not emit the quad.
+	 *
+	 * @deprecated Use {@link #fromVanilla(BakedQuad, RenderMaterial, Direction)}
+	 * which has better encapsulation and removed outdated item flag
+	 */
+	@Deprecated
+	MutableQuadView fromVanilla(int[] quadData, int startIndex, boolean isItem);
+
+	/**
+	 * Enables bulk vertex data transfer using the standard Minecraft vertex formats.
+	 * This method should be performant whenever caller's vertex representation makes it feasible.
+	 *
+	 * <p>Calling this method does not emit the quad.
+	 */
+	MutableQuadView fromVanilla(BakedQuad quad, RenderMaterial material, Direction cullFace);
 }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
@@ -33,39 +33,39 @@ import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
  * {@link QuadEmitter} and for dynamic renders/mesh transforms.
  *
  * <p>Instances of {@link MutableQuadView} will practically always be
- * threadlocal and/or reused - do not retain references.
+ * thread local and/or reused - do not retain references.
  *
  * <p>Only the renderer should implement or extend this interface.
  */
 public interface MutableQuadView extends QuadView {
 	/**
 	 * Causes texture to appear with no rotation.
-	 * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
+	 * Pass in bakeFlags parameter to {@link #spriteBake(Sprite, int)}.
 	 */
 	int BAKE_ROTATE_NONE = 0;
 
 	/**
 	 * Causes texture to appear rotated 90 deg. clockwise relative to nominal face.
-	 * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
+	 * Pass in bakeFlags parameter to {@link #spriteBake(Sprite, int)}.
 	 */
 	int BAKE_ROTATE_90 = 1;
 
 	/**
 	 * Causes texture to appear rotated 180 deg. relative to nominal face.
-	 * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
+	 * Pass in bakeFlags parameter to {@link #spriteBake(Sprite, int)}.
 	 */
 	int BAKE_ROTATE_180 = 2;
 
 	/**
 	 * Causes texture to appear rotated 270 deg. clockwise relative to nominal face.
-	 * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
+	 * Pass in bakeFlags parameter to {@link #spriteBake(Sprite, int)}.
 	 */
 	int BAKE_ROTATE_270 = 3;
 
 	/**
 	 * When enabled, texture coordinate are assigned based on vertex position.
-	 * Any existing uv coordinates will be replaced.
-	 * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
+	 * Any existing UV coordinates will be replaced.
+	 * Pass in bakeFlags parameter to {@link #spriteBake(Sprite, int)}.
 	 *
 	 * <p>UV lock always derives texture coordinates based on nominal face, even
 	 * when the quad is not co-planar with that face, and the result is
@@ -79,12 +79,12 @@ public interface MutableQuadView extends QuadView {
 	 * flipped as part of baking. Can be useful for some randomization
 	 * and texture mapping scenarios. Results are different from what
 	 * can be obtained via rotation and both can be applied.
-	 * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
+	 * Pass in bakeFlags parameter to {@link #spriteBake(Sprite, int)}.
 	 */
 	int BAKE_FLIP_U = 8;
 
 	/**
-	 * Same as {@link MutableQuadView#BAKE_FLIP_U} but for V coordinate.
+	 * Same as {@link #BAKE_FLIP_U} but for V coordinate.
 	 */
 	int BAKE_FLIP_V = 16;
 
@@ -93,13 +93,13 @@ public interface MutableQuadView extends QuadView {
 	 * with conventional Minecraft model format. This is scaled to 0-1 during
 	 * baking before interpolation. Model loaders that already have 0-1 coordinates
 	 * can avoid wasteful multiplication/division by passing 0-1 coordinates directly.
-	 * Pass in bakeFlags parameter to {@link #spriteBake(int, Sprite, int)}.
+	 * Pass in bakeFlags parameter to {@link #spriteBake(Sprite, int)}.
 	 */
 	int BAKE_NORMALIZED = 32;
 
 	/**
 	 * Sets the geometric vertex position for the given vertex,
-	 * relative to block origin. (0,0,0).  Minecraft rendering is designed
+	 * relative to block origin, (0,0,0). Minecraft rendering is designed
 	 * for models that fit within a single block space and is recommended
 	 * that coordinates remain in the 0-1 range, with multi-block meshes
 	 * split into multiple per-block models.
@@ -114,57 +114,68 @@ public interface MutableQuadView extends QuadView {
 	}
 
 	/**
-	 * Set sprite color. Behavior for {@code spriteIndex > 0} is currently undefined.
+	 * Set vertex color.
+	 *
+	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	MutableQuadView spriteColor(int vertexIndex, int spriteIndex, int color);
+	default MutableQuadView color(int vertexIndex, int color) {
+		return spriteColor(vertexIndex, 0, color);
+	}
 
 	/**
-	 * Convenience: set sprite color for all vertices at once. Behavior for {@code spriteIndex > 0} is currently undefined.
+	 * Convenience: set vertex color for all vertices at once.
 	 */
-	default MutableQuadView spriteColor(int spriteIndex, int c0, int c1, int c2, int c3) {
-		spriteColor(0, spriteIndex, c0);
-		spriteColor(1, spriteIndex, c1);
-		spriteColor(2, spriteIndex, c2);
-		spriteColor(3, spriteIndex, c3);
+	default MutableQuadView color(int c0, int c1, int c2, int c3) {
+		color(0, c0);
+		color(1, c1);
+		color(2, c2);
+		color(3, c3);
 		return this;
 	}
 
 	/**
-	 * Set sprite atlas coordinates. Behavior for {@code spriteIndex > 0} is currently undefined.
+	 * Set texture coordinates.
+	 *
+	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	MutableQuadView sprite(int vertexIndex, int spriteIndex, float u, float v);
+	default MutableQuadView uv(int vertexIndex, float u, float v) {
+		return sprite(vertexIndex, 0, u, v);
+	}
 
 	/**
-	 * Set sprite atlas coordinates. Behavior for {@code spriteIndex > 0} is currently undefined.
+	 * Set texture coordinates.
 	 *
 	 * <p>Only use this function if you already have a {@link Vec2f}.
-	 * Otherwise, see {@link MutableQuadView#sprite(int, int, float, float)}.
+	 * Otherwise, see {@link MutableQuadView#uv(int, float, float)}.
 	 */
-	default MutableQuadView sprite(int vertexIndex, int spriteIndex, Vec2f uv) {
-		return sprite(vertexIndex, spriteIndex, uv.x, uv.y);
+	default MutableQuadView uv(int vertexIndex, Vec2f uv) {
+		return uv(vertexIndex, uv.x, uv.y);
 	}
 
 	/**
 	 * Assigns sprite atlas u,v coordinates to this quad for the given sprite.
 	 * Can handle UV locking, rotation, interpolation, etc. Control this behavior
 	 * by passing additive combinations of the BAKE_ flags defined in this interface.
-	 * Behavior for {@code spriteIndex > 0} is currently undefined.
+	 *
+	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	MutableQuadView spriteBake(int spriteIndex, Sprite sprite, int bakeFlags);
+	default MutableQuadView spriteBake(Sprite sprite, int bakeFlags) {
+		return spriteBake(0, sprite, bakeFlags);
+	}
 
 	/**
 	 * Accept vanilla lightmap values.  Input values will override lightmap values
 	 * computed from world state if input values are higher. Exposed for completeness
 	 * but some rendering implementations with non-standard lighting model may not honor it.
 	 *
-	 * <p>For emissive rendering, it is better to use {@link MaterialFinder#emissive(int, boolean)}.
+	 * <p>For emissive rendering, it is better to use {@link MaterialFinder#emissive(boolean)}.
 	 */
 	MutableQuadView lightmap(int vertexIndex, int lightmap);
 
 	/**
 	 * Convenience: set lightmap for all vertices at once.
 	 *
-	 * <p>For emissive rendering, it is better to use {@link MaterialFinder#emissive(int, boolean)}.
+	 * <p>For emissive rendering, it is better to use {@link MaterialFinder#emissive(boolean)}.
 	 * See {@link #lightmap(int, int)}.
 	 */
 	default MutableQuadView lightmap(int b0, int b1, int b2, int b3) {
@@ -252,11 +263,11 @@ public interface MutableQuadView extends QuadView {
 	 *
 	 * <p>Calling this method does not emit the quad.
 	 *
-	 * @deprecated Use {@link #fromVanilla(BakedQuad, RenderMaterial, Direction)}
-	 * which has better encapsulation and removed outdated item flag
+	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	@Deprecated
-	MutableQuadView fromVanilla(int[] quadData, int startIndex, boolean isItem);
+	default MutableQuadView fromVanilla(int[] quadData, int startIndex) {
+		return fromVanilla(quadData, startIndex, false);
+	}
 
 	/**
 	 * Enables bulk vertex data transfer using the standard Minecraft vertex formats.
@@ -265,4 +276,53 @@ public interface MutableQuadView extends QuadView {
 	 * <p>Calling this method does not emit the quad.
 	 */
 	MutableQuadView fromVanilla(BakedQuad quad, RenderMaterial material, Direction cullFace);
+
+	/**
+	 * @deprecated Use {@link #color(int, int)} instead.
+	 */
+	@Deprecated
+	default MutableQuadView spriteColor(int vertexIndex, int spriteIndex, int color) {
+		return color(vertexIndex, color);
+	}
+
+	/**
+	 * @deprecated Use {@link #color(int, int, int, int)} instead.
+	 */
+	@Deprecated
+	default MutableQuadView spriteColor(int spriteIndex, int c0, int c1, int c2, int c3) {
+		color(c0, c1, c2, c3);
+		return this;
+	}
+
+	/**
+	 * @deprecated Use {@link #uv(int, float, float)} instead.
+	 */
+	@Deprecated
+	default MutableQuadView sprite(int vertexIndex, int spriteIndex, float u, float v) {
+		return uv(vertexIndex, u, v);
+	}
+
+	/**
+	 * @deprecated Use {@link #uv(int, Vec2f)} instead.
+	 */
+	@Deprecated
+	default MutableQuadView sprite(int vertexIndex, int spriteIndex, Vec2f uv) {
+		return uv(vertexIndex, uv);
+	}
+
+	/**
+	 * @deprecated Use {@link #spriteBake(Sprite, int)} instead.
+	 */
+	@Deprecated
+	default MutableQuadView spriteBake(int spriteIndex, Sprite sprite, int bakeFlags) {
+		return spriteBake(sprite, bakeFlags);
+	}
+
+	/**
+	 * @deprecated Use {@link #fromVanilla(int[], int)} instead.
+	 */
+	@Deprecated
+	default MutableQuadView fromVanilla(int[] quadData, int startIndex, boolean isItem) {
+		return fromVanilla(quadData, startIndex);
+	}
 }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
@@ -39,44 +39,11 @@ import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
  */
 public interface QuadEmitter extends MutableQuadView {
 	@Override
-	QuadEmitter material(RenderMaterial material);
-
-	@Override
-	QuadEmitter cullFace(Direction face);
-
-	@Override
-	QuadEmitter nominalFace(Direction face);
-
-	@Override
-	QuadEmitter colorIndex(int colorIndex);
-
-	@Override
-	QuadEmitter fromVanilla(int[] quadData, int startIndex, boolean isItem);
-
-	@Override
-	QuadEmitter tag(int tag);
-
-	@Override
 	QuadEmitter pos(int vertexIndex, float x, float y, float z);
 
 	@Override
 	default QuadEmitter pos(int vertexIndex, Vector3f vec) {
 		MutableQuadView.super.pos(vertexIndex, vec);
-		return this;
-	}
-
-	@Override
-	default QuadEmitter normal(int vertexIndex, Vector3f vec) {
-		MutableQuadView.super.normal(vertexIndex, vec);
-		return this;
-	}
-
-	@Override
-	QuadEmitter lightmap(int vertexIndex, int lightmap);
-
-	@Override
-	default QuadEmitter lightmap(int b0, int b1, int b2, int b3) {
-		MutableQuadView.super.lightmap(b0, b1, b2, b3);
 		return this;
 	}
 
@@ -102,6 +69,9 @@ public interface QuadEmitter extends MutableQuadView {
 		return sprite(vertexIndex, spriteIndex, uv.x, uv.y);
 	}
 
+	@Override
+	QuadEmitter spriteBake(int spriteIndex, Sprite sprite, int bakeFlags);
+
 	default QuadEmitter spriteUnitSquare(int spriteIndex) {
 		sprite(0, spriteIndex, 0, 0);
 		sprite(1, spriteIndex, 0, 1);
@@ -111,7 +81,37 @@ public interface QuadEmitter extends MutableQuadView {
 	}
 
 	@Override
-	QuadEmitter spriteBake(int spriteIndex, Sprite sprite, int bakeFlags);
+	QuadEmitter lightmap(int vertexIndex, int lightmap);
+
+	@Override
+	default QuadEmitter lightmap(int b0, int b1, int b2, int b3) {
+		MutableQuadView.super.lightmap(b0, b1, b2, b3);
+		return this;
+	}
+
+	@Override
+	default QuadEmitter normal(int vertexIndex, Vector3f vec) {
+		MutableQuadView.super.normal(vertexIndex, vec);
+		return this;
+	}
+
+	@Override
+	QuadEmitter cullFace(Direction face);
+
+	@Override
+	QuadEmitter nominalFace(Direction face);
+
+	@Override
+	QuadEmitter material(RenderMaterial material);
+
+	@Override
+	QuadEmitter colorIndex(int colorIndex);
+
+	@Override
+	QuadEmitter tag(int tag);
+
+	@Override
+	QuadEmitter fromVanilla(int[] quadData, int startIndex, boolean isItem);
 
 	/**
 	 * Tolerance for determining if the depth parameter to {@link #square(Direction, float, float, float, float, float)}

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
@@ -47,36 +47,50 @@ public interface QuadEmitter extends MutableQuadView {
 		return this;
 	}
 
+	/**
+	 * @apiNote The default implementation will be removed in the next breaking release.
+	 */
 	@Override
-	QuadEmitter spriteColor(int vertexIndex, int spriteIndex, int color);
-
-	@Override
-	default QuadEmitter spriteColor(int spriteIndex, int c0, int c1, int c2, int c3) {
-		MutableQuadView.super.spriteColor(spriteIndex, c0, c1, c2, c3);
+	default QuadEmitter color(int vertexIndex, int color) {
+		MutableQuadView.super.color(vertexIndex, color);
 		return this;
 	}
 
 	@Override
-	QuadEmitter sprite(int vertexIndex, int spriteIndex, float u, float v);
+	default QuadEmitter color(int c0, int c1, int c2, int c3) {
+		MutableQuadView.super.color(c0, c1, c2, c3);
+		return this;
+	}
 
 	/**
-	 * Set sprite atlas coordinates. Behavior for {@code spriteIndex > 0} is currently undefined.
-	 *
-	 * <p>Only use this function if you already have a {@link Vec2f}.
-	 * Otherwise, see {@link QuadEmitter#sprite(int, int, float, float)}.
+	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default QuadEmitter sprite(int vertexIndex, int spriteIndex, Vec2f uv) {
-		return sprite(vertexIndex, spriteIndex, uv.x, uv.y);
+	@Override
+	default QuadEmitter uv(int vertexIndex, float u, float v) {
+		MutableQuadView.super.uv(vertexIndex, u, v);
+		return this;
 	}
 
 	@Override
-	QuadEmitter spriteBake(int spriteIndex, Sprite sprite, int bakeFlags);
+	default QuadEmitter uv(int vertexIndex, Vec2f uv) {
+		MutableQuadView.super.uv(vertexIndex, uv);
+		return this;
+	}
 
-	default QuadEmitter spriteUnitSquare(int spriteIndex) {
-		sprite(0, spriteIndex, 0, 0);
-		sprite(1, spriteIndex, 0, 1);
-		sprite(2, spriteIndex, 1, 1);
-		sprite(3, spriteIndex, 1, 0);
+	/**
+	 * @apiNote The default implementation will be removed in the next breaking release.
+	 */
+	@Override
+	default QuadEmitter spriteBake(Sprite sprite, int bakeFlags) {
+		MutableQuadView.super.spriteBake(sprite, bakeFlags);
+		return this;
+	}
+
+	default QuadEmitter spriteUnitSquare() {
+		uv(0, 0, 0);
+		uv(1, 0, 1);
+		uv(2, 1, 1);
+		uv(3, 1, 0);
 		return this;
 	}
 
@@ -88,6 +102,10 @@ public interface QuadEmitter extends MutableQuadView {
 		MutableQuadView.super.lightmap(b0, b1, b2, b3);
 		return this;
 	}
+
+	// TODO: uncomment right before next breaking release
+	// @Override
+	// QuadEmitter normal(int vertexIndex, float x, float y, float z);
 
 	@Override
 	default QuadEmitter normal(int vertexIndex, Vector3f vec) {
@@ -110,8 +128,18 @@ public interface QuadEmitter extends MutableQuadView {
 	@Override
 	QuadEmitter tag(int tag);
 
+	/**
+	 * @apiNote The default implementation will be removed in the next breaking release.
+	 */
 	@Override
-	QuadEmitter fromVanilla(int[] quadData, int startIndex, boolean isItem);
+	default QuadEmitter fromVanilla(int[] quadData, int startIndex) {
+		MutableQuadView.super.fromVanilla(quadData, startIndex);
+		return this;
+	}
+
+	// TODO: uncomment right before next breaking release
+	// @Override
+	// QuadEmitter fromVanilla(BakedQuad quad, RenderMaterial material, Direction cullFace);
 
 	/**
 	 * Tolerance for determining if the depth parameter to {@link #square(Direction, float, float, float, float, float)}
@@ -185,4 +213,55 @@ public interface QuadEmitter extends MutableQuadView {
 	 * In both cases, current instance is reset to default values.
 	 */
 	QuadEmitter emit();
+
+	@Override
+	@Deprecated
+	default QuadEmitter spriteColor(int vertexIndex, int spriteIndex, int color) {
+		MutableQuadView.super.spriteColor(vertexIndex, spriteIndex, color);
+		return this;
+	}
+
+	@Override
+	@Deprecated
+	default QuadEmitter spriteColor(int spriteIndex, int c0, int c1, int c2, int c3) {
+		MutableQuadView.super.spriteColor(spriteIndex, c0, c1, c2, c3);
+		return this;
+	}
+
+	@Override
+	@Deprecated
+	default QuadEmitter sprite(int vertexIndex, int spriteIndex, float u, float v) {
+		MutableQuadView.super.sprite(vertexIndex, spriteIndex, u, v);
+		return this;
+	}
+
+	@Override
+	@Deprecated
+	default QuadEmitter sprite(int vertexIndex, int spriteIndex, Vec2f uv) {
+		MutableQuadView.super.sprite(vertexIndex, spriteIndex, uv);
+		return this;
+	}
+
+	@Override
+	@Deprecated
+	default QuadEmitter spriteBake(int spriteIndex, Sprite sprite, int bakeFlags) {
+		MutableQuadView.super.spriteBake(spriteIndex, sprite, bakeFlags);
+		return this;
+	}
+
+	/**
+	 * @deprecated Use {@link #spriteUnitSquare()} instead.
+	 */
+	@Deprecated
+	default QuadEmitter spriteUnitSquare(int spriteIndex) {
+		spriteUnitSquare();
+		return this;
+	}
+
+	@Override
+	@Deprecated
+	default QuadEmitter fromVanilla(int[] quadData, int startIndex, boolean isItem) {
+		MutableQuadView.super.fromVanilla(quadData, startIndex, isItem);
+		return this;
+	}
 }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadView.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadView.java
@@ -42,46 +42,78 @@ public interface QuadView {
 	int VANILLA_QUAD_STRIDE = VANILLA_VERTEX_STRIDE * 4;
 
 	/**
-	 * Reads baked vertex data and outputs standard baked quad
-	 * vertex data in the given array and location.
-	 *
-	 * @param spriteIndex The sprite to be used for the quad.
-	 * Behavior for values &gt; 0 is currently undefined.
-	 *
-	 * @param target Target array for the baked quad data.
-	 *
-	 * @param targetIndex Starting position in target array - array must have
-	 * at least 28 elements available at this index.
-	 *
-	 * @param isItem If true, will output vertex normals. Otherwise will output
-	 * lightmaps, per Minecraft vertex formats for baked models.
+	 * Geometric position, x coordinate.
 	 */
-	void toVanilla(int spriteIndex, int[] target, int targetIndex, boolean isItem);
+	float x(int vertexIndex);
 
 	/**
-	 * Extracts all quad properties except material to the given {@link MutableQuadView} instance.
-	 * Must be used before calling {link QuadEmitter#emit()} on the target instance.
-	 * Meant for re-texturing, analysis and static transformation use cases.
+	 * Geometric position, y coordinate.
 	 */
-	void copyTo(MutableQuadView target);
+	float y(int vertexIndex);
 
 	/**
-	 * Retrieves the material serialized with the quad.
+	 * Geometric position, z coordinate.
 	 */
-	RenderMaterial material();
+	float z(int vertexIndex);
 
 	/**
-	 * Retrieves the quad color index serialized with the quad.
+	 * Convenience: access x, y, z by index 0-2.
 	 */
-	int colorIndex();
+	float posByIndex(int vertexIndex, int coordinateIndex);
 
 	/**
-	 * Equivalent to {@link BakedQuad#getFace()}. This is the face used for vanilla lighting
-	 * calculations and will be the block face to which the quad is most closely aligned. Always
-	 * the same as cull face for quads that are on a block face, but never null.
+	 * Pass a non-null target to avoid allocation - will be returned with values.
+	 * Otherwise returns a new instance.
 	 */
-	@NotNull
-	Direction lightFace();
+	Vector3f copyPos(int vertexIndex, @Nullable Vector3f target);
+
+	/**
+	 * Retrieve vertex color.
+	 */
+	int spriteColor(int vertexIndex, int spriteIndex);
+
+	/**
+	 * Retrieve horizontal sprite atlas coordinates.
+	 */
+	float spriteU(int vertexIndex, int spriteIndex);
+
+	/**
+	 * Retrieve vertical sprite atlas coordinates.
+	 */
+	float spriteV(int vertexIndex, int spriteIndex);
+
+	/**
+	 * Minimum block brightness. Zero if not set.
+	 */
+	int lightmap(int vertexIndex);
+
+	/**
+	 * If false, no vertex normal was provided.
+	 * Lighting should use face normal in that case.
+	 */
+	boolean hasNormal(int vertexIndex);
+
+	/**
+	 * Will return {@link Float#NaN} if normal not present.
+	 */
+	float normalX(int vertexIndex);
+
+	/**
+	 * Will return {@link Float#NaN} if normal not present.
+	 */
+	float normalY(int vertexIndex);
+
+	/**
+	 * Will return {@link Float#NaN} if normal not present.
+	 */
+	float normalZ(int vertexIndex);
+
+	/**
+	 * Pass a non-null target to avoid allocation - will be returned with values.
+	 * Otherwise returns a new instance. Returns null if normal not present.
+	 */
+	@Nullable
+	Vector3f copyNormal(int vertexIndex, @Nullable Vector3f target);
 
 	/**
 	 * If non-null, quad should not be rendered in-world if the
@@ -90,6 +122,14 @@ public interface QuadView {
 	 * @see MutableQuadView#cullFace(Direction)
 	 */
 	@Nullable Direction cullFace();
+
+	/**
+	 * Equivalent to {@link BakedQuad#getFace()}. This is the face used for vanilla lighting
+	 * calculations and will be the block face to which the quad is most closely aligned. Always
+	 * the same as cull face for quads that are on a block face, but never null.
+	 */
+	@NotNull
+	Direction lightFace();
 
 	/**
 	 * See {@link MutableQuadView#nominalFace(Direction)}.
@@ -105,6 +145,46 @@ public interface QuadView {
 	 * utility functions for use by renderers.
 	 */
 	Vector3f faceNormal();
+
+	/**
+	 * Retrieves the material serialized with the quad.
+	 */
+	RenderMaterial material();
+
+	/**
+	 * Retrieves the quad color index serialized with the quad.
+	 */
+	int colorIndex();
+
+	/**
+	 * Retrieves the integer tag encoded with this quad via {@link MutableQuadView#tag(int)}.
+	 * Will return zero if no tag was set.  For use by models.
+	 */
+	int tag();
+
+	/**
+	 * Extracts all quad properties except material to the given {@link MutableQuadView} instance.
+	 * Must be used before calling {link QuadEmitter#emit()} on the target instance.
+	 * Meant for re-texturing, analysis and static transformation use cases.
+	 */
+	void copyTo(MutableQuadView target);
+
+	/**
+	 * Reads baked vertex data and outputs standard baked quad
+	 * vertex data in the given array and location.
+	 *
+	 * @param spriteIndex The sprite to be used for the quad.
+	 * Behavior for values &gt; 0 is currently undefined.
+	 *
+	 * @param target Target array for the baked quad data.
+	 *
+	 * @param targetIndex Starting position in target array - array must have
+	 * at least 28 elements available at this index.
+	 *
+	 * @param isItem If true, will output vertex normals. Otherwise will output
+	 * lightmaps, per Minecraft vertex formats for baked models.
+	 */
+	void toVanilla(int spriteIndex, int[] target, int targetIndex, boolean isItem);
 
 	/**
 	 * Generates a new BakedQuad instance with texture
@@ -128,84 +208,4 @@ public interface QuadView {
 		toVanilla(spriteIndex, vertexData, 0, isItem);
 		return new BakedQuad(vertexData, colorIndex(), lightFace(), sprite, true /* TODO:20w09a check me */);
 	}
-
-	/**
-	 * Retrieves the integer tag encoded with this quad via {@link MutableQuadView#tag(int)}.
-	 * Will return zero if no tag was set.  For use by models.
-	 */
-	int tag();
-
-	/**
-	 * Pass a non-null target to avoid allocation - will be returned with values.
-	 * Otherwise returns a new instance.
-	 */
-	Vector3f copyPos(int vertexIndex, @Nullable Vector3f target);
-
-	/**
-	 * Convenience: access x, y, z by index 0-2.
-	 */
-	float posByIndex(int vertexIndex, int coordinateIndex);
-
-	/**
-	 * Geometric position, x coordinate.
-	 */
-	float x(int vertexIndex);
-
-	/**
-	 * Geometric position, y coordinate.
-	 */
-	float y(int vertexIndex);
-
-	/**
-	 * Geometric position, z coordinate.
-	 */
-	float z(int vertexIndex);
-
-	/**
-	 * If false, no vertex normal was provided.
-	 * Lighting should use face normal in that case.
-	 */
-	boolean hasNormal(int vertexIndex);
-
-	/**
-	 * Pass a non-null target to avoid allocation - will be returned with values.
-	 * Otherwise returns a new instance. Returns null if normal not present.
-	 */
-	@Nullable
-	Vector3f copyNormal(int vertexIndex, @Nullable Vector3f target);
-
-	/**
-	 * Will return {@link Float#NaN} if normal not present.
-	 */
-	float normalX(int vertexIndex);
-
-	/**
-	 * Will return {@link Float#NaN} if normal not present.
-	 */
-	float normalY(int vertexIndex);
-
-	/**
-	 * Will return {@link Float#NaN} if normal not present.
-	 */
-	float normalZ(int vertexIndex);
-
-	/**
-	 * Minimum block brightness. Zero if not set.
-	 */
-	int lightmap(int vertexIndex);
-
-	/**
-	 * Retrieve vertex color.
-	 */
-	int spriteColor(int vertexIndex, int spriteIndex);
-
-	/**
-	 * Retrieve horizontal sprite atlas coordinates.
-	 */
-	float spriteU(int vertexIndex, int spriteIndex);
-
-	/**
-	 * Retrieve vertical sprite atlas coordinates.
-	 */
-	float spriteV(int vertexIndex, int spriteIndex);
 }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadView.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadView.java
@@ -42,17 +42,17 @@ public interface QuadView {
 	int VANILLA_QUAD_STRIDE = VANILLA_VERTEX_STRIDE * 4;
 
 	/**
-	 * Geometric position, x coordinate.
+	 * Retrieve geometric position, x coordinate.
 	 */
 	float x(int vertexIndex);
 
 	/**
-	 * Geometric position, y coordinate.
+	 * Retrieve geometric position, y coordinate.
 	 */
 	float y(int vertexIndex);
 
 	/**
-	 * Geometric position, z coordinate.
+	 * Retrieve geometric position, z coordinate.
 	 */
 	float z(int vertexIndex);
 
@@ -69,18 +69,30 @@ public interface QuadView {
 
 	/**
 	 * Retrieve vertex color.
+	 *
+	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	int spriteColor(int vertexIndex, int spriteIndex);
+	default int color(int vertexIndex) {
+		return spriteColor(vertexIndex, 0);
+	}
 
 	/**
-	 * Retrieve horizontal sprite atlas coordinates.
+	 * Retrieve horizontal texture coordinates.
+	 *
+	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	float spriteU(int vertexIndex, int spriteIndex);
+	default float u(int vertexIndex) {
+		return spriteU(vertexIndex, 0);
+	}
 
 	/**
-	 * Retrieve vertical sprite atlas coordinates.
+	 * Retrieve vertical texture coordinates.
+	 *
+	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	float spriteV(int vertexIndex, int spriteIndex);
+	default float v(int vertexIndex) {
+		return spriteV(vertexIndex, 0);
+	}
 
 	/**
 	 * Minimum block brightness. Zero if not set.
@@ -121,7 +133,8 @@ public interface QuadView {
 	 *
 	 * @see MutableQuadView#cullFace(Direction)
 	 */
-	@Nullable Direction cullFace();
+	@Nullable
+	Direction cullFace();
 
 	/**
 	 * Equivalent to {@link BakedQuad#getFace()}. This is the face used for vanilla lighting
@@ -138,7 +151,7 @@ public interface QuadView {
 
 	/**
 	 * Normal of the quad as implied by geometry. Will be invalid
-	 * if quad vertices are not co-planar.  Typically computed lazily
+	 * if quad vertices are not co-planar. Typically computed lazily
 	 * on demand and not encoded.
 	 *
 	 * <p>Not typically needed by models. Exposed to enable standard lighting
@@ -158,7 +171,7 @@ public interface QuadView {
 
 	/**
 	 * Retrieves the integer tag encoded with this quad via {@link MutableQuadView#tag(int)}.
-	 * Will return zero if no tag was set.  For use by models.
+	 * Will return zero if no tag was set. For use by models.
 	 */
 	int tag();
 
@@ -173,39 +186,92 @@ public interface QuadView {
 	 * Reads baked vertex data and outputs standard baked quad
 	 * vertex data in the given array and location.
 	 *
-	 * @param spriteIndex The sprite to be used for the quad.
-	 * Behavior for values &gt; 0 is currently undefined.
+	 * @apiNote The default implementation will be removed in the next breaking release.
 	 *
 	 * @param target Target array for the baked quad data.
 	 *
 	 * @param targetIndex Starting position in target array - array must have
 	 * at least 28 elements available at this index.
-	 *
-	 * @param isItem If true, will output vertex normals. Otherwise will output
-	 * lightmaps, per Minecraft vertex formats for baked models.
 	 */
-	void toVanilla(int spriteIndex, int[] target, int targetIndex, boolean isItem);
+	default void toVanilla(int[] target, int targetIndex) {
+		toVanilla(0, target, targetIndex, false);
+	}
 
 	/**
 	 * Generates a new BakedQuad instance with texture
 	 * coordinates and colors from the given sprite.
 	 *
-	 * @param spriteIndex The sprite to be used for the quad.
-	 * Behavior for {@code spriteIndex > 0} is currently undefined.
-	 *
-	 * @param sprite  {@link MutableQuadView} does not serialize sprites
+	 * @param sprite {@link MutableQuadView} does not serialize sprites
 	 * so the sprite must be provided by the caller.
 	 *
-	 * @param isItem If true, will output vertex normals. Otherwise will output
-	 * lightmaps, per Minecraft vertex formats for baked models.
+	 * @param shade Shade value that the resulting BakedQuad should use.
 	 *
 	 * @return A new baked quad instance with the closest-available appearance
 	 * supported by vanilla features. Will retain emissive light maps, for example,
 	 * but the standard Minecraft renderer will not use them.
 	 */
-	default BakedQuad toBakedQuad(int spriteIndex, Sprite sprite, boolean isItem) {
+	default BakedQuad toBakedQuad(Sprite sprite, boolean shade) {
 		int[] vertexData = new int[VANILLA_QUAD_STRIDE];
-		toVanilla(spriteIndex, vertexData, 0, isItem);
-		return new BakedQuad(vertexData, colorIndex(), lightFace(), sprite, true /* TODO:20w09a check me */);
+		toVanilla(vertexData, 0);
+		return new BakedQuad(vertexData, colorIndex(), lightFace(), sprite, shade);
+	}
+
+	/**
+	 * Generates a new BakedQuad instance with texture
+	 * coordinates and colors from the given sprite.
+	 *
+	 * <p>Similar to {@link #toBakedQuad(Sprite, boolean)}, but
+	 * automatically retrieves the shade value from this quad's material.
+	 *
+	 * @param sprite {@link MutableQuadView} does not serialize sprites
+	 * so the sprite must be provided by the caller.
+	 *
+	 * @return A new baked quad instance with the closest-available appearance
+	 * supported by vanilla features. Will retain emissive light maps, for example,
+	 * but the standard Minecraft renderer will not use them.
+	 */
+	default BakedQuad toBakedQuad(Sprite sprite) {
+		// TODO material inspection: set shade as !disableDiffuse
+		return toBakedQuad(sprite, true);
+	}
+
+	/**
+	 * @deprecated Use {@link #color(int)} instead.
+	 */
+	@Deprecated
+	default int spriteColor(int vertexIndex, int spriteIndex) {
+		return color(vertexIndex);
+	}
+
+	/**
+	 * @deprecated Use {@link #u(int)} instead.
+	 */
+	@Deprecated
+	default float spriteU(int vertexIndex, int spriteIndex) {
+		return u(vertexIndex);
+	}
+
+	/**
+	 * @deprecated Use {@link #v(int)} instead.
+	 */
+	@Deprecated
+	default float spriteV(int vertexIndex, int spriteIndex) {
+		return v(vertexIndex);
+	}
+
+	/**
+	 * @deprecated Use {@link #toVanilla(int[], int)} instead.
+	 */
+	@Deprecated
+	default void toVanilla(int spriteIndex, int[] target, int targetIndex, boolean isItem) {
+		toVanilla(target, targetIndex);
+	}
+
+	/**
+	 * @deprecated Use {@link #toBakedQuad(Sprite)} instead.
+	 */
+	@Deprecated
+	default BakedQuad toBakedQuad(int spriteIndex, Sprite sprite, boolean isItem) {
+		return toBakedQuad(sprite, true);
 	}
 }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/ModelHelper.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/ModelHelper.java
@@ -84,12 +84,8 @@ public final class ModelHelper {
 
 		if (mesh != null) {
 			mesh.forEach(q -> {
-				final int limit = q.material().spriteDepth();
-
-				for (int l = 0; l < limit; l++) {
-					Direction face = q.cullFace();
-					builders[face == null ? 6 : face.getId()].add(q.toBakedQuad(l, finder.find(q, l), false));
-				}
+				Direction cullFace = q.cullFace();
+				builders[cullFace == null ? NULL_FACE_ID : cullFace.getId()].add(q.toBakedQuad(finder.find(q)));
 			});
 		}
 

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/SpriteFinder.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/SpriteFinder.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.renderer.v1.model;
 
+import org.jetbrains.annotations.ApiStatus;
+
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.texture.SpriteAtlasTexture;
 
@@ -29,8 +31,9 @@ import net.fabricmc.fabric.impl.renderer.SpriteFinderImpl;
  * baked vertex coordinates.  Main use is for {@link Mesh}-based models
  * to generate vanilla quads on demand without tracking and retaining
  * the sprites that were baked into the mesh. In other words, this class
- * supplies the sprite parameter for {@link QuadView#toBakedQuad(int, Sprite, boolean)}.
+ * supplies the sprite parameter for {@link QuadView#toBakedQuad(Sprite)}.
  */
+@ApiStatus.NonExtendable
 public interface SpriteFinder {
 	/**
 	 * Retrieves or creates the finder for the given atlas.
@@ -51,13 +54,13 @@ public interface SpriteFinder {
 	 * Note that all the above refers to u,v coordinates. Geometric vertex does not matter,
 	 * except to the extent it was used to determine u,v.
 	 */
-	Sprite find(QuadView quad, int textureIndex);
+	Sprite find(QuadView quad);
 
 	/**
 	 * Alternative to {@link #find(QuadView, int)} when vertex centroid is already
 	 * known or unsuitable.  Expects normalized (0-1) coordinates on the atlas texture,
 	 * which should already be the case for u,v values in vanilla baked quads and in
-	 * {@link QuadView} after calling {@link MutableQuadView#spriteBake(int, Sprite, int)}.
+	 * {@link QuadView} after calling {@link MutableQuadView#spriteBake(Sprite, int)}.
 	 *
 	 * <p>Coordinates must be in the sprite interior for reliable results. Generally will
 	 * be easier to use {@link #find(QuadView, int)} unless you know the vertex
@@ -65,4 +68,12 @@ public interface SpriteFinder {
 	 * faster if you already have the centroid or another appropriate value.
 	 */
 	Sprite find(float u, float v);
+
+	/**
+	 * @deprecated Use {@link #find(QuadView)} instead.
+	 */
+	@Deprecated
+	default Sprite find(QuadView quad, int textureIndex) {
+		return find(quad);
+	}
 }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/RenderContext.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/RenderContext.java
@@ -42,23 +42,12 @@ public interface RenderContext {
 	Consumer<Mesh> meshConsumer();
 
 	/**
-	 * Fabric causes vanilla baked models to send themselves
-	 * via this interface. Can also be used by compound models that contain a mix
-	 * of vanilla baked models, packaged quads and/or dynamic elements.
-	 *
-	 * @deprecated Prefer using the more flexible {@link #bakedModelConsumer}.
-	 */
-	@Deprecated
-	default Consumer<BakedModel> fallbackConsumer() {
-		// This default implementation relies on implementors overriding bakedModelConsumer().
-		return bakedModelConsumer();
-	}
-
-	/**
 	 * Fallback consumer that can process a vanilla {@link BakedModel}.
 	 * Fabric causes vanilla baked models to send themselves
 	 * via this interface. Can also be used by compound models that contain a mix
 	 * of vanilla baked models, packaged quads and/or dynamic elements.
+	 *
+	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
 	default BakedModelConsumer bakedModelConsumer() {
 		// Default implementation is provided for compat with older renderer implementations,
@@ -112,6 +101,19 @@ public interface RenderContext {
 	 * MUST be called before exiting from {@link FabricBakedModel} .emit... methods.
 	 */
 	void popTransform();
+
+	/**
+	 * Fabric causes vanilla baked models to send themselves
+	 * via this interface. Can also be used by compound models that contain a mix
+	 * of vanilla baked models, packaged quads and/or dynamic elements.
+	 *
+	 * @deprecated Prefer using the more flexible {@link #bakedModelConsumer}.
+	 */
+	@Deprecated
+	default Consumer<BakedModel> fallbackConsumer() {
+		// This default implementation relies on implementors overriding bakedModelConsumer().
+		return bakedModelConsumer();
+	}
 
 	interface BakedModelConsumer extends Consumer<BakedModel> {
 		/**

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/RenderContext.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/RenderContext.java
@@ -42,6 +42,19 @@ public interface RenderContext {
 	Consumer<Mesh> meshConsumer();
 
 	/**
+	 * Fabric causes vanilla baked models to send themselves
+	 * via this interface. Can also be used by compound models that contain a mix
+	 * of vanilla baked models, packaged quads and/or dynamic elements.
+	 *
+	 * @deprecated Prefer using the more flexible {@link #bakedModelConsumer}.
+	 */
+	@Deprecated
+	default Consumer<BakedModel> fallbackConsumer() {
+		// This default implementation relies on implementors overriding bakedModelConsumer().
+		return bakedModelConsumer();
+	}
+
+	/**
 	 * Fallback consumer that can process a vanilla {@link BakedModel}.
 	 * Fabric causes vanilla baked models to send themselves
 	 * via this interface. Can also be used by compound models that contain a mix
@@ -62,43 +75,6 @@ public interface RenderContext {
 				fallback.accept(model);
 			}
 		};
-	}
-
-	interface BakedModelConsumer extends Consumer<BakedModel> {
-		/**
-		 * Render a baked model by processing its {@linkplain BakedModel#getQuads} using the rendered block state.
-		 *
-		 * <p>For block contexts, this will pass the block state being rendered to {@link BakedModel#getQuads}.
-		 * For item contexts, this will pass a {@code null} block state to {@link BakedModel#getQuads}.
-		 * {@link #accept(BakedModel, BlockState)} can be used instead to pass the block state explicitly.
-		 */
-		@Override
-		void accept(BakedModel model);
-
-		/**
-		 * Render a baked model by processing its {@linkplain BakedModel#getQuads} with an explicit block state.
-		 *
-		 * <p>This overload allows passing the block state (or {@code null} to query the item quads).
-		 * This is useful when a model is being wrapped, and expects a different
-		 * block state than the one of the block being rendered.
-		 *
-		 * <p>For item render contexts, you can use this function if you want to render the model with a specific block state.
-		 * Otherwise, use {@linkplain #accept(BakedModel)} the other overload} to render the usual item quads.
-		 */
-		void accept(BakedModel model, @Nullable BlockState state);
-	}
-
-	/**
-	 * Fabric causes vanilla baked models to send themselves
-	 * via this interface. Can also be used by compound models that contain a mix
-	 * of vanilla baked models, packaged quads and/or dynamic elements.
-	 *
-	 * @deprecated Prefer using the more flexible {@link #bakedModelConsumer}.
-	 */
-	@Deprecated
-	default Consumer<BakedModel> fallbackConsumer() {
-		// This default implementation relies on implementors overriding bakedModelConsumer().
-		return bakedModelConsumer();
 	}
 
 	/**
@@ -136,6 +112,30 @@ public interface RenderContext {
 	 * MUST be called before exiting from {@link FabricBakedModel} .emit... methods.
 	 */
 	void popTransform();
+
+	interface BakedModelConsumer extends Consumer<BakedModel> {
+		/**
+		 * Render a baked model by processing its {@linkplain BakedModel#getQuads} using the rendered block state.
+		 *
+		 * <p>For block contexts, this will pass the block state being rendered to {@link BakedModel#getQuads}.
+		 * For item contexts, this will pass a {@code null} block state to {@link BakedModel#getQuads}.
+		 * {@link #accept(BakedModel, BlockState)} can be used instead to pass the block state explicitly.
+		 */
+		@Override
+		void accept(BakedModel model);
+
+		/**
+		 * Render a baked model by processing its {@linkplain BakedModel#getQuads} with an explicit block state.
+		 *
+		 * <p>This overload allows passing the block state (or {@code null} to query the item quads).
+		 * This is useful when a model is being wrapped, and expects a different
+		 * block state than the one of the block being rendered.
+		 *
+		 * <p>For item render contexts, you can use this function if you want to render the model with a specific block state.
+		 * Otherwise, use {@linkplain #accept(BakedModel)} the other overload} to render the usual item quads.
+		 */
+		void accept(BakedModel model, @Nullable BlockState state);
+	}
 
 	@FunctionalInterface
 	interface QuadTransform {

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/impl/renderer/SpriteFinderImpl.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/impl/renderer/SpriteFinderImpl.java
@@ -53,13 +53,13 @@ public class SpriteFinderImpl implements SpriteFinder {
 	}
 
 	@Override
-	public Sprite find(QuadView quad, int textureIndex) {
+	public Sprite find(QuadView quad) {
 		float u = 0;
 		float v = 0;
 
 		for (int i = 0; i < 4; i++) {
-			u += quad.spriteU(i, textureIndex);
-			v += quad.spriteV(i, textureIndex);
+			u += quad.u(i);
+			v += quad.v(i);
 		}
 
 		return find(u * 0.25f, v * 0.25f);

--- a/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/client/FrameBakedModel.java
+++ b/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/client/FrameBakedModel.java
@@ -58,9 +58,9 @@ final class FrameBakedModel implements BakedModel, FabricBakedModel {
 		this.frameSprite = frameSprite;
 
 		MaterialFinder finder = RendererAccess.INSTANCE.getRenderer().materialFinder();
-		this.translucentMaterial = finder.blendMode(0, BlendMode.TRANSLUCENT).find();
+		this.translucentMaterial = finder.blendMode(BlendMode.TRANSLUCENT).find();
 		finder.clear();
-		this.translucentEmissiveMaterial = finder.blendMode(0, BlendMode.TRANSLUCENT).emissive(0, true).find();
+		this.translucentEmissiveMaterial = finder.blendMode(BlendMode.TRANSLUCENT).emissive(true).find();
 	}
 
 	@Override
@@ -173,11 +173,11 @@ final class FrameBakedModel implements BakedModel, FabricBakedModel {
 
 			// Change vertex colors to be partially transparent
 			for (int vertex = 0; vertex < 4; ++vertex) {
-				int color = quad.spriteColor(vertex, 0);
+				int color = quad.color(vertex);
 				int alpha = (color >> 24) & 0xFF;
 				alpha = alpha * 3 / 4;
 				color = (color & 0xFFFFFF) | (alpha << 24);
-				quad.spriteColor(vertex, 0, color);
+				quad.color(vertex, color);
 			}
 
 			// Return true because we want the quad to be rendered

--- a/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/client/FrameUnbakedModel.java
+++ b/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/client/FrameUnbakedModel.java
@@ -70,44 +70,44 @@ final class FrameUnbakedModel implements UnbakedModel {
 			for (Direction direction : Direction.values()) {
 				// Draw outer frame
 				emitter.square(direction, 0.0F, 0.9F, 0.9F, 1.0F, 0.0F)
-						.spriteBake(0, frameSprite, MutableQuadView.BAKE_LOCK_UV)
-						.spriteColor(0, -1, -1, -1, -1)
+						.spriteBake(frameSprite, MutableQuadView.BAKE_LOCK_UV)
+						.color(-1, -1, -1, -1)
 						.emit();
 
 				emitter.square(direction, 0.0F, 0.0F, 0.1F, 0.9F, 0.0F)
-						.spriteBake(0, frameSprite, MutableQuadView.BAKE_LOCK_UV)
-						.spriteColor(0, -1, -1, -1, -1)
+						.spriteBake(frameSprite, MutableQuadView.BAKE_LOCK_UV)
+						.color(-1, -1, -1, -1)
 						.emit();
 
 				emitter.square(direction, 0.9F, 0.1F, 1.0F, 1.0F, 0.0F)
-						.spriteBake(0, frameSprite, MutableQuadView.BAKE_LOCK_UV)
-						.spriteColor(0, -1, -1, -1, -1)
+						.spriteBake(frameSprite, MutableQuadView.BAKE_LOCK_UV)
+						.color(-1, -1, -1, -1)
 						.emit();
 
 				emitter.square(direction, 0.1F, 0.0F, 1.0F, 0.1F, 0.0F)
-						.spriteBake(0, frameSprite, MutableQuadView.BAKE_LOCK_UV)
-						.spriteColor(0, -1, -1, -1, -1)
+						.spriteBake(frameSprite, MutableQuadView.BAKE_LOCK_UV)
+						.color(-1, -1, -1, -1)
 						.emit();
 
 				// Draw inner frame - inset by 0.9 so the frame looks like an actual mesh
 				emitter.square(direction, 0.0F, 0.9F, 0.9F, 1.0F, 0.9F)
-						.spriteBake(0, frameSprite, MutableQuadView.BAKE_LOCK_UV)
-						.spriteColor(0, -1, -1, -1, -1)
+						.spriteBake(frameSprite, MutableQuadView.BAKE_LOCK_UV)
+						.color(-1, -1, -1, -1)
 						.emit();
 
 				emitter.square(direction, 0.0F, 0.0F, 0.1F, 0.9F, 0.9F)
-						.spriteBake(0, frameSprite, MutableQuadView.BAKE_LOCK_UV)
-						.spriteColor(0, -1, -1, -1, -1)
+						.spriteBake(frameSprite, MutableQuadView.BAKE_LOCK_UV)
+						.color(-1, -1, -1, -1)
 						.emit();
 
 				emitter.square(direction, 0.9F, 0.1F, 1.0F, 1.0F, 0.9F)
-						.spriteBake(0, frameSprite, MutableQuadView.BAKE_LOCK_UV)
-						.spriteColor(0, -1, -1, -1, -1)
+						.spriteBake(frameSprite, MutableQuadView.BAKE_LOCK_UV)
+						.color(-1, -1, -1, -1)
 						.emit();
 
 				emitter.square(direction, 0.1F, 0.0F, 1.0F, 0.1F, 0.9F)
-						.spriteBake(0, frameSprite, MutableQuadView.BAKE_LOCK_UV)
-						.spriteColor(0, -1, -1, -1, -1)
+						.spriteBake(frameSprite, MutableQuadView.BAKE_LOCK_UV)
+						.color(-1, -1, -1, -1)
 						.emit();
 			}
 

--- a/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/client/PillarBakedModel.java
+++ b/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/simple/client/PillarBakedModel.java
@@ -89,8 +89,8 @@ public class PillarBakedModel implements BakedModel, FabricBakedModel {
 			}
 
 			emitter.square(side, 0, 0, 1, 1, 0);
-			emitter.spriteBake(0, sprites[texture.ordinal()], MutableQuadView.BAKE_LOCK_UV);
-			emitter.spriteColor(0, -1, -1, -1, -1);
+			emitter.spriteBake(sprites[texture.ordinal()], MutableQuadView.BAKE_LOCK_UV);
+			emitter.color(-1, -1, -1, -1);
 			emitter.emit();
 		}
 	}

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/RenderMaterialImpl.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/RenderMaterialImpl.java
@@ -16,8 +16,6 @@
 
 package net.fabricmc.fabric.impl.client.indigo.renderer;
 
-import com.google.common.base.Preconditions;
-
 import net.minecraft.util.math.MathHelper;
 
 import net.fabricmc.fabric.api.renderer.v1.material.BlendMode;
@@ -52,8 +50,8 @@ public abstract class RenderMaterialImpl {
 		return VALUES[index];
 	}
 
-	public static Value setDisableDiffuse(Value material, int textureIndex, boolean disable) {
-		if (material.disableDiffuse(textureIndex) != disable) {
+	public static Value setDisableDiffuse(Value material, boolean disable) {
+		if (material.disableDiffuse() != disable) {
 			return byIndex(disable ? (material.bits | DIFFUSE_FLAG) : (material.bits & ~DIFFUSE_FLAG));
 		}
 
@@ -62,28 +60,24 @@ public abstract class RenderMaterialImpl {
 
 	protected int bits;
 
-	public BlendMode blendMode(int textureIndex) {
+	public BlendMode blendMode() {
 		return BLEND_MODES[bits & BLEND_MODE_MASK];
 	}
 
-	public boolean disableColorIndex(int textureIndex) {
+	public boolean disableColorIndex() {
 		return (bits & COLOR_DISABLE_FLAG) != 0;
 	}
 
-	public boolean emissive(int textureIndex) {
+	public boolean emissive() {
 		return (bits & EMISSIVE_FLAG) != 0;
 	}
 
-	public boolean disableDiffuse(int textureIndex) {
+	public boolean disableDiffuse() {
 		return (bits & DIFFUSE_FLAG) != 0;
 	}
 
-	public boolean disableAo(int textureIndex) {
+	public boolean disableAo() {
 		return (bits & AO_FLAG) != 0;
-	}
-
-	public int spriteDepth() {
-		return 1;
 	}
 
 	public static class Value extends RenderMaterialImpl implements RenderMaterial {
@@ -98,7 +92,7 @@ public abstract class RenderMaterialImpl {
 
 	public static class Finder extends RenderMaterialImpl implements MaterialFinder {
 		@Override
-		public MaterialFinder blendMode(int textureIndex, BlendMode blendMode) {
+		public MaterialFinder blendMode(BlendMode blendMode) {
 			if (blendMode == null) {
 				blendMode = BlendMode.DEFAULT;
 			}
@@ -108,33 +102,26 @@ public abstract class RenderMaterialImpl {
 		}
 
 		@Override
-		public MaterialFinder disableColorIndex(int textureIndex, boolean disable) {
+		public MaterialFinder disableColorIndex(boolean disable) {
 			bits = disable ? (bits | COLOR_DISABLE_FLAG) : (bits & ~COLOR_DISABLE_FLAG);
 			return this;
 		}
 
 		@Override
-		public MaterialFinder emissive(int textureIndex, boolean isEmissive) {
+		public MaterialFinder emissive(boolean isEmissive) {
 			bits = isEmissive ? (bits | EMISSIVE_FLAG) : (bits & ~EMISSIVE_FLAG);
 			return this;
 		}
 
 		@Override
-		public MaterialFinder disableDiffuse(int textureIndex, boolean disable) {
+		public MaterialFinder disableDiffuse(boolean disable) {
 			bits = disable ? (bits | DIFFUSE_FLAG) : (bits & ~DIFFUSE_FLAG);
 			return this;
 		}
 
 		@Override
-		public MaterialFinder disableAo(int textureIndex, boolean disable) {
+		public MaterialFinder disableAo(boolean disable) {
 			bits = disable ? (bits | AO_FLAG) : (bits & ~AO_FLAG);
-			return this;
-		}
-
-		@Override
-		public MaterialFinder spriteDepth(int depth) {
-			Preconditions.checkArgument(depth == 1, "Unsupported sprite depth: %s", depth);
-
 			return this;
 		}
 

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/RenderMaterialImpl.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/RenderMaterialImpl.java
@@ -70,10 +70,6 @@ public abstract class RenderMaterialImpl {
 		return (bits & COLOR_DISABLE_FLAG) != 0;
 	}
 
-	public int spriteDepth() {
-		return 1;
-	}
-
 	public boolean emissive(int textureIndex) {
 		return (bits & EMISSIVE_FLAG) != 0;
 	}
@@ -84,6 +80,10 @@ public abstract class RenderMaterialImpl {
 
 	public boolean disableAo(int textureIndex) {
 		return (bits & AO_FLAG) != 0;
+	}
+
+	public int spriteDepth() {
+		return 1;
 	}
 
 	public static class Value extends RenderMaterialImpl implements RenderMaterial {
@@ -98,17 +98,6 @@ public abstract class RenderMaterialImpl {
 
 	public static class Finder extends RenderMaterialImpl implements MaterialFinder {
 		@Override
-		public RenderMaterial find() {
-			return VALUES[bits];
-		}
-
-		@Override
-		public MaterialFinder clear() {
-			bits = 0;
-			return this;
-		}
-
-		@Override
 		public MaterialFinder blendMode(int textureIndex, BlendMode blendMode) {
 			if (blendMode == null) {
 				blendMode = BlendMode.DEFAULT;
@@ -121,13 +110,6 @@ public abstract class RenderMaterialImpl {
 		@Override
 		public MaterialFinder disableColorIndex(int textureIndex, boolean disable) {
 			bits = disable ? (bits | COLOR_DISABLE_FLAG) : (bits & ~COLOR_DISABLE_FLAG);
-			return this;
-		}
-
-		@Override
-		public MaterialFinder spriteDepth(int depth) {
-			Preconditions.checkArgument(depth == 1, "Unsupported sprite depth: %s", depth);
-
 			return this;
 		}
 
@@ -147,6 +129,24 @@ public abstract class RenderMaterialImpl {
 		public MaterialFinder disableAo(int textureIndex, boolean disable) {
 			bits = disable ? (bits | AO_FLAG) : (bits & ~AO_FLAG);
 			return this;
+		}
+
+		@Override
+		public MaterialFinder spriteDepth(int depth) {
+			Preconditions.checkArgument(depth == 1, "Unsupported sprite depth: %s", depth);
+
+			return this;
+		}
+
+		@Override
+		public MaterialFinder clear() {
+			bits = 0;
+			return this;
+		}
+
+		@Override
+		public RenderMaterial find() {
+			return VALUES[bits];
 		}
 	}
 }

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/aocalc/AoCalculator.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/aocalc/AoCalculator.java
@@ -170,7 +170,7 @@ public abstract class AoCalculator {
 	private void calcVanilla(MutableQuadViewImpl quad, float[] aoDest, int[] lightDest) {
 		vanillaAoControlBits.clear();
 		final Direction lightFace = quad.lightFace();
-		quad.toVanilla(0, vertexData, 0, false);
+		quad.toVanilla(vertexData, 0);
 
 		VanillaAoHelper.updateShape(blockInfo.blockView, blockInfo.blockState, blockInfo.blockPos, vertexData, lightFace, vanillaAoData, vanillaAoControlBits);
 		vanillaCalc.apply(blockInfo.blockView, blockInfo.blockState, blockInfo.blockPos, lightFace, vanillaAoData, vanillaAoControlBits, quad.hasShade());

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
@@ -29,8 +29,6 @@ import static net.fabricmc.fabric.impl.client.indigo.renderer.mesh.EncodingForma
 import static net.fabricmc.fabric.impl.client.indigo.renderer.mesh.EncodingFormat.VERTEX_U;
 import static net.fabricmc.fabric.impl.client.indigo.renderer.mesh.EncodingFormat.VERTEX_X;
 
-import com.google.common.base.Preconditions;
-
 import net.minecraft.client.render.model.BakedQuad;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.util.math.Direction;
@@ -76,17 +74,13 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 	}
 
 	@Override
-	public MutableQuadViewImpl spriteColor(int vertexIndex, int spriteIndex, int color) {
-		Preconditions.checkArgument(spriteIndex == 0, "Unsupported sprite index: %s", spriteIndex);
-
+	public MutableQuadViewImpl color(int vertexIndex, int color) {
 		data[baseIndex + vertexIndex * VERTEX_STRIDE + VERTEX_COLOR] = color;
 		return this;
 	}
 
 	@Override
-	public MutableQuadViewImpl sprite(int vertexIndex, int spriteIndex, float u, float v) {
-		Preconditions.checkArgument(spriteIndex == 0, "Unsupported sprite index: %s", spriteIndex);
-
+	public MutableQuadViewImpl uv(int vertexIndex, float u, float v) {
 		final int i = baseIndex + vertexIndex * VERTEX_STRIDE + VERTEX_U;
 		data[i] = Float.floatToRawIntBits(u);
 		data[i + 1] = Float.floatToRawIntBits(v);
@@ -94,10 +88,8 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 	}
 
 	@Override
-	public MutableQuadViewImpl spriteBake(int spriteIndex, Sprite sprite, int bakeFlags) {
-		Preconditions.checkArgument(spriteIndex == 0, "Unsupported sprite index: %s", spriteIndex);
-
-		TextureHelper.bakeSprite(this, spriteIndex, sprite, bakeFlags);
+	public MutableQuadViewImpl spriteBake(Sprite sprite, int bakeFlags) {
+		TextureHelper.bakeSprite(this, sprite, bakeFlags);
 		return this;
 	}
 
@@ -172,12 +164,8 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 		return this;
 	}
 
-	/**
-	 * @deprecated will be removed in 1.17 cycle - see docs in interface
-	 */
-	@Deprecated
 	@Override
-	public final MutableQuadViewImpl fromVanilla(int[] quadData, int startIndex, boolean isItem) {
+	public final MutableQuadViewImpl fromVanilla(int[] quadData, int startIndex) {
 		System.arraycopy(quadData, startIndex, data, baseIndex + HEADER_STRIDE, QUAD_STRIDE);
 		isGeometryInvalid = true;
 		return this;
@@ -185,18 +173,17 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 
 	@Override
 	public final MutableQuadViewImpl fromVanilla(BakedQuad quad, RenderMaterial material, Direction cullFace) {
-		System.arraycopy(quad.getVertexData(), 0, data, baseIndex + HEADER_STRIDE, QUAD_STRIDE);
+		fromVanilla(quad.getVertexData(), 0);
 		data[baseIndex + HEADER_BITS] = EncodingFormat.cullFace(0, cullFace);
 		nominalFace(quad.getFace());
 		colorIndex(quad.getColorIndex());
 
 		if (!quad.hasShade()) {
-			material = RenderMaterialImpl.setDisableDiffuse((Value) material, 0, true);
+			material = RenderMaterialImpl.setDisableDiffuse((Value) material, true);
 		}
 
 		material(material);
 		tag(0);
-		isGeometryInvalid = true;
 		return this;
 	}
 }

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
@@ -66,13 +66,75 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 	}
 
 	@Override
-	public final MutableQuadViewImpl material(RenderMaterial material) {
-		if (material == null) {
-			material = IndigoRenderer.MATERIAL_STANDARD;
+	public MutableQuadViewImpl pos(int vertexIndex, float x, float y, float z) {
+		final int index = baseIndex + vertexIndex * VERTEX_STRIDE + VERTEX_X;
+		data[index] = Float.floatToRawIntBits(x);
+		data[index + 1] = Float.floatToRawIntBits(y);
+		data[index + 2] = Float.floatToRawIntBits(z);
+		isGeometryInvalid = true;
+		return this;
+	}
+
+	@Override
+	public MutableQuadViewImpl spriteColor(int vertexIndex, int spriteIndex, int color) {
+		Preconditions.checkArgument(spriteIndex == 0, "Unsupported sprite index: %s", spriteIndex);
+
+		data[baseIndex + vertexIndex * VERTEX_STRIDE + VERTEX_COLOR] = color;
+		return this;
+	}
+
+	@Override
+	public MutableQuadViewImpl sprite(int vertexIndex, int spriteIndex, float u, float v) {
+		Preconditions.checkArgument(spriteIndex == 0, "Unsupported sprite index: %s", spriteIndex);
+
+		final int i = baseIndex + vertexIndex * VERTEX_STRIDE + VERTEX_U;
+		data[i] = Float.floatToRawIntBits(u);
+		data[i + 1] = Float.floatToRawIntBits(v);
+		return this;
+	}
+
+	@Override
+	public MutableQuadViewImpl spriteBake(int spriteIndex, Sprite sprite, int bakeFlags) {
+		Preconditions.checkArgument(spriteIndex == 0, "Unsupported sprite index: %s", spriteIndex);
+
+		TextureHelper.bakeSprite(this, spriteIndex, sprite, bakeFlags);
+		return this;
+	}
+
+	@Override
+	public MutableQuadViewImpl lightmap(int vertexIndex, int lightmap) {
+		data[baseIndex + vertexIndex * VERTEX_STRIDE + VERTEX_LIGHTMAP] = lightmap;
+		return this;
+	}
+
+	protected void normalFlags(int flags) {
+		data[baseIndex + HEADER_BITS] = EncodingFormat.normalFlags(data[baseIndex + HEADER_BITS], flags);
+	}
+
+	@Override
+	public MutableQuadViewImpl normal(int vertexIndex, float x, float y, float z) {
+		normalFlags(normalFlags() | (1 << vertexIndex));
+		data[baseIndex + vertexIndex * VERTEX_STRIDE + VERTEX_NORMAL] = NormalHelper.packNormal(x, y, z, 0);
+		return this;
+	}
+
+	/**
+	 * Internal helper method. Copies face normals to vertex normals lacking one.
+	 */
+	public final void populateMissingNormals() {
+		final int normalFlags = this.normalFlags();
+
+		if (normalFlags == 0b1111) return;
+
+		final int packedFaceNormal = NormalHelper.packNormal(faceNormal(), 0);
+
+		for (int v = 0; v < 4; v++) {
+			if ((normalFlags & (1 << v)) == 0) {
+				data[baseIndex + v * VERTEX_STRIDE + VERTEX_NORMAL] = packedFaceNormal;
+			}
 		}
 
-		data[baseIndex + HEADER_BITS] = EncodingFormat.material(data[baseIndex + HEADER_BITS], (Value) material);
-		return this;
+		normalFlags(0b1111);
 	}
 
 	@Override
@@ -85,6 +147,16 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 	@Override
 	public final MutableQuadViewImpl nominalFace(Direction face) {
 		nominalFace = face;
+		return this;
+	}
+
+	@Override
+	public final MutableQuadViewImpl material(RenderMaterial material) {
+		if (material == null) {
+			material = IndigoRenderer.MATERIAL_STANDARD;
+		}
+
+		data[baseIndex + HEADER_BITS] = EncodingFormat.material(data[baseIndex + HEADER_BITS], (Value) material);
 		return this;
 	}
 
@@ -125,78 +197,6 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 		material(material);
 		tag(0);
 		isGeometryInvalid = true;
-		return this;
-	}
-
-	@Override
-	public MutableQuadViewImpl pos(int vertexIndex, float x, float y, float z) {
-		final int index = baseIndex + vertexIndex * VERTEX_STRIDE + VERTEX_X;
-		data[index] = Float.floatToRawIntBits(x);
-		data[index + 1] = Float.floatToRawIntBits(y);
-		data[index + 2] = Float.floatToRawIntBits(z);
-		isGeometryInvalid = true;
-		return this;
-	}
-
-	protected void normalFlags(int flags) {
-		data[baseIndex + HEADER_BITS] = EncodingFormat.normalFlags(data[baseIndex + HEADER_BITS], flags);
-	}
-
-	@Override
-	public MutableQuadViewImpl normal(int vertexIndex, float x, float y, float z) {
-		normalFlags(normalFlags() | (1 << vertexIndex));
-		data[baseIndex + vertexIndex * VERTEX_STRIDE + VERTEX_NORMAL] = NormalHelper.packNormal(x, y, z, 0);
-		return this;
-	}
-
-	/**
-	 * Internal helper method. Copies face normals to vertex normals lacking one.
-	 */
-	public final void populateMissingNormals() {
-		final int normalFlags = this.normalFlags();
-
-		if (normalFlags == 0b1111) return;
-
-		final int packedFaceNormal = NormalHelper.packNormal(faceNormal(), 0);
-
-		for (int v = 0; v < 4; v++) {
-			if ((normalFlags & (1 << v)) == 0) {
-				data[baseIndex + v * VERTEX_STRIDE + VERTEX_NORMAL] = packedFaceNormal;
-			}
-		}
-
-		normalFlags(0b1111);
-	}
-
-	@Override
-	public MutableQuadViewImpl lightmap(int vertexIndex, int lightmap) {
-		data[baseIndex + vertexIndex * VERTEX_STRIDE + VERTEX_LIGHTMAP] = lightmap;
-		return this;
-	}
-
-	@Override
-	public MutableQuadViewImpl spriteColor(int vertexIndex, int spriteIndex, int color) {
-		Preconditions.checkArgument(spriteIndex == 0, "Unsupported sprite index: %s", spriteIndex);
-
-		data[baseIndex + vertexIndex * VERTEX_STRIDE + VERTEX_COLOR] = color;
-		return this;
-	}
-
-	@Override
-	public MutableQuadViewImpl sprite(int vertexIndex, int spriteIndex, float u, float v) {
-		Preconditions.checkArgument(spriteIndex == 0, "Unsupported sprite index: %s", spriteIndex);
-
-		final int i = baseIndex + vertexIndex * VERTEX_STRIDE + VERTEX_U;
-		data[i] = Float.floatToRawIntBits(u);
-		data[i + 1] = Float.floatToRawIntBits(v);
-		return this;
-	}
-
-	@Override
-	public MutableQuadViewImpl spriteBake(int spriteIndex, Sprite sprite, int bakeFlags) {
-		Preconditions.checkArgument(spriteIndex == 0, "Unsupported sprite index: %s", spriteIndex);
-
-		TextureHelper.bakeSprite(this, spriteIndex, sprite, bakeFlags);
 		return this;
 	}
 }

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/QuadViewImpl.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/QuadViewImpl.java
@@ -30,9 +30,11 @@ import static net.fabricmc.fabric.impl.client.indigo.renderer.mesh.EncodingForma
 import static net.fabricmc.fabric.impl.client.indigo.renderer.mesh.EncodingFormat.VERTEX_Y;
 import static net.fabricmc.fabric.impl.client.indigo.renderer.mesh.EncodingFormat.VERTEX_Z;
 
-import com.google.common.base.Preconditions;
+import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3f;
 
+import net.minecraft.client.render.model.BakedQuad;
+import net.minecraft.client.texture.Sprite;
 import net.minecraft.util.math.Direction;
 
 import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
@@ -115,7 +117,7 @@ public class QuadViewImpl implements QuadView {
 	}
 
 	public boolean hasShade() {
-		return !material().disableDiffuse(0);
+		return !material().disableDiffuse();
 	}
 
 	@Override
@@ -150,23 +152,17 @@ public class QuadViewImpl implements QuadView {
 	}
 
 	@Override
-	public int spriteColor(int vertexIndex, int spriteIndex) {
-		Preconditions.checkArgument(spriteIndex == 0, "Unsupported sprite index: %s", spriteIndex);
-
+	public int color(int vertexIndex) {
 		return data[baseIndex + vertexIndex * VERTEX_STRIDE + VERTEX_COLOR];
 	}
 
 	@Override
-	public float spriteU(int vertexIndex, int spriteIndex) {
-		Preconditions.checkArgument(spriteIndex == 0, "Unsupported sprite index: %s", spriteIndex);
-
+	public float u(int vertexIndex) {
 		return Float.intBitsToFloat(data[baseIndex + vertexIndex * VERTEX_STRIDE + VERTEX_U]);
 	}
 
 	@Override
-	public float spriteV(int vertexIndex, int spriteIndex) {
-		Preconditions.checkArgument(spriteIndex == 0, "Unsupported sprite index: %s", spriteIndex);
-
+	public float v(int vertexIndex) {
 		return Float.intBitsToFloat(data[baseIndex + vertexIndex * VERTEX_STRIDE + VERTEX_V]);
 	}
 
@@ -220,6 +216,7 @@ public class QuadViewImpl implements QuadView {
 	}
 
 	@Override
+	@NotNull
 	public final Direction lightFace() {
 		computeGeometry();
 		return EncodingFormat.lightFace(data[baseIndex + HEADER_BITS]);
@@ -260,13 +257,19 @@ public class QuadViewImpl implements QuadView {
 		RenderMaterial material = quad.material();
 		System.arraycopy(data, baseIndex, quad.data, quad.baseIndex, EncodingFormat.TOTAL_STRIDE);
 		quad.material(material);
-		quad.faceNormal.set(faceNormal.x(), faceNormal.y(), faceNormal.z());
+		quad.faceNormal.set(faceNormal);
 		quad.nominalFace = this.nominalFace;
 		quad.isGeometryInvalid = false;
 	}
 
 	@Override
-	public final void toVanilla(int textureIndex, int[] target, int targetIndex, boolean isItem) {
+	public final void toVanilla(int[] target, int targetIndex) {
 		System.arraycopy(data, baseIndex + VERTEX_X, target, targetIndex, QUAD_STRIDE);
+	}
+
+	// TODO material inspection: remove
+	@Override
+	public final BakedQuad toBakedQuad(Sprite sprite) {
+		return toBakedQuad(sprite, !material().disableDiffuse());
 	}
 }

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AbstractQuadRenderer.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AbstractQuadRenderer.java
@@ -72,29 +72,29 @@ public abstract class AbstractQuadRenderer {
 			return;
 		}
 
-		tessellateQuad(quad, 0, isVanilla);
+		tessellateQuad(quad, isVanilla);
 	}
 
 	/**
 	 * Determines color index and render layer, then routes to appropriate
 	 * tessellate routine based on material properties.
 	 */
-	private void tessellateQuad(MutableQuadViewImpl quad, int textureIndex, boolean isVanilla) {
+	private void tessellateQuad(MutableQuadViewImpl quad, boolean isVanilla) {
 		final RenderMaterialImpl.Value mat = quad.material();
-		final int colorIndex = mat.disableColorIndex(textureIndex) ? -1 : quad.colorIndex();
-		final RenderLayer renderLayer = blockInfo.effectiveRenderLayer(mat.blendMode(textureIndex));
+		final int colorIndex = mat.disableColorIndex() ? -1 : quad.colorIndex();
+		final RenderLayer renderLayer = blockInfo.effectiveRenderLayer(mat.blendMode());
 
-		if (blockInfo.defaultAo && !mat.disableAo(textureIndex)) {
+		if (blockInfo.defaultAo && !mat.disableAo()) {
 			// needs to happen before offsets are applied
 			aoCalc.compute(quad, isVanilla);
 
-			if (mat.emissive(textureIndex)) {
+			if (mat.emissive()) {
 				tessellateSmoothEmissive(quad, renderLayer, colorIndex);
 			} else {
 				tessellateSmooth(quad, renderLayer, colorIndex);
 			}
 		} else {
-			if (mat.emissive(textureIndex)) {
+			if (mat.emissive()) {
 				tessellateFlatEmissive(quad, renderLayer, colorIndex);
 			} else {
 				tessellateFlat(quad, renderLayer, colorIndex);
@@ -106,13 +106,13 @@ public abstract class AbstractQuadRenderer {
 	private void colorizeQuad(MutableQuadViewImpl q, int blockColorIndex) {
 		if (blockColorIndex == -1) {
 			for (int i = 0; i < 4; i++) {
-				q.spriteColor(i, 0, ColorHelper.swapRedBlueIfNeeded(q.spriteColor(i, 0)));
+				q.color(i, ColorHelper.swapRedBlueIfNeeded(q.color(i)));
 			}
 		} else {
 			final int blockColor = blockInfo.blockColor(blockColorIndex);
 
 			for (int i = 0; i < 4; i++) {
-				q.spriteColor(i, 0, ColorHelper.swapRedBlueIfNeeded(ColorHelper.multiplyColor(blockColor, q.spriteColor(i, 0))));
+				q.color(i, ColorHelper.swapRedBlueIfNeeded(ColorHelper.multiplyColor(blockColor, q.color(i))));
 			}
 		}
 	}
@@ -128,21 +128,20 @@ public abstract class AbstractQuadRenderer {
 		if (useNormals) {
 			quad.populateMissingNormals();
 		} else {
-			final Vector3f faceNormal = quad.faceNormal();
-			normalVec.set(faceNormal.x(), faceNormal.y(), faceNormal.z());
+			normalVec.set(quad.faceNormal());
 			normalVec.mul(normalMatrix);
 		}
 
 		for (int i = 0; i < 4; i++) {
 			buff.vertex(matrix, quad.x(i), quad.y(i), quad.z(i));
-			final int color = quad.spriteColor(i, 0);
+			final int color = quad.color(i);
 			buff.color(color & 0xFF, (color >> 8) & 0xFF, (color >> 16) & 0xFF, (color >> 24) & 0xFF);
-			buff.texture(quad.spriteU(i, 0), quad.spriteV(i, 0));
+			buff.texture(quad.u(i), quad.v(i));
 			buff.overlay(overlay);
 			buff.light(quad.lightmap(i));
 
 			if (useNormals) {
-				normalVec.set(quad.normalX(i), quad.normalY(i), quad.normalZ(i));
+				quad.copyNormal(i, normalVec);
 				normalVec.mul(normalMatrix);
 			}
 
@@ -158,7 +157,7 @@ public abstract class AbstractQuadRenderer {
 		colorizeQuad(q, blockColorIndex);
 
 		for (int i = 0; i < 4; i++) {
-			q.spriteColor(i, 0, ColorHelper.multiplyRGB(q.spriteColor(i, 0), aoCalc.ao[i]));
+			q.color(i, ColorHelper.multiplyRGB(q.color(i), aoCalc.ao[i]));
 			q.lightmap(i, ColorHelper.maxBrightness(q.lightmap(i), aoCalc.light[i]));
 		}
 
@@ -170,7 +169,7 @@ public abstract class AbstractQuadRenderer {
 		colorizeQuad(q, blockColorIndex);
 
 		for (int i = 0; i < 4; i++) {
-			q.spriteColor(i, 0, ColorHelper.multiplyRGB(q.spriteColor(i, 0), aoCalc.ao[i]));
+			q.color(i, ColorHelper.multiplyRGB(q.color(i), aoCalc.ao[i]));
 			q.lightmap(i, LightmapTextureManager.MAX_LIGHT_COORDINATE);
 		}
 
@@ -240,14 +239,14 @@ public abstract class AbstractQuadRenderer {
 			final float faceShade = blockInfo.blockView.getBrightness(quad.lightFace(), quad.hasShade());
 
 			for (int i = 0; i < 4; i++) {
-				quad.spriteColor(i, 0, ColorHelper.multiplyRGB(quad.spriteColor(i, 0), vertexShade(quad, i, faceShade)));
+				quad.color(i, ColorHelper.multiplyRGB(quad.color(i), vertexShade(quad, i, faceShade)));
 			}
 		} else {
 			final float diffuseShade = blockInfo.blockView.getBrightness(quad.lightFace(), quad.hasShade());
 
 			if (diffuseShade != 1.0f) {
 				for (int i = 0; i < 4; i++) {
-					quad.spriteColor(i, 0, ColorHelper.multiplyRGB(quad.spriteColor(i, 0), diffuseShade));
+					quad.color(i, ColorHelper.multiplyRGB(quad.color(i), diffuseShade));
 				}
 			}
 		}

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
@@ -185,13 +185,13 @@ public class ItemRenderContext extends AbstractRenderContext {
 	private void colorizeQuad(MutableQuadViewImpl q, int colorIndex) {
 		if (colorIndex == -1) {
 			for (int i = 0; i < 4; i++) {
-				q.spriteColor(i, 0, ColorHelper.swapRedBlueIfNeeded(q.spriteColor(i, 0)));
+				q.color(i, ColorHelper.swapRedBlueIfNeeded(q.color(i)));
 			}
 		} else {
 			final int itemColor = 0xFF000000 | colorMap.getColor(itemStack, colorIndex);
 
 			for (int i = 0; i < 4; i++) {
-				q.spriteColor(i, 0, ColorHelper.swapRedBlueIfNeeded(ColorHelper.multiplyColor(itemColor, q.spriteColor(i, 0))));
+				q.color(i, ColorHelper.swapRedBlueIfNeeded(ColorHelper.multiplyColor(itemColor, q.color(i))));
 			}
 		}
 	}
@@ -225,10 +225,10 @@ public class ItemRenderContext extends AbstractRenderContext {
 
 		final RenderMaterialImpl.Value mat = quad.material();
 
-		final int colorIndex = mat.disableColorIndex(0) ? -1 : quad.colorIndex();
-		final BlendMode blendMode = mat.blendMode(0);
+		final int colorIndex = mat.disableColorIndex() ? -1 : quad.colorIndex();
+		final BlendMode blendMode = mat.blendMode();
 
-		if (mat.emissive(0)) {
+		if (mat.emissive()) {
 			renderQuadEmissive(quad, blendMode, colorIndex);
 		} else {
 			renderQuad(quad, blendMode, colorIndex);

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainFallbackConsumer.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/TerrainFallbackConsumer.java
@@ -60,7 +60,7 @@ import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.MutableQuadViewImpl;
  *  manipulating the data via NIO.
  */
 public abstract class TerrainFallbackConsumer extends AbstractQuadRenderer implements RenderContext.BakedModelConsumer {
-	private static final Value MATERIAL_FLAT = (Value) IndigoRenderer.INSTANCE.materialFinder().disableAo(0, true).find();
+	private static final Value MATERIAL_FLAT = (Value) IndigoRenderer.INSTANCE.materialFinder().disableAo(true).find();
 	private static final Value MATERIAL_SHADED = (Value) IndigoRenderer.INSTANCE.materialFinder().find();
 
 	TerrainFallbackConsumer(BlockRenderInfo blockInfo, Function<RenderLayer, VertexConsumer> bufferFunc, AoCalculator aoCalc, QuadTransform transform) {


### PR DESCRIPTION
- Remove texture indices
- Add new `QuadView#toBakedQuad` that accepts a shade boolean
- Add `MutableQuadView#fromVanilla(int[], int)`
- Add `NonExtendable` annotation to `SpriteFinder` and `RendererAccess`
- Reorganize method order

[It is easier to view the useful changes by excluding the changes in the first commit.](https://github.com/PepperCode1/fabric/compare/cf5bc1b3680c23f756ed349d879fe1b8eb000903..pr/1.19.3/remove-texture-indices) The first commit includes only method reorganization and does not perform any actual code changes.