### PR TITLE
Fix resource conditions for loot tables

### DIFF
--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/mixin/resource/conditions/LootManagerMixin.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/mixin/resource/conditions/LootManagerMixin.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.resource.conditions;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.loot.LootDataType;
+import net.minecraft.loot.LootManager;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.api.resource.conditions.v1.ResourceConditions;
+import net.fabricmc.fabric.impl.resource.conditions.ResourceConditionsImpl;
+
+/**
+ * Starting with 1.20, LootManager directly implements ResourceReloader.
+ */
+@Mixin(LootManager.class)
+public class LootManagerMixin {
+	// forEach in load method
+	@Inject(method = "method_51195", at = @At("HEAD"), cancellable = true)
+	private static void applyResourceConditions(LootDataType lootDataType, Map map, Identifier id, JsonElement json, CallbackInfo ci) {
+		if (json.isJsonObject()) {
+			JsonObject obj = json.getAsJsonObject();
+
+			if (obj.has(ResourceConditions.CONDITIONS_KEY)) {
+				boolean matched = ResourceConditions.objectMatchesConditions(obj);
+
+				if (!matched) {
+					ci.cancel();
+				}
+
+				if (ResourceConditionsImpl.LOGGER.isDebugEnabled()) {
+					String verdict = matched ? "Allowed" : "Rejected";
+					ResourceConditionsImpl.LOGGER.debug("{} resource of type {} with id {}", verdict, lootDataType.getId(), id);
+				}
+			}
+		}
+	}
+}

--- a/fabric-resource-conditions-api-v1/src/main/resources/fabric-resource-conditions-api-v1.mixins.json
+++ b/fabric-resource-conditions-api-v1/src/main/resources/fabric-resource-conditions-api-v1.mixins.json
@@ -6,6 +6,7 @@
     "DataPackContentsMixin",
     "DataProviderMixin",
     "JsonDataLoaderMixin",
+    "LootManagerMixin",
     "SinglePreparationResourceReloaderMixin",
     "TagManagerLoaderMixin"
   ]

--- a/fabric-resource-conditions-api-v1/src/testmod/java/net/fabricmc/fabric/test/resource/conditions/ConditionalResourcesTest.java
+++ b/fabric-resource-conditions-api-v1/src/testmod/java/net/fabricmc/fabric/test/resource/conditions/ConditionalResourcesTest.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.test.resource.conditions;
 
+import net.minecraft.loot.LootDataType;
+import net.minecraft.loot.LootManager;
 import net.minecraft.recipe.RecipeManager;
 import net.minecraft.test.GameTest;
 import net.minecraft.test.TestContext;
@@ -64,6 +66,24 @@ public class ConditionalResourcesTest {
 
 		long loadedRecipes = manager.values().stream().filter(r -> r.getId().getNamespace().equals(MOD_ID)).count();
 		if (loadedRecipes != 5) throw new AssertionError("Unexpected loaded recipe count: " + loadedRecipes);
+
+		context.complete();
+	}
+
+	@GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)
+	public void conditionalPredicates(TestContext context) {
+		// Predicates are internally handled as a kind of loot data,
+		// hence the yarn name "loot condition".
+
+		LootManager manager = context.getWorld().getServer().getLootManager();
+
+		if (manager.getElementOptional(LootDataType.PREDICATES, id("loaded")).isEmpty()) {
+			throw new AssertionError("loaded predicate should have been loaded.");
+		}
+
+		if (manager.getElementOptional(LootDataType.PREDICATES, id("not_loaded")).isPresent()) {
+			throw new AssertionError("not_loaded predicate should not have been loaded.");
+		}
 
 		context.complete();
 	}

--- a/fabric-resource-conditions-api-v1/src/testmod/resources/data/fabric-resource-conditions-api-v1-testmod/predicates/loaded.json
+++ b/fabric-resource-conditions-api-v1/src/testmod/resources/data/fabric-resource-conditions-api-v1-testmod/predicates/loaded.json
@@ -1,0 +1,15 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "type": "minecraft:pig"
+  },
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "fabric-resource-conditions-api-v1"
+      ]
+    }
+  ]
+}

--- a/fabric-resource-conditions-api-v1/src/testmod/resources/data/fabric-resource-conditions-api-v1-testmod/predicates/not_loaded.json
+++ b/fabric-resource-conditions-api-v1/src/testmod/resources/data/fabric-resource-conditions-api-v1-testmod/predicates/not_loaded.json
@@ -1,0 +1,24 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "type": "minecraft:pig"
+  },
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:not",
+      "value": {
+        "condition": "fabric:all_mods_loaded",
+        "values": [
+          "fabric-resource-conditions-api-v1"
+        ]
+      }
+    },
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "fabric-resource-conditions-api-v1"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Resolves #3116

And predicates (loot conditions), item modifiers (loot functions). They are handled by the same method.

`LootManager` is no longer a `JsonDataLoader` - in fact it is not even a `SinglePreparationResourceReloader` anymore. Therefore it needs a new Mixin.

The new mixin, instead of manipulating a map like the old Mixin, early-returns a `forEach` call that parses JSONs.

Added two tests using predicates.