### PR TITLE
Fix FabricBlockLootTableProvider breaking depending on the mapping set

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricBlockLootTableProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricBlockLootTableProvider.java
@@ -20,22 +20,24 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
 import com.google.common.collect.Sets;
 
 import net.minecraft.block.Block;
+import net.minecraft.data.DataWriter;
 import net.minecraft.data.server.loottable.BlockLootTableGenerator;
 import net.minecraft.loot.LootTable;
 import net.minecraft.loot.LootTables;
-import net.minecraft.loot.context.LootContextType;
 import net.minecraft.loot.context.LootContextTypes;
+import net.minecraft.registry.Registries;
 import net.minecraft.resource.featuretoggle.FeatureFlags;
 import net.minecraft.util.Identifier;
-import net.minecraft.registry.Registries;
 
 import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+import net.fabricmc.fabric.impl.datagen.loot.FabricLootTableProviderImpl;
 
 /**
  * Extend this class and implement {@link FabricBlockLootTableProvider#generate}.
@@ -64,16 +66,6 @@ public abstract class FabricBlockLootTableProvider extends BlockLootTableGenerat
 	 */
 	public void excludeFromStrictValidation(Block block) {
 		excludedFromStrictValidation.add(Registries.BLOCK.getId(block));
-	}
-
-	@Override
-	public LootContextType getLootContextType() {
-		return LootContextTypes.BLOCK;
-	}
-
-	@Override
-	public FabricDataOutput getFabricDataOutput() {
-		return output;
 	}
 
 	@Override
@@ -111,6 +103,11 @@ public abstract class FabricBlockLootTableProvider extends BlockLootTableGenerat
 				throw new IllegalStateException("Missing loot table(s) for %s".formatted(missing));
 			}
 		}
+	}
+
+	@Override
+	public CompletableFuture<?> run(DataWriter writer) {
+		return FabricLootTableProviderImpl.run(writer, this, LootContextTypes.BLOCK, output);
 	}
 
 	@Override

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricLootTableProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricLootTableProvider.java
@@ -16,29 +16,16 @@
 
 package net.fabricmc.fabric.api.datagen.v1.provider;
 
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
-import com.google.gson.JsonObject;
 import org.jetbrains.annotations.ApiStatus;
 
-import net.minecraft.loot.LootDataType;
-import net.minecraft.data.DataOutput;
 import net.minecraft.data.DataProvider;
-import net.minecraft.data.DataWriter;
 import net.minecraft.data.server.loottable.LootTableGenerator;
 import net.minecraft.loot.LootTable;
-import net.minecraft.loot.context.LootContextType;
 import net.minecraft.util.Identifier;
 
-import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
 import net.fabricmc.fabric.api.datagen.v1.loot.FabricBlockLootTableGenerator;
 import net.fabricmc.fabric.api.resource.conditions.v1.ConditionJsonProvider;
 import net.fabricmc.fabric.impl.datagen.FabricDataGenHelper;
@@ -52,10 +39,6 @@ import net.fabricmc.fabric.impl.datagen.FabricDataGenHelper;
  */
 @ApiStatus.NonExtendable
 public interface FabricLootTableProvider extends LootTableGenerator, DataProvider {
-	LootContextType getLootContextType();
-
-	FabricDataOutput getFabricDataOutput();
-
 	/**
 	 * Return a new exporter that applies the specified conditions to any loot table it receives.
 	 *
@@ -67,36 +50,5 @@ public interface FabricLootTableProvider extends LootTableGenerator, DataProvide
 			FabricDataGenHelper.addConditions(table, conditions);
 			exporter.accept(id, table);
 		};
-	}
-
-	@ApiStatus.Internal
-	@Override
-	default CompletableFuture<?> run(DataWriter writer) {
-		HashMap<Identifier, LootTable> builders = Maps.newHashMap();
-		HashMap<Identifier, ConditionJsonProvider[]> conditionMap = new HashMap<>();
-
-		accept((identifier, builder) -> {
-			ConditionJsonProvider[] conditions = FabricDataGenHelper.consumeConditions(builder);
-			conditionMap.put(identifier, conditions);
-
-			if (builders.put(identifier, builder.type(getLootContextType()).build()) != null) {
-				throw new IllegalStateException("Duplicate loot table " + identifier);
-			}
-		});
-
-		final List<CompletableFuture<?>> futures = new ArrayList<>();
-
-		for (Map.Entry<Identifier, LootTable> entry : builders.entrySet()) {
-			JsonObject tableJson = (JsonObject) LootDataType.LOOT_TABLES.getGson().toJsonTree(entry.getValue());
-			ConditionJsonProvider.write(tableJson, conditionMap.remove(entry.getKey()));
-
-			futures.add(DataProvider.writeToPath(writer, tableJson, getOutputPath(entry.getKey())));
-		}
-
-		return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
-	}
-
-	private Path getOutputPath(Identifier lootTableId) {
-		return getFabricDataOutput().getResolver(DataOutput.OutputType.DATA_PACK, "loot_tables").resolveJson(lootTableId);
 	}
 }

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricLootTableProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricLootTableProvider.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
@@ -34,6 +33,7 @@ import net.minecraft.loot.LootDataType;
 import net.minecraft.data.DataOutput;
 import net.minecraft.data.DataProvider;
 import net.minecraft.data.DataWriter;
+import net.minecraft.data.server.loottable.LootTableGenerator;
 import net.minecraft.loot.LootTable;
 import net.minecraft.loot.context.LootContextType;
 import net.minecraft.util.Identifier;
@@ -51,7 +51,7 @@ import net.fabricmc.fabric.impl.datagen.FabricDataGenHelper;
  * <p>Use {@link SimpleFabricLootTableProvider} for a simple abstract class that you can implement to handle standard loot table functions.
  */
 @ApiStatus.NonExtendable
-public interface FabricLootTableProvider extends Consumer<BiConsumer<Identifier, LootTable.Builder>>, DataProvider {
+public interface FabricLootTableProvider extends LootTableGenerator, DataProvider {
 	LootContextType getLootContextType();
 
 	FabricDataOutput getFabricDataOutput();

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/SimpleFabricLootTableProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/SimpleFabricLootTableProvider.java
@@ -17,17 +17,18 @@
 package net.fabricmc.fabric.api.datagen.v1.provider;
 
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 
-import org.jetbrains.annotations.ApiStatus;
-
+import net.minecraft.data.DataWriter;
 import net.minecraft.loot.context.LootContextType;
 import net.minecraft.loot.context.LootContextTypes;
 
 import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+import net.fabricmc.fabric.impl.datagen.loot.FabricLootTableProviderImpl;
 
 /**
- * Extend this class and implement {@link java.util.function.Consumer#accept}. Register an instance of the class with {@link FabricDataGenerator.Pack#addProvider} in a {@link net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint}.
+ * Extend this class and implement {@link #accept}. Register an instance of the class with {@link FabricDataGenerator.Pack#addProvider} in a {@link net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint}.
  */
 public abstract class SimpleFabricLootTableProvider implements FabricLootTableProvider {
 	protected final FabricDataOutput output;
@@ -38,16 +39,9 @@ public abstract class SimpleFabricLootTableProvider implements FabricLootTablePr
 		this.lootContextType = lootContextType;
 	}
 
-	@ApiStatus.Internal
 	@Override
-	public final LootContextType getLootContextType() {
-		return lootContextType;
-	}
-
-	@ApiStatus.Internal
-	@Override
-	public final FabricDataOutput getFabricDataOutput() {
-		return output;
+	public CompletableFuture<?> run(DataWriter writer) {
+		return FabricLootTableProviderImpl.run(writer, this, lootContextType, output);
 	}
 
 	@Override

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/loot/FabricLootTableProviderImpl.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/loot/FabricLootTableProviderImpl.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.datagen.loot;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import com.google.common.collect.Maps;
+import com.google.gson.JsonObject;
+
+import net.minecraft.data.DataOutput;
+import net.minecraft.data.DataProvider;
+import net.minecraft.data.DataWriter;
+import net.minecraft.loot.LootDataType;
+import net.minecraft.loot.LootTable;
+import net.minecraft.loot.context.LootContextType;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricBlockLootTableProvider;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricLootTableProvider;
+import net.fabricmc.fabric.api.datagen.v1.provider.SimpleFabricLootTableProvider;
+import net.fabricmc.fabric.api.resource.conditions.v1.ConditionJsonProvider;
+import net.fabricmc.fabric.impl.datagen.FabricDataGenHelper;
+
+public final class FabricLootTableProviderImpl {
+	/**
+	 * Shared run logic for {@link FabricBlockLootTableProvider} and {@link SimpleFabricLootTableProvider}.
+	 */
+	public static CompletableFuture<?> run(
+			DataWriter writer,
+			FabricLootTableProvider provider,
+			LootContextType lootContextType,
+			FabricDataOutput fabricDataOutput) {
+		HashMap<Identifier, LootTable> builders = Maps.newHashMap();
+		HashMap<Identifier, ConditionJsonProvider[]> conditionMap = new HashMap<>();
+
+		provider.accept((identifier, builder) -> {
+			ConditionJsonProvider[] conditions = FabricDataGenHelper.consumeConditions(builder);
+			conditionMap.put(identifier, conditions);
+
+			if (builders.put(identifier, builder.type(lootContextType).build()) != null) {
+				throw new IllegalStateException("Duplicate loot table " + identifier);
+			}
+		});
+
+		final List<CompletableFuture<?>> futures = new ArrayList<>();
+
+		for (Map.Entry<Identifier, LootTable> entry : builders.entrySet()) {
+			JsonObject tableJson = (JsonObject) LootDataType.LOOT_TABLES.getGson().toJsonTree(entry.getValue());
+			ConditionJsonProvider.write(tableJson, conditionMap.remove(entry.getKey()));
+
+			futures.add(DataProvider.writeToPath(writer, tableJson, getOutputPath(fabricDataOutput, entry.getKey())));
+		}
+
+		return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
+	}
+
+	private static Path getOutputPath(FabricDataOutput dataOutput, Identifier lootTableId) {
+		return dataOutput.getResolver(DataOutput.OutputType.DATA_PACK, "loot_tables").resolveJson(lootTableId);
+	}
+
+	private FabricLootTableProviderImpl() {
+	}
+}


### PR DESCRIPTION
Fixes #3069.

Also removes unnecessary internal methods from `FabricLootTableProvider` by moving the `run` logic to an impl method.

This is not a breaking change assuming modders used the API as intended.