### PR TITLE
Fix #3215 - Only add namespace to registries added using the Fabric API.

### DIFF
--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/DynamicRegistriesImpl.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/DynamicRegistriesImpl.java
@@ -35,6 +35,7 @@ import net.fabricmc.fabric.api.event.registry.DynamicRegistries;
 
 public final class DynamicRegistriesImpl {
 	private static final List<RegistryLoader.Entry<?>> DYNAMIC_REGISTRIES = new ArrayList<>(RegistryLoader.DYNAMIC_REGISTRIES);
+	public static final Set<RegistryKey<?>> FABRIC_DYNAMIC_REGISTRY_KEYS = new HashSet<>();
 	public static final Set<RegistryKey<? extends Registry<?>>> DYNAMIC_REGISTRY_KEYS = new HashSet<>();
 	public static final Set<RegistryKey<? extends Registry<?>>> SKIP_EMPTY_SYNC_REGISTRIES = new HashSet<>();
 
@@ -61,6 +62,7 @@ public final class DynamicRegistriesImpl {
 
 		var entry = new RegistryLoader.Entry<>(key, codec);
 		DYNAMIC_REGISTRIES.add(entry);
+		FABRIC_DYNAMIC_REGISTRY_KEYS.add(key);
 	}
 
 	public static <T> void addSyncedRegistry(RegistryKey<? extends Registry<T>> registryKey, Codec<T> networkCodec, DynamicRegistries.SyncOption... options) {

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/RegistryLoaderMixin.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/RegistryLoaderMixin.java
@@ -21,12 +21,9 @@ import java.util.List;
 import java.util.Map;
 
 import com.mojang.datafixers.util.Pair;
-import com.mojang.serialization.Decoder;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
@@ -45,9 +42,6 @@ import net.fabricmc.fabric.impl.registry.sync.DynamicRegistryViewImpl;
 
 @Mixin(RegistryLoader.class)
 public class RegistryLoaderMixin {
-	@Unique
-	private static final ThreadLocal<RegistryKey<?>> REGISTRY_KEY_THREAD_LOCAL = new ThreadLocal<>();
-
 	@Inject(
 			method = "load(Lnet/minecraft/resource/ResourceManager;Lnet/minecraft/registry/DynamicRegistryManager;Ljava/util/List;)Lnet/minecraft/registry/DynamicRegistryManager$Immutable;",
 			at = @At(
@@ -67,24 +61,14 @@ public class RegistryLoaderMixin {
 		DynamicRegistrySetupCallback.EVENT.invoker().onRegistrySetup(new DynamicRegistryViewImpl(registries));
 	}
 
-	@Inject(at = @At("HEAD"), method = "load(Lnet/minecraft/registry/RegistryOps$RegistryInfoGetter;Lnet/minecraft/resource/ResourceManager;Lnet/minecraft/registry/RegistryKey;Lnet/minecraft/registry/MutableRegistry;Lcom/mojang/serialization/Decoder;Ljava/util/Map;)V")
-	private static <E> void captureRegistryKey(RegistryOps.RegistryInfoGetter registryInfoGetter, ResourceManager resourceManager, RegistryKey<? extends Registry<E>> registryKey, MutableRegistry<E> newRegistry, Decoder<E> decoder, Map<RegistryKey<?>, Exception> exceptions, CallbackInfo ci) {
-		REGISTRY_KEY_THREAD_LOCAL.set(registryKey);
-	}
-
 	// Vanilla doesn't mark namespaces in the directories of dynamic registries at all,
 	// so we prepend the directories with the namespace if it's a modded registry registered using the Fabric API.
 	@Inject(method = "getPath", at = @At("RETURN"), cancellable = true)
 	private static void prependDirectoryWithNamespace(Identifier id, CallbackInfoReturnable<String> info) {
 		if (!id.getNamespace().equals(Identifier.DEFAULT_NAMESPACE)
-				&& DynamicRegistriesImpl.FABRIC_DYNAMIC_REGISTRY_KEYS.contains(REGISTRY_KEY_THREAD_LOCAL.get())) {
+				&& DynamicRegistriesImpl.FABRIC_DYNAMIC_REGISTRY_KEYS.contains(RegistryKey.ofRegistry(id))) {
 			final String newPath = id.getNamespace() + "/" + info.getReturnValue();
 			info.setReturnValue(newPath);
 		}
-	}
-
-	@Inject(at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/registry/RegistryLoader;getPath(Lnet/minecraft/util/Identifier;)Ljava/lang/String;"), method = "load(Lnet/minecraft/registry/RegistryOps$RegistryInfoGetter;Lnet/minecraft/resource/ResourceManager;Lnet/minecraft/registry/RegistryKey;Lnet/minecraft/registry/MutableRegistry;Lcom/mojang/serialization/Decoder;Ljava/util/Map;)V")
-	private static <E> void clearRegistryKey(RegistryOps.RegistryInfoGetter registryInfoGetter, ResourceManager resourceManager, RegistryKey<? extends Registry<E>> registryKey, MutableRegistry<E> newRegistry, Decoder<E> decoder, Map<RegistryKey<?>, Exception> exceptions, CallbackInfo ci) {
-		REGISTRY_KEY_THREAD_LOCAL.set(null);
 	}
 }


### PR DESCRIPTION
This fixes mods that previously added a dyn registery without using the fabric API no longer working as expected.

Closes #3215