### PR TITLE
Update ClientCommandInternals.java

### DIFF
--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/impl/command/client/ClientCommandInternals.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/impl/command/client/ClientCommandInternals.java
@@ -130,7 +130,7 @@ public final class ClientCommandInternals {
 		Text message = Texts.toText(e.getRawMessage());
 		String context = e.getContext();
 
-		return context != null ? Text.translatable("command.context.parse_error", message, context) : message;
+		return context != null ? Text.translatable("command.context.parse_error", message, e.getCursor(), context) : message;
 	}
 
 	/**


### PR DESCRIPTION
Fixed a translation bug where "command.context.parse_error" was translated with two arguments, while it takes three as input.