### PR TITLE
Make some experimental APIs stable.

### DIFF
--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModification.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModification.java
@@ -30,8 +30,6 @@ import net.fabricmc.fabric.impl.biome.modification.BiomeModificationImpl;
  * Provides methods for modifying biomes. To create an instance, call
  * {@link BiomeModifications#create(Identifier)}.
  *
- * <p><b>Experimental feature</b>, may be removed or changed without further notice.
- *
  * @see BiomeModifications
  */
 public class BiomeModification {

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModificationContext.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModificationContext.java
@@ -40,8 +40,6 @@ import net.minecraft.world.gen.feature.PlacedFeature;
 
 /**
  * Allows {@link Biome} properties to be modified.
- *
- * <p><b>Experimental feature</b>, may be removed or changed without further notice.
  */
 public interface BiomeModificationContext {
 	/**

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModifications.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModifications.java
@@ -34,8 +34,6 @@ import net.minecraft.world.gen.feature.PlacedFeature;
  * Provides an API to modify Biomes after they have been loaded and before they are used in the World.
  *
  * <p>Any modifications made to biomes will not be available for use in the demo level.
- *
- * <p><b>Experimental feature</b>, may be removed or changed without further notice.
  */
 public final class BiomeModifications {
 	private BiomeModifications() {

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeSelectors.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeSelectors.java
@@ -34,8 +34,6 @@ import net.fabricmc.fabric.impl.biome.modification.BuiltInRegistryKeys;
 
 /**
  * Provides several convenient biome selectors that can be used with {@link BiomeModifications}.
- *
- * <p><b>Experimental feature</b>, may be removed or changed without further notice.
  */
 public final class BiomeSelectors {
 	private BiomeSelectors() {

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/ModificationPhase.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/ModificationPhase.java
@@ -27,8 +27,6 @@ package net.fabricmc.fabric.api.biome.v1;
  *     <li>Replacements (removal + add) in biomes</li>
  *     <li>Generic post-processing of biomes</li>
  * </ol>
- *
- * <p><b>Experimental feature</b>, may be removed or changed without further notice.
  */
 public enum ModificationPhase {
 	/**

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/NetherBiomes.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/NetherBiomes.java
@@ -24,8 +24,6 @@ import net.fabricmc.fabric.impl.biome.NetherBiomeData;
 
 /**
  * API that exposes the internals of Minecraft's nether biome code.
- *
- * <p><b>Experimental feature</b>, may be removed or changed without further notice.
  */
 public final class NetherBiomes {
 	private NetherBiomes() {

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/TheEndBiomes.java
@@ -25,9 +25,6 @@ import net.fabricmc.fabric.impl.biome.TheEndBiomeData;
 /**
  * API that exposes some internals of the minecraft default biome source for The End.
  *
- * <p><b>Experimental feature</b>, may be removed or changed without further notice.
- * Because of the volatility of world generation in Minecraft 1.16, this API is marked experimental
- * since it is likely to change in future Minecraft versions.
  */
 public final class TheEndBiomes {
 	private TheEndBiomes() {

--- a/fabric-biome-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-biome-api-v1/src/main/resources/fabric.mod.json
@@ -25,6 +25,6 @@
   ],
   "accessWidener" : "fabric-biome-api-v1.accesswidener",
   "custom": {
-    "fabric-api:module-lifecycle": "experimental"
+    "fabric-api:module-lifecycle": "stable"
   }
 }

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricDynamicRegistryProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricDynamicRegistryProvider.java
@@ -58,7 +58,6 @@ import net.fabricmc.fabric.impl.registry.sync.DynamicRegistriesImpl;
  * A provider to help with data-generation of dynamic registry objects,
  * such as biomes, features, or message types.
  */
-@ApiStatus.Experimental
 public abstract class FabricDynamicRegistryProvider implements DataProvider {
 	private static final Logger LOGGER = LoggerFactory.getLogger(FabricDynamicRegistryProvider.class);
 

--- a/fabric-item-group-api-v1/src/main/java/net/fabricmc/fabric/api/itemgroup/v1/FabricItemGroupEntries.java
+++ b/fabric-item-group-api-v1/src/main/java/net/fabricmc/fabric/api/itemgroup/v1/FabricItemGroupEntries.java
@@ -32,7 +32,6 @@ import net.minecraft.resource.featuretoggle.FeatureSet;
 /**
  * This class allows the entries of {@linkplain ItemGroup item groups} to be modified by the events in {@link ItemGroupEvents}.
  */
-@ApiStatus.Experimental
 public class FabricItemGroupEntries implements ItemGroup.Entries {
 	private final ItemGroup.DisplayContext context;
 	private final List<ItemStack> displayStacks;

--- a/fabric-message-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-message-api-v1/src/main/resources/fabric.mod.json
@@ -28,6 +28,6 @@
     }
   ],
   "custom": {
-    "fabric-api:module-lifecycle": "experimental"
+    "fabric-api:module-lifecycle": "stable"
   }
 }

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientConfigurationConnectionEvents.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientConfigurationConnectionEvents.java
@@ -16,8 +16,6 @@
 
 package net.fabricmc.fabric.api.client.networking.v1;
 
-import org.jetbrains.annotations.ApiStatus;
-
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientConfigurationNetworkHandler;
 import net.minecraft.util.Identifier;

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientConfigurationConnectionEvents.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientConfigurationConnectionEvents.java
@@ -28,7 +28,6 @@ import net.fabricmc.fabric.api.event.EventFactory;
 /**
  * Offers access to events related to the configuration connection to a server on a logical client.
  */
-@ApiStatus.Experimental
 public final class ClientConfigurationConnectionEvents {
 	/**
 	 * Event indicating a connection entering the CONFIGURATION state, ready for registering channel handlers.

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientConfigurationNetworking.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientConfigurationNetworking.java
@@ -19,7 +19,6 @@ package net.fabricmc.fabric.api.client.networking.v1;
 import java.util.Objects;
 import java.util.Set;
 
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.client.MinecraftClient;

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientConfigurationNetworking.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientConfigurationNetworking.java
@@ -51,7 +51,6 @@ import net.fabricmc.fabric.mixin.networking.client.accessor.ClientCommonNetworkH
  *
  * @see ServerConfigurationNetworking
  */
-@ApiStatus.Experimental
 public final class ClientConfigurationNetworking {
 	/**
 	 * Registers a handler to a channel.

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/ServerConfigurationConnectionEvents.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/ServerConfigurationConnectionEvents.java
@@ -16,8 +16,6 @@
 
 package net.fabricmc.fabric.api.networking.v1;
 
-import org.jetbrains.annotations.ApiStatus;
-
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerConfigurationNetworkHandler;
 

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/ServerConfigurationConnectionEvents.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/ServerConfigurationConnectionEvents.java
@@ -27,7 +27,6 @@ import net.fabricmc.fabric.api.event.EventFactory;
 /**
  * Offers access to events related to the connection to a client on a logical server while a client is configuring.
  */
-@ApiStatus.Experimental
 public final class ServerConfigurationConnectionEvents {
 	/**
 	 * Event fired before any vanilla configuration has taken place.

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/ServerConfigurationNetworking.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/ServerConfigurationNetworking.java
@@ -19,7 +19,6 @@ package net.fabricmc.fabric.api.networking.v1;
 import java.util.Objects;
 import java.util.Set;
 
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.network.PacketByteBuf;

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/ServerConfigurationNetworking.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/ServerConfigurationNetworking.java
@@ -48,7 +48,6 @@ import net.fabricmc.fabric.mixin.networking.accessor.ServerCommonNetworkHandlerA
  * @see ServerLoginNetworking
  * @see ServerConfigurationNetworking
  */
-@ApiStatus.Experimental
 public final class ServerConfigurationNetworking {
 	/**
 	 * Registers a handler to a channel.

--- a/fabric-resource-conditions-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-resource-conditions-api-v1/src/main/resources/fabric.mod.json
@@ -23,6 +23,6 @@
     "fabric-resource-conditions-api-v1.mixins.json"
   ],
   "custom": {
-    "fabric-api:module-lifecycle": "experimental"
+    "fabric-api:module-lifecycle": "stable"
   }
 }


### PR DESCRIPTION
The following APIs have been made stable:

- Biome API, suggestions such as #3316 can be made without breaking the existing API.
- FabricDynamicRegistryProvider, well tested and widely used.
- FabricItemGroupEntries, well tested and widely used.
- Message API
- Configuration networking APIs
- Resource conditions

Transfer API is still expertimental as there are some APIs that will be removed during the next snapshot cycle.