### PR TITLE
Improve missing local registry entries error message.

### DIFF
--- a/fabric-registry-sync-v0/build.gradle
+++ b/fabric-registry-sync-v0/build.gradle
@@ -11,5 +11,6 @@ moduleDependencies(project, [
 ])
 
 testDependencies(project, [
-        ':fabric-lifecycle-events-v1'
+        ':fabric-lifecycle-events-v1',
+		':fabric-command-api-v2',
 ])

--- a/fabric-registry-sync-v0/build.gradle
+++ b/fabric-registry-sync-v0/build.gradle
@@ -11,6 +11,6 @@ moduleDependencies(project, [
 ])
 
 testDependencies(project, [
-        ':fabric-lifecycle-events-v1',
+		':fabric-lifecycle-events-v1',
 		':fabric-command-api-v2',
 ])

--- a/fabric-registry-sync-v0/src/client/java/net/fabricmc/fabric/impl/client/registry/sync/FabricRegistryClientInit.java
+++ b/fabric-registry-sync-v0/src/client/java/net/fabricmc/fabric/impl/client/registry/sync/FabricRegistryClientInit.java
@@ -24,6 +24,7 @@ import net.minecraft.text.Text;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.impl.registry.sync.RegistrySyncManager;
+import net.fabricmc.fabric.impl.registry.sync.RemapException;
 import net.fabricmc.fabric.impl.registry.sync.packet.RegistryPacketHandler;
 
 public class FabricRegistryClientInit implements ClientModInitializer {
@@ -39,8 +40,19 @@ public class FabricRegistryClientInit implements ClientModInitializer {
 		ClientPlayNetworking.registerGlobalReceiver(packetHandler.getPacketId(), (client, handler, buf, responseSender) ->
 				RegistrySyncManager.receivePacket(client, packetHandler, buf, RegistrySyncManager.DEBUG || !client.isInSingleplayer(), (e) -> {
 					LOGGER.error("Registry remapping failed!", e);
-
-					client.execute(() -> handler.getConnection().disconnect(Text.literal("Registry remapping failed: " + e.getMessage())));
+					client.execute(() -> handler.getConnection().disconnect(getText(e)));
 				}));
+	}
+
+	private Text getText(Exception e) {
+		if (e instanceof RemapException remapException) {
+			final Text text = remapException.getText();
+
+			if (text != null) {
+				return text;
+			}
+		}
+
+		return Text.literal("Registry remapping failed: " + e.getMessage());
 	}
 }

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
@@ -375,14 +375,13 @@ public final class RegistrySyncManager {
 		final int count = missingEntries.values().stream().mapToInt(List::size).sum();
 
 		if (count == 1) {
-			text = text.append("Received a registry entry that is unknown to this client.\n");
+			text = text.append(Text.translatable("fabric-registry-sync-v0.unknown-remote.title.singular"));
 		} else {
-			text = text.append("Received %d registry entries that are unknown to this client.\n".formatted(count));
+			text = text.append(Text.translatable("fabric-registry-sync-v0.unknown-remote.title.plural", count));
 		}
 
-		text = text.append(Text.literal("This is usually caused by a mismatched mod set between the client and server.").formatted(Formatting.GREEN));
-		text = text.append(" See the client logs for more details.\n");
-		text = text.append("The following registry entry namespaces may be related:\n");
+		text = text.append(Text.translatable("fabric-registry-sync-v0.unknown-remote.subtitle.1").formatted(Formatting.GREEN));
+		text = text.append(Text.translatable("fabric-registry-sync-v0.unknown-remote.subtitle.2"));
 
 		final int toDisplay = 4;
 		// Get the distinct missing namespaces
@@ -393,15 +392,13 @@ public final class RegistrySyncManager {
 				.sorted()
 				.toList();
 
-		text = text.append("\n");
-
 		for (int i = 0; i < Math.min(namespaces.size(), toDisplay); i++) {
 			text = text.append(Text.literal(namespaces.get(i)).formatted(Formatting.YELLOW));
 			text = text.append("\n");
 		}
 
 		if (namespaces.size() > toDisplay) {
-			text = text.append("And %d more...".formatted(namespaces.size() - toDisplay));
+			text = text.append(Text.translatable("fabric-registry-sync-v0.unknown-remote.footer", namespaces.size() - toDisplay));
 		}
 
 		throw new RemapException(text);

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RemapException.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RemapException.java
@@ -16,12 +16,26 @@
 
 package net.fabricmc.fabric.impl.registry.sync;
 
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.text.Text;
+
 public class RemapException extends Exception {
+	@Nullable
+	private final Text text;
+
 	public RemapException(String message) {
 		super(message);
+		this.text = null;
 	}
 
-	public RemapException(String message, Throwable t) {
-		super(message, t);
+	public RemapException(Text text) {
+		super(text.getString());
+		this.text = text;
+	}
+
+	@Nullable
+	public Text getText() {
+		return text;
 	}
 }

--- a/fabric-registry-sync-v0/src/main/resources/assets/fabric-registry-sync-v0/lang/en_us.json
+++ b/fabric-registry-sync-v0/src/main/resources/assets/fabric-registry-sync-v0/lang/en_us.json
@@ -1,0 +1,7 @@
+{
+  "fabric-registry-sync-v0.unknown-remote.title.singular" : "Received a registry entry that is unknown to this client.\n",
+  "fabric-registry-sync-v0.unknown-remote.title.plural" : "Received %d registry entries that are unknown to this client.\n",
+  "fabric-registry-sync-v0.unknown-remote.subtitle.1" : "This is usually caused by a mismatched mod set between the client and server.",
+  "fabric-registry-sync-v0.unknown-remote.subtitle.2" : " See the client logs for more details.\nThe following registry entry namespaces may be related:\n\n",
+  "fabric-registry-sync-v0.unknown-remote.footer" : "And %d more..."
+}

--- a/fabric-registry-sync-v0/src/testmod/java/net/fabricmc/fabric/test/registry/sync/RegistrySyncTest.java
+++ b/fabric-registry-sync-v0/src/testmod/java/net/fabricmc/fabric/test/registry/sync/RegistrySyncTest.java
@@ -147,7 +147,7 @@ public class RegistrySyncTest implements ModInitializer {
 					} catch (RemapException e) {
 						final ServerPlayerEntity player = context.getSource().getPlayer();
 
-						if (player != null ){
+						if (player != null) {
 							player.networkHandler.disconnect(Objects.requireNonNull(e.getText()));
 						}
 

--- a/fabric-registry-sync-v0/src/testmod/java/net/fabricmc/fabric/test/registry/sync/RegistrySyncTest.java
+++ b/fabric-registry-sync-v0/src/testmod/java/net/fabricmc/fabric/test/registry/sync/RegistrySyncTest.java
@@ -17,10 +17,12 @@
 package net.fabricmc.fabric.test.registry.sync;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.mojang.logging.LogUtils;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 
@@ -37,6 +39,8 @@ import net.minecraft.registry.SimpleRegistry;
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.registry.DynamicRegistrySetupCallback;
 import net.fabricmc.fabric.api.event.registry.FabricRegistryBuilder;
@@ -45,6 +49,7 @@ import net.fabricmc.fabric.api.event.registry.RegistryAttributeHolder;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.impl.registry.sync.RegistrySyncManager;
+import net.fabricmc.fabric.impl.registry.sync.RemapException;
 import net.fabricmc.fabric.impl.registry.sync.packet.DirectRegistryPacketHandler;
 import net.fabricmc.fabric.impl.registry.sync.packet.NbtRegistryPacketHandler;
 import net.fabricmc.fabric.impl.registry.sync.packet.RegistryPacketHandler;
@@ -128,6 +133,23 @@ public class RegistrySyncTest implements ModInitializer {
 
 		// Vanilla status effects don't have an entry for the int id 0, test we can handle this.
 		RegistryAttributeHolder.get(Registries.STATUS_EFFECT).addAttribute(RegistryAttribute.MODDED);
+
+		ClientCommandRegistrationCallback.EVENT.register((dispatcher, registryAccess) ->
+				dispatcher.register(ClientCommandManager.literal("remote_remap_error_test").executes(context -> {
+					Map<Identifier, Object2IntMap<Identifier>> registryData = Map.of(
+							RegistryKeys.BLOCK.getValue(), createFakeRegistryEntries(),
+							RegistryKeys.ITEM.getValue(), createFakeRegistryEntries()
+					);
+
+					try {
+						RegistrySyncManager.checkRemoteRemap(registryData);
+					} catch (RemapException e) {
+						context.getSource().getPlayer().networkHandler.getConnection().disconnect(Objects.requireNonNull(e.getText()));
+						return 1;
+					}
+
+					throw new IllegalStateException();
+				})));
 	}
 
 	private static void registerBlocks(String namespace, int amount, int startingId) {
@@ -140,5 +162,15 @@ public class RegistrySyncTest implements ModInitializer {
 				Registry.register(Registries.ITEM, new Identifier(namespace, "block_" + (i + startingId)), blockItem);
 			}
 		}
+	}
+
+	private static Object2IntMap<Identifier> createFakeRegistryEntries() {
+		Object2IntMap<Identifier> map = new Object2IntOpenHashMap<>();
+
+		for (int i = 0; i < 12; i++) {
+			map.put(new Identifier("mod_" + i, "entry"), 0);
+		}
+
+		return map;
 	}
 }


### PR DESCRIPTION
<img width="966" alt="Screenshot 2023-04-10 at 18 53 28" src="https://user-images.githubusercontent.com/4324090/230961913-168b666b-3784-467c-a8c8-f82311dd653e.png">

- Improves the user experience for players, the old error isnt very helpful.
- All registries are validated before trying to remap, the logs contain the errors for all registries, not just the first to fail
- Required as in 1.20 we cannot easily make the disconnect screen scrollable.

Adds a `/remote_remap_error_test` testmod command to test this. Please ~~bikeshead~~ discuss the wording and colors.