### PR TITLE
Add the cherry grove biome to the floral biome tag

### DIFF
--- a/fabric-convention-tags-v1/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BiomeTagGenerator.java
+++ b/fabric-convention-tags-v1/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BiomeTagGenerator.java
@@ -82,7 +82,7 @@ public class BiomeTagGenerator extends FabricTagProvider<Biome> {
 				.add(BiomeKeys.STONY_PEAKS).add(BiomeKeys.MUSHROOM_FIELDS).add(BiomeKeys.DRIPSTONE_CAVES)
 				.add(BiomeKeys.LUSH_CAVES).add(BiomeKeys.SNOWY_BEACH).add(BiomeKeys.SWAMP).add(BiomeKeys.STONY_SHORE)
 				.add(BiomeKeys.DEEP_DARK).add(BiomeKeys.MANGROVE_SWAMP)
-				.addOptional(BiomeKeys.CHERRY_GROVE);
+				.add(BiomeKeys.CHERRY_GROVE);
 	}
 
 	private void generateCategoryTags() {
@@ -235,6 +235,7 @@ public class BiomeTagGenerator extends FabricTagProvider<Biome> {
 		getOrCreateTagBuilder(ConventionalBiomeTags.FLORAL)
 				.add(BiomeKeys.SUNFLOWER_PLAINS)
 				.add(BiomeKeys.MEADOW)
+				.add(BiomeKeys.CHERRY_GROVE)
 				.addOptionalTag(ConventionalBiomeTags.FLOWER_FORESTS);
 	}
 

--- a/fabric-convention-tags-v1/src/generated/resources/data/c/tags/worldgen/biome/floral.json
+++ b/fabric-convention-tags-v1/src/generated/resources/data/c/tags/worldgen/biome/floral.json
@@ -3,6 +3,7 @@
   "values": [
     "minecraft:sunflower_plains",
     "minecraft:meadow",
+    "minecraft:cherry_grove",
     {
       "id": "#c:flower_forests",
       "required": false

--- a/fabric-convention-tags-v1/src/generated/resources/data/c/tags/worldgen/biome/in_overworld.json
+++ b/fabric-convention-tags-v1/src/generated/resources/data/c/tags/worldgen/biome/in_overworld.json
@@ -57,9 +57,6 @@
     "minecraft:stony_shore",
     "minecraft:deep_dark",
     "minecraft:mangrove_swamp",
-    {
-      "id": "minecraft:cherry_grove",
-      "required": false
-    }
+    "minecraft:cherry_grove"
   ]
 }


### PR DESCRIPTION
The pink petal is in the `flowers` block tag, so the cherry grove must be added to the `floral` biome tag.

[Since Mojang have confirmed that the cherry grove is technically not a forest](https://bugs.mojang.com/browse/MC-263202), this biome should be added to the `floral` tag instead of `flower_forests`.

Also use `add` instead of `addOptional` for cherry grove since 1.20 is already out
