### PR TITLE
Handle null being passed as the datafix type to PersistentState.Type

### DIFF
--- a/fabric-object-builder-api-v1/build.gradle
+++ b/fabric-object-builder-api-v1/build.gradle
@@ -5,7 +5,10 @@ moduleDependencies(project, [
 	'fabric-resource-loader-v0'
 ])
 
-testDependencies(project, [':fabric-command-api-v2'])
+testDependencies(project, [
+	':fabric-command-api-v2',
+	':fabric-lifecycle-events-v1'
+])
 
 loom {
 	accessWidenerPath = file("src/main/resources/fabric-object-builder-api-v1.accesswidener")

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/PersistentStateManagerMixin.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/PersistentStateManagerMixin.java
@@ -31,7 +31,7 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.world.PersistentStateManager;
 
 @Mixin(PersistentStateManager.class)
-public class PersistentStateManagerMixin {
+class PersistentStateManagerMixin {
 	/**
 	 * Handle mods passing a null DataFixTypes to a PersistentState.Type.
 	 */

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/PersistentStateManagerMixin.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/PersistentStateManagerMixin.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.object.builder;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.PushbackInputStream;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import net.minecraft.datafixer.DataFixTypes;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.world.PersistentStateManager;
+
+@Mixin(PersistentStateManager.class)
+public class PersistentStateManagerMixin {
+	/**
+	 * Handle mods passing a null DataFixTypes to a PersistentState.Type
+	 */
+	@Inject(method = "readNbt", at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NbtHelper;getDataVersion(Lnet/minecraft/nbt/NbtCompound;I)I"), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD)
+	private void handleNullDataFixType(String id, DataFixTypes dataFixTypes, int currentSaveVersion, CallbackInfoReturnable<NbtCompound> cir, File file, FileInputStream fileInputStream, PushbackInputStream pushbackInputStream, NbtCompound nbtCompound) {
+		if (dataFixTypes == null) {
+			cir.setReturnValue(nbtCompound);
+		}
+	}
+}

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/PersistentStateManagerMixin.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/PersistentStateManagerMixin.java
@@ -33,7 +33,7 @@ import net.minecraft.world.PersistentStateManager;
 @Mixin(PersistentStateManager.class)
 public class PersistentStateManagerMixin {
 	/**
-	 * Handle mods passing a null DataFixTypes to a PersistentState.Type
+	 * Handle mods passing a null DataFixTypes to a PersistentState.Type.
 	 */
 	@Inject(method = "readNbt", at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NbtHelper;getDataVersion(Lnet/minecraft/nbt/NbtCompound;I)I"), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD)
 	private void handleNullDataFixType(String id, DataFixTypes dataFixTypes, int currentSaveVersion, CallbackInfoReturnable<NbtCompound> cir, File file, FileInputStream fileInputStream, PushbackInputStream pushbackInputStream, NbtCompound nbtCompound) {

--- a/fabric-object-builder-api-v1/src/main/resources/fabric-object-builder-v1.mixins.json
+++ b/fabric-object-builder-api-v1/src/main/resources/fabric-object-builder-v1.mixins.json
@@ -8,6 +8,7 @@
     "DefaultAttributeRegistryAccessor",
     "DefaultAttributeRegistryMixin",
     "DetectorRailBlockMixin",
+    "PersistentStateManagerMixin",
     "TradeOffersTypeAwareBuyForOneEmeraldFactoryMixin"
   ],
   "injectors": {

--- a/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/PersistentStateManagerTest.java
+++ b/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/PersistentStateManagerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.object.builder;
+
+import java.util.Objects;
+
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.world.PersistentState;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+
+public class PersistentStateManagerTest implements ModInitializer {
+	private boolean ranTests = false;
+
+	@Override
+	public void onInitialize() {
+		ServerTickEvents.END_WORLD_TICK.register(world -> {
+			if (ranTests) return;
+			ranTests = true;
+
+			TestState.getOrCreate(world).setValue("Hello!");
+			assert Objects.equals(TestState.getOrCreate(world).getValue(), "Hello!");
+		});
+	}
+
+	private static class TestState extends PersistentState {
+		/**
+		 * We are testing that null can be passed as the dataFixType.
+		 */
+		private static final PersistentState.Type<TestState> TYPE = new Type<>(TestState::new, TestState::fromTag, null);
+
+		public static TestState getOrCreate(ServerWorld world) {
+			return world.getPersistentStateManager().getOrCreate(TestState.TYPE, ObjectBuilderTestConstants.id("test_state").toString());
+		}
+
+		private String value = "";
+
+		private TestState() {
+		}
+
+		private TestState(String value) {
+			this.value = value;
+		}
+
+		public String getValue() {
+			return value;
+		}
+
+		public void setValue(String value) {
+			this.value = value;
+			markDirty();
+		}
+
+		@Override
+		public NbtCompound writeNbt(NbtCompound nbt) {
+			nbt.putString("value", value);
+			return nbt;
+		}
+
+		private static TestState fromTag(NbtCompound tag) {
+			return new TestState(tag.getString("value"));
+		}
+	}
+}

--- a/fabric-object-builder-api-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-object-builder-api-v1/src/testmod/resources/fabric.mod.json
@@ -32,7 +32,8 @@
       "net.fabricmc.fabric.test.object.builder.FabricBlockSettingsTest",
       "net.fabricmc.fabric.test.object.builder.VillagerTypeTest1",
       "net.fabricmc.fabric.test.object.builder.VillagerTypeTest2",
-      "net.fabricmc.fabric.test.object.builder.TealSignTest"
+      "net.fabricmc.fabric.test.object.builder.TealSignTest",
+      "net.fabricmc.fabric.test.object.builder.PersistentStateManagerTest"
     ],
     "client": [
       "net.fabricmc.fabric.test.object.builder.client.TealSignClientTest"


### PR DESCRIPTION
Closes #3327

The discoverbility is low, however I think most people will first try null and then realise it crashes. At the moment this is by far the easyist fix.