### PR TITLE
Support resource pack filters, overlays and features from pack.mcmeta files in mods.

### DIFF
--- a/fabric-resource-loader-v0/build.gradle
+++ b/fabric-resource-loader-v0/build.gradle
@@ -7,5 +7,6 @@ loom {
 testDependencies(project, [
 	':fabric-lifecycle-events-v1',
 	':fabric-api-base',
-	':fabric-resource-loader-v0'
+	':fabric-resource-loader-v0',
+	':fabric-networking-api-v1'
 ])

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/FabricModResourcePack.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/FabricModResourcePack.java
@@ -141,7 +141,8 @@ public class FabricModResourcePack extends GroupResourcePack {
 						LOGGER.error("Failed to get {} section from pack {}", serializer.getKey(), pack.getName());
 						return null; // Not a fatal error, matches LifecycledResourceManagerImpl.parseResourceFilter
 					}
-				}).filter(Objects::nonNull);
+				})
+				.filter(Objects::nonNull);
 	}
 
 	// Collects to an optional list. The optional is not empty when the list contains at least 1 element

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/FabricModResourcePack.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/FabricModResourcePack.java
@@ -84,9 +84,9 @@ public class FabricModResourcePack extends GroupResourcePack {
 		}
 
 		final var resourceMetadata = new PackResourceMetadata(
-						Text.translatableWithFallback("pack.description.modResources", "Mod resources."),
-						SharedConstants.getGameVersion().getResourceVersion(type),
-				Optional.empty()
+					Text.translatableWithFallback("pack.description.modResources", "Mod resources."),
+					SharedConstants.getGameVersion().getResourceVersion(type),
+					Optional.empty()
 		);
 
 		final List<BlockEntry> blockEntries = collectBlockEntries();

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/PackFeatureSetMetadataAccessor.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/PackFeatureSetMetadataAccessor.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.resource.loader;
+
+import com.mojang.serialization.Codec;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.resource.metadata.PackFeatureSetMetadata;
+
+@Mixin(PackFeatureSetMetadata.class)
+public interface PackFeatureSetMetadataAccessor {
+	@Accessor("CODEC")
+	static Codec<PackFeatureSetMetadata> getCodec() {
+		throw new IllegalStateException();
+	}
+}

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/PackOverlaysMetadataAccessor.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/PackOverlaysMetadataAccessor.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.resource.loader;
+
+import com.mojang.serialization.Codec;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.resource.metadata.PackOverlaysMetadata;
+
+@Mixin(PackOverlaysMetadata.class)
+public interface PackOverlaysMetadataAccessor {
+	@Accessor("CODEC")
+	static Codec<PackOverlaysMetadata> getCodec() {
+		throw new IllegalStateException();
+	}
+}

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/ResourceFilterAccessor.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/ResourceFilterAccessor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.resource.loader;
+
+import java.util.List;
+
+import com.mojang.serialization.Codec;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.resource.metadata.BlockEntry;
+import net.minecraft.resource.metadata.ResourceFilter;
+
+@Mixin(ResourceFilter.class)
+public interface ResourceFilterAccessor {
+	@Accessor
+	List<BlockEntry> getBlocks();
+
+	@Accessor("CODEC")
+	static Codec<ResourceFilter> getCodec() {
+		throw new IllegalStateException();
+	}
+}

--- a/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
+++ b/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
@@ -7,6 +7,8 @@
     "LifecycledResourceManagerImplMixin",
     "MinecraftServerMixin",
     "NamespaceResourceManagerMixin",
+    "PackFeatureSetMetadataAccessor",
+    "PackOverlaysMetadataAccessor",
     "ReloadableResourceManagerImplMixin",
     "ResourceFilterAccessor",
     "ResourceMixin",

--- a/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
+++ b/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
@@ -8,6 +8,7 @@
     "MinecraftServerMixin",
     "NamespaceResourceManagerMixin",
     "ReloadableResourceManagerImplMixin",
+    "ResourceFilterAccessor",
     "ResourceMixin",
     "ResourcePackManagerMixin",
     "ResourcePackProfileMixin",

--- a/fabric-resource-loader-v0/src/test/java/net/fabricmc/fabric/test/resource/loader/FabricModResourcePackTest.java
+++ b/fabric-resource-loader-v0/src/test/java/net/fabricmc/fabric/test/resource/loader/FabricModResourcePackTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.resource.loader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.resource.ResourceType;
+import net.minecraft.resource.metadata.PackResourceMetadata;
+import net.minecraft.resource.metadata.ResourceFilter;
+
+import net.fabricmc.fabric.api.resource.ModResourcePack;
+import net.fabricmc.fabric.api.resource.ResourcePackActivationType;
+import net.fabricmc.fabric.impl.resource.loader.FabricModResourcePack;
+import net.fabricmc.fabric.impl.resource.loader.ModNioResourcePack;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.metadata.ModMetadata;
+
+public class FabricModResourcePackTest {
+	@BeforeAll
+	static void beforeAll() {
+		SharedConstants.createGameVersion();
+	}
+
+	@Test
+	void resourcePackMetadata(@TempDir Path rootPath) throws IOException {
+		writeDummyResources("test1", rootPath);
+
+		try (var resourcePack = new FabricModResourcePack(ResourceType.CLIENT_RESOURCES, List.of(
+				createModResourcePack("test1", rootPath)
+		))) {
+			final PackResourceMetadata resourceMetadata = resourcePack.parseMetadata(PackResourceMetadata.SERIALIZER);
+			assertNotNull(resourceMetadata);
+			assertEquals(resourceMetadata.description().getString(), "Mod resources.");
+
+			final ResourceFilter resourceFilter = resourcePack.parseMetadata(ResourceFilter.SERIALIZER);
+			assertNull(resourceFilter);
+		}
+	}
+
+	@Test
+	void resourcePackFiters(@TempDir Path rootPath) throws IOException {
+		@Language("json")
+		String mcmeta = """
+				{
+					"pack": {
+						"pack_format": 18,
+						"description": "My epic test mod"
+					},
+					"filter": {
+						"block": [
+							{
+								"namespace": "minecraft",
+								"path": "recipes/.*"
+							}
+						]
+					}
+				}""";
+
+		writeDummyResources("test1", rootPath);
+		Files.writeString(rootPath.resolve("pack.mcmeta"), mcmeta);
+
+		try (var resourcePack = new FabricModResourcePack(ResourceType.CLIENT_RESOURCES, List.of(
+				createModResourcePack("test1", rootPath)
+		))) {
+			final ResourceFilter resourceFilter = resourcePack.parseMetadata(ResourceFilter.SERIALIZER);
+			assertNotNull(resourceFilter);
+
+			assertTrue(resourceFilter.isNamespaceBlocked("minecraft"));
+			assertFalse(resourceFilter.isNamespaceBlocked("fabric"));
+
+			assertTrue(resourceFilter.isPathBlocked("recipes/example.json"));
+			assertFalse(resourceFilter.isPathBlocked("blocks/example.json"));
+		}
+	}
+
+	private static ModResourcePack createModResourcePack(String modId, Path rootDir) {
+		final ModMetadata modMetadata = mock(ModMetadata.class);
+		when(modMetadata.getId()).thenReturn(modId);
+
+		final ModContainer modContainer = mock(ModContainer.class);
+		when(modContainer.getRootPaths()).thenReturn(List.of(rootDir));
+		when(modContainer.getMetadata()).thenReturn(modMetadata);
+
+		ModNioResourcePack modNioResourcePack = ModNioResourcePack.create(modId, modContainer, null, ResourceType.CLIENT_RESOURCES, ResourcePackActivationType.ALWAYS_ENABLED);
+		assertNotNull(modNioResourcePack);
+		return modNioResourcePack;
+	}
+
+	// A resource pack will only be loaded when it has either an assets or data directory.
+	private static void writeDummyResources(String modId, Path rootPath) throws IOException {
+		Files.createDirectories(rootPath.resolve("assets/%s/".formatted(modId)));
+		Files.createDirectories(rootPath.resolve("data/%s/".formatted(modId)));
+	}
+}


### PR DESCRIPTION
Closes #3302

See: https://www.minecraft.net/en-us/article/minecraft-snapshot-22w11a for more info about filters.

Mods cannot filter each other, but they can filter packs (such as Minecraft its self) that are loaded before. Overlays and features are also supported.