### PR TITLE
Fix `getName` for builtin packs not returning an internal name

### DIFF
--- a/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/GameOptionsMixin.java
+++ b/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/GameOptionsMixin.java
@@ -40,7 +40,6 @@ import net.minecraft.nbt.NbtList;
 import net.minecraft.nbt.NbtString;
 import net.minecraft.resource.ResourcePack;
 import net.minecraft.resource.ResourcePackProfile;
-import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.impl.resource.loader.ModNioResourcePack;
 import net.fabricmc.fabric.impl.resource.loader.ModResourcePackCreator;
@@ -71,7 +70,7 @@ public class GameOptionsMixin {
 		}
 
 		File trackerFile = new File(dataDir, "fabricDefaultResourcePacks.dat");
-		Set<Identifier> trackedPacks = new HashSet<>();
+		Set<String> trackedPacks = new HashSet<>();
 
 		if (trackerFile.exists()) {
 			try {
@@ -79,14 +78,14 @@ public class GameOptionsMixin {
 				NbtList values = data.getList("values", NbtElement.STRING_TYPE);
 
 				for (int i = 0; i < values.size(); i++) {
-					trackedPacks.add(new Identifier(values.getString(i)));
+					trackedPacks.add(values.getString(i));
 				}
 			} catch (IOException e) {
 				LOGGER.warn("[Fabric Resource Loader] Could not read " + trackerFile.getAbsolutePath(), e);
 			}
 		}
 
-		Set<Identifier> removedPacks = new HashSet<>(trackedPacks);
+		Set<String> removedPacks = new HashSet<>(trackedPacks);
 		Set<String> resourcePacks = new LinkedHashSet<>(this.resourcePacks);
 
 		List<ResourcePackProfile> profiles = new ArrayList<>();
@@ -101,10 +100,10 @@ public class GameOptionsMixin {
 
 			try (ResourcePack pack = profile.createResourcePack()) {
 				if (pack instanceof ModNioResourcePack builtinPack && builtinPack.getActivationType().isEnabledByDefault()) {
-					if (trackedPacks.add(builtinPack.getId())) {
+					if (trackedPacks.add(builtinPack.getName())) {
 						resourcePacks.add(profile.getName());
 					} else {
-						removedPacks.remove(builtinPack.getId());
+						removedPacks.remove(builtinPack.getName());
 					}
 				}
 			}
@@ -113,9 +112,9 @@ public class GameOptionsMixin {
 		try {
 			NbtList values = new NbtList();
 
-			for (Identifier id : trackedPacks) {
+			for (String id : trackedPacks) {
 				if (!removedPacks.contains(id)) {
-					values.add(NbtString.of(id.toString()));
+					values.add(NbtString.of(id));
 				}
 			}
 

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/FabricModResourcePack.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/FabricModResourcePack.java
@@ -76,7 +76,7 @@ public class FabricModResourcePack extends GroupResourcePack {
 
 	@Override
 	public String getName() {
-		return "Fabric Mods";
+		return "fabric";
 	}
 
 	@Override

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModNioResourcePack.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModNioResourcePack.java
@@ -45,7 +45,6 @@ import net.minecraft.resource.InputSupplier;
 import net.minecraft.resource.ResourcePack;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.resource.metadata.ResourceMetadataReader;
-import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.PathUtil;
 
@@ -59,8 +58,7 @@ public class ModNioResourcePack implements ResourcePack, ModResourcePack {
 	private static final Pattern RESOURCE_PACK_PATH = Pattern.compile("[a-z0-9-_.]+");
 	private static final FileSystem DEFAULT_FS = FileSystems.getDefault();
 
-	private final Identifier id;
-	private final Text name;
+	private final String id;
 	private final ModMetadata modInfo;
 	private final List<Path> basePaths;
 	private final ResourceType type;
@@ -68,7 +66,7 @@ public class ModNioResourcePack implements ResourcePack, ModResourcePack {
 	private final ResourcePackActivationType activationType;
 	private final Map<ResourceType, Set<String>> namespaces;
 
-	public static ModNioResourcePack create(Identifier id, Text name, ModContainer mod, String subPath, ResourceType type, ResourcePackActivationType activationType) {
+	public static ModNioResourcePack create(String id, ModContainer mod, String subPath, ResourceType type, ResourcePackActivationType activationType) {
 		List<Path> rootPaths = mod.getRootPaths();
 		List<Path> paths;
 
@@ -91,14 +89,13 @@ public class ModNioResourcePack implements ResourcePack, ModResourcePack {
 
 		if (paths.isEmpty()) return null;
 
-		ModNioResourcePack ret = new ModNioResourcePack(id, name, mod.getMetadata(), paths, type, null, activationType);
+		ModNioResourcePack ret = new ModNioResourcePack(id, mod.getMetadata(), paths, type, null, activationType);
 
 		return ret.getNamespaces(type).isEmpty() ? null : ret;
 	}
 
-	private ModNioResourcePack(Identifier id, Text name, ModMetadata modInfo, List<Path> paths, ResourceType type, AutoCloseable closer, ResourcePackActivationType activationType) {
+	private ModNioResourcePack(String id, ModMetadata modInfo, List<Path> paths, ResourceType type, AutoCloseable closer, ResourcePackActivationType activationType) {
 		this.id = id;
-		this.name = name;
 		this.modInfo = modInfo;
 		this.basePaths = paths;
 		this.type = type;
@@ -281,10 +278,6 @@ public class ModNioResourcePack implements ResourcePack, ModResourcePack {
 
 	@Override
 	public String getName() {
-		return name.getString();
-	}
-
-	public Identifier getId() {
 		return id;
 	}
 

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModResourcePackUtil.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModResourcePackUtil.java
@@ -38,7 +38,6 @@ import net.minecraft.resource.ResourcePackProfile;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.resource.featuretoggle.FeatureFlags;
 import net.minecraft.text.Text;
-import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.api.resource.ModResourcePack;
 import net.fabricmc.fabric.api.resource.ResourcePackActivationType;
@@ -68,7 +67,7 @@ public final class ModResourcePackUtil {
 				continue;
 			}
 
-			ModResourcePack pack = ModNioResourcePack.create(new Identifier("fabric", container.getMetadata().getId()), getName(container.getMetadata()), container, subPath, type, ResourcePackActivationType.ALWAYS_ENABLED);
+			ModResourcePack pack = ModNioResourcePack.create(container.getMetadata().getId(), container, subPath, type, ResourcePackActivationType.ALWAYS_ENABLED);
 
 			if (pack != null) {
 				packs.add(pack);

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ResourceManagerHelperImpl.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ResourceManagerHelperImpl.java
@@ -73,8 +73,8 @@ public class ResourceManagerHelperImpl implements ResourceManagerHelper {
 		List<Path> paths = container.getRootPaths();
 		String separator = paths.get(0).getFileSystem().getSeparator();
 		subPath = subPath.replace("/", separator);
-		ModNioResourcePack resourcePack = ModNioResourcePack.create(id, displayName, container, subPath, ResourceType.CLIENT_RESOURCES, activationType);
-		ModNioResourcePack dataPack = ModNioResourcePack.create(id, displayName, container, subPath, ResourceType.SERVER_DATA, activationType);
+		ModNioResourcePack resourcePack = ModNioResourcePack.create(id.toString(), container, subPath, ResourceType.CLIENT_RESOURCES, activationType);
+		ModNioResourcePack dataPack = ModNioResourcePack.create(id.toString(), container, subPath, ResourceType.SERVER_DATA, activationType);
 		if (resourcePack == null && dataPack == null) return false;
 
 		if (resourcePack != null) {
@@ -112,7 +112,7 @@ public class ResourceManagerHelperImpl implements ResourceManagerHelper {
 			if (!pack.getNamespaces(resourceType).isEmpty()) {
 				// Make the resource pack profile for built-in pack, should never be always enabled.
 				ResourcePackProfile profile = ResourcePackProfile.create(
-						entry.getRight().getId().toString(),
+						entry.getRight().getName(),
 						entry.getLeft(),
 						pack.getActivationType() == ResourcePackActivationType.ALWAYS_ENABLED,
 						ignored -> entry.getRight(),


### PR DESCRIPTION
`getName` should return an identifier rather than a user-facing name. In particular, the stringified version of the `Text` used for display is bad because lang resources may not be loaded yet.

#### List of changes
- Change `getName` of the "Fabric Mods" pack to `fabric`. This matches what appears in `options.txt` (the id of the `ResourcePackProfile`).
- Replace the `Identifier id` in `ModNioResourcePack` by a `String`, since it is only used as a string anyway. This makes the next change possible.
- Remove `name` from `ModNioResourcePack`. Change `getName` of the mod resource packs to be exactly the modid. This changes the log entry to the modid instead of the mod name.

#### With these changes
- `options.txt`:
```resourcePacks:["vanilla","fabric","fabric-resource-loader-v0-testmod:test"]```
- log line for the reload:
```[10:47:57] [Render thread/INFO] (Minecraft) Reloading ResourceManager: vanilla, fabric (fabric-renderer-api-v1-testmod, fabric-entity-events-v1, fabric-particles-v1, fabric-crash-report-info-v1, fabric-game-rule-api-v1, fabric-networking-v0, fabric-recipe-api-v1, fabric-blockrenderlayer-v1, fabric-command-api-v1, fabric-networking-api-v1, fabric-rendering-data-attachment-v1, fabric-loot-tables-v1, fabric-renderer-indigo, fabric-lifecycle-events-v1, fabric-transfer-api-v1, fabric-data-generation-api-v1, fabric-convention-tags-v1, fabric-resource-loader-v0, fabric-object-builder-api-v1-testmod, fabric-renderer-api-v1, fabric-message-api-v1, fabric-screen-handler-api-v1-testmod, fabric-screen-handler-api-v1, fabric-models-v0, fabric-key-binding-api-v1, fabric-sound-api-v1-testmod, fabric-rendering-v1-testmod, fabric-keybindings-v0, fabric-command-api-v2, fabric-data-gen-api-v1-testmod, fabric-object-builder-api-v1, fabric-renderer-registries-v1, fabric-biome-api-v1, fabric-rendering-fluids-v1, fabric-item-api-v1-testmod, fabric-resource-loader-v0-testmod, fabric-rendering-v1, fabric-registry-sync-v0, fabric-containers-v0, fabric-content-registries-v0, fabric-mining-level-api-v1, fabric-networking-api-v1-testmod, fabric-rendering-fluids-v1-testmod, fabric-events-lifecycle-v0, fabricloader, fabric-gametest-api-v1, fabric-api-base, fabric-game-rule-api-v1-testmod, fabric-item-api-v1, fabric-screen-api-v1, fabric-commands-v0, fabric-models-v0-testmod, fabric-transitive-access-wideners-v1, fabric-events-interaction-v0, fabric-resource-conditions-api-v1, fabric-rendering-v0, fabric-api, fabric-client-tags-api-v1, fabric-sound-api-v1, fabric-dimensions-v1, fabric-key-binding-api-v1-testmod, fabric-block-api-v1, fabric-item-group-api-v1, fabric-api-lookup-api-v1, fabric-loot-api-v2), fabric-resource-loader-v0-testmod:test```

The old log line would have been `vanilla, Fabric Mods (mod name 1, mod name 2, etc...), <stringified version of the display name text used by the test builtin pack>`

 
