### PR TITLE
Pass ScreenHandler to ExtendedScreenHandlerFactory

### DIFF
--- a/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/api/screenhandler/v1/ExtendedScreenHandlerFactory.java
+++ b/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/api/screenhandler/v1/ExtendedScreenHandlerFactory.java
@@ -32,6 +32,14 @@ public interface ExtendedScreenHandlerFactory extends NamedScreenHandlerFactory 
 	 *
 	 * @param player the player that is opening the screen
 	 * @param buf    the packet buffer
-	 */
+	 */,
 	void writeScreenOpeningData(ServerPlayerEntity player, PacketByteBuf buf);
+
+	interface WithScreenHandler extends ExtendedScreenHandlerFactory {
+		default void writeScreenOpeningData(ServerPlayerEntity player, PacketByteBuf buf) {
+			throw new UnsupportedOperationException("Use writeScreenOpeningData with ScreenHandler context to use");
+		}
+
+		void writeScreenOpeningData(ServerPlayerEntity player, PacketByteBuf buf, ScreenHandler handler);
+	}
 }

--- a/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/api/screenhandler/v1/ExtendedScreenHandlerFactory.java
+++ b/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/api/screenhandler/v1/ExtendedScreenHandlerFactory.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.api.screenhandler.v1;
 
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.screen.NamedScreenHandlerFactory;
+import net.minecraft.screen.ScreenHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 
 /**
@@ -32,10 +33,11 @@ public interface ExtendedScreenHandlerFactory extends NamedScreenHandlerFactory 
 	 *
 	 * @param player the player that is opening the screen
 	 * @param buf    the packet buffer
-	 */,
+	 */
 	void writeScreenOpeningData(ServerPlayerEntity player, PacketByteBuf buf);
 
 	interface WithScreenHandler extends ExtendedScreenHandlerFactory {
+		@Override
 		default void writeScreenOpeningData(ServerPlayerEntity player, PacketByteBuf buf) {
 			throw new UnsupportedOperationException("Use writeScreenOpeningData with ScreenHandler context to use");
 		}

--- a/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/impl/screenhandler/Networking.java
+++ b/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/impl/screenhandler/Networking.java
@@ -65,7 +65,11 @@ public final class Networking {
 		buf.writeIdentifier(typeId);
 		buf.writeVarInt(syncId);
 		buf.writeText(factory.getDisplayName());
-		factory.writeScreenOpeningData(player, buf);
+		if(factory instanceof ExtendedScreenHandlerFactory.WithScreenHandler withHandlerFactory) {
+			withHandlerFactory.writeScreenOpeningData(player, buf, handler);
+		} else {
+			factory.writeScreenOpeningData(player, buf);
+		}
 
 		ServerPlayNetworking.send(player, OPEN_ID, buf);
 	}


### PR DESCRIPTION
Addresses #2963

In order to retain backwards compatibility with the old API, a second interface (WithScreenHandler) was created, that throws if you use the old method to initialize it.