### PR TITLE
Make deprecated modules opt-out instead of opt-in

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -657,7 +657,7 @@ publishing {
 			pom.withXml {
 				def depsNode = asNode().appendNode("dependencies")
 				subprojects.each {
-					// The maven BOM containing all of the deprecated modules is added manually bellow.
+					// The maven BOM containing all of the deprecated modules is added manually below.
 					if (it.path.startsWith(":deprecated")) {
 						return
 					}

--- a/build.gradle
+++ b/build.gradle
@@ -657,7 +657,6 @@ publishing {
 			pom.withXml {
 				def depsNode = asNode().appendNode("dependencies")
 				subprojects.each {
-					// Dont depend on the deprecated modules in the main artifact.
 					if (it.path.startsWith(":deprecated")) {
 						return
 					}
@@ -668,6 +667,13 @@ publishing {
 					depNode.appendNode("version", it.version)
 					depNode.appendNode("scope", "compile")
 				}
+
+				// Depend on the deprecated BOM to allow opting out of deprecated modules.
+				def depNode = depsNode.appendNode("dependency")
+				depNode.appendNode("groupId", group)
+				depNode.appendNode("artifactId", "fabric-api-deprecated")
+				depNode.appendNode("version", version)
+				depNode.appendNode("scope", "compile")
 			}
 		}
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -657,6 +657,7 @@ publishing {
 			pom.withXml {
 				def depsNode = asNode().appendNode("dependencies")
 				subprojects.each {
+					// The maven BOM containing all of the deprecated modules is added manually bellow.
 					if (it.path.startsWith(":deprecated")) {
 						return
 					}


### PR DESCRIPTION
This adds back the deprecated modules into dev envs by default, its causing too much confusing. Mod devs can opt out of having these modules like so:

```kotlin
modImplementation("net.fabricmc.fabric-api:fabric-api:0.86.1+local-1.20.1") {
   exclude(module = "fabric-api-deprecated")
}
```