### PR TITLE
Clarify nullability of `ModelModifier.AfterBake`

### DIFF
--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/ModelModifier.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/ModelModifier.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.api.client.model.loading.v1;
 import java.util.function.Function;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.client.render.model.Baker;
@@ -168,6 +169,10 @@ public final class ModelModifier {
 		 * This handler is invoked to allow modification of the baked model instance right after it is baked and before
 		 * it is cached.
 		 *
+		 * <p>Note that the passed baked model may be null and that this handler may return a null baked model, since
+		 * {@link UnbakedModel#bake} may also return a null baked model. Null baked models are not cached; if a baked
+		 * model for a particular ID is queried but does not exist in the cache, the missing model is returned.
+		 *
 		 * <p>For further information, see the docs of {@link ModelLoadingPlugin.Context#modifyModelAfterBake()}.
 		 *
 		 * @param model the current baked model instance
@@ -175,7 +180,8 @@ public final class ModelModifier {
 		 * @return the model that should be used in this scenario. If no changes are needed, just return {@code model} as-is.
 		 * @see ModelLoadingPlugin.Context#modifyModelAfterBake
 		 */
-		BakedModel modifyModelAfterBake(BakedModel model, Context context);
+		@Nullable
+		BakedModel modifyModelAfterBake(@Nullable BakedModel model, Context context);
 
 		/**
 		 * The context for an after bake model modification event.

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/ModelModifier.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/ModelModifier.java
@@ -170,8 +170,8 @@ public final class ModelModifier {
 		 * it is cached.
 		 *
 		 * <p>Note that the passed baked model may be null and that this handler may return a null baked model, since
-		 * {@link UnbakedModel#bake} may also return a null baked model. Null baked models are not cached; if a baked
-		 * model for a particular ID is queried but does not exist in the cache, the missing model is returned.
+		 * {@link UnbakedModel#bake} and {@link Baker#bake} may also return null baked models. Null baked models are
+		 * automatically mapped to the missing model during model retrieval.
 		 *
 		 * <p>For further information, see the docs of {@link ModelLoadingPlugin.Context#modifyModelAfterBake()}.
 		 *

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/ModelLoadingEventDispatcher.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/ModelLoadingEventDispatcher.java
@@ -279,7 +279,8 @@ public class ModelLoadingEventDispatcher {
 		return model;
 	}
 
-	public BakedModel modifyModelAfterBake(BakedModel model, Identifier id, UnbakedModel sourceModel, Function<SpriteIdentifier, Sprite> textureGetter, ModelBakeSettings settings, Baker baker) {
+	@Nullable
+	public BakedModel modifyModelAfterBake(@Nullable BakedModel model, Identifier id, UnbakedModel sourceModel, Function<SpriteIdentifier, Sprite> textureGetter, ModelBakeSettings settings, Baker baker) {
 		if (afterBakeModifierContextStack.isEmpty()) {
 			afterBakeModifierContextStack.add(new AfterBakeModifierContext());
 		}

--- a/fabric-model-loading-api-v1/src/client/resources/fabric.mod.json
+++ b/fabric-model-loading-api-v1/src/client/resources/fabric.mod.json
@@ -19,6 +19,9 @@
     "fabricloader": ">=0.14.21",
     "fabric-api-base": "*"
   },
+  "breaks": {
+    "fabric-models-v0": "<0.4.0"
+  },
   "description": "Provides hooks for model loading.",
   "mixins": [
     {


### PR DESCRIPTION
The after bake modifier may receive a null baked model because `UnbakedModel#bake` can return a null baked model. `Nullable` annotations have been added where appropriate and the behavior of a null baked model has been explained in the modifier's documentation.

Model Loading API v1 now contains a `"breaks"` definition for Models v0 versions <0.4.0. Running v1 with v0 <0.4.0 causes errors that are very difficult to debug.