### PR TITLE
Fix a regresstion preveting clients with an un modded regsitry joining servers with modded registries.

### DIFF
--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
@@ -347,6 +347,13 @@ public final class RegistrySyncManager {
 				continue;
 			}
 
+			final RegistryAttributeHolder attributeHolder = RegistryAttributeHolder.get(registry.getKey());
+
+			if (!attributeHolder.hasAttribute(RegistryAttribute.MODDED)) {
+				// Registry is not modded on the client, dont check. A print to debug is logged in apply.
+				continue;
+			}
+
 			for (Identifier remoteId : remoteRegistry.keySet()) {
 				if (!registry.containsId(remoteId)) {
 					// Found a registry entry from the server that is


### PR DESCRIPTION
This now matches the previous behaviour, however I dont believe its the best behaviour so unless anyone has any strong feelings I think this will be best left out of 1.20.