### PR TITLE
Add `#c:flower_forests` to `#c:floral` convention tag

### DIFF
--- a/fabric-convention-tags-v1/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BiomeTagGenerator.java
+++ b/fabric-convention-tags-v1/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BiomeTagGenerator.java
@@ -234,7 +234,7 @@ public class BiomeTagGenerator extends FabricTagProvider<Biome> {
 				.addOptionalTag(ConventionalBiomeTags.SAVANNA);
 		getOrCreateTagBuilder(ConventionalBiomeTags.FLORAL)
 				.add(BiomeKeys.SUNFLOWER_PLAINS)
-				.add(BiomeKeys.FLOWER_FOREST);
+				.addOptionalTag(ConventionalBiomeTags.FLOWER_FORESTS);
 	}
 
 	private void generateTerrainDescriptorTags() {

--- a/fabric-convention-tags-v1/src/generated/resources/data/c/tags/worldgen/biome/floral.json
+++ b/fabric-convention-tags-v1/src/generated/resources/data/c/tags/worldgen/biome/floral.json
@@ -2,6 +2,9 @@
   "replace": false,
   "values": [
     "minecraft:sunflower_plains",
-    "minecraft:flower_forest"
+    {
+      "id": "#c:flower_forests",
+      "required": false
+    }
   ]
 }


### PR DESCRIPTION
This will make it a bit easier to develop custom biomes and update the FAPI for new versions of the game. I do not see the point in this duplication anyway