### PR TITLE
Add Client After Block Break Event

### DIFF
--- a/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/api/event/client/player/ClientPlayerBlockBreakEvents.java
+++ b/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/api/event/client/player/ClientPlayerBlockBreakEvents.java
@@ -17,9 +17,9 @@
 package net.fabricmc.fabric.api.event.client.player;
 
 import net.minecraft.block.BlockState;
-import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
 
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
@@ -28,6 +28,7 @@ import net.fabricmc.fabric.api.event.EventFactory;
  * Contains client side events triggered by block breaking.
  *
  * <p>For preventing block breaking client side and other purposes, see {@link net.fabricmc.fabric.api.event.player.AttackBlockCallback}.
+ * For server side block break events, see {@link net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents}.
  */
 public class ClientPlayerBlockBreakEvents {
 	/**
@@ -53,6 +54,6 @@ public class ClientPlayerBlockBreakEvents {
 		 * @param pos    the position where the block was broken
 		 * @param state  the block state <strong>before</strong> the block was broken
 		 */
-		void afterBlockBreak(World world, PlayerEntity player, BlockPos pos, BlockState state);
+		void afterBlockBreak(ClientWorld world, ClientPlayerEntity player, BlockPos pos, BlockState state);
 	}
 }

--- a/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/api/event/client/player/ClientPlayerBlockBreakEvents.java
+++ b/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/api/event/client/player/ClientPlayerBlockBreakEvents.java
@@ -16,10 +16,7 @@
 
 package net.fabricmc.fabric.api.event.client.player;
 
-import org.jetbrains.annotations.Nullable;
-
 import net.minecraft.block.BlockState;
-import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -39,9 +36,9 @@ public class ClientPlayerBlockBreakEvents {
 	 * <p>Only called client side.
 	 */
 	public static final Event<After> AFTER = EventFactory.createArrayBacked(After.class,
-			(listeners) -> (world, player, pos, state, entity) -> {
+			(listeners) -> (world, player, pos, state) -> {
 				for (After event : listeners) {
-					event.afterBlockBreak(world, player, pos, state, entity);
+					event.afterBlockBreak(world, player, pos, state);
 				}
 			}
 	);
@@ -51,12 +48,11 @@ public class ClientPlayerBlockBreakEvents {
 		/**
 		 * Called after a block is successfully broken.
 		 *
-		 * @param world the world where the block was broken
+		 * @param world  the world where the block was broken
 		 * @param player the player who broke the block
-		 * @param pos the position where the block was broken
-		 * @param state the block state <strong>before</strong> the block was broken
-		 * @param blockEntity the block entity of the broken block, can be {@code null}
+		 * @param pos    the position where the block was broken
+		 * @param state  the block state <strong>before</strong> the block was broken
 		 */
-		void afterBlockBreak(World world, PlayerEntity player, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity);
+		void afterBlockBreak(World world, PlayerEntity player, BlockPos pos, BlockState state);
 	}
 }

--- a/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/api/event/client/player/ClientPlayerBlockBreakEvents.java
+++ b/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/api/event/client/player/ClientPlayerBlockBreakEvents.java
@@ -1,0 +1,46 @@
+package net.fabricmc.fabric.api.event.client.player;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+/**
+ * Contains client side events triggered by block breaking.
+ *
+ * <p>For preventing block breaking client side and other purposes, see {@link net.fabricmc.fabric.api.event.player.AttackBlockCallback}.
+ */
+public class ClientPlayerBlockBreakEvents {
+	/**
+	 * Callback after a block is broken.
+	 *
+	 * <p>Only called client side.
+	 */
+	public static final Event<After> AFTER = EventFactory.createArrayBacked(After.class,
+			(listeners) -> (world, player, pos, state, entity) -> {
+				for (After event : listeners) {
+					event.afterBlockBreak(world, player, pos, state, entity);
+				}
+			}
+	);
+
+	@FunctionalInterface
+	public interface After {
+		/**
+		 * Called after a block is successfully broken.
+		 *
+		 * @param world the world where the block was broken
+		 * @param player the player who broke the block
+		 * @param pos the position where the block was broken
+		 * @param state the block state <strong>before</strong> the block was broken
+		 * @param blockEntity the block entity of the broken block, can be {@code null}
+		 */
+		void afterBlockBreak(World world, PlayerEntity player, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity);
+	}
+}

--- a/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/api/event/client/player/ClientPlayerBlockBreakEvents.java
+++ b/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/api/event/client/player/ClientPlayerBlockBreakEvents.java
@@ -32,9 +32,9 @@ import net.fabricmc.fabric.api.event.EventFactory;
  */
 public class ClientPlayerBlockBreakEvents {
 	/**
-	 * Callback after a block is broken.
+	 * Callback after a block is broken client side.
 	 *
-	 * <p>Only called client side.
+	 * <p>Only called client side. For server side see {@link net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents#AFTER}
 	 */
 	public static final Event<After> AFTER = EventFactory.createArrayBacked(After.class,
 			(listeners) -> (world, player, pos, state) -> {

--- a/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/api/event/client/player/ClientPlayerBlockBreakEvents.java
+++ b/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/api/event/client/player/ClientPlayerBlockBreakEvents.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.api.event.client.player;
 
 import org.jetbrains.annotations.Nullable;

--- a/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/mixin/event/interaction/client/ClientPlayerInteractionManagerMixin.java
+++ b/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/mixin/event/interaction/client/ClientPlayerInteractionManagerMixin.java
@@ -50,9 +50,9 @@ import net.minecraft.util.math.Direction;
 import net.minecraft.world.GameMode;
 import net.minecraft.world.World;
 
+import net.fabricmc.fabric.api.event.client.player.ClientPlayerBlockBreakEvents;
 import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
 import net.fabricmc.fabric.api.event.player.AttackEntityCallback;
-import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
 import net.fabricmc.fabric.api.event.player.UseBlockCallback;
 import net.fabricmc.fabric.api.event.player.UseItemCallback;
 
@@ -96,7 +96,7 @@ public abstract class ClientPlayerInteractionManagerMixin {
 
 	@Inject(method = "breakBlock", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/Block;onBroken(Lnet/minecraft/world/WorldAccess;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;)V"), locals = LocalCapture.CAPTURE_FAILHARD)
 	private void fabric$onBlockBroken(BlockPos pos, CallbackInfoReturnable<Boolean> cir, World world, BlockState blockState) {
-		PlayerBlockBreakEvents.AFTER.invoker().afterBlockBreak(world, this.client.player, pos, blockState, world.getBlockEntity(pos));
+		ClientPlayerBlockBreakEvents.AFTER.invoker().afterBlockBreak(world, this.client.player, pos, blockState, world.getBlockEntity(pos));
 	}
 
 	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;sendSequencedPacket(Lnet/minecraft/client/world/ClientWorld;Lnet/minecraft/client/network/SequencedPacketCreator;)V"), method = "interactBlock", cancellable = true)

--- a/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/mixin/event/interaction/client/ClientPlayerInteractionManagerMixin.java
+++ b/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/mixin/event/interaction/client/ClientPlayerInteractionManagerMixin.java
@@ -96,7 +96,7 @@ public abstract class ClientPlayerInteractionManagerMixin {
 
 	@Inject(method = "breakBlock", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/Block;onBroken(Lnet/minecraft/world/WorldAccess;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;)V"), locals = LocalCapture.CAPTURE_FAILHARD)
 	private void fabric$onBlockBroken(BlockPos pos, CallbackInfoReturnable<Boolean> cir, World world, BlockState blockState) {
-		ClientPlayerBlockBreakEvents.AFTER.invoker().afterBlockBreak(world, this.client.player, pos, blockState);
+		ClientPlayerBlockBreakEvents.AFTER.invoker().afterBlockBreak(client.world, client.player, pos, blockState);
 	}
 
 	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;sendSequencedPacket(Lnet/minecraft/client/world/ClientWorld;Lnet/minecraft/client/network/SequencedPacketCreator;)V"), method = "interactBlock", cancellable = true)

--- a/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/mixin/event/interaction/client/ClientPlayerInteractionManagerMixin.java
+++ b/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/mixin/event/interaction/client/ClientPlayerInteractionManagerMixin.java
@@ -96,7 +96,7 @@ public abstract class ClientPlayerInteractionManagerMixin {
 
 	@Inject(method = "breakBlock", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/Block;onBroken(Lnet/minecraft/world/WorldAccess;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;)V"), locals = LocalCapture.CAPTURE_FAILHARD)
 	private void fabric$onBlockBroken(BlockPos pos, CallbackInfoReturnable<Boolean> cir, World world, BlockState blockState) {
-		ClientPlayerBlockBreakEvents.AFTER.invoker().afterBlockBreak(world, this.client.player, pos, blockState, world.getBlockEntity(pos));
+		ClientPlayerBlockBreakEvents.AFTER.invoker().afterBlockBreak(world, this.client.player, pos, blockState);
 	}
 
 	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;sendSequencedPacket(Lnet/minecraft/client/world/ClientWorld;Lnet/minecraft/client/network/SequencedPacketCreator;)V"), method = "interactBlock", cancellable = true)

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/PlayerBlockBreakEvents.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/PlayerBlockBreakEvents.java
@@ -29,8 +29,8 @@ import net.fabricmc.fabric.api.event.EventFactory;
 
 /**
  * Contains events triggered by block breaking.
- * <p>
- * {@link #BEFORE} and {@link #CANCELED} are only called on the server while
+ *
+ * <p>{@link #BEFORE} and {@link #CANCELED} are only called on the server while
  * {@link #AFTER} is called on both the server and the client.
  */
 public final class PlayerBlockBreakEvents {

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/PlayerBlockBreakEvents.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/PlayerBlockBreakEvents.java
@@ -27,6 +27,12 @@ import net.minecraft.world.World;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
+/**
+ * Contains events triggered by block breaking.
+ * <p>
+ * {@link #BEFORE} and {@link #CANCELED} are only called on the server while
+ * {@link #AFTER} is called on both the server and the client.
+ */
 public final class PlayerBlockBreakEvents {
 	private PlayerBlockBreakEvents() { }
 
@@ -55,7 +61,7 @@ public final class PlayerBlockBreakEvents {
 	/**
 	 * Callback after a block is broken.
 	 *
-	 * <p>Only called on a logical server.
+	 * <p>Called on both server and client side.
 	 */
 	public static final Event<After> AFTER = EventFactory.createArrayBacked(After.class,
 			(listeners) -> (world, player, pos, state, entity) -> {

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/PlayerBlockBreakEvents.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/PlayerBlockBreakEvents.java
@@ -32,6 +32,7 @@ import net.fabricmc.fabric.api.event.EventFactory;
  *
  * <p>{@link #BEFORE} and {@link #CANCELED} are only called on the server while
  * {@link #AFTER} is called on both the server and the client.
+ * For preventing block breaking client side and other purposes, see {@link AttackBlockCallback}.
  */
 public final class PlayerBlockBreakEvents {
 	private PlayerBlockBreakEvents() { }

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/PlayerBlockBreakEvents.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/PlayerBlockBreakEvents.java
@@ -56,10 +56,11 @@ public final class PlayerBlockBreakEvents {
 	);
 
 	/**
-	 * Callback after a block is broken.
+	 * Callback after a block is broken server side.
 	 *
-	 * <p>Only called on a logical server.
+	 * <p>Only called on a logical server. For client side see {@link net.fabricmc.fabric.api.event.client.player.ClientPlayerBlockBreakEvents#AFTER}
 	 */
+	@SuppressWarnings("JavadocReference")
 	public static final Event<After> AFTER = EventFactory.createArrayBacked(After.class,
 			(listeners) -> (world, player, pos, state, entity) -> {
 				for (After event : listeners) {

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/PlayerBlockBreakEvents.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/PlayerBlockBreakEvents.java
@@ -28,11 +28,7 @@ import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
 /**
- * Contains events triggered by block breaking.
- *
- * <p>{@link #BEFORE} and {@link #CANCELED} are only called on the server while
- * {@link #AFTER} is called on both the server and the client.
- * For preventing block breaking client side and other purposes, see {@link AttackBlockCallback}.
+ * Contains server side events triggered by block breaking.
  */
 public final class PlayerBlockBreakEvents {
 	private PlayerBlockBreakEvents() { }
@@ -62,7 +58,7 @@ public final class PlayerBlockBreakEvents {
 	/**
 	 * Callback after a block is broken.
 	 *
-	 * <p>Called on both server and client side.
+	 * <p>Only called on a logical server.
 	 */
 	public static final Event<After> AFTER = EventFactory.createArrayBacked(After.class,
 			(listeners) -> (world, player, pos, state, entity) -> {

--- a/fabric-events-interaction-v0/src/testmod/java/net/fabricmc/fabric/test/event/interaction/PlayerBreakBlockTests.java
+++ b/fabric-events-interaction-v0/src/testmod/java/net/fabricmc/fabric/test/event/interaction/PlayerBreakBlockTests.java
@@ -29,16 +29,10 @@ public class PlayerBreakBlockTests implements ModInitializer {
 
 	@Override
 	public void onInitialize() {
-		PlayerBlockBreakEvents.BEFORE.register(((world, player, pos, state, entity) -> {
-			return state.getBlock() != Blocks.BEDROCK;
-		}));
+		PlayerBlockBreakEvents.BEFORE.register(((world, player, pos, state, entity) -> state.getBlock() != Blocks.BEDROCK));
 
-		PlayerBlockBreakEvents.CANCELED.register(((world, player, pos, state, entity) -> {
-			LOGGER.info("Block break event canceled at " + pos.getX() + ", " + pos.getY() + ", " + pos.getZ());
-		}));
+		PlayerBlockBreakEvents.CANCELED.register(((world, player, pos, state, entity) -> LOGGER.info("Block break event canceled at {}, {}, {} (client-side = {})", pos.getX(), pos.getY(), pos.getZ(), world.isClient())));
 
-		PlayerBlockBreakEvents.AFTER.register(((world, player, pos, state, entity) -> {
-			LOGGER.info("Block broken at " + pos.getX() + ", " + pos.getY() + ", " + pos.getZ());
-		}));
+		PlayerBlockBreakEvents.AFTER.register(((world, player, pos, state, entity) -> LOGGER.info("Block broken at {}, {}, {} (client-side = {})", pos.getX(), pos.getY(), pos.getZ(), world.isClient())));
 	}
 }

--- a/fabric-events-interaction-v0/src/testmod/resources/fabric.mod.json
+++ b/fabric-events-interaction-v0/src/testmod/resources/fabric.mod.json
@@ -19,6 +19,7 @@
     ],
     "client": [
       "net.fabricmc.fabric.test.client.event.interaction.ClientPreAttackTests",
+      "net.fabricmc.fabric.test.client.event.interaction.ClientPlayerBlockBreakTests",
       "net.fabricmc.fabric.test.client.event.interaction.PlayerPickBlockTests"
     ]
   }

--- a/fabric-events-interaction-v0/src/testmodClient/java/net/fabricmc/fabric/test/client/event/interaction/ClientPlayerBlockBreakTests.java
+++ b/fabric-events-interaction-v0/src/testmodClient/java/net/fabricmc/fabric/test/client/event/interaction/ClientPlayerBlockBreakTests.java
@@ -27,6 +27,6 @@ public class ClientPlayerBlockBreakTests implements ClientModInitializer {
 
 	@Override
 	public void onInitializeClient() {
-		ClientPlayerBlockBreakEvents.AFTER.register(((world, player, pos, state, entity) -> LOGGER.info("Block broken at {}, {}, {} (client-side = {})", pos.getX(), pos.getY(), pos.getZ(), world.isClient())));
+		ClientPlayerBlockBreakEvents.AFTER.register(((world, player, pos, state) -> LOGGER.info("Block broken at {}, {}, {} (client-side = {})", pos.getX(), pos.getY(), pos.getZ(), world.isClient())));
 	}
 }

--- a/fabric-events-interaction-v0/src/testmodClient/java/net/fabricmc/fabric/test/client/event/interaction/ClientPlayerBlockBreakTests.java
+++ b/fabric-events-interaction-v0/src/testmodClient/java/net/fabricmc/fabric/test/client/event/interaction/ClientPlayerBlockBreakTests.java
@@ -1,0 +1,16 @@
+package net.fabricmc.fabric.test.client.event.interaction;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.event.client.player.ClientPlayerBlockBreakEvents;
+
+public class ClientPlayerBlockBreakTests implements ClientModInitializer {
+	public static final Logger LOGGER = LoggerFactory.getLogger(ClientPlayerBlockBreakTests.class);
+
+	@Override
+	public void onInitializeClient() {
+		ClientPlayerBlockBreakEvents.AFTER.register(((world, player, pos, state, entity) -> LOGGER.info("Block broken at {}, {}, {} (client-side = {})", pos.getX(), pos.getY(), pos.getZ(), world.isClient())));
+	}
+}

--- a/fabric-events-interaction-v0/src/testmodClient/java/net/fabricmc/fabric/test/client/event/interaction/ClientPlayerBlockBreakTests.java
+++ b/fabric-events-interaction-v0/src/testmodClient/java/net/fabricmc/fabric/test/client/event/interaction/ClientPlayerBlockBreakTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.test.client.event.interaction;
 
 import org.slf4j.Logger;


### PR DESCRIPTION
Add `ClientPlayerBlockBreakEvents.AFTER` client side.  

This does not add to the current `PlayerBlockBreakEvents` since it could be a breaking change.  
This does not add client-side `ClientPlayerBlockBreakEvents.BEFORE` and `ClientPlayerBlockBreakEvents.CANCELED` since the use case is covered by `AttackBlockCallback`.  