### PR TITLE
fix: floral tag missing meadow biome

### DIFF
--- a/fabric-convention-tags-v1/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BiomeTagGenerator.java
+++ b/fabric-convention-tags-v1/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BiomeTagGenerator.java
@@ -234,6 +234,7 @@ public class BiomeTagGenerator extends FabricTagProvider<Biome> {
 				.addOptionalTag(ConventionalBiomeTags.SAVANNA);
 		getOrCreateTagBuilder(ConventionalBiomeTags.FLORAL)
 				.add(BiomeKeys.SUNFLOWER_PLAINS)
+				.add(BiomeKeys.MEADOW)
 				.addOptionalTag(ConventionalBiomeTags.FLOWER_FORESTS);
 	}
 

--- a/fabric-convention-tags-v1/src/generated/resources/data/c/tags/worldgen/biome/floral.json
+++ b/fabric-convention-tags-v1/src/generated/resources/data/c/tags/worldgen/biome/floral.json
@@ -2,6 +2,7 @@
   "replace": false,
   "values": [
     "minecraft:sunflower_plains",
+    "minecraft:meadow",
     {
       "id": "#c:flower_forests",
       "required": false


### PR DESCRIPTION
https://minecraft.fandom.com/wiki/Meadow
> filled with patches of flowers