### PR TITLE
Move injection point of `TooltipComponentCallback`

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/TooltipComponentMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/TooltipComponentMixin.java
@@ -16,29 +16,28 @@
 
 package net.fabricmc.fabric.mixin.client.rendering;
 
-import java.util.List;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.tooltip.TooltipComponent;
 import net.minecraft.client.item.TooltipData;
 
 import net.fabricmc.fabric.api.client.rendering.v1.TooltipComponentCallback;
 
-@Mixin(Screen.class)
-public class ScreenMixin {
-	// Synthetic lambda body in renderTooltip
-	@Inject(at = @At("HEAD"), method = "method_32635(Ljava/util/List;Lnet/minecraft/client/item/TooltipData;)V", cancellable = true)
-	private static void injectRenderTooltipLambda(List<TooltipComponent> components, TooltipData data, CallbackInfo ci) {
+@Mixin(TooltipComponent.class)
+public interface TooltipComponentMixin {
+	@Inject(
+			method = "of(Lnet/minecraft/client/item/TooltipData;)Lnet/minecraft/client/gui/tooltip/TooltipComponent;",
+			at = @At("HEAD"),
+			cancellable = true
+	)
+	private static void convertCustomTooltipData(TooltipData data, CallbackInfoReturnable<TooltipComponent> cir) {
 		TooltipComponent component = TooltipComponentCallback.EVENT.invoker().getComponent(data);
 
 		if (component != null) {
-			components.add(1, component);
-			ci.cancel();
+			cir.setReturnValue(component);
 		}
 	}
 }

--- a/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
+++ b/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
@@ -15,7 +15,7 @@
     "LivingEntityRendererAccessor",
     "BlockEntityRendererFactoriesMixin",
     "EntityRenderersMixin",
-    "ScreenMixin",
+    "TooltipComponentMixin",
     "DimensionEffectsAccessor",
     "shader.GameRendererMixin",
     "shader.ShaderProgramImportProcessorMixin",

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/TooltipComponentTests.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/TooltipComponentTests.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.test.rendering.client;
 
+import java.util.Objects;
+
 import net.minecraft.client.gui.tooltip.TooltipComponent;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
@@ -35,5 +37,8 @@ public class TooltipComponentTests implements ClientModInitializer {
 
 			return null;
 		});
+
+		// Test that TooltipComponent.of works with custom TooltipData
+		Objects.requireNonNull(TooltipComponent.of(new TooltipComponentTestInit.Data("Hello world!")));
 	}
 }


### PR DESCRIPTION
The old injection point in the `Screen` lambda predates Chocohead's mixin changes that allowed injectors in interface methods. Moving the injection point to where it should have been (i.e. inside `TooltipComponent.of`) will fix issues such as https://github.com/emilyploszaj/emi/issues/175.