### PR TITLE
Add `BEFORE_SPAWN` event

### DIFF
--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -27,6 +27,7 @@ public final class ServerPlayerEvents {
 	 * An event that is called before a player is spawned when opening a world or joining a server.
 	 *
 	 * <p>Mods may use this event to set the player's world and position before it is completely spawned.
+	 *
 	 * <p>Note: this event is not called when a player is respawned.
 	 * For that purpose, {@link ServerPlayerEvents#COPY_FROM} should be used.
 	 */
@@ -41,9 +42,12 @@ public final class ServerPlayerEvents {
 	 *
 	 * <p>This event is typically called before a player is completely respawned.
 	 * Mods may use this event to copy old player data to a new player.
+	 *
 	 * <p>Notes:
-	 * <ul><li>Unlike event {@link ServerPlayerEvents#BEFORE_SPAWN}, changing the player's world might cause undefined behaviour and crash the game.
-	 * <li>Changing the player's position may have undesired effects because respawn side effects (such as the respawn anchor losing a charge) will happen anyway.
+	 * <ul>
+	 * <li>Unlike event {@link ServerPlayerEvents#BEFORE_SPAWN}, changing the player's world might cause undefined behaviour and crash the game.</li>
+	 * <li>Changing the player's position may have undesired effects because respawn side effects (such as the respawn anchor losing a charge) will happen anyway.</li>
+	 * </ul>
 	 */
 	public static final Event<ServerPlayerEvents.CopyFrom> COPY_FROM = EventFactory.createArrayBacked(ServerPlayerEvents.CopyFrom.class, callbacks -> (oldPlayer, newPlayer, alive) -> {
 		for (CopyFrom callback : callbacks) {
@@ -97,8 +101,10 @@ public final class ServerPlayerEvents {
 		 * Called when player data is copied to a new player.
 		 *
 		 * <p>Notes:
-		 * <ul><li>Unlike event {@link ServerPlayerEvents#BEFORE_SPAWN}, changing the player's world might cause undefined behaviour and crash the game.
-		 * <li>Changing the player's position may have undesired effects because respawn side effects (such as the respawn anchor losing a charge) will happen anyway.
+		 * <ul>
+		 * <li>Unlike event {@link ServerPlayerEvents#BEFORE_SPAWN}, changing the player's world might cause undefined behaviour and crash the game.</li>
+		 * <li>Changing the player's position may have undesired effects because respawn side effects (such as the respawn anchor losing a charge) will happen anyway.</li>
+		 * </ul>
 		 *
 		 * @param oldPlayer the old player
 		 * @param newPlayer the new player

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -62,6 +62,17 @@ public final class ServerPlayerEvents {
 		return true;
 	});
 
+	/**
+	 * An event that is called before a player is initially spawned.
+	 *
+	 * <p>Mods may use this event to set the player's world and position before it is completely spawned.
+	 */
+	public static final Event<BeforeSpawn> BEFORE_SPAWN = EventFactory.createArrayBacked(BeforeSpawn.class, callbacks -> (player) -> {
+		for (BeforeSpawn callback : callbacks) {
+			callback.beforeSpawn(player);
+		}
+	});
+
 	@FunctionalInterface
 	public interface CopyFrom {
 		/**
@@ -101,6 +112,16 @@ public final class ServerPlayerEvents {
 		 * @return true if the death should go ahead, false otherwise.
 		 */
 		boolean allowDeath(ServerPlayerEntity player, DamageSource damageSource, float damageAmount);
+	}
+
+	@FunctionalInterface
+	public interface BeforeSpawn {
+		/**
+		 * Called before a player is first spawned when opening a world or joining a server.
+		 *
+		 * @param player the player
+		 */
+		void beforeSpawn(ServerPlayerEntity player);
 	}
 
 	private ServerPlayerEvents() {

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -24,6 +24,17 @@ import net.fabricmc.fabric.api.event.EventFactory;
 
 public final class ServerPlayerEvents {
 	/**
+	 * An event that is called before a player is spawned when opening a world or joining a server.
+	 *
+	 * <p>Mods may use this event to set the player's world and position before it is completely spawned.
+	 */
+	public static final Event<BeforeSpawn> BEFORE_SPAWN = EventFactory.createArrayBacked(BeforeSpawn.class, callbacks -> (player) -> {
+		for (BeforeSpawn callback : callbacks) {
+			callback.beforeSpawn(player);
+		}
+	});
+
+	/**
 	 * An event that is called when the data from an old player is copied to a new player.
 	 *
 	 * <p>This event is typically called before a player is completely respawned.
@@ -62,16 +73,15 @@ public final class ServerPlayerEvents {
 		return true;
 	});
 
-	/**
-	 * An event that is called before a player is initially spawned.
-	 *
-	 * <p>Mods may use this event to set the player's world and position before it is completely spawned.
-	 */
-	public static final Event<BeforeSpawn> BEFORE_SPAWN = EventFactory.createArrayBacked(BeforeSpawn.class, callbacks -> (player) -> {
-		for (BeforeSpawn callback : callbacks) {
-			callback.beforeSpawn(player);
-		}
-	});
+	@FunctionalInterface
+	public interface BeforeSpawn {
+		/**
+		 * Called before a player is spawned when opening a world or joining a server.
+		 *
+		 * @param player the player
+		 */
+		void beforeSpawn(ServerPlayerEntity player);
+	}
 
 	@FunctionalInterface
 	public interface CopyFrom {
@@ -112,16 +122,6 @@ public final class ServerPlayerEvents {
 		 * @return true if the death should go ahead, false otherwise.
 		 */
 		boolean allowDeath(ServerPlayerEntity player, DamageSource damageSource, float damageAmount);
-	}
-
-	@FunctionalInterface
-	public interface BeforeSpawn {
-		/**
-		 * Called before a player is first spawned when opening a world or joining a server.
-		 *
-		 * @param player the player
-		 */
-		void beforeSpawn(ServerPlayerEntity player);
 	}
 
 	private ServerPlayerEvents() {

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -27,6 +27,8 @@ public final class ServerPlayerEvents {
 	 * An event that is called before a player is spawned when opening a world or joining a server.
 	 *
 	 * <p>Mods may use this event to set the player's world and position before it is completely spawned.
+	 * <p>Note: this event is not called when a player is respawned.
+	 * For that purpose, {@link ServerPlayerEvents#COPY_FROM} should be used.
 	 */
 	public static final Event<BeforeSpawn> BEFORE_SPAWN = EventFactory.createArrayBacked(BeforeSpawn.class, callbacks -> (player) -> {
 		for (BeforeSpawn callback : callbacks) {
@@ -39,6 +41,9 @@ public final class ServerPlayerEvents {
 	 *
 	 * <p>This event is typically called before a player is completely respawned.
 	 * Mods may use this event to copy old player data to a new player.
+	 * <p>Notes:
+	 * <ul><li>Unlike event {@link ServerPlayerEvents#BEFORE_SPAWN}, changing the player's world might cause undefined behaviour and crash the game.
+	 * <li>Changing the player's position may have undesired effects because respawn side effects (such as the respawn anchor losing a charge) will happen anyway.
 	 */
 	public static final Event<ServerPlayerEvents.CopyFrom> COPY_FROM = EventFactory.createArrayBacked(ServerPlayerEvents.CopyFrom.class, callbacks -> (oldPlayer, newPlayer, alive) -> {
 		for (CopyFrom callback : callbacks) {
@@ -78,6 +83,9 @@ public final class ServerPlayerEvents {
 		/**
 		 * Called before a player is spawned when opening a world or joining a server.
 		 *
+		 * <p>Note: this event is not called when a player is respawned.
+		 * For that purpose, {@link ServerPlayerEvents#COPY_FROM} should be used.
+		 *
 		 * @param player the player
 		 */
 		void beforeSpawn(ServerPlayerEntity player);
@@ -87,6 +95,10 @@ public final class ServerPlayerEvents {
 	public interface CopyFrom {
 		/**
 		 * Called when player data is copied to a new player.
+		 *
+		 * <p>Notes:
+		 * <ul><li>Unlike event {@link ServerPlayerEvents#BEFORE_SPAWN}, changing the player's world might cause undefined behaviour and crash the game.
+		 * <li>Changing the player's position may have undesired effects because respawn side effects (such as the respawn anchor losing a charge) will happen anyway.
 		 *
 		 * @param oldPlayer the old player
 		 * @param newPlayer the new player

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/PlayerManagerMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/PlayerManagerMixin.java
@@ -44,12 +44,12 @@ abstract class PlayerManagerMixin {
 		ServerPlayerEvents.BEFORE_SPAWN.invoker().beforeSpawn(player);
 	}
 
-	@ModifyVariable(method = "onPlayerConnect", name = "serverWorld2", at = @At(value = "INVOKE", target = "net/minecraft/server/network/ServerPlayerEntity.setWorld(Lnet/minecraft/server/world/ServerWorld;)V", shift = At.Shift.AFTER))
+	@ModifyVariable(method = "onPlayerConnect", ordinal = 1, at = @At(value = "INVOKE", target = "net/minecraft/server/network/ServerPlayerEntity.setWorld(Lnet/minecraft/server/world/ServerWorld;)V", shift = At.Shift.AFTER))
 	private ServerWorld fixServerWorld(ServerWorld world, ClientConnection connection, ServerPlayerEntity player) {
 		return player.getWorld();
 	}
 
-	@ModifyVariable(method = "onPlayerConnect", name = "registryKey", at = @At(value = "INVOKE", target = "net/minecraft/server/network/ServerPlayerEntity.setWorld(Lnet/minecraft/server/world/ServerWorld;)V", shift = At.Shift.AFTER))
+	@ModifyVariable(method = "onPlayerConnect", ordinal = 0, at = @At(value = "INVOKE", target = "net/minecraft/server/network/ServerPlayerEntity.setWorld(Lnet/minecraft/server/world/ServerWorld;)V", shift = At.Shift.AFTER))
 	private RegistryKey<World> fixRegistryKey(RegistryKey<World> world, ClientConnection connection, ServerPlayerEntity player) {
 		return player.getWorld().getRegistryKey();
 	}

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.test.entity.event;
 
+import java.util.Objects;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +41,7 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
@@ -78,6 +81,15 @@ public final class EntityEventTests implements ModInitializer {
 
 		ServerPlayerEvents.AFTER_RESPAWN.register((oldPlayer, newPlayer, alive) -> {
 			LOGGER.info("Respawned {}, [{}, {}]", oldPlayer.getGameProfile().getName(), oldPlayer.getWorld().getRegistryKey().getValue(), newPlayer.getWorld().getRegistryKey().getValue());
+		});
+
+		// Spawn players holding an ender pearl in the end
+		ServerPlayerEvents.BEFORE_SPAWN.register(player -> {
+			if (player.getStackInHand(Hand.MAIN_HAND).isOf(Items.ENDER_PEARL)) {
+				LOGGER.info("Spawning {} in the end because it was holding an ender pearl", player.getGameProfile().getName());
+				player.setWorld(Objects.requireNonNull(player.getServer()).getWorld(World.END));
+				player.setPos(0.5, 65, 0.5);
+			}
 		});
 
 		// No fall damage if holding a feather in the main hand


### PR DESCRIPTION
This pull request adds a new event invoked before a player is spawned (i.e. when opening a single-player world or joining a server).
Some use cases are:
- Detecting when a player is about to spawn.
- Overriding where a player initially spawns.
- Changing a player's initial data before the server sends it to the client.

I have tested it on `1.19.4` and `1.19.3`, but it should work with most previous versions.