### PR TITLE
Add LootTableEvents.LOADED event 

### DIFF
--- a/fabric-loot-api-v2/src/main/java/net/fabricmc/fabric/api/loot/v2/LootTableEvents.java
+++ b/fabric-loot-api-v2/src/main/java/net/fabricmc/fabric/api/loot/v2/LootTableEvents.java
@@ -92,9 +92,9 @@ public final class LootTableEvents {
 	/**
 	 * This event can be used for post-processing after all loot tables have been loaded and modified by fabric.
 	 */
-	public static final Event<Loaded> LOADED = EventFactory.createArrayBacked(Loaded.class, listeners -> (resourceManager, lootManager) -> {
+	public static final Event<Loaded> ALL_LOADED = EventFactory.createArrayBacked(Loaded.class, listeners -> (resourceManager, lootManager) -> {
 		for (Loaded listener : listeners) {
-			listener.onLootTableLoaded(resourceManager, lootManager);
+			listener.onLootTablesLoaded(resourceManager, lootManager);
 		}
 	});
 
@@ -133,6 +133,6 @@ public final class LootTableEvents {
 		 * @param resourceManager the server resource manager
 		 * @param lootManager     the loot manager
 		 */
-		void onLootTableLoaded(ResourceManager resourceManager, LootManager lootManager);
+		void onLootTablesLoaded(ResourceManager resourceManager, LootManager lootManager);
 	}
 }

--- a/fabric-loot-api-v2/src/main/java/net/fabricmc/fabric/api/loot/v2/LootTableEvents.java
+++ b/fabric-loot-api-v2/src/main/java/net/fabricmc/fabric/api/loot/v2/LootTableEvents.java
@@ -89,6 +89,15 @@ public final class LootTableEvents {
 		}
 	});
 
+	/**
+	 * This event can be used for post-processing after all loot tables have been loaded and modified by fabric.
+	 */
+	public static final Event<Loaded> LOADED = EventFactory.createArrayBacked(Loaded.class, listeners -> (resourceManager, lootManager) -> {
+		for (Loaded listener : listeners) {
+			listener.onLootTableLoaded(resourceManager, lootManager);
+		}
+	});
+
 	public interface Replace {
 		/**
 		 * Replaces loot tables.
@@ -115,5 +124,15 @@ public final class LootTableEvents {
 		 * @param source          the source of the loot table
 		 */
 		void modifyLootTable(ResourceManager resourceManager, LootManager lootManager, Identifier id, LootTable.Builder tableBuilder, LootTableSource source);
+	}
+
+	public interface Loaded {
+		/**
+		 * Called when all loot tables have been loaded and {@link LootTableEvents#REPLACE} and {@link LootTableEvents#MODIFY} have been invoked.
+		 *
+		 * @param resourceManager the server resource manager
+		 * @param lootManager     the loot manager
+		 */
+		void onLootTableLoaded(ResourceManager resourceManager, LootManager lootManager);
 	}
 }

--- a/fabric-loot-api-v2/src/main/java/net/fabricmc/fabric/api/loot/v2/LootTableEvents.java
+++ b/fabric-loot-api-v2/src/main/java/net/fabricmc/fabric/api/loot/v2/LootTableEvents.java
@@ -90,7 +90,7 @@ public final class LootTableEvents {
 	});
 
 	/**
-	 * This event can be used for post-processing after all loot tables have been loaded and modified by fabric.
+	 * This event can be used for post-processing after all loot tables have been loaded and modified by Fabric.
 	 */
 	public static final Event<Loaded> ALL_LOADED = EventFactory.createArrayBacked(Loaded.class, listeners -> (resourceManager, lootManager) -> {
 		for (Loaded listener : listeners) {

--- a/fabric-loot-api-v2/src/main/java/net/fabricmc/fabric/mixin/loot/LootManagerMixin.java
+++ b/fabric-loot-api-v2/src/main/java/net/fabricmc/fabric/mixin/loot/LootManagerMixin.java
@@ -95,6 +95,6 @@ abstract class LootManagerMixin {
 		});
 
 		this.keyToValue = newTables.build();
-		LootTableEvents.LOADED.invoker().onLootTableLoaded(resourceManager, lootManager);
+		LootTableEvents.ALL_LOADED.invoker().onLootTablesLoaded(resourceManager, lootManager);
 	}
 }

--- a/fabric-loot-api-v2/src/main/java/net/fabricmc/fabric/mixin/loot/LootManagerMixin.java
+++ b/fabric-loot-api-v2/src/main/java/net/fabricmc/fabric/mixin/loot/LootManagerMixin.java
@@ -95,5 +95,6 @@ abstract class LootManagerMixin {
 		});
 
 		this.keyToValue = newTables.build();
+		LootTableEvents.LOADED.invoker().onLootTableLoaded(resourceManager, lootManager);
 	}
 }

--- a/fabric-loot-api-v2/src/testmod/java/net/fabricmc/fabric/test/loot/LootTest.java
+++ b/fabric-loot-api-v2/src/testmod/java/net/fabricmc/fabric/test/loot/LootTest.java
@@ -93,7 +93,7 @@ public class LootTest implements ModInitializer {
 			}
 		});
 
-		LootTableEvents.LOADED.register((resourceManager, lootManager) -> {
+		LootTableEvents.ALL_LOADED.register((resourceManager, lootManager) -> {
 			LootTable blackWoolTable = lootManager.getLootTable(Blocks.BLACK_WOOL.getLootTableId());
 
 			if (blackWoolTable == LootTable.EMPTY) {

--- a/fabric-loot-api-v2/src/testmod/java/net/fabricmc/fabric/test/loot/LootTest.java
+++ b/fabric-loot-api-v2/src/testmod/java/net/fabricmc/fabric/test/loot/LootTest.java
@@ -92,5 +92,12 @@ public class LootTest implements ModInitializer {
 				tableBuilder.modifyPools(poolBuilder -> poolBuilder.with(ItemEntry.builder(Items.EMERALD)));
 			}
 		});
+
+		LootTableEvents.LOADED.register((resourceManager, lootManager) -> {
+			LootTable blackWoolTable = lootManager.getLootTable(Blocks.BLACK_WOOL.getLootTableId());
+			if(blackWoolTable == LootTable.EMPTY) {
+				throw new AssertionError("black wool loot table should not be empty");
+			}
+		});
 	}
 }

--- a/fabric-loot-api-v2/src/testmod/java/net/fabricmc/fabric/test/loot/LootTest.java
+++ b/fabric-loot-api-v2/src/testmod/java/net/fabricmc/fabric/test/loot/LootTest.java
@@ -95,7 +95,8 @@ public class LootTest implements ModInitializer {
 
 		LootTableEvents.LOADED.register((resourceManager, lootManager) -> {
 			LootTable blackWoolTable = lootManager.getLootTable(Blocks.BLACK_WOOL.getLootTableId());
-			if(blackWoolTable == LootTable.EMPTY) {
+
+			if (blackWoolTable == LootTable.EMPTY) {
 				throw new AssertionError("black wool loot table should not be empty");
 			}
 		});


### PR DESCRIPTION
Hey,

The current loot table mixin <https://github.com/FabricMC/fabric/blob/1.20.1/fabric-loot-api-v2/src/main/java/net/fabricmc/fabric/mixin/loot/LootManagerMixin.java#L55> updates the return value which will automatically blocks all modded mixins with the same injection but higher priority. 

So I added an event which can be used to track down when all loot tables are loaded + modified by fabric events.
My first idea was to move the mixin to `apply` again like in previous versions but the current mixin requires the `ResourceManager` which does not exist in `apply` and I wasn't sure if collecting the `ResourceManager` first, storing it in the class and passing it later on is a preferable way for fabric. 