### PR TITLE
Fix `ProgrammerArtResourcePack::getName`

### DIFF
--- a/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/impl/client/resource/loader/ProgrammerArtResourcePack.java
+++ b/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/impl/client/resource/loader/ProgrammerArtResourcePack.java
@@ -87,7 +87,7 @@ public class ProgrammerArtResourcePack extends GroupResourcePack {
 
 	@Override
 	public String getName() {
-		return "Programmer Art";
+		return this.originalResourcePack.getName();
 	}
 
 	@Override


### PR DESCRIPTION
`getName` is a misleading Yarn name and should instead be called `getId`. Because of that misleading name I made the method return `Programmer Art` instead of the correct `programmer_art` in #2957. See the initial issue report here:  https://discord.com/channels/507304429255393322/566276937035546624/1090437627108413511.

This PR restores the correct Vanilla behavior.