### PR TITLE
Terminally deprecate `EventFactory` `isProfilingEnabled` and `invalidate`

### DIFF
--- a/deprecated/fabric-events-lifecycle-v0/src/client/java/net/fabricmc/fabric/api/event/client/ClientTickCallback.java
+++ b/deprecated/fabric-events-lifecycle-v0/src/client/java/net/fabricmc/fabric/api/event/client/ClientTickCallback.java
@@ -30,25 +30,11 @@ public interface ClientTickCallback {
 	@Deprecated
 	Event<ClientTickCallback> EVENT = EventFactory.createArrayBacked(ClientTickCallback.class,
 			(listeners) -> {
-				if (EventFactory.isProfilingEnabled()) {
-					return (client) -> {
-						client.getProfiler().push("fabricClientTick");
-
-						for (ClientTickCallback event : listeners) {
-							client.getProfiler().push(EventFactory.getHandlerName(event));
-							event.tick(client);
-							client.getProfiler().pop();
-						}
-
-						client.getProfiler().pop();
-					};
-				} else {
-					return (client) -> {
-						for (ClientTickCallback event : listeners) {
-							event.tick(client);
-						}
-					};
-				}
+				return (client) -> {
+					for (ClientTickCallback event : listeners) {
+						event.tick(client);
+					}
+				};
 			}
 	);
 

--- a/deprecated/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/server/ServerTickCallback.java
+++ b/deprecated/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/server/ServerTickCallback.java
@@ -30,25 +30,11 @@ public interface ServerTickCallback {
 	@Deprecated
 	Event<ServerTickCallback> EVENT = EventFactory.createArrayBacked(ServerTickCallback.class,
 			(listeners) -> {
-				if (EventFactory.isProfilingEnabled()) {
-					return (server) -> {
-						server.getProfiler().push("fabricServerTick");
-
-						for (ServerTickCallback event : listeners) {
-							server.getProfiler().push(EventFactory.getHandlerName(event));
-							event.tick(server);
-							server.getProfiler().pop();
-						}
-
-						server.getProfiler().pop();
-					};
-				} else {
-					return (server) -> {
-						for (ServerTickCallback event : listeners) {
-							event.tick(server);
-						}
-					};
-				}
+				return (server) -> {
+					for (ServerTickCallback event : listeners) {
+						event.tick(server);
+					}
+				};
 			}
 	);
 

--- a/deprecated/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/world/WorldTickCallback.java
+++ b/deprecated/fabric-events-lifecycle-v0/src/main/java/net/fabricmc/fabric/api/event/world/WorldTickCallback.java
@@ -31,25 +31,11 @@ public interface WorldTickCallback {
 	@Deprecated
 	Event<WorldTickCallback> EVENT = EventFactory.createArrayBacked(WorldTickCallback.class,
 			(listeners) -> {
-				if (EventFactory.isProfilingEnabled()) {
-					return (world) -> {
-						world.getProfiler().push("fabricWorldTick");
-
-						for (WorldTickCallback event : listeners) {
-							world.getProfiler().push(EventFactory.getHandlerName(event));
-							event.tick(world);
-							world.getProfiler().pop();
-						}
-
-						world.getProfiler().pop();
-					};
-				} else {
-					return (world) -> {
-						for (WorldTickCallback event : listeners) {
-							event.tick(world);
-						}
-					};
-				}
+				return (world) -> {
+					for (WorldTickCallback event : listeners) {
+						event.tick(world);
+					}
+				};
 			}
 	);
 

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
@@ -110,12 +110,9 @@ public final class EventFactory {
 	}
 
 	/**
-	 * Get the listener object name. This can be used in debugging/profiling
-	 * scenarios.
-	 *
-	 * @param handler The listener object.
-	 * @return The listener name.
+	 * @deprecated This is not to be used in events anymore.
 	 */
+	@Deprecated
 	public static String getHandlerName(Object handler) {
 		return handler.getClass().getName();
 	}

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
@@ -26,26 +26,7 @@ import net.fabricmc.fabric.impl.base.event.EventFactoryImpl;
  * Helper for creating {@link Event} classes.
  */
 public final class EventFactory {
-	private static boolean profilingEnabled = true;
-
 	private EventFactory() { }
-
-	/**
-	 * @return True if events are supposed to be profiled.
-	 */
-	public static boolean isProfilingEnabled() {
-		return profilingEnabled;
-	}
-
-	/**
-	 * Invalidate and re-create all existing "invoker" instances across
-	 * events created by this EventFactory. Use this if, for instance,
-	 * the profilingEnabled field changes.
-	 */
-	// TODO: Turn this into an event?
-	public static void invalidate() {
-		EventFactoryImpl.invalidate();
-	}
 
 	/**
 	 * Create an "array-backed" Event instance.
@@ -137,5 +118,25 @@ public final class EventFactory {
 	 */
 	public static String getHandlerName(Object handler) {
 		return handler.getClass().getName();
+	}
+
+	/**
+	 * @deprecated Always returns {@code false}, do not use.
+	 */
+	@Deprecated(forRemoval = true)
+	public static boolean isProfilingEnabled() {
+		return false;
+	}
+
+	/**
+	 * Invalidate and re-create all existing "invoker" instances across
+	 * events created by this EventFactory. Use this if, for instance,
+	 * the profilingEnabled field changes.
+	 *
+	 * @deprecated Do not use, will be removed in a future release.
+	 */
+	@Deprecated(forRemoval = true)
+	public static void invalidate() {
+		EventFactoryImpl.invalidate();
 	}
 }

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/event/EventFactory.java
@@ -121,9 +121,9 @@ public final class EventFactory {
 	}
 
 	/**
-	 * @deprecated Always returns {@code false}, do not use.
+	 * @deprecated Always returns {@code false}, do not use. This is not to be used in events anymore, standard Java profilers will do fine.
 	 */
-	@Deprecated(forRemoval = true)
+	@Deprecated
 	public static boolean isProfilingEnabled() {
 		return false;
 	}

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientBlockEntityEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientBlockEntityEvents.java
@@ -18,7 +18,6 @@ package net.fabricmc.fabric.api.client.event.lifecycle.v1;
 
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.client.world.ClientWorld;
-import net.minecraft.util.profiler.Profiler;
 
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
@@ -34,21 +33,8 @@ public final class ClientBlockEntityEvents {
 	 * However, its data might not be loaded yet, so don't rely on it.
 	 */
 	public static final Event<ClientBlockEntityEvents.Load> BLOCK_ENTITY_LOAD = EventFactory.createArrayBacked(ClientBlockEntityEvents.Load.class, callbacks -> (blockEntity, world) -> {
-		if (EventFactory.isProfilingEnabled()) {
-			final Profiler profiler = world.getProfiler();
-			profiler.push("fabricClientBlockEntityLoad");
-
-			for (ClientBlockEntityEvents.Load callback : callbacks) {
-				profiler.push(EventFactory.getHandlerName(callback));
-				callback.onLoad(blockEntity, world);
-				profiler.pop();
-			}
-
-			profiler.pop();
-		} else {
-			for (ClientBlockEntityEvents.Load callback : callbacks) {
-				callback.onLoad(blockEntity, world);
-			}
+		for (Load callback : callbacks) {
+			callback.onLoad(blockEntity, world);
 		}
 	});
 
@@ -58,21 +44,8 @@ public final class ClientBlockEntityEvents {
 	 * <p>When this event is called, the block entity is still present on the world.
 	 */
 	public static final Event<ClientBlockEntityEvents.Unload> BLOCK_ENTITY_UNLOAD = EventFactory.createArrayBacked(ClientBlockEntityEvents.Unload.class, callbacks -> (blockEntity, world) -> {
-		if (EventFactory.isProfilingEnabled()) {
-			final Profiler profiler = world.getProfiler();
-			profiler.push("fabricClientBlockEntityUnload");
-
-			for (ClientBlockEntityEvents.Unload callback : callbacks) {
-				profiler.push(EventFactory.getHandlerName(callback));
-				callback.onUnload(blockEntity, world);
-				profiler.pop();
-			}
-
-			profiler.pop();
-		} else {
-			for (ClientBlockEntityEvents.Unload callback : callbacks) {
-				callback.onUnload(blockEntity, world);
-			}
+		for (Unload callback : callbacks) {
+			callback.onUnload(blockEntity, world);
 		}
 	});
 

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientChunkEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientChunkEvents.java
@@ -17,7 +17,6 @@
 package net.fabricmc.fabric.api.client.event.lifecycle.v1;
 
 import net.minecraft.client.world.ClientWorld;
-import net.minecraft.util.profiler.Profiler;
 import net.minecraft.world.chunk.WorldChunk;
 
 import net.fabricmc.fabric.api.event.Event;
@@ -33,21 +32,8 @@ public final class ClientChunkEvents {
 	 * <p>When this event is called, the chunk is already in the world.
 	 */
 	public static final Event<ClientChunkEvents.Load> CHUNK_LOAD = EventFactory.createArrayBacked(ClientChunkEvents.Load.class, callbacks -> (clientWorld, chunk) -> {
-		if (EventFactory.isProfilingEnabled()) {
-			Profiler profiler = clientWorld.getProfiler();
-			profiler.push("fabricClientChunkLoad");
-
-			for (ClientChunkEvents.Load callback : callbacks) {
-				profiler.push(EventFactory.getHandlerName(callback));
-				callback.onChunkLoad(clientWorld, chunk);
-				profiler.pop();
-			}
-
-			profiler.pop();
-		} else {
-			for (ClientChunkEvents.Load callback : callbacks) {
-				callback.onChunkLoad(clientWorld, chunk);
-			}
+		for (Load callback : callbacks) {
+			callback.onChunkLoad(clientWorld, chunk);
 		}
 	});
 
@@ -57,21 +43,8 @@ public final class ClientChunkEvents {
 	 * <p>When this event is called, the chunk is still present in the world.
 	 */
 	public static final Event<ClientChunkEvents.Unload> CHUNK_UNLOAD = EventFactory.createArrayBacked(ClientChunkEvents.Unload.class, callbacks -> (clientWorld, chunk) -> {
-		if (EventFactory.isProfilingEnabled()) {
-			final Profiler profiler = clientWorld.getProfiler();
-			profiler.push("fabricClientChunkUnload");
-
-			for (ClientChunkEvents.Unload callback : callbacks) {
-				profiler.push(EventFactory.getHandlerName(callback));
-				callback.onChunkUnload(clientWorld, chunk);
-				profiler.pop();
-			}
-
-			profiler.pop();
-		} else {
-			for (ClientChunkEvents.Unload callback : callbacks) {
-				callback.onChunkUnload(clientWorld, chunk);
-			}
+		for (Unload callback : callbacks) {
+			callback.onChunkUnload(clientWorld, chunk);
 		}
 	});
 

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientEntityEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientEntityEvents.java
@@ -18,7 +18,6 @@ package net.fabricmc.fabric.api.client.event.lifecycle.v1;
 
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.Entity;
-import net.minecraft.util.profiler.Profiler;
 
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
@@ -33,21 +32,8 @@ public final class ClientEntityEvents {
 	 * <p>When this event is called, the chunk is already in the world.
 	 */
 	public static final Event<ClientEntityEvents.Load> ENTITY_LOAD = EventFactory.createArrayBacked(ClientEntityEvents.Load.class, callbacks -> (entity, world) -> {
-		if (EventFactory.isProfilingEnabled()) {
-			final Profiler profiler = world.getProfiler();
-			profiler.push("fabricClientEntityLoad");
-
-			for (ClientEntityEvents.Load callback : callbacks) {
-				profiler.push(EventFactory.getHandlerName(callback));
-				callback.onLoad(entity, world);
-				profiler.pop();
-			}
-
-			profiler.pop();
-		} else {
-			for (ClientEntityEvents.Load callback : callbacks) {
-				callback.onLoad(entity, world);
-			}
+		for (Load callback : callbacks) {
+			callback.onLoad(entity, world);
 		}
 	});
 
@@ -57,21 +43,8 @@ public final class ClientEntityEvents {
 	 * <p>This event is called before the entity is unloaded from the world.
 	 */
 	public static final Event<ClientEntityEvents.Unload> ENTITY_UNLOAD = EventFactory.createArrayBacked(ClientEntityEvents.Unload.class, callbacks -> (entity, world) -> {
-		if (EventFactory.isProfilingEnabled()) {
-			final Profiler profiler = world.getProfiler();
-			profiler.push("fabricClientEntityUnload");
-
-			for (ClientEntityEvents.Unload callback : callbacks) {
-				profiler.push(EventFactory.getHandlerName(callback));
-				callback.onUnload(entity, world);
-				profiler.pop();
-			}
-
-			profiler.pop();
-		} else {
-			for (ClientEntityEvents.Unload callback : callbacks) {
-				callback.onUnload(entity, world);
-			}
+		for (Unload callback : callbacks) {
+			callback.onUnload(entity, world);
 		}
 	});
 

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientTickEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientTickEvents.java
@@ -18,7 +18,6 @@ package net.fabricmc.fabric.api.client.event.lifecycle.v1;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.world.ClientWorld;
-import net.minecraft.util.profiler.Profiler;
 
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
@@ -31,21 +30,8 @@ public final class ClientTickEvents {
 	 * Called at the start of the client tick.
 	 */
 	public static final Event<StartTick> START_CLIENT_TICK = EventFactory.createArrayBacked(StartTick.class, callbacks -> client -> {
-		if (EventFactory.isProfilingEnabled()) {
-			final Profiler profiler = client.getProfiler();
-			profiler.push("fabricStartClientTick");
-
-			for (StartTick event : callbacks) {
-				profiler.push(EventFactory.getHandlerName(event));
-				event.onStartTick(client);
-				profiler.pop();
-			}
-
-			profiler.pop();
-		} else {
-			for (StartTick event : callbacks) {
-				event.onStartTick(client);
-			}
+		for (StartTick event : callbacks) {
+			event.onStartTick(client);
 		}
 	});
 
@@ -53,21 +39,8 @@ public final class ClientTickEvents {
 	 * Called at the end of the client tick.
 	 */
 	public static final Event<EndTick> END_CLIENT_TICK = EventFactory.createArrayBacked(EndTick.class, callbacks -> client -> {
-		if (EventFactory.isProfilingEnabled()) {
-			final Profiler profiler = client.getProfiler();
-			profiler.push("fabricEndClientTick");
-
-			for (EndTick event : callbacks) {
-				profiler.push(EventFactory.getHandlerName(event));
-				event.onEndTick(client);
-				profiler.pop();
-			}
-
-			profiler.pop();
-		} else {
-			for (EndTick event : callbacks) {
-				event.onEndTick(client);
-			}
+		for (EndTick event : callbacks) {
+			event.onEndTick(client);
 		}
 	});
 
@@ -75,21 +48,8 @@ public final class ClientTickEvents {
 	 * Called at the start of a ClientWorld's tick.
 	 */
 	public static final Event<StartWorldTick> START_WORLD_TICK = EventFactory.createArrayBacked(StartWorldTick.class, callbacks -> world -> {
-		if (EventFactory.isProfilingEnabled()) {
-			final Profiler profiler = world.getProfiler();
-			profiler.push("fabricStartClientWorldTick");
-
-			for (StartWorldTick callback : callbacks) {
-				profiler.push(EventFactory.getHandlerName(callback));
-				callback.onStartTick(world);
-				profiler.pop();
-			}
-
-			profiler.pop();
-		} else {
-			for (StartWorldTick callback : callbacks) {
-				callback.onStartTick(world);
-			}
+		for (StartWorldTick callback : callbacks) {
+			callback.onStartTick(world);
 		}
 	});
 
@@ -99,21 +59,8 @@ public final class ClientTickEvents {
 	 * <p>End of world tick may be used to start async computations for the next tick.
 	 */
 	public static final Event<EndWorldTick> END_WORLD_TICK = EventFactory.createArrayBacked(EndWorldTick.class, callbacks -> world -> {
-		if (EventFactory.isProfilingEnabled()) {
-			final Profiler profiler = world.getProfiler();
-			profiler.push("fabricEndClientWorldTick");
-
-			for (EndWorldTick callback : callbacks) {
-				profiler.push(EventFactory.getHandlerName(callback));
-				callback.onEndTick(world);
-				profiler.pop();
-			}
-
-			profiler.pop();
-		} else {
-			for (EndWorldTick callback : callbacks) {
-				callback.onEndTick(world);
-			}
+		for (EndWorldTick callback : callbacks) {
+			callback.onEndTick(world);
 		}
 	});
 

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerBlockEntityEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerBlockEntityEvents.java
@@ -18,7 +18,6 @@ package net.fabricmc.fabric.api.event.lifecycle.v1;
 
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.profiler.Profiler;
 
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
@@ -34,21 +33,8 @@ public final class ServerBlockEntityEvents {
 	 * However, its data might not be loaded yet, so don't rely on it.
 	 */
 	public static final Event<ServerBlockEntityEvents.Load> BLOCK_ENTITY_LOAD = EventFactory.createArrayBacked(ServerBlockEntityEvents.Load.class, callbacks -> (blockEntity, world) -> {
-		if (EventFactory.isProfilingEnabled()) {
-			final Profiler profiler = world.getProfiler();
-			profiler.push("fabricServerBlockEntityLoad");
-
-			for (ServerBlockEntityEvents.Load callback : callbacks) {
-				profiler.push(EventFactory.getHandlerName(callback));
-				callback.onLoad(blockEntity, world);
-				profiler.pop();
-			}
-
-			profiler.pop();
-		} else {
-			for (ServerBlockEntityEvents.Load callback : callbacks) {
-				callback.onLoad(blockEntity, world);
-			}
+		for (Load callback : callbacks) {
+			callback.onLoad(blockEntity, world);
 		}
 	});
 
@@ -58,21 +44,8 @@ public final class ServerBlockEntityEvents {
 	 * <p>When this event is called, the block entity is still present on the world.
 	 */
 	public static final Event<Unload> BLOCK_ENTITY_UNLOAD = EventFactory.createArrayBacked(ServerBlockEntityEvents.Unload.class, callbacks -> (blockEntity, world) -> {
-		if (EventFactory.isProfilingEnabled()) {
-			final Profiler profiler = world.getProfiler();
-			profiler.push("fabricServerBlockEntityUnload");
-
-			for (ServerBlockEntityEvents.Unload callback : callbacks) {
-				profiler.push(EventFactory.getHandlerName(callback));
-				callback.onUnload(blockEntity, world);
-				profiler.pop();
-			}
-
-			profiler.pop();
-		} else {
-			for (ServerBlockEntityEvents.Unload callback : callbacks) {
-				callback.onUnload(blockEntity, world);
-			}
+		for (Unload callback : callbacks) {
+			callback.onUnload(blockEntity, world);
 		}
 	});
 

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkEvents.java
@@ -17,7 +17,6 @@
 package net.fabricmc.fabric.api.event.lifecycle.v1;
 
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.profiler.Profiler;
 import net.minecraft.world.chunk.WorldChunk;
 
 import net.fabricmc.fabric.api.event.Event;
@@ -33,21 +32,8 @@ public final class ServerChunkEvents {
 	 * <p>When this event is called, the chunk is already in the world.
 	 */
 	public static final Event<ServerChunkEvents.Load> CHUNK_LOAD = EventFactory.createArrayBacked(ServerChunkEvents.Load.class, callbacks -> (serverWorld, chunk) -> {
-		if (EventFactory.isProfilingEnabled()) {
-			final Profiler profiler = serverWorld.getProfiler();
-			profiler.push("fabricServerChunkLoad");
-
-			for (ServerChunkEvents.Load callback : callbacks) {
-				profiler.push(EventFactory.getHandlerName(callback));
-				callback.onChunkLoad(serverWorld, chunk);
-				profiler.pop();
-			}
-
-			profiler.pop();
-		} else {
-			for (ServerChunkEvents.Load callback : callbacks) {
-				callback.onChunkLoad(serverWorld, chunk);
-			}
+		for (Load callback : callbacks) {
+			callback.onChunkLoad(serverWorld, chunk);
 		}
 	});
 
@@ -57,21 +43,8 @@ public final class ServerChunkEvents {
 	 * <p>When this event is called, the chunk is still present in the world.
 	 */
 	public static final Event<ServerChunkEvents.Unload> CHUNK_UNLOAD = EventFactory.createArrayBacked(ServerChunkEvents.Unload.class, callbacks -> (serverWorld, chunk) -> {
-		if (EventFactory.isProfilingEnabled()) {
-			final Profiler profiler = serverWorld.getProfiler();
-			profiler.push("fabricServerChunkUnload");
-
-			for (ServerChunkEvents.Unload callback : callbacks) {
-				profiler.push(EventFactory.getHandlerName(callback));
-				callback.onChunkUnload(serverWorld, chunk);
-				profiler.pop();
-			}
-
-			profiler.pop();
-		} else {
-			for (ServerChunkEvents.Unload callback : callbacks) {
-				callback.onChunkUnload(serverWorld, chunk);
-			}
+		for (Unload callback : callbacks) {
+			callback.onChunkUnload(serverWorld, chunk);
 		}
 	});
 

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerEntityEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerEntityEvents.java
@@ -21,7 +21,6 @@ import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.profiler.Profiler;
 
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
@@ -36,21 +35,8 @@ public final class ServerEntityEvents {
 	 * <p>When this event is called, the entity is already in the world.
 	 */
 	public static final Event<ServerEntityEvents.Load> ENTITY_LOAD = EventFactory.createArrayBacked(ServerEntityEvents.Load.class, callbacks -> (entity, world) -> {
-		if (EventFactory.isProfilingEnabled()) {
-			final Profiler profiler = world.getProfiler();
-			profiler.push("fabricServerEntityLoad");
-
-			for (ServerEntityEvents.Load callback : callbacks) {
-				profiler.push(EventFactory.getHandlerName(callback));
-				callback.onLoad(entity, world);
-				profiler.pop();
-			}
-
-			profiler.pop();
-		} else {
-			for (ServerEntityEvents.Load callback : callbacks) {
-				callback.onLoad(entity, world);
-			}
+		for (Load callback : callbacks) {
+			callback.onLoad(entity, world);
 		}
 	});
 
@@ -60,21 +46,8 @@ public final class ServerEntityEvents {
 	 * <p>This event is called before the entity is removed from the world.
 	 */
 	public static final Event<ServerEntityEvents.Unload> ENTITY_UNLOAD = EventFactory.createArrayBacked(ServerEntityEvents.Unload.class, callbacks -> (entity, world) -> {
-		if (EventFactory.isProfilingEnabled()) {
-			final Profiler profiler = world.getProfiler();
-			profiler.push("fabricServerEntityUnload");
-
-			for (ServerEntityEvents.Unload callback : callbacks) {
-				profiler.push(EventFactory.getHandlerName(callback));
-				callback.onUnload(entity, world);
-				profiler.pop();
-			}
-
-			profiler.pop();
-		} else {
-			for (ServerEntityEvents.Unload callback : callbacks) {
-				callback.onUnload(entity, world);
-			}
+		for (Unload callback : callbacks) {
+			callback.onUnload(entity, world);
 		}
 	});
 

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerTickEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerTickEvents.java
@@ -18,7 +18,6 @@ package net.fabricmc.fabric.api.event.lifecycle.v1;
 
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.profiler.Profiler;
 
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
@@ -31,21 +30,8 @@ public final class ServerTickEvents {
 	 * Called at the start of the server tick.
 	 */
 	public static final Event<StartTick> START_SERVER_TICK = EventFactory.createArrayBacked(StartTick.class, callbacks -> server -> {
-		if (EventFactory.isProfilingEnabled()) {
-			final Profiler profiler = server.getProfiler();
-			profiler.push("fabricStartServerTick");
-
-			for (StartTick event : callbacks) {
-				profiler.push(EventFactory.getHandlerName(event));
-				event.onStartTick(server);
-				profiler.pop();
-			}
-
-			profiler.pop();
-		} else {
-			for (StartTick event : callbacks) {
-				event.onStartTick(server);
-			}
+		for (StartTick event : callbacks) {
+			event.onStartTick(server);
 		}
 	});
 
@@ -53,21 +39,8 @@ public final class ServerTickEvents {
 	 * Called at the end of the server tick.
 	 */
 	public static final Event<EndTick> END_SERVER_TICK = EventFactory.createArrayBacked(EndTick.class, callbacks -> server -> {
-		if (EventFactory.isProfilingEnabled()) {
-			final Profiler profiler = server.getProfiler();
-			profiler.push("fabricEndServerTick");
-
-			for (EndTick event : callbacks) {
-				profiler.push(EventFactory.getHandlerName(event));
-				event.onEndTick(server);
-				profiler.pop();
-			}
-
-			profiler.pop();
-		} else {
-			for (EndTick event : callbacks) {
-				event.onEndTick(server);
-			}
+		for (EndTick event : callbacks) {
+			event.onEndTick(server);
 		}
 	});
 
@@ -75,21 +48,8 @@ public final class ServerTickEvents {
 	 * Called at the start of a ServerWorld's tick.
 	 */
 	public static final Event<StartWorldTick> START_WORLD_TICK = EventFactory.createArrayBacked(StartWorldTick.class, callbacks -> world -> {
-		if (EventFactory.isProfilingEnabled()) {
-			final Profiler profiler = world.getProfiler();
-			profiler.push("fabricStartServerWorldTick_" + world.getRegistryKey().getValue());
-
-			for (StartWorldTick callback : callbacks) {
-				profiler.push(EventFactory.getHandlerName(callback));
-				callback.onStartTick(world);
-				profiler.pop();
-			}
-
-			profiler.pop();
-		} else {
-			for (StartWorldTick callback : callbacks) {
-				callback.onStartTick(world);
-			}
+		for (StartWorldTick callback : callbacks) {
+			callback.onStartTick(world);
 		}
 	});
 
@@ -99,21 +59,8 @@ public final class ServerTickEvents {
 	 * <p>End of world tick may be used to start async computations for the next tick.
 	 */
 	public static final Event<EndWorldTick> END_WORLD_TICK = EventFactory.createArrayBacked(EndWorldTick.class, callbacks -> world -> {
-		if (EventFactory.isProfilingEnabled()) {
-			final Profiler profiler = world.getProfiler();
-			profiler.push("fabricEndServerWorldTick_" + world.getRegistryKey().getValue());
-
-			for (EndWorldTick callback : callbacks) {
-				profiler.push(EventFactory.getHandlerName(callback));
-				callback.onEndTick(world);
-				profiler.pop();
-			}
-
-			profiler.pop();
-		} else {
-			for (EndWorldTick callback : callbacks) {
-				callback.onEndTick(world);
-			}
+		for (EndWorldTick callback : callbacks) {
+			callback.onEndTick(world);
 		}
 	});
 


### PR DESCRIPTION
This functionality is useless clutter, using a proper profiler is much better.

Fixes #2849.