### PR TITLE
Include namespace in modded registry tag path

### DIFF
--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/DynamicRegistries.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/DynamicRegistries.java
@@ -37,6 +37,10 @@ import net.fabricmc.fabric.impl.registry.sync.DynamicRegistriesImpl;
  * <p>The list of all dynamic registries, whether from vanilla or mods, can be accessed using
  * {@link #getDynamicRegistries()}.
  *
+ * <p>Tags for the entries of a custom registry must be placed in
+ * {@code /tags/<registry namespace>/<registry path>/}. For example, the tags for the example
+ * registry below would be placed in {@code /tags/my_mod/my_data/}.
+ *
  * <h2 id="sync">Synchronization</h2>
  * Dynamic registries are not synchronized to the client by default.
  * To register a <em>synced dynamic registry</em>, you can replace the {@link #register} call

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/FabricRegistryBuilder.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/FabricRegistryBuilder.java
@@ -44,6 +44,10 @@ import net.fabricmc.fabric.mixin.registry.sync.RegistriesAccessor;
  * 	}
  * </pre>
  *
+ * <p>Tags for the entries of a custom registry must be placed in
+ * {@code /tags/<registry namespace>/<registry path>/}. For example, the tags for the example
+ * registry above would be placed in {@code /tags/modid/registry_name/}.
+ *
  * @param <T> The type stored in the Registry
  * @param <R> The registry type
  */

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/TagManagerLoaderMixin.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/TagManagerLoaderMixin.java
@@ -26,22 +26,16 @@ import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.tag.TagManagerLoader;
 import net.minecraft.util.Identifier;
 
-import net.fabricmc.fabric.impl.registry.sync.DynamicRegistriesImpl;
-
 // Adds namespaces to tag directories for registries added by mods.
 @Mixin(TagManagerLoader.class)
 abstract class TagManagerLoaderMixin {
 	@Inject(method = "getPath", at = @At("HEAD"), cancellable = true)
 	private static void onGetPath(RegistryKey<? extends Registry<?>> registry, CallbackInfoReturnable<String> info) {
-		// TODO: Expand this change to static registries in the future.
-		if (!DynamicRegistriesImpl.DYNAMIC_REGISTRY_KEYS.contains(registry)) {
-			return;
-		}
-
 		Identifier id = registry.getValue();
 
 		// Vanilla doesn't mark namespaces in the directories of tags at all,
 		// so we prepend the directories with the namespace if it's a modded registry id.
+		// No need to check DIRECTORIES, since this is only used by vanilla registries.
 		if (!id.getNamespace().equals(Identifier.DEFAULT_NAMESPACE)) {
 			info.setReturnValue("tags/" + id.getNamespace() + "/" + id.getPath());
 		}


### PR DESCRIPTION
**Breaking change** for 1.20.2.

In #3163, modded **dynamic** registries had the registry namespace added to the tag paths. This change now also applies to static registries. This breaks data packs, including bundled ones, if they use tags for custom registries. **This does not affect vanilla tags** like block tags, item tags, or entity type tags.

Javadoc changes included, to document this behavior.