### PR TITLE
[1.20.2] Update Minecraft Wiki link to new domain

### DIFF
--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
@@ -163,7 +163,7 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 			// - Create a new fabric server with the ingredient API.
 			// - Copy the generated recipes to a datapack, for example to world/datapacks/<packname>/data/test/recipes/.
 			// - Remember to also include a pack.mcmeta file in world/datapacks/<packname>.
-			// (see https://minecraft.fandom.com/wiki/Tutorials/Creating_a_data_pack)
+			// (see https://minecraft.wiki/w/Tutorials/Creating_a_data_pack)
 			// - Start the server and connect to it with a vanilla client.
 			// - Test all the following recipes
 


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the wiki url accordingly.