### PR TITLE
Sort item groups to ensure they are in a deterministic order between runs.

### DIFF
--- a/fabric-item-group-api-v1/src/main/java/net/fabricmc/fabric/mixin/itemgroup/ItemGroupsMixin.java
+++ b/fabric-item-group-api-v1/src/main/java/net/fabricmc/fabric/mixin/itemgroup/ItemGroupsMixin.java
@@ -31,6 +31,7 @@ import static net.minecraft.item.ItemGroups.SEARCH;
 import static net.minecraft.item.ItemGroups.SPAWN_EGGS;
 import static net.minecraft.item.ItemGroups.TOOLS;
 
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 
@@ -58,7 +59,12 @@ public class ItemGroupsMixin {
 
 		int count = 0;
 
-		for (RegistryKey<ItemGroup> registryKey : Registries.ITEM_GROUP.getKeys()) {
+		// Sort the item groups to ensure they are in a deterministic order.
+		final List<RegistryKey<ItemGroup>> sortedItemGroups = Registries.ITEM_GROUP.getKeys().stream()
+				.sorted(Comparator.comparing(RegistryKey::getValue))
+				.toList();
+
+		for (RegistryKey<ItemGroup> registryKey : sortedItemGroups) {
 			final ItemGroup itemGroup = Registries.ITEM_GROUP.getOrThrow(registryKey);
 			final FabricItemGroup fabricItemGroup = (FabricItemGroup) itemGroup;
 


### PR DESCRIPTION
This uses the Identifer to sort by and not the display name. Sorting by display name would require us to re-order the groups when the language changes. If there is keen intrest in sorting by the display name this doesnt seem to hard to do, but this PR is a trival easy win either way.

