### PR TITLE
Improve transfer debug messages

### DIFF
--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/base/EmptyItemFluidStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/base/EmptyItemFluidStorage.java
@@ -127,4 +127,10 @@ public final class EmptyItemFluidStorage implements InsertionOnlyStorage<FluidVa
 	public Iterator<StorageView<FluidVariant>> iterator() {
 		return blankView.iterator();
 	}
+
+	@Override
+	public String toString() {
+		return "EmptyItemFluidStorage[context=%s, insertableFluid=%s, insertableAmount=%d]"
+				.formatted(context, insertableFluid, insertableAmount);
+	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/base/FullItemFluidStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/base/FullItemFluidStorage.java
@@ -132,4 +132,10 @@ public final class FullItemFluidStorage implements ExtractionOnlyStorage<FluidVa
 		// Capacity is the same as the amount.
 		return getAmount();
 	}
+
+	@Override
+	public String toString() {
+		return "FullItemFluidStorage[context=%s, fluid=%s, amount=%d]"
+				.formatted(context, containedFluid, containedAmount);
+	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleStackStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleStackStorage.java
@@ -164,4 +164,9 @@ public abstract class SingleStackStorage extends SnapshotParticipant<ItemStack> 
 	protected void readSnapshot(ItemStack snapshot) {
 		setStack(snapshot);
 	}
+
+	@Override
+	public String toString() {
+		return "SingleStackStorage[" + getStack() + "]";
+	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StorageUtil.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StorageUtil.java
@@ -25,6 +25,8 @@ import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.inventory.Inventory;
 import net.minecraft.screen.ScreenHandler;
+import net.minecraft.util.crash.CrashException;
+import net.minecraft.util.crash.CrashReport;
 import net.minecraft.util.math.MathHelper;
 
 import net.fabricmc.fabric.api.transfer.v1.storage.base.ResourceAmount;
@@ -118,6 +120,15 @@ public final class StorageUtil {
 			}
 
 			iterationTransaction.commit();
+		} catch (Exception e) {
+			CrashReport report = CrashReport.create(e, "Moving resources between storages");
+			report.addElement("Move details")
+					.add("Input storage", from)
+					.add("Output storage", to)
+					.add("Filter", filter)
+					.add("Max amount", maxAmount)
+					.add("Transaction", transaction);
+			throw new CrashException(report);
 		}
 
 		return totalMoved;
@@ -140,10 +151,19 @@ public final class StorageUtil {
 
 		if (storage == null) return null;
 
-		for (StorageView<T> view : storage.nonEmptyViews()) {
-			T resource = view.getResource();
-			long amount = view.extract(resource, maxAmount, transaction);
-			if (amount > 0) return new ResourceAmount<>(resource, amount);
+		try {
+			for (StorageView<T> view : storage.nonEmptyViews()) {
+				T resource = view.getResource();
+				long amount = view.extract(resource, maxAmount, transaction);
+				if (amount > 0) return new ResourceAmount<>(resource, amount);
+			}
+		} catch (Exception e) {
+			CrashReport report = CrashReport.create(e, "Extracting resources from storage");
+			report.addElement("Extraction details")
+					.add("Storage", storage)
+					.add("Max amount", maxAmount)
+					.add("Transaction", transaction);
+			throw new CrashException(report);
 		}
 
 		return null;
@@ -160,16 +180,26 @@ public final class StorageUtil {
 		StoragePreconditions.notNegative(maxAmount);
 		long amount = 0;
 
-		for (SingleSlotStorage<T> slot : slots) {
-			if (!slot.isResourceBlank()) {
+		try {
+			for (SingleSlotStorage<T> slot : slots) {
+				if (!slot.isResourceBlank()) {
+					amount += slot.insert(resource, maxAmount - amount, transaction);
+					if (amount == maxAmount) return amount;
+				}
+			}
+
+			for (SingleSlotStorage<T> slot : slots) {
 				amount += slot.insert(resource, maxAmount - amount, transaction);
 				if (amount == maxAmount) return amount;
 			}
-		}
-
-		for (SingleSlotStorage<T> slot : slots) {
-			amount += slot.insert(resource, maxAmount - amount, transaction);
-			if (amount == maxAmount) return amount;
+		} catch (Exception e) {
+			CrashReport report = CrashReport.create(e, "Inserting resources into slots");
+			report.addElement("Slotted insertion details")
+					.add("Slots", slots)
+					.add("Resource", resource)
+					.add("Max amount", maxAmount)
+					.add("Transaction", transaction);
+			throw new CrashException(report);
 		}
 
 		return amount;
@@ -187,12 +217,22 @@ public final class StorageUtil {
 	public static <T> long tryInsertStacking(@Nullable Storage<T> storage, T resource, long maxAmount, TransactionContext transaction) {
 		StoragePreconditions.notNegative(maxAmount);
 
-		if (storage instanceof SlottedStorage<T> slottedStorage) {
-			return insertStacking(slottedStorage.getSlots(), resource, maxAmount, transaction);
-		} else if (storage != null) {
-			return storage.insert(resource, maxAmount, transaction);
-		} else {
-			return 0;
+		try {
+			if (storage instanceof SlottedStorage<T> slottedStorage) {
+				return insertStacking(slottedStorage.getSlots(), resource, maxAmount, transaction);
+			} else if (storage != null) {
+				return storage.insert(resource, maxAmount, transaction);
+			} else {
+				return 0;
+			}
+		} catch (Exception e) {
+			CrashReport report = CrashReport.create(e, "Inserting resources into a storage");
+			report.addElement("Insertion details")
+					.add("Storage", storage)
+					.add("Resource", resource)
+					.add("Max amount", maxAmount)
+					.add("Transaction", transaction);
+			throw new CrashException(report);
 		}
 	}
 

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StorageUtil.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/StorageUtil.java
@@ -123,9 +123,9 @@ public final class StorageUtil {
 		} catch (Exception e) {
 			CrashReport report = CrashReport.create(e, "Moving resources between storages");
 			report.addElement("Move details")
-					.add("Input storage", from)
-					.add("Output storage", to)
-					.add("Filter", filter)
+					.add("Input storage", from::toString)
+					.add("Output storage", to::toString)
+					.add("Filter", filter::toString)
 					.add("Max amount", maxAmount)
 					.add("Transaction", transaction);
 			throw new CrashException(report);
@@ -160,7 +160,7 @@ public final class StorageUtil {
 		} catch (Exception e) {
 			CrashReport report = CrashReport.create(e, "Extracting resources from storage");
 			report.addElement("Extraction details")
-					.add("Storage", storage)
+					.add("Storage", storage::toString)
 					.add("Max amount", maxAmount)
 					.add("Transaction", transaction);
 			throw new CrashException(report);
@@ -195,8 +195,8 @@ public final class StorageUtil {
 		} catch (Exception e) {
 			CrashReport report = CrashReport.create(e, "Inserting resources into slots");
 			report.addElement("Slotted insertion details")
-					.add("Slots", slots)
-					.add("Resource", resource)
+					.add("Slots", () -> Objects.toString(slots, null))
+					.add("Resource", () -> Objects.toString(resource, null))
 					.add("Max amount", maxAmount)
 					.add("Transaction", transaction);
 			throw new CrashException(report);
@@ -228,8 +228,8 @@ public final class StorageUtil {
 		} catch (Exception e) {
 			CrashReport report = CrashReport.create(e, "Inserting resources into a storage");
 			report.addElement("Insertion details")
-					.add("Storage", storage)
-					.add("Resource", resource)
+					.add("Storage", () -> Objects.toString(storage, null))
+					.add("Resource", () -> Objects.toString(resource, null))
 					.add("Max amount", maxAmount)
 					.add("Transaction", transaction);
 			throw new CrashException(report);

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/CombinedSlottedStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/CombinedSlottedStorage.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.api.transfer.v1.storage.base;
 
 import java.util.List;
+import java.util.StringJoiner;
 
 import org.jetbrains.annotations.ApiStatus;
 
@@ -63,5 +64,16 @@ public class CombinedSlottedStorage<T, S extends SlottedStorage<T>> extends Comb
 		}
 
 		throw new IndexOutOfBoundsException("Slot " + slot + " is out of bounds. This storage has size " + getSlotCount());
+	}
+
+	@Override
+	public String toString() {
+		StringJoiner partNames = new StringJoiner(", ");
+
+		for (S part : parts) {
+			partNames.add(part.toString());
+		}
+
+		return "CombinedSlottedStorage[" + partNames + "]";
 	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/CombinedStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/CombinedStorage.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.api.transfer.v1.storage.base;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.StringJoiner;
 
 import org.jetbrains.annotations.ApiStatus;
 
@@ -97,6 +98,17 @@ public class CombinedStorage<T, S extends Storage<T>> implements Storage<T> {
 	@Override
 	public Iterator<StorageView<T>> iterator() {
 		return new CombinedIterator();
+	}
+
+	@Override
+	public String toString() {
+		StringJoiner partNames = new StringJoiner(", ");
+
+		for (S part : parts) {
+			partNames.add(part.toString());
+		}
+
+		return "CombinedStorage[" + partNames + "]";
 	}
 
 	/**

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/FilteringStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/FilteringStorage.java
@@ -182,6 +182,11 @@ public abstract class FilteringStorage<T> implements Storage<T> {
 		return backingStorage.get().getVersion();
 	}
 
+	@Override
+	public String toString() {
+		return "FilteringStorage[" + backingStorage.get() + "/" + backingStorage + "]";
+	}
+
 	/**
 	 * This is used to ensure extractions through storage views of the backing stored also get checked by {@link #canExtract}.
 	 */

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/SingleVariantItemStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/SingleVariantItemStorage.java
@@ -222,4 +222,9 @@ public abstract class SingleVariantItemStorage<T extends TransferVariant<?>> imp
 			return 0;
 		}
 	}
+
+	@Override
+	public String toString() {
+		return "SingleVariantItemStorage[" + context + "/" + item + "]";
+	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/SingleVariantStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/SingleVariantStorage.java
@@ -158,4 +158,9 @@ public abstract class SingleVariantStorage<T extends TransferVariant<?>> extends
 		variant = snapshot.resource();
 		amount = snapshot.amount();
 	}
+
+	@Override
+	public String toString() {
+		return "SingleVariantStorage[%d %s]".formatted(amount, variant);
+	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/DebugMessages.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/DebugMessages.java
@@ -16,11 +16,10 @@
 
 package net.fabricmc.fabric.impl.transfer;
 
-import net.minecraft.entity.player.PlayerEntity;
-
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.util.math.BlockPos;

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/DebugMessages.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/DebugMessages.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.transfer;
+
+import net.minecraft.entity.player.PlayerEntity;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public final class DebugMessages {
+	public static String forGlobalPos(@Nullable World world, BlockPos pos) {
+		String dimension = world != null ? world.getDimensionKey().getValue().toString() : "<no dimension>";
+		return dimension + "@" + pos.toShortString();
+	}
+
+	public static String forInventory(@Nullable Inventory inventory) {
+		if (inventory == null) {
+			return "~~NULL~~"; // like in crash reports
+		} else if (inventory instanceof PlayerInventory playerInventory) {
+			PlayerEntity player = playerInventory.player;
+			return player.getEntityName() + "/" + player.getUuidAsString();
+		} else {
+			String result = inventory.toString();
+
+			if (inventory instanceof BlockEntity blockEntity) {
+				result += " (%s, %s)".formatted(blockEntity.getCachedState(), forGlobalPos(blockEntity.getWorld(), blockEntity.getPos()));
+			}
+
+			return result;
+		}
+	}
+}

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/DebugMessages.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/DebugMessages.java
@@ -32,12 +32,15 @@ public final class DebugMessages {
 		return dimension + "@" + pos.toShortString();
 	}
 
+	public static String forPlayer(PlayerEntity player) {
+		return player.getEntityName() + "/" + player.getUuidAsString();
+	}
+
 	public static String forInventory(@Nullable Inventory inventory) {
 		if (inventory == null) {
 			return "~~NULL~~"; // like in crash reports
 		} else if (inventory instanceof PlayerInventory playerInventory) {
-			PlayerEntity player = playerInventory.player;
-			return player.getEntityName() + "/" + player.getUuidAsString();
+			return forPlayer(playerInventory.player);
 		} else {
 			String result = inventory.toString();
 

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/TransferApiImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/TransferApiImpl.java
@@ -66,6 +66,11 @@ public class TransferApiImpl {
 		public long getVersion() {
 			return 0;
 		}
+
+		@Override
+		public String toString() {
+			return "EmptyStorage";
+		}
 	};
 
 	public static <T> Iterator<T> singletonIterator(T it) {

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/context/ConstantContainerItemContext.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/context/ConstantContainerItemContext.java
@@ -76,4 +76,10 @@ public class ConstantContainerItemContext implements ContainerItemContext {
 	public List<SingleSlotStorage<ItemVariant>> getAdditionalSlots() {
 		return Collections.emptyList();
 	}
+
+	@Override
+	public String toString() {
+		return "ConstantContainerItemContext[%d %s]"
+				.formatted(getMainSlot().getAmount(), getMainSlot().getResource());
+	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/context/CreativeInteractionContainerItemContext.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/context/CreativeInteractionContainerItemContext.java
@@ -56,4 +56,10 @@ public class CreativeInteractionContainerItemContext extends ConstantContainerIt
 		// Insertion always succeeds from the POV of the context user.
 		return maxAmount;
 	}
+
+	@Override
+	public String toString() {
+		return "CreativeInteractionContainerItemContext[%d %s]"
+				.formatted(getMainSlot().getAmount(), getMainSlot().getResource());
+	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/context/PlayerContainerItemContext.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/context/PlayerContainerItemContext.java
@@ -59,6 +59,7 @@ public class PlayerContainerItemContext implements ContainerItemContext {
 
 	@Override
 	public String toString() {
-		return "PlayerContainerItemContext[" + playerWrapper + "]";
+		return "PlayerContainerItemContext[%d %s %s/%s]"
+				.formatted(slot.getAmount(), slot.getResource(), playerWrapper, slot);
 	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/context/PlayerContainerItemContext.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/context/PlayerContainerItemContext.java
@@ -56,4 +56,9 @@ public class PlayerContainerItemContext implements ContainerItemContext {
 	public List<SingleSlotStorage<ItemVariant>> getAdditionalSlots() {
 		return playerWrapper.getSlots();
 	}
+
+	@Override
+	public String toString() {
+		return "PlayerContainerItemContext[" + playerWrapper + "]";
+	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/context/SingleSlotContainerItemContext.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/context/SingleSlotContainerItemContext.java
@@ -49,6 +49,7 @@ public class SingleSlotContainerItemContext implements ContainerItemContext {
 
 	@Override
 	public String toString() {
-		return "SingleSlotContainerItemContext[" + slot + "]";
+		return "SingleSlotContainerItemContext[%d %s %s]"
+				.formatted(slot.getAmount(), slot.getResource(), slot);
 	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/context/SingleSlotContainerItemContext.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/context/SingleSlotContainerItemContext.java
@@ -46,4 +46,9 @@ public class SingleSlotContainerItemContext implements ContainerItemContext {
 	public List<SingleSlotStorage<ItemVariant>> getAdditionalSlots() {
 		return Collections.emptyList();
 	}
+
+	@Override
+	public String toString() {
+		return "SingleSlotContainerItemContext[" + slot + "]";
+	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/CauldronStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/CauldronStorage.java
@@ -32,6 +32,7 @@ import net.fabricmc.fabric.api.transfer.v1.storage.StoragePreconditions;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleSlotStorage;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.fabricmc.fabric.api.transfer.v1.transaction.base.SnapshotParticipant;
+import net.fabricmc.fabric.impl.transfer.DebugMessages;
 
 /**
  * Standard implementation of {@code Storage<FluidVariant>}, using cauldron/fluid mappings registered in {@link CauldronFluidContent}.
@@ -49,7 +50,7 @@ public class CauldronStorage extends SnapshotParticipant<BlockState> implements 
 	private record WorldLocation(World world, BlockPos pos) {
 		@Override
 		public String toString() {
-			return world.getDimensionKey().getValue() + "@" + pos.toShortString();
+			return DebugMessages.forGlobalPos(world, pos);
 		}
 	}
 

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/CauldronStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/CauldronStorage.java
@@ -47,6 +47,10 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.base.SnapshotParticipant;
 public class CauldronStorage extends SnapshotParticipant<BlockState> implements SingleSlotStorage<FluidVariant> {
 	// Record is used for convenient constructor, hashcode and equals implementations.
 	private record WorldLocation(World world, BlockPos pos) {
+		@Override
+		public String toString() {
+			return world.getDimensionKey().getValue() + "@" + pos.toShortString();
+		}
 	}
 
 	// Weak values to make sure wrappers are cleaned up after use, thread-safe.
@@ -203,5 +207,10 @@ public class CauldronStorage extends SnapshotParticipant<BlockState> implements 
 			// Then do the actual change with normal block updates
 			location.world.setBlockState(location.pos, state);
 		}
+	}
+
+	@Override
+	public String toString() {
+		return "CauldronStorage[" + location + "]";
 	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/EmptyBucketStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/EmptyBucketStorage.java
@@ -70,4 +70,9 @@ public class EmptyBucketStorage implements InsertionOnlyStorage<FluidVariant> {
 	public Iterator<StorageView<FluidVariant>> iterator() {
 		return blankView.iterator();
 	}
+
+	@Override
+	public String toString() {
+		return "EmptyBucketStorage[" + context + "]";
+	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/FluidVariantImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/FluidVariantImpl.java
@@ -131,7 +131,7 @@ public class FluidVariantImpl implements FluidVariant {
 
 	@Override
 	public String toString() {
-		return "FluidVariantImpl{fluid=" + fluid + ", tag=" + nbt + '}';
+		return "FluidVariant{fluid=" + fluid + ", tag=" + nbt + '}';
 	}
 
 	@Override

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/WaterPotionStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/WaterPotionStorage.java
@@ -114,4 +114,9 @@ public class WaterPotionStorage implements ExtractionOnlyStorage<FluidVariant>, 
 		// Capacity is the same as the amount.
 		return getAmount();
 	}
+
+	@Override
+	public String toString() {
+		return "WaterPotionStorage[" + context + "]";
+	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/ComposterWrapper.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/ComposterWrapper.java
@@ -55,6 +55,11 @@ public class ComposterWrapper extends SnapshotParticipant<Float> {
 		private void setBlockState(BlockState state) {
 			world.setBlockState(pos, state);
 		}
+
+		@Override
+		public String toString() {
+			return world.getDimensionKey().getValue() + "@" + pos.toShortString();
+		}
 	}
 
 	// Weak values to make sure wrappers are cleaned up after use, thread-safe.
@@ -147,6 +152,11 @@ public class ComposterWrapper extends SnapshotParticipant<Float> {
 			increaseProbability = insertedIncreaseProbability;
 			return 1;
 		}
+
+		@Override
+		public String toString() {
+			return "ComposterWrapper[" + location + "/top]";
+		}
 	}
 
 	private class BottomStorage implements ExtractionOnlyStorage<ItemVariant>, SingleSlotStorage<ItemVariant> {
@@ -191,6 +201,11 @@ public class ComposterWrapper extends SnapshotParticipant<Float> {
 		@Override
 		public long getCapacity() {
 			return 1;
+		}
+
+		@Override
+		public String toString() {
+			return "ComposterWrapper[" + location + "/bottom]";
 		}
 	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/ComposterWrapper.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/ComposterWrapper.java
@@ -41,6 +41,7 @@ import net.fabricmc.fabric.api.transfer.v1.storage.base.InsertionOnlyStorage;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleSlotStorage;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.fabricmc.fabric.api.transfer.v1.transaction.base.SnapshotParticipant;
+import net.fabricmc.fabric.impl.transfer.DebugMessages;
 
 /**
  * Implementation of {@code Storage<ItemVariant>} for composters.
@@ -58,7 +59,7 @@ public class ComposterWrapper extends SnapshotParticipant<Float> {
 
 		@Override
 		public String toString() {
-			return world.getDimensionKey().getValue() + "@" + pos.toShortString();
+			return DebugMessages.forGlobalPos(world, pos);
 		}
 	}
 

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/CursorSlotWrapper.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/CursorSlotWrapper.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import com.google.common.collect.MapMaker;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.registry.Registries;
 import net.minecraft.screen.ScreenHandler;
 
 import net.fabricmc.fabric.api.transfer.v1.item.base.SingleStackStorage;
@@ -49,5 +50,10 @@ public class CursorSlotWrapper extends SingleStackStorage {
 	@Override
 	protected void setStack(ItemStack stack) {
 		screenHandler.setCursorStack(stack);
+	}
+
+	@Override
+	public String toString() {
+		return "CursorSlotWrapper[" + screenHandler + "/" + Registries.SCREEN_HANDLER.getId(screenHandler.getType()) + "]";
 	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/InventorySlotWrapper.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/InventorySlotWrapper.java
@@ -161,4 +161,9 @@ class InventorySlotWrapper extends SingleStackStorage {
 			original.setCount(0);
 		}
 	}
+
+	@Override
+	public String toString() {
+		return "InventorySlotWrapper[%s#%d]".formatted(storage.inventory, slot);
+	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/InventorySlotWrapper.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/InventorySlotWrapper.java
@@ -16,8 +16,6 @@
 
 package net.fabricmc.fabric.impl.transfer.item;
 
-import net.fabricmc.fabric.impl.transfer.DebugMessages;
-
 import net.minecraft.block.ChestBlock;
 import net.minecraft.block.entity.AbstractFurnaceBlockEntity;
 import net.minecraft.block.entity.BrewingStandBlockEntity;
@@ -28,9 +26,10 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.util.math.BlockPos;
 
-import net.fabricmc.fabric.api.transfer.v1.item.base.SingleStackStorage;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import net.fabricmc.fabric.api.transfer.v1.item.base.SingleStackStorage;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
+import net.fabricmc.fabric.impl.transfer.DebugMessages;
 
 /**
  * A wrapper around a single slot of an inventory.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/InventorySlotWrapper.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/InventorySlotWrapper.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.impl.transfer.item;
 
+import net.fabricmc.fabric.impl.transfer.DebugMessages;
+
 import net.minecraft.block.ChestBlock;
 import net.minecraft.block.entity.AbstractFurnaceBlockEntity;
 import net.minecraft.block.entity.BrewingStandBlockEntity;
@@ -164,6 +166,6 @@ class InventorySlotWrapper extends SingleStackStorage {
 
 	@Override
 	public String toString() {
-		return "InventorySlotWrapper[%s#%d]".formatted(storage.inventory, slot);
+		return "InventorySlotWrapper[%s#%d]".formatted(DebugMessages.forInventory(storage.inventory), slot);
 	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/InventoryStorageImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/InventoryStorageImpl.java
@@ -22,9 +22,6 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.MapMaker;
-
-import net.fabricmc.fabric.impl.transfer.DebugMessages;
-
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.entity.player.PlayerInventory;
@@ -37,6 +34,7 @@ import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.CombinedStorage;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleSlotStorage;
 import net.fabricmc.fabric.api.transfer.v1.transaction.base.SnapshotParticipant;
+import net.fabricmc.fabric.impl.transfer.DebugMessages;
 
 /**
  * Implementation of {@link InventoryStorage}.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/InventoryStorageImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/InventoryStorageImpl.java
@@ -112,6 +112,11 @@ public class InventoryStorageImpl extends CombinedStorage<ItemVariant, SingleSlo
 		}
 	}
 
+	@Override
+	public String toString() {
+		return "InventoryStorage[" + inventory + "]";
+	}
+
 	// Boolean is used to prevent allocation. Null values are not allowed by SnapshotParticipant.
 	class MarkDirtyParticipant extends SnapshotParticipant<Boolean> {
 		@Override

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/InventoryStorageImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/InventoryStorageImpl.java
@@ -22,6 +22,9 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.MapMaker;
+
+import net.fabricmc.fabric.impl.transfer.DebugMessages;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.entity.player.PlayerInventory;
@@ -114,7 +117,7 @@ public class InventoryStorageImpl extends CombinedStorage<ItemVariant, SingleSlo
 
 	@Override
 	public String toString() {
-		return "InventoryStorage[" + inventory + "]";
+		return "InventoryStorage[" + DebugMessages.forInventory(inventory) + "]";
 	}
 
 	// Boolean is used to prevent allocation. Null values are not allowed by SnapshotParticipant.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/ItemVariantImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/ItemVariantImpl.java
@@ -122,7 +122,7 @@ public class ItemVariantImpl implements ItemVariant {
 
 	@Override
 	public String toString() {
-		return "ItemVariantImpl{item=" + item + ", tag=" + nbt + '}';
+		return "ItemVariant{item=" + item + ", tag=" + nbt + '}';
 	}
 
 	@Override

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/PlayerInventoryStorageImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/PlayerInventoryStorageImpl.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.util.Hand;
 
@@ -31,6 +30,7 @@ import net.fabricmc.fabric.api.transfer.v1.storage.StorageUtil;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleSlotStorage;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.fabricmc.fabric.api.transfer.v1.transaction.base.SnapshotParticipant;
+import net.fabricmc.fabric.impl.transfer.DebugMessages;
 
 class PlayerInventoryStorageImpl extends InventoryStorageImpl implements PlayerInventoryStorage {
 	private final DroppedStacks droppedStacks;
@@ -99,8 +99,7 @@ class PlayerInventoryStorageImpl extends InventoryStorageImpl implements PlayerI
 
 	@Override
 	public String toString() {
-		PlayerEntity player = playerInventory.player;
-		return "PlayerInventoryStorage[" + player.getEntityName() + "/" + player.getUuidAsString() + "]";
+		return "PlayerInventoryStorage[" + DebugMessages.forInventory(playerInventory) + "]";
 	}
 
 	private class DroppedStacks extends SnapshotParticipant<Integer> {

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/PlayerInventoryStorageImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/PlayerInventoryStorageImpl.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.util.Hand;
 
@@ -94,6 +95,12 @@ class PlayerInventoryStorageImpl extends InventoryStorageImpl implements PlayerI
 		} else {
 			throw new UnsupportedOperationException("Unknown hand: " + hand);
 		}
+	}
+
+	@Override
+	public String toString() {
+		PlayerEntity player = playerInventory.player;
+		return "PlayerInventoryStorage[" + player.getEntityName() + "/" + player.getUuidAsString() + "]";
 	}
 
 	private class DroppedStacks extends SnapshotParticipant<Integer> {

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/SidedInventorySlotWrapper.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/SidedInventorySlotWrapper.java
@@ -23,6 +23,7 @@ import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleSlotStorage;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
+import net.fabricmc.fabric.impl.transfer.DebugMessages;
 
 /**
  * Wrapper around an {@link InventorySlotWrapper}, with additional canInsert and canExtract checks.
@@ -83,6 +84,6 @@ class SidedInventorySlotWrapper implements SingleSlotStorage<ItemVariant> {
 
 	@Override
 	public String toString() {
-		return "SidedInventorySlotWrapper[%s#%d/%s]".formatted(sidedInventory, slotWrapper.slot, direction.getName());
+		return "SidedInventorySlotWrapper[%s#%d/%s]".formatted(DebugMessages.forInventory(sidedInventory), slotWrapper.slot, direction.getName());
 	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/SidedInventorySlotWrapper.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/SidedInventorySlotWrapper.java
@@ -80,4 +80,9 @@ class SidedInventorySlotWrapper implements SingleSlotStorage<ItemVariant> {
 	public StorageView<ItemVariant> getUnderlyingView() {
 		return slotWrapper.getUnderlyingView();
 	}
+
+	@Override
+	public String toString() {
+		return "SidedInventorySlotWrapper[%s#%d/%s]".formatted(sidedInventory, slotWrapper.slot, direction.getName());
+	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/SidedInventoryStorageImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/SidedInventoryStorageImpl.java
@@ -32,8 +32,11 @@ import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleSlotStorage;
  * Sidedness-aware wrapper around a {@link InventoryStorageImpl} for sided inventories.
  */
 class SidedInventoryStorageImpl extends CombinedStorage<ItemVariant, SingleSlotStorage<ItemVariant>> implements InventoryStorage {
+	private final InventoryStorageImpl backingStorage;
+
 	SidedInventoryStorageImpl(InventoryStorageImpl storage, Direction direction) {
 		super(Collections.unmodifiableList(createWrapperList(storage, direction)));
+		this.backingStorage = storage;
 	}
 
 	@Override
@@ -51,5 +54,11 @@ class SidedInventoryStorageImpl extends CombinedStorage<ItemVariant, SingleSlotS
 		}
 
 		return Arrays.asList(slots);
+	}
+
+	@Override
+	public String toString() {
+		// These two are the same from the user's perspective.
+		return backingStorage.toString();
 	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/transaction/TransactionManagerImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/transaction/TransactionManagerImpl.java
@@ -238,7 +238,7 @@ public class TransactionManagerImpl {
 
 		@Override
 		public String toString() {
-			return "Transaction[depth=%d, lifecycle=%s]".formatted(nestingDepth, lifecycle.name());
+			return "Transaction[depth=%d, lifecycle=%s, thread=%s]".formatted(nestingDepth, lifecycle.name(), thread);
 		}
 	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/transaction/TransactionManagerImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/transaction/TransactionManagerImpl.java
@@ -238,7 +238,7 @@ public class TransactionManagerImpl {
 
 		@Override
 		public String toString() {
-			return "Transaction[depth=%d, lifecycle=%s, thread=%s]".formatted(nestingDepth, lifecycle.name(), thread);
+			return "Transaction[depth=%d, lifecycle=%s, thread=%s]".formatted(nestingDepth, lifecycle.name(), thread.getName());
 		}
 	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/transaction/TransactionManagerImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/transaction/TransactionManagerImpl.java
@@ -235,5 +235,10 @@ public class TransactionManagerImpl {
 
 			outerCloseCallbacks.add(outerCloseCallback);
 		}
+
+		@Override
+		public String toString() {
+			return "Transaction[depth=%d, lifecycle=%s]".formatted(nestingDepth, lifecycle.name());
+		}
 	}
 }


### PR DESCRIPTION
## Changes

- Added `toString` to all default `Storage`, `ContainerItemContext` and `Transaction` implementations
- Removed `Impl` suffix from `ItemVariantImpl.toString` and `FluidVariantImpl.toString`. Since they are the only implementations, the suffix offers no meaningful info for callers.
- In `StorageUtil` and `FluidStorageUtil` methods for moving resources, exceptions are now caught are more context is added to them with `CrashReport`.
  - Open question: Would it make sense to catch the precondition exceptions thrown by the methods themselves?

## Example
Helps a bit with #2923, but without adding context like dimensions and positions everywhere, it's hard to fix completely.

With this PR, the error message would've looked somewhat like:

```
java.lang.IllegalArgumentException: Amount may not be negative, but it is: -1024
     ....stacktrace...

A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- Move details --
Details:
    Input storage: SingleStackStorage[10 minecraft:diamond]
    Output storage: com.example.badmod.BrokenStorage@12345678
    Filter: some lambda
    Max amount: 64
    Transaction: Transaction[depth=0, lifecycle=NONE, thread=Server thread]
```