### PR TITLE
Fixed NBT ingredient json (1.19.2)

### DIFF
--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/builtin/NbtIngredient.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/builtin/NbtIngredient.java
@@ -143,7 +143,7 @@ public class NbtIngredient implements CustomIngredient {
 			json.addProperty("strict", ingredient.strict);
 
 			if (ingredient.nbt != null) {
-				json.add("nbt", ingredient.nbt.toString());
+				json.addProperty("nbt", ingredient.nbt.toString());
 			}
 		}
 

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/builtin/NbtIngredient.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/builtin/NbtIngredient.java
@@ -145,7 +145,7 @@ public class NbtIngredient implements CustomIngredient {
 			json.addProperty("strict", ingredient.strict);
 
 			if (ingredient.nbt != null) {
-				json.add("nbt", NbtOps.INSTANCE.convertTo(JsonOps.INSTANCE, ingredient.nbt));
+				json.add("nbt", ingredient.nbt.toString());
 			}
 		}
 

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/builtin/NbtIngredient.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/builtin/NbtIngredient.java
@@ -97,7 +97,6 @@ public class NbtIngredient implements CustomIngredient {
 	}
 
 	private static class Serializer implements CustomIngredientSerializer<NbtIngredient> {
-		private final Gson gson = new GsonBuilder().disableHtmlEscaping().create();
 		private final Identifier id = new Identifier("fabric", "nbt");
 
 		@Override

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/builtin/NbtIngredient.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/builtin/NbtIngredient.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Objects;
 
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import com.mojang.serialization.JsonOps;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
@@ -32,7 +31,6 @@ import org.jetbrains.annotations.Nullable;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtHelper;
-import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.StringNbtReader;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.predicate.NbtPredicate;


### PR DESCRIPTION
Fixed number type erasure bug when serializing custom NBT ingredient. This should be fixed in future versions too.