### PR TITLE
Fixed end biome source injection

### DIFF
--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/TheEndBiomeSourceMixin.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/TheEndBiomeSourceMixin.java
@@ -55,6 +55,9 @@ public class TheEndBiomeSourceMixin extends BiomeSourceMixin {
 	@Unique
 	private boolean biomeSetModified = false;
 
+	@Unique
+	private boolean hasCheckedForModifiedSet = false;
+
 	/**
 	 * Modifies the codec, so it calls the static factory method that gives us access to the
 	 * full biome registry instead of just the pre-defined biomes that vanilla uses.
@@ -106,8 +109,12 @@ public class TheEndBiomeSourceMixin extends BiomeSourceMixin {
 
 	@Override
 	protected void fabric_modifyBiomeSet(Set<RegistryEntry<Biome>> biomes) {
-		if (!biomeSetModified) {
-			biomeSetModified = true;
+		if (!hasCheckedForModifiedSet) {
+			hasCheckedForModifiedSet = true;
+			biomeSetModified = !overrides.get().customBiomes.isEmpty();
+		}
+
+		if (biomeSetModified) {
 			biomes.addAll(overrides.get().customBiomes);
 		}
 	}


### PR DESCRIPTION
While I know of no mod that actually uses the Fabric API system to inject biomes into the end, I am fairly certain this code is bugged. Not sure how this was missed

biomeSetModified is set to false initially. When a locate command or anything calls getBiomes(), biomeSetModified is set to true and the modded biomes added to output of getBiomes(). Afterwards, all future calls to getBiomes() will never have the modded biomes because biomeSetModified is now true which makes the if statement fail.

You can change the implementation if you wish but this PR is just a quick fix alternative by introducing another bool to use to properly set biomeSetModified as true or false based on if there are modded biomes or not. And then always add the modded biomes to getBiomes() output if biomeSetModified is true.