### PR TITLE
[Lifecycle Events] Start and end task execution

### DIFF
--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientTickEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientTickEvents.java
@@ -64,6 +64,30 @@ public final class ClientTickEvents {
 		}
 	});
 
+	/**
+	 * Called every tick before running scheduled tasks through {@link MinecraftClient#execute(Runnable)}.
+	 * This differs from the regular client tick, which can run multiple times per frame depending on frame rate.
+	 * This is called before {@link ClientTickEvents#START_CLIENT_TICK}.
+	 */
+	public static final Event<StartTaskExecution> START_TASK_EXECUTION = EventFactory.createArrayBacked(StartTaskExecution.class, callbacks -> client -> {
+		for (StartTaskExecution callback : callbacks) {
+			callback.onStartTaskExecution(client);
+		}
+	});
+
+	/**
+	 * Called every tick after running scheduled tasks through {@link MinecraftClient#execute(Runnable)}.
+	 * This differs from the regular client tick, which can run multiple times per frame depending on frame rate.
+	 * Keyboard and mouse input is processed through the afformentioned method, so you can do things like emulate keypresses
+	 * here, guaranteed to be processed before the tick.
+	 * This is called before {@link ClientTickEvents#START_CLIENT_TICK}.
+	 */
+	public static final Event<EndTaskExecution> END_TASK_EXECUTION = EventFactory.createArrayBacked(EndTaskExecution.class, callbacks -> client -> {
+		for (EndTaskExecution callback : callbacks) {
+			callback.onEndTaskExecution(client);
+		}
+	});
+
 	@FunctionalInterface
 	public interface StartTick {
 		void onStartTick(MinecraftClient client);
@@ -82,5 +106,15 @@ public final class ClientTickEvents {
 	@FunctionalInterface
 	public interface EndWorldTick {
 		void onEndTick(ClientWorld world);
+	}
+
+	@FunctionalInterface
+	public interface StartTaskExecution {
+		void onStartTaskExecution(MinecraftClient client);
+	}
+
+	@FunctionalInterface
+	public interface EndTaskExecution {
+		void onEndTaskExecution(MinecraftClient client);
 	}
 }

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/MinecraftClientMixin.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/MinecraftClientMixin.java
@@ -48,4 +48,14 @@ public abstract class MinecraftClientMixin {
 	private void onStart(CallbackInfo ci) {
 		ClientLifecycleEvents.CLIENT_STARTED.invoker().onClientStarted((MinecraftClient) (Object) this);
 	}
+
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;runTasks()V", shift = At.Shift.BEFORE), method = "render")
+	private void onStartExecuteTasks(CallbackInfo ci) {
+		ClientLifecycleEvents.CLIENT_STARTED.invoker().onClientStarted((MinecraftClient) (Object) this);
+	}
+
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;runTasks()V", shift = At.Shift.AFTER), method = "render")
+	private void onEndExecuteTasks(CallbackInfo ci) {
+		ClientLifecycleEvents.CLIENT_STARTED.invoker().onClientStarted((MinecraftClient) (Object) this);
+	}
 }

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/MinecraftClientMixin.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/MinecraftClientMixin.java
@@ -51,11 +51,11 @@ public abstract class MinecraftClientMixin {
 
 	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;runTasks()V", shift = At.Shift.BEFORE), method = "render")
 	private void onStartExecuteTasks(CallbackInfo ci) {
-		ClientLifecycleEvents.CLIENT_STARTED.invoker().onClientStarted((MinecraftClient) (Object) this);
+		ClientTickEvents.START_TASK_EXECUTION.invoker().onStartTaskExecution((MinecraftClient) (Object) this);
 	}
 
 	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;runTasks()V", shift = At.Shift.AFTER), method = "render")
 	private void onEndExecuteTasks(CallbackInfo ci) {
-		ClientLifecycleEvents.CLIENT_STARTED.invoker().onClientStarted((MinecraftClient) (Object) this);
+		ClientTickEvents.END_TASK_EXECUTION.invoker().onEndTaskExecution((MinecraftClient) (Object) this);
 	}
 }

--- a/fabric-lifecycle-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientTickTests.java
+++ b/fabric-lifecycle-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientTickTests.java
@@ -29,6 +29,7 @@ import net.fabricmc.fabric.test.event.lifecycle.ServerLifecycleTests;
 public final class ClientTickTests implements ClientModInitializer {
 	private final Map<RegistryKey<World>, Integer> tickTracker = new HashMap<>();
 	private int ticks;
+	private int scheduledTicks;
 
 	@Override
 	public void onInitializeClient() {
@@ -48,6 +49,14 @@ public final class ClientTickTests implements ClientModInitializer {
 			}
 
 			this.tickTracker.put(world.getRegistryKey(), worldTicks + 1);
+		});
+
+		ClientTickEvents.END_TASK_EXECUTION.register(client -> {
+			this.scheduledTicks++;
+
+			if (this.ticks % 200 == 0) {
+				ServerLifecycleTests.LOGGER.info("Ticked Client task scheduler at " + this.scheduledTicks + " ticks.");
+			}
 		});
 	}
 }

--- a/fabric-lifecycle-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientTickTests.java
+++ b/fabric-lifecycle-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientTickTests.java
@@ -54,7 +54,7 @@ public final class ClientTickTests implements ClientModInitializer {
 		ClientTickEvents.END_TASK_EXECUTION.register(client -> {
 			this.scheduledTicks++;
 
-			if (this.ticks % 200 == 0) {
+			if (this.scheduledTicks % 200 == 0) {
 				ServerLifecycleTests.LOGGER.info("Ticked Client task scheduler at " + this.scheduledTicks + " ticks.");
 			}
 		});


### PR DESCRIPTION
New events to hook into before and after `Minecraft#render.runTasks()` is ran. This is where all scheduled tasks are ran, including keyboard and mouse handling.

Use cases for this are unlimited, and guarantees that the event is ran after any scheduled tasks. It also proves a great place to hook to add custom keypresses for KeyBinding. Such as running `KeyBinding.onKeyPress(Key)` manually to press a key automatically.