### PR TITLE
Fix `FabricWrappedVanillaResourcePack::getName`

### DIFF
--- a/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/impl/client/resource/loader/FabricWrappedVanillaResourcePack.java
+++ b/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/impl/client/resource/loader/FabricWrappedVanillaResourcePack.java
@@ -27,7 +27,6 @@ import net.minecraft.resource.AbstractFileResourcePack;
 import net.minecraft.resource.InputSupplier;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.resource.metadata.ResourceMetadataReader;
-import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.PathUtil;
 

--- a/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/impl/client/resource/loader/FabricWrappedVanillaResourcePack.java
+++ b/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/impl/client/resource/loader/FabricWrappedVanillaResourcePack.java
@@ -42,12 +42,10 @@ import net.fabricmc.fabric.impl.resource.loader.GroupResourcePack;
  */
 public class FabricWrappedVanillaResourcePack extends GroupResourcePack {
 	private final AbstractFileResourcePack originalResourcePack;
-	private final Text displayName;
 
-	public FabricWrappedVanillaResourcePack(AbstractFileResourcePack originalResourcePack, Text displayName, List<ModResourcePack> modResourcePacks) {
+	public FabricWrappedVanillaResourcePack(AbstractFileResourcePack originalResourcePack, List<ModResourcePack> modResourcePacks) {
 		super(ResourceType.CLIENT_RESOURCES, modResourcePacks);
 		this.originalResourcePack = originalResourcePack;
-		this.displayName = displayName;
 	}
 
 	@Override
@@ -90,7 +88,7 @@ public class FabricWrappedVanillaResourcePack extends GroupResourcePack {
 
 	@Override
 	public String getName() {
-		return displayName.getString();
+		return this.originalResourcePack.getName();
 	}
 
 	@Override

--- a/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/DefaultClientResourcePackProviderMixin.java
+++ b/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/DefaultClientResourcePackProviderMixin.java
@@ -51,7 +51,7 @@ public class DefaultClientResourcePackProviderMixin {
 	)
 	private ResourcePackProfile.PackFactory onCreateVanillaBuiltinResourcePack(String name, Text displayName, boolean alwaysEnabled,
 			ResourcePackProfile.PackFactory packFactory, ResourceType type, ResourcePackProfile.InsertionPosition position, ResourcePackSource source) {
-		return factory -> new FabricWrappedVanillaResourcePack((AbstractFileResourcePack) packFactory.open(name), displayName, getModResourcePacks(name));
+		return factory -> new FabricWrappedVanillaResourcePack((AbstractFileResourcePack) packFactory.open(name), getModResourcePacks(name));
 	}
 
 	/**


### PR DESCRIPTION
Quoting @PepperCode1:
> Fabric API's `FabricWrappedVanillaResourcePack` does not use the name of the original pack. The regular programmer art pack's name is the string `"programmer_art"`, but with Fabric API it's the string result of a translatable component with the key `"resourcePack.programmer_art.name"`.

This PR fixes said issue; see #2997 for more details.