### PR TITLE
Fix #3170

### DIFF
--- a/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/message/ClientPlayNetworkHandlerMixin.java
+++ b/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/message/ClientPlayNetworkHandlerMixin.java
@@ -40,7 +40,7 @@ public abstract class ClientPlayNetworkHandlerMixin {
 		}
 	}
 
-	@ModifyVariable(method = "sendChatMessage", at = @At(value = "LOAD", ordinal = 0), ordinal = 0, argsOnly = true)
+	@ModifyVariable(method = "sendChatMessage", at = @At("HEAD"), ordinal = 0, argsOnly = true)
 	private String fabric_modifySendChatMessage(String content) {
 		content = ClientSendMessageEvents.MODIFY_CHAT.invoker().modifySendChatMessage(content);
 		ClientSendMessageEvents.CHAT.invoker().onSendChatMessage(content);
@@ -55,7 +55,7 @@ public abstract class ClientPlayNetworkHandlerMixin {
 		}
 	}
 
-	@ModifyVariable(method = "sendChatCommand", at = @At(value = "LOAD", ordinal = 0), ordinal = 0, argsOnly = true)
+	@ModifyVariable(method = "sendChatCommand", at = @At("HEAD"), ordinal = 0, argsOnly = true)
 	private String fabric_modifySendCommandMessage(String command) {
 		command = ClientSendMessageEvents.MODIFY_COMMAND.invoker().modifySendCommandMessage(command);
 		ClientSendMessageEvents.COMMAND.invoker().onSendCommandMessage(command);

--- a/fabric-message-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/message/client/ChatTestClient.java
+++ b/fabric-message-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/message/client/ChatTestClient.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.test.message.client;
 
+import com.mojang.brigadier.Command;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +37,11 @@ public class ChatTestClient implements ClientModInitializer {
 		ClientCommandRegistrationCallback.EVENT.register((dispatcher, dedicated) -> dispatcher.register(ClientCommandManager.literal("block").then(ClientCommandManager.literal("send").executes(context -> {
 			throw new AssertionError("This client command should be blocked!");
 		}))));
+		//Register the modified result command from ClientSendMessageEvents#MODIFY_COMMAND to ensure that MODIFY_COMMAND executes before the client command api
+		ClientCommandRegistrationCallback.EVENT.register((dispatcher, dedicated) -> dispatcher.register(ClientCommandManager.literal("sending").then(ClientCommandManager.literal("modified").then(ClientCommandManager.literal("command").then(ClientCommandManager.literal("message").executes(context -> {
+			LOGGER.info("Command modified by ClientSendMessageEvents#MODIFY_COMMAND successfully processed by fabric client command api");
+			return Command.SINGLE_SUCCESS;
+		}))))));
 		//Test client send message events
 		ClientSendMessageEvents.ALLOW_CHAT.register((message) -> {
 			if (message.contains("block send")) {


### PR DESCRIPTION
Fix #3170 by moving injection point of `MODIFY_COMMAND` to `HEAD`.  
Add test for `MODIFY_COMMAND` and the client command api.  
Also moves `MODIFY_MESSAGE` to `HEAD` for consistency.  