### PR TITLE
Renderer implementation breaks for 1.20

### DIFF
--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/material/MaterialFinder.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/material/MaterialFinder.java
@@ -37,21 +37,13 @@ public interface MaterialFinder extends MaterialView {
 	 * Defines how sprite pixels will be blended with the scene.
 	 *
 	 * <p>See {@link BlendMode} for more information.
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default MaterialFinder blendMode(BlendMode blendMode) {
-		return blendMode(0, blendMode);
-	}
+	MaterialFinder blendMode(BlendMode blendMode);
 
 	/**
 	 * Vertex color(s) will be modified for quad color index unless disabled.
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default MaterialFinder disableColorIndex(boolean disable) {
-		return disableColorIndex(0, disable);
-	}
+	MaterialFinder disableColorIndex(boolean disable);
 
 	/**
 	 * When true, sprite texture and color will be rendered at full brightness.
@@ -64,24 +56,16 @@ public interface MaterialFinder extends MaterialView {
 	 *
 	 * <p>Note that color will still be modified by diffuse shading and ambient occlusion,
 	 * unless disabled via {@link #disableDiffuse(boolean)} and {@link #ambientOcclusion(TriState)}.
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default MaterialFinder emissive(boolean isEmissive) {
-		return emissive(0, isEmissive);
-	}
+	MaterialFinder emissive(boolean isEmissive);
 
 	/**
 	 * Vertex color(s) will be modified for diffuse shading unless disabled.
 	 *
 	 * <p>This property is guaranteed to be respected in block contexts. Some renderers may also respect it in item
 	 * contexts, but this is not guaranteed.
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default MaterialFinder disableDiffuse(boolean disable) {
-		return disableDiffuse(0, disable);
-	}
+	MaterialFinder disableDiffuse(boolean disable);
 
 	/**
 	 * Controls whether vertex color(s) will be modified for ambient occlusion.
@@ -91,12 +75,8 @@ public interface MaterialFinder extends MaterialView {
 	 * Set to {@link TriState#TRUE} or {@link TriState#FALSE} to override this behavior.
 	 *
 	 * <p>This property is respected only in block contexts. It will not have an effect in other contexts.
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default MaterialFinder ambientOcclusion(TriState mode) {
-		return disableAo(0, mode == TriState.FALSE);
-	}
+	MaterialFinder ambientOcclusion(TriState mode);
 
 	/**
 	 * Controls whether glint should be applied.
@@ -106,27 +86,13 @@ public interface MaterialFinder extends MaterialView {
 	 *
 	 * <p>This property is guaranteed to be respected in item contexts. Some renderers may also respect it in block
 	 * contexts, but this is not guaranteed.
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default MaterialFinder glint(TriState mode) {
-		return this;
-	}
+	MaterialFinder glint(TriState mode);
 
 	/**
 	 * Copies all properties from the given {@link MaterialView} to this material finder.
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default MaterialFinder copyFrom(MaterialView material) {
-		blendMode(material.blendMode());
-		disableColorIndex(material.disableColorIndex());
-		emissive(material.emissive());
-		disableDiffuse(material.disableDiffuse());
-		ambientOcclusion(material.ambientOcclusion());
-		glint(material.glint());
-		return this;
-	}
+	MaterialFinder copyFrom(MaterialView material);
 
 	/**
 	 * Resets this instance to default values. Values will match those

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/material/MaterialView.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/material/MaterialView.java
@@ -27,55 +27,31 @@ import net.fabricmc.fabric.api.util.TriState;
 public interface MaterialView {
 	/**
 	 * @see MaterialFinder#blendMode(BlendMode)
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default BlendMode blendMode() {
-		return BlendMode.DEFAULT;
-	}
+	BlendMode blendMode();
 
 	/**
 	 * @see MaterialFinder#disableColorIndex(boolean)
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default boolean disableColorIndex() {
-		return false;
-	}
+	boolean disableColorIndex();
 
 	/**
 	 * @see MaterialFinder#emissive(boolean)
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default boolean emissive() {
-		return false;
-	}
+	boolean emissive();
 
 	/**
 	 * @see MaterialFinder#disableDiffuse(boolean)
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default boolean disableDiffuse() {
-		return false;
-	}
+	boolean disableDiffuse();
 
 	/**
 	 * @see MaterialFinder#ambientOcclusion(TriState)
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default TriState ambientOcclusion() {
-		return TriState.DEFAULT;
-	}
+	TriState ambientOcclusion();
 
 	/**
 	 * @see MaterialFinder#glint(TriState)
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default TriState glint() {
-		return TriState.DEFAULT;
-	}
+	TriState glint();
 }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
@@ -116,12 +116,8 @@ public interface MutableQuadView extends QuadView {
 
 	/**
 	 * Set vertex color.
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default MutableQuadView color(int vertexIndex, int color) {
-		return spriteColor(vertexIndex, 0, color);
-	}
+	MutableQuadView color(int vertexIndex, int color);
 
 	/**
 	 * Convenience: set vertex color for all vertices at once.
@@ -136,12 +132,8 @@ public interface MutableQuadView extends QuadView {
 
 	/**
 	 * Set texture coordinates.
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default MutableQuadView uv(int vertexIndex, float u, float v) {
-		return sprite(vertexIndex, 0, u, v);
-	}
+	MutableQuadView uv(int vertexIndex, float u, float v);
 
 	/**
 	 * Set texture coordinates.
@@ -157,12 +149,8 @@ public interface MutableQuadView extends QuadView {
 	 * Assigns sprite atlas u,v coordinates to this quad for the given sprite.
 	 * Can handle UV locking, rotation, interpolation, etc. Control this behavior
 	 * by passing additive combinations of the BAKE_ flags defined in this interface.
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default MutableQuadView spriteBake(Sprite sprite, int bakeFlags) {
-		return spriteBake(0, sprite, bakeFlags);
-	}
+	MutableQuadView spriteBake(Sprite sprite, int bakeFlags);
 
 	/**
 	 * Accept vanilla lightmap values.  Input values will override lightmap values
@@ -260,14 +248,8 @@ public interface MutableQuadView extends QuadView {
 	 * Copies all quad properties from the given {@link QuadView} to this quad.
 	 *
 	 * <p>Calling this method does not emit the quad.
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default MutableQuadView copyFrom(QuadView quad) {
-		quad.copyTo(this);
-		material(quad.material());
-		return this;
-	}
+	MutableQuadView copyFrom(QuadView quad);
 
 	/**
 	 * Enables bulk vertex data transfer using the standard Minecraft vertex formats.
@@ -278,12 +260,8 @@ public interface MutableQuadView extends QuadView {
 	 * unless you have a specific reason to use this one.
 	 *
 	 * <p>Calling this method does not emit the quad.
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default MutableQuadView fromVanilla(int[] quadData, int startIndex) {
-		return fromVanilla(quadData, startIndex, false);
-	}
+	MutableQuadView fromVanilla(int[] quadData, int startIndex);
 
 	/**
 	 * Enables bulk vertex data transfer using the standard Minecraft quad format.

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import org.joml.Vector2f;
 import org.joml.Vector3f;
 
+import net.minecraft.client.render.model.BakedQuad;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec2f;
@@ -49,14 +50,8 @@ public interface QuadEmitter extends MutableQuadView {
 		return this;
 	}
 
-	/**
-	 * @apiNote The default implementation will be removed in the next breaking release.
-	 */
 	@Override
-	default QuadEmitter color(int vertexIndex, int color) {
-		MutableQuadView.super.color(vertexIndex, color);
-		return this;
-	}
+	QuadEmitter color(int vertexIndex, int color);
 
 	@Override
 	default QuadEmitter color(int c0, int c1, int c2, int c3) {
@@ -64,14 +59,8 @@ public interface QuadEmitter extends MutableQuadView {
 		return this;
 	}
 
-	/**
-	 * @apiNote The default implementation will be removed in the next breaking release.
-	 */
 	@Override
-	default QuadEmitter uv(int vertexIndex, float u, float v) {
-		MutableQuadView.super.uv(vertexIndex, u, v);
-		return this;
-	}
+	QuadEmitter uv(int vertexIndex, float u, float v);
 
 	@Override
 	default QuadEmitter uv(int vertexIndex, Vector2f uv) {
@@ -79,14 +68,8 @@ public interface QuadEmitter extends MutableQuadView {
 		return this;
 	}
 
-	/**
-	 * @apiNote The default implementation will be removed in the next breaking release.
-	 */
 	@Override
-	default QuadEmitter spriteBake(Sprite sprite, int bakeFlags) {
-		MutableQuadView.super.spriteBake(sprite, bakeFlags);
-		return this;
-	}
+	QuadEmitter spriteBake(Sprite sprite, int bakeFlags);
 
 	default QuadEmitter uvUnitSquare() {
 		uv(0, 0, 0);
@@ -105,9 +88,8 @@ public interface QuadEmitter extends MutableQuadView {
 		return this;
 	}
 
-	// TODO: uncomment right before next breaking release
-	// @Override
-	// QuadEmitter normal(int vertexIndex, float x, float y, float z);
+	@Override
+	QuadEmitter normal(int vertexIndex, float x, float y, float z);
 
 	@Override
 	default QuadEmitter normal(int vertexIndex, Vector3f normal) {
@@ -130,26 +112,13 @@ public interface QuadEmitter extends MutableQuadView {
 	@Override
 	QuadEmitter tag(int tag);
 
-	/**
-	 * @apiNote The default implementation will be removed in the next breaking release.
-	 */
-	default QuadEmitter copyFrom(QuadView quad) {
-		MutableQuadView.super.copyFrom(quad);
-		return this;
-	}
+	QuadEmitter copyFrom(QuadView quad);
 
-	/**
-	 * @apiNote The default implementation will be removed in the next breaking release.
-	 */
 	@Override
-	default QuadEmitter fromVanilla(int[] quadData, int startIndex) {
-		MutableQuadView.super.fromVanilla(quadData, startIndex);
-		return this;
-	}
+	QuadEmitter fromVanilla(int[] quadData, int startIndex);
 
-	// TODO: uncomment right before next breaking release
-	// @Override
-	// QuadEmitter fromVanilla(BakedQuad quad, RenderMaterial material, @Nullable Direction cullFace);
+	@Override
+	QuadEmitter fromVanilla(BakedQuad quad, RenderMaterial material, @Nullable Direction cullFace);
 
 	/**
 	 * Tolerance for determining if the depth parameter to {@link #square(Direction, float, float, float, float, float)}

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadView.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadView.java
@@ -70,45 +70,24 @@ public interface QuadView {
 
 	/**
 	 * Retrieve vertex color.
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default int color(int vertexIndex) {
-		return spriteColor(vertexIndex, 0);
-	}
+	int color(int vertexIndex);
 
 	/**
 	 * Retrieve horizontal texture coordinates.
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default float u(int vertexIndex) {
-		return spriteU(vertexIndex, 0);
-	}
+	float u(int vertexIndex);
 
 	/**
 	 * Retrieve vertical texture coordinates.
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default float v(int vertexIndex) {
-		return spriteV(vertexIndex, 0);
-	}
+	float v(int vertexIndex);
 
 	/**
 	 * Pass a non-null target to avoid allocation - will be returned with values.
 	 * Otherwise returns a new instance.
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default Vector2f copyUv(int vertexIndex, @Nullable Vector2f target) {
-		if (target == null) {
-			target = new Vector2f();
-		}
-
-		target.set(u(vertexIndex), v(vertexIndex));
-		return target;
-	}
+	Vector2f copyUv(int vertexIndex, @Nullable Vector2f target);
 
 	/**
 	 * Minimum block brightness. Zero if not set.
@@ -196,16 +175,12 @@ public interface QuadView {
 	 * Reads baked vertex data and outputs standard {@link BakedQuad#getVertexData() baked quad vertex data}
 	 * in the given array and location.
 	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
-	 *
 	 * @param target Target array for the baked quad data.
 	 *
 	 * @param targetIndex Starting position in target array - array must have
 	 * at least 28 elements available at this index.
 	 */
-	default void toVanilla(int[] target, int targetIndex) {
-		toVanilla(0, target, targetIndex, false);
-	}
+	void toVanilla(int[] target, int targetIndex);
 
 	/**
 	 * Generates a new BakedQuad instance with texture

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/RenderContext.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/RenderContext.java
@@ -46,25 +46,8 @@ public interface RenderContext {
 	 * Fabric causes vanilla baked models to send themselves
 	 * via this interface. Can also be used by compound models that contain a mix
 	 * of vanilla baked models, packaged quads and/or dynamic elements.
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default BakedModelConsumer bakedModelConsumer() {
-		// Default implementation is provided for compat with older renderer implementations,
-		// but they should always override this function.
-		Consumer<BakedModel> fallback = fallbackConsumer();
-		return new BakedModelConsumer() {
-			@Override
-			public void accept(BakedModel model) {
-				fallback.accept(model);
-			}
-
-			@Override
-			public void accept(BakedModel model, @Nullable BlockState state) {
-				fallback.accept(model);
-			}
-		};
-	}
+	BakedModelConsumer bakedModelConsumer();
 
 	/**
 	 * Returns a {@link QuadEmitter} instance that emits directly to the render buffer.
@@ -111,7 +94,6 @@ public interface RenderContext {
 	 */
 	@Deprecated
 	default Consumer<BakedModel> fallbackConsumer() {
-		// This default implementation relies on implementors overriding bakedModelConsumer().
 		return bakedModelConsumer();
 	}
 


### PR DESCRIPTION
This PR removes default implementations for the new FRAPI methods, to ensure that all renderers will support them going forward.

I suggest a major version bump for FRAPI for this change (and for any subsequent change that breaks renderer implementations).

Note that Indigo is unchanged since it was already supporting the new methods.