### PR TITLE
Key binding context

### DIFF
--- a/deprecated/fabric-keybindings-v0/src/client/java/net/fabricmc/fabric/api/client/keybinding/KeyBindingRegistry.java
+++ b/deprecated/fabric-keybindings-v0/src/client/java/net/fabricmc/fabric/api/client/keybinding/KeyBindingRegistry.java
@@ -37,7 +37,7 @@ public interface KeyBindingRegistry {
 
 		@Override
 		public boolean register(FabricKeyBinding binding) {
-			return KeyBindingRegistryImpl.registerKeyBinding(binding) != null;
+			return KeyBindingHelper.registerKeyBinding(binding) != null;
 		}
 	};
 

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingContext.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingContext.java
@@ -58,7 +58,7 @@ public interface KeyBindingContext {
 	 * Returns whether one context conflicts with the other.
 	 */
 	static boolean conflicts(KeyBindingContext left, KeyBindingContext right) {
-		return left.conflictsWith(right) || right.conflictsWith(left);
+		return left.conflicts(right) || right.conflicts(left);
 	}
 
 	/**
@@ -77,5 +77,5 @@ public interface KeyBindingContext {
 	 * <pre>return this == other || other == IN_GAME;</pre>
 	 */
 	@ApiStatus.OverrideOnly
-	boolean conflictsWith(KeyBindingContext other);
+	boolean conflicts(KeyBindingContext other);
 }

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingContext.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingContext.java
@@ -25,8 +25,8 @@ import net.fabricmc.fabric.impl.client.keybinding.KeyBindingExtensions;
 
 /**
  * {@link KeyBindingContext} decides how {@link KeyBinding} with same bounded key behaves in regard to each other.
- * <p>
- * Bindings with different context will not conflict with each other even if they have the same bounded key.
+ *
+ * <p>Bindings with different context will not conflict with each other even if they have the same bounded key.
  */
 public interface KeyBindingContext {
 	/**

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingContext.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingContext.java
@@ -21,54 +21,61 @@ import org.jetbrains.annotations.ApiStatus;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
 
+import net.fabricmc.fabric.impl.client.keybinding.KeyBindingContextImpl;
 import net.fabricmc.fabric.impl.client.keybinding.KeyBindingExtensions;
 
 /**
  * {@link KeyBindingContext} decides how {@link KeyBinding} with same bounded key behaves in regard to each other.
  *
  * <p>Bindings with different context will not conflict with each other even if they have the same bounded key.
+ *
+ * <p>Along with the provided generic contexts, mods can also create its own context by implementing this interface.
  */
 public interface KeyBindingContext {
 	/**
 	 * {@link KeyBinding} that used in-game. All vanilla key binds have this context.
 	 */
-	KeyBindingContext IN_GAME = () -> MinecraftClient.getInstance().currentScreen == null;
+	KeyBindingContext IN_GAME = KeyBindingContextImpl.IN_GAME;
 
 	/**
 	 * {@link KeyBinding} that used when a screen is open.
 	 */
-	KeyBindingContext IN_SCREEN = () -> MinecraftClient.getInstance().currentScreen != null;
+	KeyBindingContext IN_SCREEN = KeyBindingContextImpl.IN_SCREEN;
 
 	/**
 	 * {@link KeyBinding} that might be used in any context. This context conflicts with any other context.
 	 */
-	KeyBindingContext ALL = new KeyBindingContext() {
-		@Override
-		public boolean isActive() {
-			return true;
-		}
+	KeyBindingContext ALL = KeyBindingContextImpl.ALL;
 
-		@Override
-		public boolean conflictsWith(KeyBindingContext other) {
-			return true;
-		}
-	};
-
+	/**
+	 * Returns the context of the key binding.
+	 */
 	static KeyBindingContext of(KeyBinding binding) {
 		return ((KeyBindingExtensions) binding).fabric_getContext();
 	}
 
+	/**
+	 * Returns whether one context conflicts with the other.
+	 */
 	static boolean conflicts(KeyBindingContext left, KeyBindingContext right) {
 		return left.conflictsWith(right) || right.conflictsWith(left);
 	}
 
-	boolean isActive();
+	/**
+	 * Returns whether the key bind can be activated in the current state of the game.
+	 * If not, {@link KeyBinding#isPressed()} and {@link KeyBinding#wasPressed()} will always return {@code false}.
+	 */
+	boolean isActive(MinecraftClient client);
 
 	/**
-	 * Use {@link #conflicts(KeyBindingContext, KeyBindingContext)} for checking if two context conflicts.
+	 * Returns whether this context conflict with the other.
+	 *
+	 * <p>Do not call! Use {@link #conflicts(KeyBindingContext, KeyBindingContext)} instead.
+	 *
+	 * <p>Along with the same instance, most custom context implementation should probably conflict with either
+	 * {@link #IN_GAME} or {@link #IN_SCREEN}, unless it needs to be called alongside the generic context.
+	 * <pre>return this == other || other == IN_GAME;</pre>
 	 */
 	@ApiStatus.OverrideOnly
-	default boolean conflictsWith(KeyBindingContext other) {
-		return this == other;
-	}
+	boolean conflictsWith(KeyBindingContext other);
 }

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingContext.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingContext.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.client.keybinding.v1;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.option.KeyBinding;
+
+import net.fabricmc.fabric.impl.client.keybinding.KeyBindingExtensions;
+
+/**
+ * {@link KeyBindingContext} decides how {@link KeyBinding} with same bounded key behaves in regard to each other.
+ * <p>
+ * Bindings with different context will not conflict with each other even if they have the same bounded key.
+ */
+public interface KeyBindingContext {
+	/**
+	 * {@link KeyBinding} that used in-game. All vanilla key binds have this context.
+	 */
+	KeyBindingContext IN_GAME = () -> MinecraftClient.getInstance().currentScreen == null;
+
+	/**
+	 * {@link KeyBinding} that used when a screen is open.
+	 */
+	KeyBindingContext IN_SCREEN = () -> MinecraftClient.getInstance().currentScreen != null;
+
+	/**
+	 * {@link KeyBinding} that might be used in any context. This context conflicts with any other context.
+	 */
+	KeyBindingContext ALL = new KeyBindingContext() {
+		@Override
+		public boolean isActive() {
+			return true;
+		}
+
+		@Override
+		public boolean conflictsWith(KeyBindingContext other) {
+			return true;
+		}
+	};
+
+	static KeyBindingContext of(KeyBinding binding) {
+		return ((KeyBindingExtensions) binding).fabric_getContext();
+	}
+
+	static boolean conflicts(KeyBindingContext left, KeyBindingContext right) {
+		return left.conflictsWith(right) || right.conflictsWith(left);
+	}
+
+	boolean isActive();
+
+	/**
+	 * Use {@link #conflicts(KeyBindingContext, KeyBindingContext)} for checking if two context conflicts.
+	 */
+	@ApiStatus.OverrideOnly
+	default boolean conflictsWith(KeyBindingContext other) {
+		return this == other;
+	}
+}

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingHelper.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingHelper.java
@@ -60,6 +60,7 @@ public final class KeyBindingHelper {
 	 */
 	public static KeyBinding registerKeyBinding(KeyBinding keyBinding, KeyBindingContext context) {
 		Objects.requireNonNull(keyBinding, "key binding cannot be null");
+		Objects.requireNonNull(context, "context cannot be null");
 		return KeyBindingRegistryImpl.registerKeyBinding(keyBinding, context);
 	}
 

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingHelper.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingHelper.java
@@ -47,8 +47,20 @@ public final class KeyBindingHelper {
 	 * @throws IllegalArgumentException when a key binding with the same ID is already registered
 	 */
 	public static KeyBinding registerKeyBinding(KeyBinding keyBinding) {
+		return registerKeyBinding(keyBinding, KeyBindingContext.IN_GAME);
+	}
+
+	/**
+	 * Registers the keybinding and add the keybinding category if required.
+	 *
+	 * @param keyBinding the keybinding
+	 * @param context    the keybinding context
+	 * @return the keybinding itself
+	 * @throws IllegalArgumentException when a key binding with the same ID is already registered
+	 */
+	public static KeyBinding registerKeyBinding(KeyBinding keyBinding, KeyBindingContext context) {
 		Objects.requireNonNull(keyBinding, "key binding cannot be null");
-		return KeyBindingRegistryImpl.registerKeyBinding(keyBinding);
+		return KeyBindingRegistryImpl.registerKeyBinding(keyBinding, context);
 	}
 
 	/**

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingContextImpl.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingContextImpl.java
@@ -28,7 +28,7 @@ public class KeyBindingContextImpl {
 		}
 
 		@Override
-		public boolean conflictsWith(KeyBindingContext other) {
+		public boolean conflicts(KeyBindingContext other) {
 			return this == other;
 		}
 	};
@@ -40,7 +40,7 @@ public class KeyBindingContextImpl {
 		}
 
 		@Override
-		public boolean conflictsWith(KeyBindingContext other) {
+		public boolean conflicts(KeyBindingContext other) {
 			return this == other;
 		}
 	};
@@ -52,7 +52,7 @@ public class KeyBindingContextImpl {
 		}
 
 		@Override
-		public boolean conflictsWith(KeyBindingContext other) {
+		public boolean conflicts(KeyBindingContext other) {
 			return true;
 		}
 	};

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingContextImpl.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingContextImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.keybinding;
+
+import net.minecraft.client.MinecraftClient;
+
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingContext;
+
+public class KeyBindingContextImpl {
+	public static final KeyBindingContext IN_GAME = new KeyBindingContext() {
+		@Override
+		public boolean isActive(MinecraftClient client) {
+			return client.currentScreen == null;
+		}
+
+		@Override
+		public boolean conflictsWith(KeyBindingContext other) {
+			return this == other;
+		}
+	};
+
+	public static final KeyBindingContext IN_SCREEN = new KeyBindingContext() {
+		@Override
+		public boolean isActive(MinecraftClient client) {
+			return client.currentScreen != null;
+		}
+
+		@Override
+		public boolean conflictsWith(KeyBindingContext other) {
+			return this == other;
+		}
+	};
+
+	public static final KeyBindingContext ALL = new KeyBindingContext() {
+		@Override
+		public boolean isActive(MinecraftClient client) {
+			return true;
+		}
+
+		@Override
+		public boolean conflictsWith(KeyBindingContext other) {
+			return true;
+		}
+	};
+}

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingExtensions.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingExtensions.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.keybinding;
+
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingContext;
+
+public interface KeyBindingExtensions {
+	KeyBindingContext fabric_getContext();
+
+	void fabric_setContext(KeyBindingContext context);
+}

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
@@ -16,9 +16,7 @@
 
 package net.fabricmc.fabric.impl.client.keybinding;
 
-import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/impl/client/keybinding/KeyBindingRegistryImpl.java
@@ -16,6 +16,10 @@
 
 package net.fabricmc.fabric.impl.client.keybinding;
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -25,10 +29,13 @@ import it.unimi.dsi.fastutil.objects.ReferenceArrayList;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
+import net.minecraft.client.util.InputUtil;
 
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingContext;
 import net.fabricmc.fabric.mixin.client.keybinding.KeyBindingAccessor;
 
 public final class KeyBindingRegistryImpl {
+	public static final Map<InputUtil.Key, List<KeyBinding>> KEY_TO_BINDINGS = new HashMap<>();
 	private static final List<KeyBinding> MODDED_KEY_BINDINGS = new ReferenceArrayList<>(); // ArrayList with identity based comparisons for contains/remove/indexOf etc., required for correctly handling duplicate keybinds
 
 	private KeyBindingRegistryImpl() {
@@ -51,7 +58,7 @@ public final class KeyBindingRegistryImpl {
 		return true;
 	}
 
-	public static KeyBinding registerKeyBinding(KeyBinding binding) {
+	public static KeyBinding registerKeyBinding(KeyBinding binding, KeyBindingContext context) {
 		if (MinecraftClient.getInstance().options != null) {
 			throw new IllegalStateException("GameOptions has already been initialised");
 		}
@@ -66,6 +73,7 @@ public final class KeyBindingRegistryImpl {
 
 		// This will do nothing if the category already exists.
 		addCategory(binding.getCategory());
+		((KeyBindingExtensions) binding).fabric_setContext(context);
 		MODDED_KEY_BINDINGS.add(binding);
 		return binding;
 	}
@@ -79,5 +87,9 @@ public final class KeyBindingRegistryImpl {
 		newKeysAll.removeAll(MODDED_KEY_BINDINGS);
 		newKeysAll.addAll(MODDED_KEY_BINDINGS);
 		return newKeysAll.toArray(new KeyBinding[0]);
+	}
+
+	public static void putToMap(InputUtil.Key key, KeyBinding binding) {
+		KEY_TO_BINDINGS.computeIfAbsent(key, k -> new ArrayList<>()).add(binding);
 	}
 }

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/keybinding/KeyBindingEntryMixin.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/keybinding/KeyBindingEntryMixin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.client.keybinding;
 
 import org.spongepowered.asm.mixin.Mixin;

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/keybinding/KeyBindingEntryMixin.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/keybinding/KeyBindingEntryMixin.java
@@ -1,0 +1,20 @@
+package net.fabricmc.fabric.mixin.client.keybinding;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import net.minecraft.client.gui.screen.option.ControlsListWidget;
+
+@Mixin(ControlsListWidget.KeyBindingEntry.class)
+public class KeyBindingEntryMixin {
+	@ModifyConstant(method = "update", constant = @Constant(stringValue = ", "))
+	private String makeConflictTextMultiline(String constant) {
+		return "\n";
+	}
+
+	@ModifyConstant(method = "update", constant = @Constant(stringValue = "controls.keybinds.duplicateKeybinds"))
+	private String replaceConflictText(String constant) {
+		return "fabric.keybinding.conflicts";
+	}
+}

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/keybinding/KeyBindingEntryMixin.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/keybinding/KeyBindingEntryMixin.java
@@ -30,7 +30,6 @@ import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingContext;
 
 @Mixin(ControlsListWidget.KeyBindingEntry.class)
 public abstract class KeyBindingEntryMixin {
-
 	@Shadow
 	@Final
 	private KeyBinding binding;

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/keybinding/KeyBindingEntryMixin.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/keybinding/KeyBindingEntryMixin.java
@@ -16,14 +16,25 @@
 
 package net.fabricmc.fabric.mixin.client.keybinding;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.option.ControlsListWidget;
+import net.minecraft.client.option.KeyBinding;
+
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingContext;
 
 @Mixin(ControlsListWidget.KeyBindingEntry.class)
-public class KeyBindingEntryMixin {
+public abstract class KeyBindingEntryMixin {
+
+	@Shadow
+	@Final
+	private KeyBinding binding;
+
 	@ModifyConstant(method = "update", constant = @Constant(stringValue = ", "))
 	private String makeConflictTextMultiline(String constant) {
 		return "\n";
@@ -31,6 +42,14 @@ public class KeyBindingEntryMixin {
 
 	@ModifyConstant(method = "update", constant = @Constant(stringValue = "controls.keybinds.duplicateKeybinds"))
 	private String replaceConflictText(String constant) {
-		return "fabric.keybinding.conflicts";
+		for (KeyBinding otherBinding : MinecraftClient.getInstance().options.allKeys) {
+			if (otherBinding == binding || !binding.equals(otherBinding)) continue;
+
+			if (KeyBindingContext.of(binding) != KeyBindingContext.of(otherBinding)) {
+				return "fabric.keybinding.conflicts";
+			}
+		}
+
+		return constant;
 	}
 }

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/keybinding/KeyBindingMixin.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/keybinding/KeyBindingMixin.java
@@ -77,12 +77,12 @@ public abstract class KeyBindingMixin implements KeyBindingExtensions {
 		List<KeyBinding> list = KeyBindingRegistryImpl.KEY_TO_BINDINGS.get(key);
 		if (list == null) return;
 
-		Set<KeyBinding> uniqueKeyBinds = Collections.newSetFromMap(new IdentityHashMap<>());
+		Set<KeyBinding> uniqueKeyBinds = list.size() <= 1 ? null : Collections.newSetFromMap(new IdentityHashMap<>());
 
 		for (KeyBinding binding : list) {
 			KeyBindingMixin mixed = (KeyBindingMixin) (Object) binding;
 
-			if (mixed.fabric_context.isActive(MinecraftClient.getInstance()) && uniqueKeyBinds.addAll(mixed.fabric_conflictingKeyBinds)) {
+			if (mixed.fabric_context.isActive(MinecraftClient.getInstance()) && (uniqueKeyBinds == null || uniqueKeyBinds.addAll(mixed.fabric_conflictingKeyBinds))) {
 				((KeyBindingMixin) (Object) binding).timesPressed++;
 			}
 		}
@@ -93,12 +93,12 @@ public abstract class KeyBindingMixin implements KeyBindingExtensions {
 		List<KeyBinding> list = KeyBindingRegistryImpl.KEY_TO_BINDINGS.get(key);
 		if (list == null) return;
 
-		Set<KeyBinding> uniqueKeyBinds = Collections.newSetFromMap(new IdentityHashMap<>());
+		Set<KeyBinding> uniqueKeyBinds = list.size() <= 1 ? null : Collections.newSetFromMap(new IdentityHashMap<>());
 
 		for (KeyBinding binding : list) {
 			KeyBindingMixin mixed = (KeyBindingMixin) (Object) binding;
 
-			if (mixed.fabric_context.isActive(MinecraftClient.getInstance()) && uniqueKeyBinds.addAll(mixed.fabric_conflictingKeyBinds)) {
+			if (mixed.fabric_context.isActive(MinecraftClient.getInstance()) && (uniqueKeyBinds == null || uniqueKeyBinds.addAll(mixed.fabric_conflictingKeyBinds))) {
 				binding.setPressed(pressed);
 			}
 		}
@@ -114,7 +114,9 @@ public abstract class KeyBindingMixin implements KeyBindingExtensions {
 
 		for (List<KeyBinding> bindings : KeyBindingRegistryImpl.KEY_TO_BINDINGS.values()) {
 			for (KeyBinding binding : bindings) {
-				((KeyBindingMixin) (Object) binding).fabric_conflictingKeyBinds.clear();
+				KeyBindingMixin mixed = (KeyBindingMixin) (Object) binding;
+				mixed.fabric_conflictingKeyBinds.clear();
+				mixed.fabric_conflictingKeyBinds.add(binding);
 			}
 
 			for (KeyBinding binding : bindings) {

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/keybinding/KeyBindingMixin.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/keybinding/KeyBindingMixin.java
@@ -35,6 +35,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.util.InputUtil;
 
@@ -81,7 +82,7 @@ public abstract class KeyBindingMixin implements KeyBindingExtensions {
 		for (KeyBinding binding : list) {
 			KeyBindingMixin mixed = (KeyBindingMixin) (Object) binding;
 
-			if (mixed.fabric_context.isActive() && uniqueKeyBinds.addAll(mixed.fabric_conflictingKeyBinds)) {
+			if (mixed.fabric_context.isActive(MinecraftClient.getInstance()) && uniqueKeyBinds.addAll(mixed.fabric_conflictingKeyBinds)) {
 				((KeyBindingMixin) (Object) binding).timesPressed++;
 			}
 		}
@@ -97,7 +98,7 @@ public abstract class KeyBindingMixin implements KeyBindingExtensions {
 		for (KeyBinding binding : list) {
 			KeyBindingMixin mixed = (KeyBindingMixin) (Object) binding;
 
-			if (mixed.fabric_context.isActive() && uniqueKeyBinds.addAll(mixed.fabric_conflictingKeyBinds)) {
+			if (mixed.fabric_context.isActive(MinecraftClient.getInstance()) && uniqueKeyBinds.addAll(mixed.fabric_conflictingKeyBinds)) {
 				binding.setPressed(pressed);
 			}
 		}

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/keybinding/KeyBindingMixin.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/keybinding/KeyBindingMixin.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.keybinding;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.client.option.KeyBinding;
+import net.minecraft.client.util.InputUtil;
+
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingContext;
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+import net.fabricmc.fabric.impl.client.keybinding.KeyBindingExtensions;
+import net.fabricmc.fabric.impl.client.keybinding.KeyBindingRegistryImpl;
+
+@Mixin(KeyBinding.class)
+public abstract class KeyBindingMixin implements KeyBindingExtensions {
+	@Shadow
+	private int timesPressed;
+
+	@Shadow
+	@Final
+	private static Map<String, KeyBinding> KEYS_BY_ID;
+
+	@Shadow
+	private InputUtil.Key boundKey;
+
+	@Unique
+	private KeyBindingContext context = KeyBindingContext.IN_GAME;
+
+	@Override
+	public KeyBindingContext fabric_getContext() {
+		return context;
+	}
+
+	@Override
+	public void fabric_setContext(KeyBindingContext context) {
+		this.context = context;
+	}
+
+	@Inject(method = "onKeyPressed", at = @At("HEAD"))
+	private static void onKeyPressed(InputUtil.Key key, CallbackInfo ci) {
+		List<KeyBinding> list = KeyBindingRegistryImpl.KEY_TO_BINDINGS.get(key);
+		if (list == null) return;
+
+		for (KeyBinding binding : list) {
+			if (KeyBindingContext.of(binding).isActive()) {
+				((KeyBindingMixin) (Object) binding).timesPressed++;
+				break;
+			}
+		}
+	}
+
+	@Inject(method = "setKeyPressed", at = @At("HEAD"))
+	private static void setKeyPressed(InputUtil.Key key, boolean pressed, CallbackInfo ci) {
+		List<KeyBinding> list = KeyBindingRegistryImpl.KEY_TO_BINDINGS.get(key);
+		if (list == null) return;
+
+		for (KeyBinding binding : list) {
+			if (KeyBindingContext.of(binding).isActive()) {
+				binding.setPressed(pressed);
+				break;
+			}
+		}
+	}
+
+	@Inject(method = "updateKeysByCode", at = @At("HEAD"))
+	private static void updateKeysByCode(CallbackInfo ci) {
+		KeyBindingRegistryImpl.KEY_TO_BINDINGS.clear();
+
+		for (KeyBinding binding : KEYS_BY_ID.values()) {
+			KeyBindingRegistryImpl.putToMap(KeyBindingHelper.getBoundKeyOf(binding), binding);
+		}
+	}
+
+	@Inject(method = "<init>(Ljava/lang/String;Lnet/minecraft/client/util/InputUtil$Type;ILjava/lang/String;)V", at = @At("TAIL"))
+	private void init(String translationKey, InputUtil.Type type, int code, String category, CallbackInfo ci) {
+		KeyBindingRegistryImpl.putToMap(boundKey, (KeyBinding) (Object) this);
+	}
+
+	@Inject(method = "equals", at = @At("RETURN"), cancellable = true)
+	private void equals(KeyBinding other, CallbackInfoReturnable<Boolean> cir) {
+		if (!KeyBindingContext.conflicts(context, KeyBindingContext.of(other))) {
+			cir.setReturnValue(false);
+		}
+	}
+
+	// Return empty set, skipping the loop
+	@Redirect(method = "updateKeysByCode", at = @At(value = "INVOKE", target = "Ljava/util/Map;values()Ljava/util/Collection;"))
+	private static Collection<?> skipVanillaLoop(Map<?, ?> instance) {
+		return Collections.emptySet();
+	}
+
+	// Skip putting this to KEY_TO_BINDINGS
+	@Redirect(method = "<init>(Ljava/lang/String;Lnet/minecraft/client/util/InputUtil$Type;ILjava/lang/String;)V", at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;", ordinal = 1))
+	private Object skipVanillaMapping(Map<?, ?> instance, Object k, Object v) {
+		return null;
+	}
+}

--- a/fabric-key-binding-api-v1/src/client/resources/assets/fabric-key-binding-api-v1/lang/en_us.json
+++ b/fabric-key-binding-api-v1/src/client/resources/assets/fabric-key-binding-api-v1/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+  "fabric.keybinding.conflicts": "This key is conflicting with:\n%s"
+}

--- a/fabric-key-binding-api-v1/src/client/resources/fabric-key-binding-api-v1.mixins.json
+++ b/fabric-key-binding-api-v1/src/client/resources/fabric-key-binding-api-v1.mixins.json
@@ -5,6 +5,7 @@
   "client": [
     "GameOptionsMixin",
     "KeyBindingAccessor",
+    "KeyBindingEntryMixin",
     "KeyBindingMixin"
   ],
   "injectors": {

--- a/fabric-key-binding-api-v1/src/client/resources/fabric-key-binding-api-v1.mixins.json
+++ b/fabric-key-binding-api-v1/src/client/resources/fabric-key-binding-api-v1.mixins.json
@@ -3,8 +3,9 @@
   "package": "net.fabricmc.fabric.mixin.client.keybinding",
   "compatibilityLevel": "JAVA_16",
   "client": [
+    "GameOptionsMixin",
     "KeyBindingAccessor",
-    "GameOptionsMixin"
+    "KeyBindingMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/CustomKeyBindingContext.java
+++ b/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/CustomKeyBindingContext.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.client.keybinding;
+
+import net.minecraft.client.MinecraftClient;
+
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingContext;
+
+public class CustomKeyBindingContext implements KeyBindingContext {
+	@Override
+	public boolean isActive() {
+		return MinecraftClient.getInstance().currentScreen == null;
+	}
+}

--- a/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/CustomKeyBindingContext.java
+++ b/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/CustomKeyBindingContext.java
@@ -22,7 +22,12 @@ import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingContext;
 
 public class CustomKeyBindingContext implements KeyBindingContext {
 	@Override
-	public boolean isActive() {
-		return MinecraftClient.getInstance().currentScreen == null;
+	public boolean isActive(MinecraftClient client) {
+		return client.currentScreen == null;
+	}
+
+	@Override
+	public boolean conflictsWith(KeyBindingContext other) {
+		return this == other;
 	}
 }

--- a/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/CustomKeyBindingContext.java
+++ b/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/CustomKeyBindingContext.java
@@ -27,7 +27,7 @@ public class CustomKeyBindingContext implements KeyBindingContext {
 	}
 
 	@Override
-	public boolean conflictsWith(KeyBindingContext other) {
+	public boolean conflicts(KeyBindingContext other) {
 		return this == other;
 	}
 }

--- a/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/ItemKeyBindingContext.java
+++ b/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/ItemKeyBindingContext.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.client.keybinding;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.item.Item;
+import net.minecraft.util.Hand;
+
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingContext;
+
+public class ItemKeyBindingContext implements KeyBindingContext {
+	private final Item item;
+
+	public ItemKeyBindingContext(Item item) {
+		this.item = item;
+	}
+
+	@Override
+	public boolean isActive(MinecraftClient client) {
+		ClientPlayerEntity player = client.player;
+		return IN_GAME.isActive(client) && player != null && player.getStackInHand(Hand.MAIN_HAND).isOf(item);
+	}
+
+	@Override
+	public boolean conflictsWith(KeyBindingContext other) {
+		return this == other || IN_GAME == other;
+	}
+}

--- a/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/ItemKeyBindingContext.java
+++ b/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/ItemKeyBindingContext.java
@@ -37,7 +37,7 @@ public class ItemKeyBindingContext implements KeyBindingContext {
 	}
 
 	@Override
-	public boolean conflictsWith(KeyBindingContext other) {
+	public boolean conflicts(KeyBindingContext other) {
 		return this == other || IN_GAME == other;
 	}
 }

--- a/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/KeyBindingsTest.java
+++ b/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/KeyBindingsTest.java
@@ -94,5 +94,4 @@ public class KeyBindingsTest implements ClientModInitializer {
 			client.player.sendMessage(Text.literal(message));
 		}
 	}
-
 }

--- a/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/KeyBindingsTest.java
+++ b/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/KeyBindingsTest.java
@@ -40,6 +40,16 @@ public class KeyBindingsTest implements ClientModInitializer {
 		KeyBinding screenBinding = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.screen_keybinding", GLFW.GLFW_KEY_EQUAL, "key.category.context"), KeyBindingContext.IN_SCREEN);
 		KeyBinding allBinding = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.all_keybinding", GLFW.GLFW_KEY_BACKSLASH, "key.category.context"), KeyBindingContext.ALL);
 
+		// context1 won't conflict with context2
+		// therefore, one key from context1 and context2 will both be registered as pressed
+		CustomKeyBindingContext context1 = new CustomKeyBindingContext();
+		KeyBinding customCtxBinding1 = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.custom_context_1", GLFW.GLFW_KEY_SEMICOLON, "key.category.context"), context1);
+		KeyBinding customCtxBinding2 = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.custom_context_2", GLFW.GLFW_KEY_SEMICOLON, "key.category.context"), context1);
+
+		CustomKeyBindingContext context2 = new CustomKeyBindingContext();
+		KeyBinding customCtxBinding3 = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.custom_context_3", GLFW.GLFW_KEY_SEMICOLON, "key.category.context"), context2);
+		KeyBinding customCtxBinding4 = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.custom_context_4", GLFW.GLFW_KEY_SEMICOLON, "key.category.context"), context2);
+
 		ClientTickEvents.END_CLIENT_TICK.register(client -> {
 			while (binding1.wasPressed()) {
 				client.player.sendMessage(Text.literal("Key 1 was pressed!"), false);
@@ -59,6 +69,26 @@ public class KeyBindingsTest implements ClientModInitializer {
 
 			while (inGameBinding.wasPressed()) {
 				client.player.sendMessage(Text.literal("In-game key was pressed"));
+			}
+
+			while (allBinding.wasPressed()) {
+				client.player.sendMessage(Text.literal("ALL context key was pressed!"));
+			}
+
+			while (customCtxBinding1.wasPressed()) {
+				client.player.sendMessage(Text.literal("Custom Context Key 1 was pressed!"));
+			}
+
+			while (customCtxBinding2.wasPressed()) {
+				client.player.sendMessage(Text.literal("Custom Context Key 2 was pressed!"));
+			}
+
+			while (customCtxBinding3.wasPressed()) {
+				client.player.sendMessage(Text.literal("Custom Context Key 3 was pressed!"));
+			}
+
+			while (customCtxBinding4.wasPressed()) {
+				client.player.sendMessage(Text.literal("Custom Context Key 4 was pressed!"));
 			}
 		});
 	}

--- a/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/KeyBindingsTest.java
+++ b/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/KeyBindingsTest.java
@@ -18,9 +18,11 @@ package net.fabricmc.fabric.test.client.keybinding;
 
 import org.lwjgl.glfw.GLFW;
 
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.option.StickyKeyBinding;
 import net.minecraft.client.util.InputUtil;
+import net.minecraft.item.Items;
 import net.minecraft.text.Text;
 
 import net.fabricmc.api.ClientModInitializer;
@@ -36,19 +38,22 @@ public class KeyBindingsTest implements ClientModInitializer {
 		KeyBinding stickyBinding = KeyBindingHelper.registerKeyBinding(new StickyKeyBinding("key.fabric-key-binding-api-v1-testmod.test_keybinding_sticky", GLFW.GLFW_KEY_R, "key.category.first.test", () -> true));
 		KeyBinding duplicateBinding = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.test_keybinding_duplicate", GLFW.GLFW_KEY_RIGHT_SHIFT, "key.category.first.test"));
 
-		KeyBinding inGameBinding = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.in_game_keybinding", GLFW.GLFW_KEY_EQUAL, "key.category.context"), KeyBindingContext.IN_GAME);
-		KeyBinding screenBinding = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.screen_keybinding", GLFW.GLFW_KEY_EQUAL, "key.category.context"), KeyBindingContext.IN_SCREEN);
-		KeyBinding allBinding = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.all_keybinding", GLFW.GLFW_KEY_BACKSLASH, "key.category.context"), KeyBindingContext.ALL);
+		KeyBinding inGameBinding = register("in_game_keybinding", GLFW.GLFW_KEY_EQUAL, "context", KeyBindingContext.IN_GAME);
+		KeyBinding screenBinding = register("screen_keybinding", GLFW.GLFW_KEY_EQUAL, "context", KeyBindingContext.IN_SCREEN);
+		KeyBinding allBinding = register("all_keybinding", GLFW.GLFW_KEY_BACKSLASH, "context", KeyBindingContext.ALL);
 
 		// context1 won't conflict with context2
 		// therefore, one key from context1 and context2 will both be registered as pressed
 		CustomKeyBindingContext context1 = new CustomKeyBindingContext();
-		KeyBinding customCtxBinding1 = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.custom_context_1", GLFW.GLFW_KEY_SEMICOLON, "key.category.context"), context1);
-		KeyBinding customCtxBinding2 = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.custom_context_2", GLFW.GLFW_KEY_SEMICOLON, "key.category.context"), context1);
+		KeyBinding customCtxBinding1 = register("custom_context_1", GLFW.GLFW_KEY_SEMICOLON, "context", context1);
+		KeyBinding customCtxBinding2 = register("custom_context_2", GLFW.GLFW_KEY_SEMICOLON, "context", context1);
 
 		CustomKeyBindingContext context2 = new CustomKeyBindingContext();
-		KeyBinding customCtxBinding3 = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.custom_context_3", GLFW.GLFW_KEY_SEMICOLON, "key.category.context"), context2);
-		KeyBinding customCtxBinding4 = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.custom_context_4", GLFW.GLFW_KEY_SEMICOLON, "key.category.context"), context2);
+		KeyBinding customCtxBinding3 = register("custom_context_3", GLFW.GLFW_KEY_SEMICOLON, "context", context2);
+		KeyBinding customCtxBinding4 = register("custom_context_4", GLFW.GLFW_KEY_SEMICOLON, "context", context2);
+
+		KeyBinding diamondSwordBinding = register("diamond_sword", GLFW.GLFW_KEY_I, "context", new ItemKeyBindingContext(Items.DIAMOND_SWORD));
+		KeyBinding netheriteSwordBinding = register("netherite_sword", GLFW.GLFW_KEY_I, "context", new ItemKeyBindingContext(Items.NETHERITE_SWORD));
 
 		ClientTickEvents.END_CLIENT_TICK.register(client -> {
 			while (binding1.wasPressed()) {
@@ -67,29 +72,28 @@ public class KeyBindingsTest implements ClientModInitializer {
 				client.player.sendMessage(Text.literal("Duplicate Key was pressed!"), false);
 			}
 
-			while (inGameBinding.wasPressed()) {
-				client.player.sendMessage(Text.literal("In-game key was pressed"));
-			}
+			sendMessageWhenPressed(client, inGameBinding, "In-game key was pressed");
+			sendMessageWhenPressed(client, allBinding, "ALL context key was pressed!");
 
-			while (allBinding.wasPressed()) {
-				client.player.sendMessage(Text.literal("ALL context key was pressed!"));
-			}
+			// 1 and 3 should be called at the same time
+			sendMessageWhenPressed(client, customCtxBinding1, "Custom Context Key 1 was pressed!");
+			sendMessageWhenPressed(client, customCtxBinding2, "Custom Context Key 2 was pressed!");
+			sendMessageWhenPressed(client, customCtxBinding3, "Custom Context Key 3 was pressed!");
+			sendMessageWhenPressed(client, customCtxBinding4, "Custom Context Key 4 was pressed!");
 
-			while (customCtxBinding1.wasPressed()) {
-				client.player.sendMessage(Text.literal("Custom Context Key 1 was pressed!"));
-			}
-
-			while (customCtxBinding2.wasPressed()) {
-				client.player.sendMessage(Text.literal("Custom Context Key 2 was pressed!"));
-			}
-
-			while (customCtxBinding3.wasPressed()) {
-				client.player.sendMessage(Text.literal("Custom Context Key 3 was pressed!"));
-			}
-
-			while (customCtxBinding4.wasPressed()) {
-				client.player.sendMessage(Text.literal("Custom Context Key 4 was pressed!"));
-			}
+			sendMessageWhenPressed(client, diamondSwordBinding, "Diamond Sword Key was pressed!");
+			sendMessageWhenPressed(client, netheriteSwordBinding, "Netherite Sword Key was pressed!");
 		});
 	}
+
+	private static KeyBinding register(String key, int code, String category, KeyBindingContext context) {
+		return KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod." + key, code, "key.category." + category), context);
+	}
+
+	private static void sendMessageWhenPressed(MinecraftClient client, KeyBinding binding, String message) {
+		while (binding.wasPressed()) {
+			client.player.sendMessage(Text.literal(message));
+		}
+	}
+
 }

--- a/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/KeyBindingsTest.java
+++ b/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/KeyBindingsTest.java
@@ -71,15 +71,23 @@ public class KeyBindingsTest implements ClientModInitializer {
 				client.player.sendMessage(Text.literal("Duplicate Key was pressed!"), false);
 			}
 
+			// When ALL binding is set to the same key, it then will conflict with all other bindings
+			// only one binding will be marked as pressed, based on what binding registered first.
+			// Vanilla bindings are registered last as it is made on GameOptions ctor instead of statically.
+			// - allBinding & inGameBinding conflicts -> inGameBinding will be called
+			// - allBinding & customCtxBinding conflicts -> allBinding will be called
+			// - allBinding & vanilla conflicts -> allBinding will be called
 			sendMessageWhenPressed(client, inGameBinding, "In-game key was pressed");
 			sendMessageWhenPressed(client, allBinding, "ALL context key was pressed!");
 
-			// 1 and 3 should be called at the same time
+			// 1 and 2 will conflict, 3 and 4 will conflict.
+			// 1 and 3 should be called at the same time.
 			sendMessageWhenPressed(client, customCtxBinding1, "Custom Context Key 1 was pressed!");
 			sendMessageWhenPressed(client, customCtxBinding2, "Custom Context Key 2 was pressed!");
 			sendMessageWhenPressed(client, customCtxBinding3, "Custom Context Key 3 was pressed!");
 			sendMessageWhenPressed(client, customCtxBinding4, "Custom Context Key 4 was pressed!");
 
+			// Won't conflict with each other, hold the respective item and press.
 			sendMessageWhenPressed(client, diamondSwordBinding, "Diamond Sword Key was pressed!");
 			sendMessageWhenPressed(client, netheriteSwordBinding, "Netherite Sword Key was pressed!");
 		});

--- a/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/KeyBindingsTest.java
+++ b/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/KeyBindingsTest.java
@@ -25,6 +25,7 @@ import net.minecraft.text.Text;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingContext;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 
 public class KeyBindingsTest implements ClientModInitializer {
@@ -34,6 +35,10 @@ public class KeyBindingsTest implements ClientModInitializer {
 		KeyBinding binding2 = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.test_keybinding_2", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_U, "key.category.second.test"));
 		KeyBinding stickyBinding = KeyBindingHelper.registerKeyBinding(new StickyKeyBinding("key.fabric-key-binding-api-v1-testmod.test_keybinding_sticky", GLFW.GLFW_KEY_R, "key.category.first.test", () -> true));
 		KeyBinding duplicateBinding = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.test_keybinding_duplicate", GLFW.GLFW_KEY_RIGHT_SHIFT, "key.category.first.test"));
+
+		KeyBinding inGameBinding = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.in_game_keybinding", GLFW.GLFW_KEY_EQUAL, "key.category.context"), KeyBindingContext.IN_GAME);
+		KeyBinding screenBinding = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.screen_keybinding", GLFW.GLFW_KEY_EQUAL, "key.category.context"), KeyBindingContext.IN_SCREEN);
+		KeyBinding allBinding = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.all_keybinding", GLFW.GLFW_KEY_BACKSLASH, "key.category.context"), KeyBindingContext.ALL);
 
 		ClientTickEvents.END_CLIENT_TICK.register(client -> {
 			while (binding1.wasPressed()) {
@@ -50,6 +55,10 @@ public class KeyBindingsTest implements ClientModInitializer {
 
 			while (duplicateBinding.wasPressed()) {
 				client.player.sendMessage(Text.literal("Duplicate Key was pressed!"), false);
+			}
+
+			while (inGameBinding.wasPressed()) {
+				client.player.sendMessage(Text.literal("In-game key was pressed"));
 			}
 		});
 	}

--- a/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/KeyBindingsTest.java
+++ b/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/KeyBindingsTest.java
@@ -39,7 +39,6 @@ public class KeyBindingsTest implements ClientModInitializer {
 		KeyBinding duplicateBinding = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.test_keybinding_duplicate", GLFW.GLFW_KEY_RIGHT_SHIFT, "key.category.first.test"));
 
 		KeyBinding inGameBinding = register("in_game_keybinding", GLFW.GLFW_KEY_EQUAL, "context", KeyBindingContext.IN_GAME);
-		KeyBinding screenBinding = register("screen_keybinding", GLFW.GLFW_KEY_EQUAL, "context", KeyBindingContext.IN_SCREEN);
 		KeyBinding allBinding = register("all_keybinding", GLFW.GLFW_KEY_BACKSLASH, "context", KeyBindingContext.ALL);
 
 		// context1 won't conflict with context2

--- a/fabric-key-binding-api-v1/src/testmodClient/resources/assets/fabric-keybindings-v1-testmod/lang/en_us.json
+++ b/fabric-key-binding-api-v1/src/testmodClient/resources/assets/fabric-keybindings-v1-testmod/lang/en_us.json
@@ -12,5 +12,7 @@
   "key.fabric-key-binding-api-v1-testmod.custom_context_1": "Custom Context 1",
   "key.fabric-key-binding-api-v1-testmod.custom_context_2": "Custom Context 2",
   "key.fabric-key-binding-api-v1-testmod.custom_context_3": "Custom Context 3",
-  "key.fabric-key-binding-api-v1-testmod.custom_context_4": "Custom Context 4"
+  "key.fabric-key-binding-api-v1-testmod.custom_context_4": "Custom Context 4",
+  "key.fabric-key-binding-api-v1-testmod.diamond_sword": "Diamond Sword",
+  "key.fabric-key-binding-api-v1-testmod.netherite_sword": "Netherite Sword"
 }

--- a/fabric-key-binding-api-v1/src/testmodClient/resources/assets/fabric-keybindings-v1-testmod/lang/en_us.json
+++ b/fabric-key-binding-api-v1/src/testmodClient/resources/assets/fabric-keybindings-v1-testmod/lang/en_us.json
@@ -1,8 +1,12 @@
 {
   "key.category.first.test": "First Test Category",
   "key.category.second.test": "Second Test Category",
+  "key.category.context": "Context Test Category",
   "key.fabric-key-binding-api-v1-testmod.test_keybinding_1": "Test 1",
   "key.fabric-key-binding-api-v1-testmod.test_keybinding_2": "Test 2",
   "key.fabric-key-binding-api-v1-testmod.test_keybinding_sticky": "Sticky Test",
-  "key.fabric-key-binding-api-v1-testmod.test_keybinding_duplicate": "Duplicate Test"
+  "key.fabric-key-binding-api-v1-testmod.test_keybinding_duplicate": "Duplicate Test",
+  "key.fabric-key-binding-api-v1-testmod.in_game_keybinding": "In Game",
+  "key.fabric-key-binding-api-v1-testmod.screen_keybinding": "In Screen",
+  "key.fabric-key-binding-api-v1-testmod.all_keybinding": "All"
 }

--- a/fabric-key-binding-api-v1/src/testmodClient/resources/assets/fabric-keybindings-v1-testmod/lang/en_us.json
+++ b/fabric-key-binding-api-v1/src/testmodClient/resources/assets/fabric-keybindings-v1-testmod/lang/en_us.json
@@ -8,5 +8,9 @@
   "key.fabric-key-binding-api-v1-testmod.test_keybinding_duplicate": "Duplicate Test",
   "key.fabric-key-binding-api-v1-testmod.in_game_keybinding": "In Game",
   "key.fabric-key-binding-api-v1-testmod.screen_keybinding": "In Screen",
-  "key.fabric-key-binding-api-v1-testmod.all_keybinding": "All"
+  "key.fabric-key-binding-api-v1-testmod.all_keybinding": "All",
+  "key.fabric-key-binding-api-v1-testmod.custom_context_1": "Custom Context 1",
+  "key.fabric-key-binding-api-v1-testmod.custom_context_2": "Custom Context 2",
+  "key.fabric-key-binding-api-v1-testmod.custom_context_3": "Custom Context 3",
+  "key.fabric-key-binding-api-v1-testmod.custom_context_4": "Custom Context 4"
 }

--- a/fabric-screen-api-v1/build.gradle
+++ b/fabric-screen-api-v1/build.gradle
@@ -1,4 +1,4 @@
 archivesBaseName = "fabric-screen-api-v1"
 version = getSubprojectVersion(project)
 
-moduleDependencies(project, ['fabric-api-base'])
+moduleDependencies(project, ['fabric-api-base', 'fabric-key-binding-api-v1'])

--- a/fabric-screen-api-v1/src/client/resources/fabric.mod.json
+++ b/fabric-screen-api-v1/src/client/resources/fabric.mod.json
@@ -17,7 +17,8 @@
   ],
   "depends": {
     "fabricloader": ">=0.8.2",
-    "fabric-api-base": "*"
+    "fabric-api-base": "*",
+    "fabric-key-binding-api-v1": "*"
   },
   "description": "Adds screen related hooks.",
   "mixins": [

--- a/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/ScreenTests.java
+++ b/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/ScreenTests.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.test.screen;
 
 import java.util.List;
 
+import org.lwjgl.glfw.GLFW;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,9 +26,12 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.TitleScreen;
 import net.minecraft.client.gui.widget.ClickableWidget;
+import net.minecraft.client.option.KeyBinding;
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingContext;
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenKeyboardEvents;
 import net.fabricmc.fabric.api.client.screen.v1.Screens;
@@ -35,6 +39,8 @@ import net.fabricmc.fabric.api.client.screen.v1.Screens;
 public final class ScreenTests implements ClientModInitializer {
 	public static final Identifier GUI_ICONS_TEXTURE = new Identifier("textures/gui/icons.png");
 	private static final Logger LOGGER = LoggerFactory.getLogger("FabricScreenApiTests");
+
+	private static final KeyBinding SCREEN_BINDING = new KeyBinding("key.fabric-screen-api-v1-testmod.screen_keybinding", GLFW.GLFW_KEY_EQUAL, "key.category.context");
 
 	@Override
 	public void onInitializeClient() {
@@ -44,6 +50,7 @@ public final class ScreenTests implements ClientModInitializer {
 		});
 
 		ScreenEvents.AFTER_INIT.register(this::afterInitScreen);
+		KeyBindingHelper.registerKeyBinding(SCREEN_BINDING, KeyBindingContext.IN_SCREEN);
 	}
 
 	private void afterInitScreen(MinecraftClient client, Screen screen, int windowWidth, int windowHeight) {
@@ -88,5 +95,11 @@ public final class ScreenTests implements ClientModInitializer {
 				LOGGER.warn("Pressed, Code: {}, Scancode: {}, Modifiers: {}", key, scancode, modifiers);
 			});
 		}
+
+		ScreenKeyboardEvents.beforeKeyPress(screen).register((screen1, key, scancode, modifiers) -> {
+			if (SCREEN_BINDING.isPressed()) {
+				LOGGER.info("Screen key binding was pressed on screen {}!", screen.getClass().getSimpleName());
+			}
+		});
 	}
 }

--- a/fabric-screen-api-v1/src/testmodClient/resources/assets/fabric-screen-api-v1-testmod/lang/en_us.json
+++ b/fabric-screen-api-v1/src/testmodClient/resources/assets/fabric-screen-api-v1-testmod/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+  "key.fabric-screen-api-v1-testmod.screen_keybinding": "In Screen"
+}


### PR DESCRIPTION
Add `KeyBindingContext` to register multiple key binds that won't conflict with others.

This PR doesn't change vanilla behavior in which only one conflicting key (same context and key) will be registered as pressed. 
The order in which what key to functions depends on when the `KeyBinding` instance is created.

~~Do we want `KeyBinding#isPressed` and `wasPressed` to work when a screen is open?~~ Now it also makes it usable on screen.
