### PR TITLE
Pass handler to clientside ConfigurationPacketHandler

### DIFF
--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientConfigurationNetworking.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientConfigurationNetworking.java
@@ -105,10 +105,10 @@ public final class ClientConfigurationNetworking {
 					// Normally, packets are handled on the network IO thread - though it is
 					// not guaranteed (for example, with 1.19.4 S2C packet bundling)
 					// Since we're handling it right now, connection check is redundant.
-					handler.receive(packet, sender);
+					handler.receive(packet, networkHandler, sender);
 				} else {
 					client.execute(() -> {
-						if (((ClientCommonNetworkHandlerAccessor) networkHandler).getConnection().isOpen()) handler.receive(packet, sender);
+						if (((ClientCommonNetworkHandlerAccessor) networkHandler).getConnection().isOpen()) handler.receive(packet, networkHandler, sender);
 					});
 				}
 			}
@@ -218,10 +218,10 @@ public final class ClientConfigurationNetworking {
 					// Normally, packets are handled on the network IO thread - though it is
 					// not guaranteed (for example, with 1.19.4 S2C packet bundling)
 					// Since we're handling it right now, connection check is redundant.
-					handler.receive(packet, sender);
+					handler.receive(packet, networkHandler, sender);
 				} else {
 					client.execute(() -> {
-						if (((ClientCommonNetworkHandlerAccessor) networkHandler).getConnection().isOpen()) handler.receive(packet, sender);
+						if (((ClientCommonNetworkHandlerAccessor) networkHandler).getConnection().isOpen()) handler.receive(packet, networkHandler, sender);
 					});
 				}
 			}
@@ -451,9 +451,10 @@ public final class ClientConfigurationNetworking {
 		 *
 		 *
 		 * @param packet the packet
+		 * @param networkHandler the network handler
 		 * @param responseSender the packet sender
 		 * @see FabricPacket
 		 */
-		void receive(T packet, PacketSender responseSender);
+		void receive(T packet, ClientConfigurationNetworkHandler networkHandler, PacketSender responseSender);
 	}
 }

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientConfigurationNetworking.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientConfigurationNetworking.java
@@ -27,6 +27,7 @@ import net.minecraft.client.network.ClientConfigurationNetworkHandler;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.listener.ServerCommonPacketListener;
 import net.minecraft.network.packet.Packet;
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.thread.ThreadExecutor;
 
@@ -391,6 +392,14 @@ public final class ClientConfigurationNetworking {
 		}
 
 		throw new IllegalStateException("Cannot send packet while not configuring!");
+	}
+
+	/**
+	 * Disconnects from the server.
+	 * @param handler the network handler
+	 */
+	public static void disconnect(ClientConfigurationNetworkHandler handler, Text reason) {
+		((ClientCommonNetworkHandlerAccessor) handler).getConnection().disconnect(reason);
 	}
 
 	private ClientConfigurationNetworking() {

--- a/fabric-networking-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/networking/client/configuration/NetworkingConfigurationClientTest.java
+++ b/fabric-networking-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/networking/client/configuration/NetworkingConfigurationClientTest.java
@@ -23,7 +23,7 @@ import net.fabricmc.fabric.test.networking.configuration.NetworkingConfiguration
 public class NetworkingConfigurationClientTest implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
-		ClientConfigurationNetworking.registerGlobalReceiver(NetworkingConfigurationTest.ConfigurationPacket.PACKET_TYPE, (packet, responseSender) -> {
+		ClientConfigurationNetworking.registerGlobalReceiver(NetworkingConfigurationTest.ConfigurationPacket.PACKET_TYPE, (packet, handler, responseSender) -> {
 			// Handle stuff here
 
 			// Respond back to the server that the task is complete


### PR DESCRIPTION
Breaking change, needs to be merged ASAP.

Turns out you cannot query CCNH from MinecraftClient. We first need to get ClientConnection (which is also PITA - the impl already does that elsewhere), then get the handler through Netty internals and several casting.

Also adds a helper method to disconnect, as there is currently no way to do so. I wasn't sure if interface injection or static method was better; you can revert the commit if this needs to be discussed later.