### PR TITLE
Set player.currentScreenHandler before invoking ExtendedScreenHandlerFactory

### DIFF
--- a/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/impl/screenhandler/Networking.java
+++ b/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/impl/screenhandler/Networking.java
@@ -61,6 +61,8 @@ public final class Networking {
 			return;
 		}
 
+		player.currentScreenHandler = handler;
+
 		PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
 		buf.writeIdentifier(typeId);
 		buf.writeVarInt(syncId);

--- a/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/impl/screenhandler/Networking.java
+++ b/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/impl/screenhandler/Networking.java
@@ -61,6 +61,7 @@ public final class Networking {
 			return;
 		}
 
+		// Set the screen handler, so the factory method can access it through the player. Vanilla sets it too but a bit too late.
 		player.currentScreenHandler = handler;
 
 		PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());

--- a/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/impl/screenhandler/Networking.java
+++ b/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/impl/screenhandler/Networking.java
@@ -61,9 +61,6 @@ public final class Networking {
 			return;
 		}
 
-		// Set the screen handler, so the factory method can access it through the player. Vanilla sets it too but a bit too late.
-		player.currentScreenHandler = handler;
-
 		PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
 		buf.writeIdentifier(typeId);
 		buf.writeVarInt(syncId);


### PR DESCRIPTION
Fixes #2963

Alternative fix from https://github.com/FabricMC/fabric/pull/2964