### PR TITLE
Model load observation API

### DIFF
--- a/fabric-models-v0/src/client/java/net/fabricmc/fabric/api/client/model/ModelLoadObserver.java
+++ b/fabric-models-v0/src/client/java/net/fabricmc/fabric/api/client/model/ModelLoadObserver.java
@@ -1,0 +1,51 @@
+package net.fabricmc.fabric.api.client.model;
+
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.render.model.Baker;
+import net.minecraft.client.render.model.ModelBakeSettings;
+import net.minecraft.client.render.model.ModelLoader;
+import net.minecraft.client.render.model.UnbakedModel;
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.client.util.ModelIdentifier;
+import net.minecraft.client.util.SpriteIdentifier;
+import net.minecraft.util.Identifier;
+
+import java.util.function.Function;
+
+public interface ModelLoadObserver {
+	/**
+	 * Use this event to modify/observe the unbaked model that will be added to the registry for a given identifier.
+	 * @param location the {@link Identifier} of the model (this may be a {@link ModelIdentifier})
+	 * @param originalModel the original model
+	 * @param loader the model loader
+	 * @return the model which should actually be loaded for this resource location
+	 */
+	default UnbakedModel onUnbakedModelLoad(Identifier location, UnbakedModel originalModel, ModelLoader loader) {
+		return originalModel;
+	}
+
+	/**
+	 * Use this event to change the unbaked model that will be used for baking a given identifier.
+	 * @param location the {@link Identifier} of the model (this may be a {@link ModelIdentifier})
+	 * @param originalModel the original model
+	 * @param loader the model loader
+	 * @return the model which will be used for baking this identifier
+	 */
+	default UnbakedModel onUnbakedModelPreBake(Identifier location, UnbakedModel originalModel, ModelLoader loader) {
+		return originalModel;
+	}
+
+	/**
+	 * Use this event to modify the baked model that will be added to the model registry for this identifier.
+	 * @param location the {@link Identifier} of the model (this may be a {@link ModelIdentifier})
+	 * @param originalModel the original model
+	 * @param textureGetter a function to retrieve textures
+	 * @param settings the settings the model was baked with
+	 * @param baker a Baker that can be used to bake other models
+	 * @param loader the model loader
+	 * @return the model which should actually be loaded for this identifier
+	 */
+	default BakedModel onBakedModelLoad(Identifier location, UnbakedModel unbakedModel, BakedModel originalModel, Function<SpriteIdentifier, Sprite> textureGetter, ModelBakeSettings settings, Baker baker, ModelLoader loader) {
+		return originalModel;
+	}
+}

--- a/fabric-models-v0/src/client/java/net/fabricmc/fabric/api/client/model/ModelLoadingRegistry.java
+++ b/fabric-models-v0/src/client/java/net/fabricmc/fabric/api/client/model/ModelLoadingRegistry.java
@@ -52,4 +52,11 @@ public interface ModelLoadingRegistry {
 	 * @param providerSupplier The ModelVariantProvider supplier, instantiated with every ModelLoader.
 	 */
 	void registerVariantProvider(Function<ResourceManager, ModelVariantProvider> providerSupplier);
+
+	/**
+	 * Register a ModelLoadObserver supplier.
+	 *
+	 * @param providerSupplier The ModelLoadObserver supplier, instantiated with every ModelLoader.
+	 */
+	void registerLoadObserver(Function<ResourceManager, ModelLoadObserver> providerSupplier);
 }

--- a/fabric-models-v0/src/client/java/net/fabricmc/fabric/impl/client/model/ModelLoaderHooks.java
+++ b/fabric-models-v0/src/client/java/net/fabricmc/fabric/impl/client/model/ModelLoaderHooks.java
@@ -23,4 +23,6 @@ public interface ModelLoaderHooks {
 	void fabric_addModel(Identifier id);
 
 	UnbakedModel fabric_loadModel(Identifier id);
+
+	ModelLoadingRegistryImpl.LoaderInstance fabric_getLoader();
 }

--- a/fabric-models-v0/src/client/java/net/fabricmc/fabric/mixin/client/model/ModelLoaderBakerImplMixin.java
+++ b/fabric-models-v0/src/client/java/net/fabricmc/fabric/mixin/client/model/ModelLoaderBakerImplMixin.java
@@ -1,0 +1,53 @@
+package net.fabricmc.fabric.mixin.client.model;
+
+import net.fabricmc.fabric.impl.client.model.ModelLoaderHooks;
+
+import net.fabricmc.fabric.impl.client.model.ModelLoadingRegistryImpl;
+
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.render.model.Baker;
+import net.minecraft.client.render.model.ModelBakeSettings;
+import net.minecraft.client.render.model.ModelLoader;
+import net.minecraft.client.render.model.UnbakedModel;
+
+import net.minecraft.client.render.model.json.JsonUnbakedModel;
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.client.util.SpriteIdentifier;
+import net.minecraft.util.Identifier;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Coerce;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.function.Function;
+
+@Mixin(targets = { "net/minecraft/client/render/model/ModelLoader$BakerImpl"})
+public class ModelLoaderBakerImplMixin {
+	@Shadow
+	@Final
+	private ModelLoader field_40571;
+
+	@Redirect(method = "bake", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/model/ModelLoader$BakerImpl;getOrLoadModel(Lnet/minecraft/util/Identifier;)Lnet/minecraft/client/render/model/UnbakedModel;"))
+	private UnbakedModel firePreBakeEvent(@Coerce Baker baker, Identifier id) {
+		UnbakedModel m = baker.getOrLoadModel(id);
+		ModelLoadingRegistryImpl.LoaderInstance loader = ((ModelLoaderHooks)this.field_40571).fabric_getLoader();
+		return loader.onUnbakedModelPreBake(id, m);
+	}
+
+	@Redirect(method = "bake", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/model/UnbakedModel;bake(Lnet/minecraft/client/render/model/Baker;Ljava/util/function/Function;Lnet/minecraft/client/render/model/ModelBakeSettings;Lnet/minecraft/util/Identifier;)Lnet/minecraft/client/render/model/BakedModel;"))
+	private BakedModel fireRegularBakeEvent(UnbakedModel instance, Baker baker, Function<SpriteIdentifier, Sprite> textureGetter, ModelBakeSettings settings, Identifier identifier) {
+		BakedModel theModel = instance.bake(baker, textureGetter, settings, identifier);
+		ModelLoadingRegistryImpl.LoaderInstance loader = ((ModelLoaderHooks)this.field_40571).fabric_getLoader();
+		return loader.onBakedModelLoad(identifier, instance, theModel, textureGetter, settings, baker);
+	}
+
+	@Redirect(method = "bake", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/model/json/JsonUnbakedModel;bake(Lnet/minecraft/client/render/model/Baker;Lnet/minecraft/client/render/model/json/JsonUnbakedModel;Ljava/util/function/Function;Lnet/minecraft/client/render/model/ModelBakeSettings;Lnet/minecraft/util/Identifier;Z)Lnet/minecraft/client/render/model/BakedModel;"))
+	private BakedModel fireRegularBakeEvent(JsonUnbakedModel instance, Baker baker, JsonUnbakedModel parent, Function<SpriteIdentifier, Sprite> textureGetter, ModelBakeSettings settings, Identifier identifier, boolean hasDepth) {
+		BakedModel theModel = instance.bake(baker, parent, textureGetter, settings, identifier, hasDepth);
+		ModelLoadingRegistryImpl.LoaderInstance loader = ((ModelLoaderHooks)this.field_40571).fabric_getLoader();
+		return loader.onBakedModelLoad(identifier, instance, theModel, textureGetter, settings, baker);
+	}
+}

--- a/fabric-models-v0/src/client/resources/fabric-models-v0.mixins.json
+++ b/fabric-models-v0/src/client/resources/fabric-models-v0.mixins.json
@@ -4,7 +4,8 @@
   "compatibilityLevel": "JAVA_16",
   "client": [
     "BakedModelManagerMixin",
-    "ModelLoaderMixin"
+    "ModelLoaderMixin",
+    "ModelLoaderBakerImplMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/fabric-models-v0/src/testmodClient/java/net/fabricmc/fabric/test/model/ModelTestModClient.java
+++ b/fabric-models-v0/src/testmodClient/java/net/fabricmc/fabric/test/model/ModelTestModClient.java
@@ -16,7 +16,18 @@
 
 package net.fabricmc.fabric.test.model;
 
+import net.fabricmc.fabric.api.client.model.ModelLoadObserver;
+
+import net.minecraft.block.Blocks;
 import net.minecraft.client.render.entity.PlayerEntityRenderer;
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.render.model.BakedQuad;
+import net.minecraft.client.render.model.Baker;
+import net.minecraft.client.render.model.ModelBakeSettings;
+import net.minecraft.client.render.model.ModelLoader;
+import net.minecraft.client.render.model.UnbakedModel;
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.client.util.SpriteIdentifier;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.util.Identifier;
 
@@ -24,6 +35,12 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.model.ModelLoadingRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.LivingEntityFeatureRendererRegistrationCallback;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
+
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.random.Random;
+
+import java.util.List;
+import java.util.function.Function;
 
 public class ModelTestModClient implements ClientModInitializer {
 	public static final String ID = "fabric-models-v0-testmod";
@@ -34,6 +51,20 @@ public class ModelTestModClient implements ClientModInitializer {
 	public void onInitializeClient() {
 		ModelLoadingRegistry.INSTANCE.registerModelProvider((manager, out) -> {
 			out.accept(MODEL_ID);
+		});
+
+		// Remove the bottom face on dirt blocks
+		ModelLoadingRegistry.INSTANCE.registerLoadObserver(manager -> new ModelLoadObserver() {
+			@Override
+			public BakedModel onBakedModelLoad(Identifier location, UnbakedModel unbakedModel, BakedModel originalModel, Function<SpriteIdentifier, Sprite> textureGetter, ModelBakeSettings settings, Baker baker, ModelLoader loader) {
+				if(location.getPath().equals("block/dirt")) {
+					// modders, treating quad list as mutable can break performance mods like FerriteCore, this is being
+					// done here purely for test purposes
+					List<BakedQuad> quads = originalModel.getQuads(Blocks.DIRT.getDefaultState(), Direction.DOWN, Random.create());
+					quads.clear();
+				}
+				return originalModel;
+			}
 		});
 
 		ResourceManagerHelper.get(ResourceType.CLIENT_RESOURCES).registerReloadListener(SpecificModelReloadListener.INSTANCE);


### PR DESCRIPTION
The following PR implements a standardized API mods such as Continuity can use to have low-level control over what model instances are loaded and baked within the `ModelLoader`. One benefit of standardizing this system is that it will allow optimization mods such as my own to safely implement dynamic model loading/unloading at runtime without running into compatibility problems when mods that inject into `ModelLoader` directly. It also makes it easy for modders to replace models without needing to learn exactly how the model loader works.

EDIT: Will run checkstyle after other concerns are addressed.