### PR TITLE
fix: ClassCastException in fabric-loot-api-v2 (23w14a)

### DIFF
--- a/fabric-loot-api-v2/src/main/java/net/fabricmc/fabric/mixin/loot/LootManagerMixin.java
+++ b/fabric-loot-api-v2/src/main/java/net/fabricmc/fabric/mixin/loot/LootManagerMixin.java
@@ -69,7 +69,11 @@ abstract class LootManagerMixin {
 				return;
 			}
 
-			if (!(entry instanceof LootTable table)) return;
+			if (!(entry instanceof LootTable table)) {
+				// We only want to modify loot tables
+				newTables.put(id, entry);
+				return;
+			}
 
 			LootTableSource source = LootUtil.determineSource(id.location(), resourceManager);
 			// Invoke the REPLACE event for the current loot table.

--- a/fabric-loot-api-v2/src/main/java/net/fabricmc/fabric/mixin/loot/LootManagerMixin.java
+++ b/fabric-loot-api-v2/src/main/java/net/fabricmc/fabric/mixin/loot/LootManagerMixin.java
@@ -69,7 +69,7 @@ abstract class LootManagerMixin {
 				return;
 			}
 
-			LootTable table = (LootTable) entry;
+			if (!(entry instanceof LootTable table)) return;
 
 			LootTableSource source = LootUtil.determineSource(id.location(), resourceManager);
 			// Invoke the REPLACE event for the current loot table.

--- a/fabric-loot-api-v2/src/testmod/resources/data/minecraft/loot_tables/blocks/red_wool.json
+++ b/fabric-loot-api-v2/src/testmod/resources/data/minecraft/loot_tables/blocks/red_wool.json
@@ -11,6 +11,10 @@
       ],
       "conditions": [
         {
+          "condition": "minecraft:reference",
+          "name": "minecraft:match_tool_shears"
+        },
+        {
           "condition": "minecraft:survives_explosion"
         }
       ]

--- a/fabric-loot-api-v2/src/testmod/resources/data/minecraft/predicates/match_tool_shears.json
+++ b/fabric-loot-api-v2/src/testmod/resources/data/minecraft/predicates/match_tool_shears.json
@@ -1,0 +1,8 @@
+{
+  "condition": "minecraft:match_tool",
+  "predicate": {
+    "items": [
+      "minecraft:shears"
+    ]
+  }
+}


### PR DESCRIPTION
In 23w14a `LootManager` class was changed to not only handle `LootTable`, but also `LootFunction` and `LootCondition`.

When the API was updated, this was not taken into account and all entries in  `field_44492` are assumed to be of type `LootTable`.

This can cause this issue, when running the latest fabric api with a datapack with predicates:
```
[12:01:36] [main/WARN]: Failed to load datapacks, can't proceed with server load. You can either fix your datapacks or reset to vanilla with --safeMode
java.util.concurrent.ExecutionException: java.lang.ClassCastException: class net.minecraft.class_60$class_5334 cannot be cast to class net.minecraft.class_52 (net.minecraft.class_60$class_5334 and net.minecraft.class_52 are in unnamed module of loader net.fabricmc.loader.impl.launch.knot.KnotClassLoader @7946e1f4)
        at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396) ~[?:?]
        at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073) ~[?:?]
        at net.minecraft.server.Main.main(Main.java:209) ~[server-intermediary.jar:?]
        at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:462) ~[fabric-loader-0.14.19.jar:?]
        at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74) ~[fabric-loader-0.14.19.jar:?]
        at net.fabricmc.loader.impl.launch.knot.KnotServer.main(KnotServer.java:23) ~[fabric-loader-0.14.19.jar:?]
        at net.fabricmc.loader.impl.launch.server.FabricServerLauncher.main(FabricServerLauncher.java:69) ~[fabric-loader-0.14.19.jar:?]
Caused by: java.lang.ClassCastException: class net.minecraft.class_60$class_5334 cannot be cast to class net.minecraft.class_52 (net.minecraft.class_60$class_5334 and net.minecraft.class_52 are in unnamed module of loader net.fabricmc.loader.impl.launch.knot.KnotClassLoader @7946e1f4)
        at net.minecraft.class_60.md089aa1$fabric-loot-api-v2$lambda$applyLootTableEvents$1$0(class_60.java:572) ~[server-intermediary.jar:?]
        at com.google.common.collect.RegularImmutableMap.forEach(RegularImmutableMap.java:292) ~[guava-31.1-jre.jar:?]
        at net.minecraft.class_60.applyLootTableEvents(class_60.java:564) ~[server-intermediary.jar:?]
        at net.minecraft.class_60.md089aa1$fabric-loot-api-v2$lambda$reload$0$1(class_60.java:555) ~[server-intermediary.jar:?]
        at java.util.concurrent.CompletableFuture$UniRun.tryFire(CompletableFuture.java:787) ~[?:?]
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) ~[?:?]
        at java.util.concurrent.CompletableFuture.postFire(CompletableFuture.java:614) ~[?:?]
        at java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:726) ~[?:?]
        at java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482) ~[?:?]
        at net.minecraft.class_4014.method_18365(class_4014.java:69) ~[server-intermediary.jar:?]
        at net.minecraft.class_156.method_43498(class_156.java:933) ~[server-intermediary.jar:?]
        at net.minecraft.class_156.method_43499(class_156.java:921) ~[server-intermediary.jar:?]
        at net.minecraft.server.Main.main(Main.java:160) ~[server-intermediary.jar:?]
        ... 4 more
```

This PR fixes this by skipping all non `LootTable` entries.