### PR TITLE
Fix custom packet inside of bundled packet not being processed

### DIFF
--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientPlayNetworkAddon.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientPlayNetworkAddon.java
@@ -84,11 +84,6 @@ public final class ClientPlayNetworkAddon extends AbstractChanneledNetworkAddon<
 	 * @return true if the packet has been handled
 	 */
 	public boolean handle(CustomPayloadS2CPacket packet) {
-		// Do not handle the packet on game thread
-		if (this.client.isOnThread()) {
-			return false;
-		}
-
 		PacketByteBuf buf = packet.getData();
 
 		try {

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/server/ServerPlayNetworkAddon.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/server/ServerPlayNetworkAddon.java
@@ -76,11 +76,6 @@ public final class ServerPlayNetworkAddon extends AbstractChanneledNetworkAddon<
 	 * @return true if the packet has been handled
 	 */
 	public boolean handle(CustomPayloadC2SPacket packet) {
-		// Do not handle the packet on game thread
-		if (this.server.isOnThread()) {
-			return false;
-		}
-
 		CustomPayloadC2SPacketAccessor access = (CustomPayloadC2SPacketAccessor) packet;
 		return this.handle(access.getChannel(), access.getData());
 	}

--- a/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/play/NetworkingPlayPacketTest.java
+++ b/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/play/NetworkingPlayPacketTest.java
@@ -20,11 +20,14 @@ import static com.mojang.brigadier.arguments.StringArgumentType.string;
 import static net.minecraft.server.command.CommandManager.argument;
 import static net.minecraft.server.command.CommandManager.literal;
 
+import java.util.List;
+
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
 
 import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.packet.s2c.play.BundleS2CPacket;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
@@ -49,11 +52,24 @@ public final class NetworkingPlayPacketTest implements ModInitializer {
 	public static void registerCommand(CommandDispatcher<ServerCommandSource> dispatcher) {
 		NetworkingTestmods.LOGGER.info("Registering test command");
 
-		dispatcher.register(literal("networktestcommand").then(argument("stuff", string()).executes(ctx -> {
-			String stuff = StringArgumentType.getString(ctx, "stuff");
-			sendToTestChannel(ctx.getSource().getPlayer(), stuff);
-			return Command.SINGLE_SUCCESS;
-		})));
+		dispatcher.register(literal("networktestcommand")
+				.then(argument("stuff", string()).executes(ctx -> {
+					String stuff = StringArgumentType.getString(ctx, "stuff");
+					sendToTestChannel(ctx.getSource().getPlayer(), stuff);
+					return Command.SINGLE_SUCCESS;
+				}))
+				.then(literal("bundled").executes(ctx -> {
+					PacketByteBuf buf1 = PacketByteBufs.create();
+					buf1.writeText(Text.literal("bundled #1"));
+					PacketByteBuf buf2 = PacketByteBufs.create();
+					buf2.writeText(Text.literal("bundled #2"));
+
+					BundleS2CPacket packet = new BundleS2CPacket(List.of(
+							ServerPlayNetworking.createS2CPacket(TEST_CHANNEL, buf1),
+							ServerPlayNetworking.createS2CPacket(TEST_CHANNEL, buf2)));
+					ctx.getSource().getPlayer().networkHandler.sendPacket(packet);
+					return Command.SINGLE_SUCCESS;
+				})));
 	}
 
 	@Override


### PR DESCRIPTION
The contents of a bundled packet are processed on the main thread, so we shouldn't ignore custom payload packets on the main thread.

This fix has the side-effect of going through the ClientPlayNetworkAddon interception logic twice if the custom packet is not registered, but that should not cause problems (it's just a map lookup).

PS: Trying to flag the packet as "processed" could technically be incorrect in case the packet is sent multiple times in an integration connection, so I think it's best avoided.