### PR TITLE
Implement `RenderAttachedBlockView` on `ChunkRendererRegion`

### DIFF
--- a/deprecated/fabric-rendering-data-attachment-v1/src/client/java/net/fabricmc/fabric/mixin/rendering/data/client/ChunkRendererRegionMixin.java
+++ b/deprecated/fabric-rendering-data-attachment-v1/src/client/java/net/fabricmc/fabric/mixin/rendering/data/client/ChunkRendererRegionMixin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.rendering.data.client;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import net.minecraft.client.render.chunk.ChunkRendererRegion;
+import net.minecraft.world.WorldView;
+
+import net.fabricmc.fabric.api.rendering.data.v1.RenderAttachedBlockView;
+
+/**
+ * Since {@link RenderAttachedBlockView} is only automatically implemented on {@link WorldView} instances and
+ * {@link ChunkRendererRegion} does not implement {@link WorldView}, this mixin manually implements
+ * {@link RenderAttachedBlockView} on {@link ChunkRendererRegion}. The BlockView API v2 implementation ensures
+ * that all default method implementations of {@link RenderAttachedBlockView} work here automatically.
+ */
+@Mixin(ChunkRendererRegion.class)
+public abstract class ChunkRendererRegionMixin implements RenderAttachedBlockView {
+}

--- a/deprecated/fabric-rendering-data-attachment-v1/src/client/resources/fabric-rendering-data-attachment-v1.client.mixins.json
+++ b/deprecated/fabric-rendering-data-attachment-v1/src/client/resources/fabric-rendering-data-attachment-v1.client.mixins.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "package": "net.fabricmc.fabric.mixin.rendering.data.client",
+  "compatibilityLevel": "JAVA_17",
+  "client": [
+    "ChunkRendererRegionMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/deprecated/fabric-rendering-data-attachment-v1/src/main/resources/fabric.mod.json
+++ b/deprecated/fabric-rendering-data-attachment-v1/src/main/resources/fabric.mod.json
@@ -21,7 +21,11 @@
   },
   "description": "Thread-safe hooks for block entity data use during terrain rendering.",
   "mixins": [
-    "fabric-rendering-data-attachment-v1.mixins.json"
+    "fabric-rendering-data-attachment-v1.mixins.json",
+    {
+      "config": "fabric-rendering-data-attachment-v1.client.mixins.json",
+      "environment": "client"
+    }
   ],
   "custom": {
     "fabric-api:module-lifecycle": "deprecated"


### PR DESCRIPTION
#3268 accidentally changed the code such that `ChunkRendererRegion` no longer implements `RenderAttachedBlockView`. This pull request restores the old behavior and is critical since almost all users of Rendering Data Attachment v1 rely on `ChunkRendererRegion` to implement `RenderAttachedBlockView`.