### PR TITLE
Fix FabricBlockLootTableProvider breaking depending on the mapping set (1.19.4 simplified edition)

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricLootTableProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricLootTableProvider.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
@@ -33,6 +32,7 @@ import org.jetbrains.annotations.ApiStatus;
 import net.minecraft.data.DataOutput;
 import net.minecraft.data.DataProvider;
 import net.minecraft.data.DataWriter;
+import net.minecraft.data.server.loottable.LootTableGenerator;
 import net.minecraft.loot.LootManager;
 import net.minecraft.loot.LootTable;
 import net.minecraft.loot.context.LootContextType;
@@ -51,7 +51,7 @@ import net.fabricmc.fabric.impl.datagen.FabricDataGenHelper;
  * <p>Use {@link SimpleFabricLootTableProvider} for a simple abstract class that you can implement to handle standard loot table functions.
  */
 @ApiStatus.NonExtendable
-public interface FabricLootTableProvider extends Consumer<BiConsumer<Identifier, LootTable.Builder>>, DataProvider {
+public interface FabricLootTableProvider extends LootTableGenerator, DataProvider {
 	LootContextType getLootContextType();
 
 	FabricDataOutput getFabricDataOutput();


### PR DESCRIPTION
1.19.4 fix for #3069, as suggested by @ChampionAsh5357.