### PR TITLE
Add support for partially synced client tags

### DIFF
--- a/fabric-client-tags-api-v1/build.gradle
+++ b/fabric-client-tags-api-v1/build.gradle
@@ -6,4 +6,5 @@ moduleDependencies(project, ['fabric-api-base'])
 testDependencies(project, [
 	':fabric-convention-tags-v1',
 	':fabric-lifecycle-events-v1',
+	':fabric-resource-loader-v0',
 ])

--- a/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/api/tag/client/v1/ClientTags.java
+++ b/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/api/tag/client/v1/ClientTags.java
@@ -62,6 +62,24 @@ public final class ClientTags {
 	}
 
 	/**
+	 * Checks if an entry is in a tag.
+	 *
+	 * <p>If the synced tag does exist, it is queried. If it does not exist,
+	 * the tag populated from the available mods is checked, recursively checking the
+	 * synced tags and entries contained within.
+	 *
+	 * @param tagKey the {@code TagKey} to being checked
+	 * @param entry  the entry to check
+	 * @return if the entry is in the given tag
+	 */
+	public static <T> boolean isInWithLocalFallback(TagKey<T> tagKey, T entry) {
+		Objects.requireNonNull(tagKey);
+		Objects.requireNonNull(entry);
+
+		return getRegistryEntry(tagKey, entry).map(re -> isInWithLocalFallback(tagKey, re)).orElse(false);
+	}
+
+	/**
 	 * Checks if an entry is in a tag, for use with entries from a dynamic registry,
 	 * such as {@link net.minecraft.world.biome.Biome}s.
 	 *
@@ -73,6 +91,7 @@ public final class ClientTags {
 	 * @param registryEntry the entry to check
 	 * @return if the entry is in the given tag
 	 */
+	@SuppressWarnings("unchecked")
 	public static <T> boolean isInWithLocalFallback(TagKey<T> tagKey, RegistryEntry<T> registryEntry) {
 		Objects.requireNonNull(tagKey);
 		Objects.requireNonNull(registryEntry);
@@ -102,24 +121,6 @@ public final class ClientTags {
 		}
 
 		return isIn;
-	}
-
-	/**
-	 * Checks if an entry is in a tag.
-	 *
-	 * <p>If the synced tag does exist, it is queried. If it does not exist,
-	 * the tag populated from the available mods is checked, recursively checking the
-	 * synced tags and entries contained within.
-	 *
-	 * @param tagKey the {@code TagKey} to being checked
-	 * @param entry  the entry to check
-	 * @return if the entry is in the given tag
-	 */
-	public static <T> boolean isInWithLocalFallback(TagKey<T> tagKey, T entry) {
-		Objects.requireNonNull(tagKey);
-		Objects.requireNonNull(entry);
-
-		return getRegistryEntry(tagKey, entry).map(re -> isInWithLocalFallback(tagKey, re)).orElse(false);
 	}
 
 	/**

--- a/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/api/tag/client/v1/ClientTags.java
+++ b/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/api/tag/client/v1/ClientTags.java
@@ -17,17 +17,14 @@
 package net.fabricmc.fabric.api.tag.client.v1;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 
-import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.registry.tag.TagKey;
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.impl.tag.client.ClientTagsImpl;
-import net.fabricmc.fabric.impl.tag.client.ClientTagsLoader;
 
 /**
  * Allows the use of tags by directly loading them from the installed mods.
@@ -85,48 +82,10 @@ public final class ClientTags {
 	 * @param registryEntry the entry to check
 	 * @return if the entry is in the given tag
 	 */
-	@SuppressWarnings("unchecked")
 	public static <T> boolean isInWithLocalFallback(TagKey<T> tagKey, RegistryEntry<T> registryEntry) {
 		Objects.requireNonNull(tagKey);
 		Objects.requireNonNull(registryEntry);
-
-		// Check if the tag exists in the dynamic registry first
-		Optional<? extends Registry<T>> maybeRegistry = ClientTagsImpl.getRegistry(tagKey);
-
-		if (maybeRegistry.isPresent()) {
-			// Check the synced tag exists and use that
-			if (maybeRegistry.get().getEntryList(tagKey).isPresent()) {
-				return registryEntry.isIn(tagKey);
-			}
-		}
-
-		if (registryEntry.getKey().isEmpty()) {
-			// No key?
-			return false;
-		}
-
-		ClientTagsLoader.LoadedTag wt = ClientTagsImpl.getOrCreatePartiallySyncedTag(tagKey);
-
-		if (wt.immediateChildIds().contains(registryEntry.getKey().get().getValue())) {
-			return true;
-		}
-
-		// Check if child tags exist
-		for (TagKey<?> childTag : wt.completeChildTags()) {
-			if (maybeRegistry.isPresent()) {
-				// Check the synced tag exists and use that
-				if (maybeRegistry.get().getEntryList((TagKey<T>) childTag).isPresent()) {
-					if (registryEntry.isIn((TagKey<T>) childTag)) {
-						return true;
-					}
-				// Check local tag
-				} else if (getOrCreateLocalTag(childTag).contains(registryEntry.getKey().get().getValue())) {
-					return true;
-				}
-			}
-		}
-
-		return false;
+		return ClientTagsImpl.isInWithLocalFallback(tagKey, registryEntry);
 	}
 
 	/**

--- a/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/api/tag/client/v1/ClientTags.java
+++ b/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/api/tag/client/v1/ClientTags.java
@@ -73,7 +73,7 @@ public final class ClientTags {
 	 * @param registryEntry the entry to check
 	 * @return if the entry is in the given tag
 	 */
-	public static <T> boolean isInPartiallySyncedTag(TagKey<T> tagKey, RegistryEntry<T> registryEntry) {
+	public static <T> boolean isInWithLocalFallback(TagKey<T> tagKey, RegistryEntry<T> registryEntry) {
 		Objects.requireNonNull(tagKey);
 		Objects.requireNonNull(registryEntry);
 
@@ -98,7 +98,7 @@ public final class ClientTags {
 		Iterator<TagKey<?>> it = wt.immediateChildTags().iterator();
 
 		while (!isIn && it.hasNext()) {
-			isIn = isInPartiallySyncedTag((TagKey<T>) it.next(), registryEntry);
+			isIn = isInWithLocalFallback((TagKey<T>) it.next(), registryEntry);
 		}
 
 		return isIn;
@@ -115,59 +115,11 @@ public final class ClientTags {
 	 * @param entry  the entry to check
 	 * @return if the entry is in the given tag
 	 */
-	public static <T> boolean isInPartiallySyncedTag(TagKey<T> tagKey, T entry) {
-		Objects.requireNonNull(tagKey);
-		Objects.requireNonNull(entry);
-
-		return getRegistryEntry(tagKey, entry).map(re -> isInPartiallySyncedTag(tagKey, re)).orElse(false);
-	}
-
-	/**
-	 * Checks if an entry is in a tag.
-	 *
-	 * <p>If the synced tag does exist, it is queried. If it does not exist,
-	 * the tag populated from the available mods is checked.
-	 *
-	 * @param tagKey the {@code TagKey} to being checked
-	 * @param entry  the entry to check
-	 * @return if the entry is in the given tag
-	 */
 	public static <T> boolean isInWithLocalFallback(TagKey<T> tagKey, T entry) {
 		Objects.requireNonNull(tagKey);
 		Objects.requireNonNull(entry);
 
 		return getRegistryEntry(tagKey, entry).map(re -> isInWithLocalFallback(tagKey, re)).orElse(false);
-	}
-
-	/**
-	 * Checks if an entry is in a tag, for use with entries from a dynamic registry,
-	 * such as {@link net.minecraft.world.biome.Biome}s.
-	 *
-	 * <p>If the synced tag does exist, it is queried. If it does not exist,
-	 * the tag populated from the available mods is checked.
-	 *
-	 * @param tagKey        the {@code TagKey} to be checked
-	 * @param registryEntry the entry to check
-	 * @return if the entry is in the given tag
-	 */
-	public static <T> boolean isInWithLocalFallback(TagKey<T> tagKey, RegistryEntry<T> registryEntry) {
-		Objects.requireNonNull(tagKey);
-		Objects.requireNonNull(registryEntry);
-
-		// Check if the tag exists in the dynamic registry first
-		Optional<? extends Registry<T>> maybeRegistry = getRegistry(tagKey);
-
-		if (maybeRegistry.isPresent()) {
-			if (maybeRegistry.get().getEntryList(tagKey).isPresent()) {
-				return registryEntry.isIn(tagKey);
-			}
-		}
-
-		if (registryEntry.getKey().isPresent()) {
-			return isInLocal(tagKey, registryEntry.getKey().get());
-		}
-
-		return false;
 	}
 
 	/**

--- a/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/api/tag/client/v1/ClientTags.java
+++ b/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/api/tag/client/v1/ClientTags.java
@@ -113,14 +113,18 @@ public final class ClientTags {
 
 		// Recursively search the entries contained with the tag
 		ClientTagsLoader.LoadedTag wt = getOrCreatePartiallySyncedTag(tagKey);
-		boolean isIn = wt.immediateChildIds().contains(registryEntry.getKey().get().getValue());
-		Iterator<TagKey<?>> it = wt.immediateChildTags().iterator();
 
-		while (!isIn && it.hasNext()) {
-			isIn = isInWithLocalFallback((TagKey<T>) it.next(), registryEntry);
+		if (wt.immediateChildIds().contains(registryEntry.getKey().get().getValue())) {
+			return true;
 		}
 
-		return isIn;
+		for (TagKey<?> key : wt.immediateChildTags()) {
+			if (isInWithLocalFallback((TagKey<T>) key, registryEntry)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/api/tag/client/v1/ClientTags.java
+++ b/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/api/tag/client/v1/ClientTags.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.fabric.api.tag.client.v1;
 
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;

--- a/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/api/tag/client/v1/ClientTags.java
+++ b/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/api/tag/client/v1/ClientTags.java
@@ -107,6 +107,10 @@ public final class ClientTags {
 
 		ClientTagsLoader.LoadedTag wt = ClientTagsImpl.getOrCreatePartiallySyncedTag(tagKey);
 
+		if (wt.immediateChildIds().contains(registryEntry.getKey().get().getValue())) {
+			return true;
+		}
+
 		// Check if child tags exist
 		for (TagKey<?> childTag : wt.completeChildTags()) {
 			if (maybeRegistry.isPresent()) {
@@ -115,11 +119,14 @@ public final class ClientTags {
 					if (registryEntry.isIn((TagKey<T>) childTag)) {
 						return true;
 					}
+				// Check local tag
+				} else if (getOrCreateLocalTag(childTag).contains(registryEntry.getKey().get().getValue())) {
+					return true;
 				}
 			}
 		}
 
-		return wt.completeIds().contains(registryEntry.getKey().get().getValue());
+		return false;
 	}
 
 	/**

--- a/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/impl/tag/client/ClientTagsImpl.java
+++ b/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/impl/tag/client/ClientTagsImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.tag.client;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.registry.tag.TagKey;
+
+public class ClientTagsImpl {
+	private static final Map<TagKey<?>, ClientTagsLoader.LoadedTag> LOCAL_TAG_HIERARCHY = new ConcurrentHashMap<>();
+
+	@SuppressWarnings("unchecked")
+	public static <T> Optional<? extends Registry<T>> getRegistry(TagKey<T> tagKey) {
+		Objects.requireNonNull(tagKey);
+
+		// Check if the tag represents a dynamic registry
+		if (MinecraftClient.getInstance() != null) {
+			if (MinecraftClient.getInstance().world != null) {
+				if (MinecraftClient.getInstance().world.getRegistryManager() != null) {
+					Optional<? extends Registry<T>> maybeRegistry = MinecraftClient.getInstance().world
+							.getRegistryManager().getOptional(tagKey.registry());
+					if (maybeRegistry.isPresent()) return maybeRegistry;
+				}
+			}
+		}
+
+		return (Optional<? extends Registry<T>>) Registries.REGISTRIES.getOrEmpty(tagKey.registry().getValue());
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> Optional<RegistryEntry<T>> getRegistryEntry(TagKey<T> tagKey, T entry) {
+		Optional<? extends Registry<?>> maybeRegistry = getRegistry(tagKey);
+
+		if (maybeRegistry.isEmpty() || !tagKey.isOf(maybeRegistry.get().getKey())) {
+			return Optional.empty();
+		}
+
+		Registry<T> registry = (Registry<T>) maybeRegistry.get();
+
+		Optional<RegistryKey<T>> maybeKey = registry.getKey(entry);
+
+		return maybeKey.map(registry::entryOf);
+	}
+
+	public static ClientTagsLoader.LoadedTag getOrCreatePartiallySyncedTag(TagKey<?> tagKey) {
+		ClientTagsLoader.LoadedTag loadedTag = LOCAL_TAG_HIERARCHY.get(tagKey);
+
+		if (loadedTag == null) {
+			loadedTag = ClientTagsLoader.loadTag(tagKey);
+			LOCAL_TAG_HIERARCHY.put(tagKey, loadedTag);
+		}
+
+		return loadedTag;
+	}
+}

--- a/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/impl/tag/client/ClientTagsImpl.java
+++ b/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/impl/tag/client/ClientTagsImpl.java
@@ -43,6 +43,8 @@ public class ClientTagsImpl {
 			return false;
 		}
 
+		checked.add(tagKey);
+
 		// Check if the tag exists in the dynamic registry first
 		Optional<? extends Registry<T>> maybeRegistry = ClientTagsImpl.getRegistry(tagKey);
 
@@ -64,8 +66,6 @@ public class ClientTagsImpl {
 		if (wt.immediateChildIds().contains(registryEntry.getKey().get().getValue())) {
 			return true;
 		}
-
-		checked.add(tagKey);
 
 		for (TagKey<?> key : wt.immediateChildTags()) {
 			if (isInWithLocalFallback((TagKey<T>) key, registryEntry, checked)) {

--- a/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/impl/tag/client/ClientTagsLoader.java
+++ b/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/impl/tag/client/ClientTagsLoader.java
@@ -73,7 +73,6 @@ public class ClientTagsLoader {
 		}
 
 		HashSet<Identifier> completeIds = new HashSet<>();
-		HashSet<TagKey<?>> completeTags = new HashSet<>();
 		HashSet<Identifier> immediateChildIds = new HashSet<>();
 		HashSet<TagKey<?>> immediateChildTags = new HashSet<>();
 
@@ -91,23 +90,19 @@ public class ClientTagsLoader {
 				public Collection<Identifier> tag(Identifier id) {
 					TagKey<?> tag = TagKey.of(tagKey.registry(), id);
 					immediateChildTags.add(tag);
-					LoadedTag localTag = ClientTagsImpl.getOrCreatePartiallySyncedTag(tag);
-					completeTags.addAll(localTag.completeChildTags);
-					completeTags.add(tag);
-					return localTag.completeIds;
+					return ClientTagsImpl.getOrCreatePartiallySyncedTag(tag).completeIds;
 				}
 			}, completeIds::add);
 		}
 
 		// Ensure that the tag does not refer to itself
-		completeTags.remove(tagKey);
 		immediateChildTags.remove(tagKey);
 
-		return new LoadedTag(Collections.unmodifiableSet(completeIds), Collections.unmodifiableSet(completeTags),
-				Collections.unmodifiableSet(immediateChildTags), Collections.unmodifiableSet(immediateChildIds));
+		return new LoadedTag(Collections.unmodifiableSet(completeIds), Collections.unmodifiableSet(immediateChildTags),
+				Collections.unmodifiableSet(immediateChildIds));
 	}
 
-	public record LoadedTag(Set<Identifier> completeIds, Set<TagKey<?>> completeChildTags, Set<TagKey<?>> immediateChildTags, Set<Identifier> immediateChildIds) {
+	public record LoadedTag(Set<Identifier> completeIds, Set<TagKey<?>> immediateChildTags, Set<Identifier> immediateChildIds) {
 	}
 
 	/**

--- a/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/impl/tag/client/ClientTagsLoader.java
+++ b/fabric-client-tags-api-v1/src/client/java/net/fabricmc/fabric/impl/tag/client/ClientTagsLoader.java
@@ -96,15 +96,11 @@ public class ClientTagsLoader {
 			}, ids::add);
 		}
 
-		return new LoadedTag(Collections.unmodifiableSet(ids), new ChildHolder(Collections.unmodifiableSet(immediateChildTags),
-				Collections.unmodifiableSet(immediateChildIds)));
+		return new LoadedTag(Collections.unmodifiableSet(ids), Collections.unmodifiableSet(immediateChildTags),
+				Collections.unmodifiableSet(immediateChildIds));
 	}
 
-	//todo merge these?
-	public record ChildHolder(Set<TagKey<?>> immediateChildTags, Set<Identifier> immediateChildIds) {
-	}
-
-	public record LoadedTag(Set<Identifier> completeIds, ChildHolder childHolder) {
+	public record LoadedTag(Set<Identifier> completeIds, Set<TagKey<?>> immediateChildTags, Set<Identifier> immediateChildIds) {
 	}
 
 	/**

--- a/fabric-client-tags-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/tag/client/v1/ClientTagTest.java
+++ b/fabric-client-tags-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/tag/client/v1/ClientTagTest.java
@@ -42,10 +42,12 @@ public class ClientTagTest implements ClientModInitializer {
 
 	@Override
 	public void onInitializeClient() {
-		FabricLoader.getInstance().getModContainer(MODID)
-				.map(container -> ResourceManagerHelper.registerBuiltinResourcePack(new Identifier(MODID, "test2"),
-						container, ResourcePackActivationType.ALWAYS_ENABLED))
-				.filter(success -> !success).ifPresent(success -> LOGGER.warn("Could not register built-in resource pack."));
+		final ModContainer container = FabricLoader.getInstance().getModContainer(MODID).get();
+
+		if (!ResourceManagerHelper.registerBuiltinResourcePack(new Identifier(MODID, "test2"),
+				container, ResourcePackActivationType.ALWAYS_ENABLED)) {
+			throw new IllegalStateException("Could not register built-in resource pack.");
+		}
 
 		ClientLifecycleEvents.CLIENT_STARTED.register(client -> {
 			if (ClientTags.getOrCreateLocalTag(ConventionalEnchantmentTags.INCREASES_BLOCK_DROPS) == null) {

--- a/fabric-client-tags-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/tag/client/v1/ClientTagTest.java
+++ b/fabric-client-tags-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/tag/client/v1/ClientTagTest.java
@@ -35,6 +35,7 @@ import net.fabricmc.fabric.api.tag.convention.v1.ConventionalBiomeTags;
 import net.fabricmc.fabric.api.tag.convention.v1.ConventionalBlockTags;
 import net.fabricmc.fabric.api.tag.convention.v1.ConventionalEnchantmentTags;
 import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
 
 public class ClientTagTest implements ClientModInitializer {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ClientTagTest.class);

--- a/fabric-client-tags-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/tag/client/v1/ClientTagTest.java
+++ b/fabric-client-tags-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/tag/client/v1/ClientTagTest.java
@@ -76,6 +76,9 @@ public class ClientTagTest implements ClientModInitializer {
 			LOGGER.info("The tests for client tags passed!");
 		});
 
+		// This should be tested on a server with the datapack from the builtin resourcepack.
+		// That is, fabric:sword_efficient should NOT exist on the server (can be confirmed with F3 on a dirt block),
+		// but the this test should pass as minecraft:sword_efficient will contain dirt on the server
 		ClientTickEvents.END_WORLD_TICK.register(client -> {
 			if (!ClientTags.isInWithLocalFallback(TagKey.of(Registries.BLOCK.getKey(),
 					new Identifier("fabric", "sword_efficient")), Blocks.DIRT)) {

--- a/fabric-client-tags-api-v1/src/testmodClient/resources/data/fabric/tags/blocks/sword_efficient.json
+++ b/fabric-client-tags-api-v1/src/testmodClient/resources/data/fabric/tags/blocks/sword_efficient.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "#fabric:mineable/sword",
+      "required": false
+    },
+    {
+      "id": "#minecraft:sword_efficient",
+      "required": false
+    },
+    {
+      "id": "minecraft:bamboo",
+      "required": false
+    },
+    {
+      "id": "minecraft:cobweb",
+      "required": false
+    },
+    {
+      "id": "minecraft:bamboo_sapling",
+      "required": false
+    }
+  ]
+}

--- a/fabric-client-tags-api-v1/src/testmodClient/resources/resourcepacks/test2/data/minecraft/tags/blocks/sword_efficient.json
+++ b/fabric-client-tags-api-v1/src/testmodClient/resources/resourcepacks/test2/data/minecraft/tags/blocks/sword_efficient.json
@@ -1,0 +1,10 @@
+{
+    "replace": false,
+    "values": [
+        "minecraft:dirt",
+        {
+            "id": "",
+            "required": false
+        }
+    ]
+}

--- a/fabric-client-tags-api-v1/src/testmodClient/resources/resourcepacks/test2/pack.mcmeta
+++ b/fabric-client-tags-api-v1/src/testmodClient/resources/resourcepacks/test2/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 9,
+    "description": "Test Dirt in SwordEfficient"
+  }
+}


### PR DESCRIPTION
Allows for client tags to reference tags that may be synced from a server, allowing for them to be used.

An example of this being useful is in AutoSwitch. To address `mc:sword_efficient` not containing bamboo, a wrapper tag is needed `as:sword_efficient`. With partially synced tags it would allow for server-side changes to `mc:sword_efficient` to be seen in `as:sword_efficient`, which better reflects the intent of the tag.

This is a draft as implementation is worked out, some todos are left in with some questions.