### PR TITLE
Fix inconsistency of placed feature locations

### DIFF
--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/BiomeSourceMixin.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/BiomeSourceMixin.java
@@ -17,7 +17,7 @@
 package net.fabricmc.fabric.mixin.biome;
 
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -33,7 +33,7 @@ import net.minecraft.world.biome.source.BiomeSource;
 public class BiomeSourceMixin {
 	@Redirect(method = "getBiomes", at = @At(value = "INVOKE", target = "Ljava/util/function/Supplier;get()Ljava/lang/Object;"))
 	private Object getBiomes(Supplier<Set<RegistryEntry<Biome>>> instance) {
-		var biomes = new HashSet<>(instance.get());
+		var biomes = new LinkedHashSet<>(instance.get());
 		fabric_modifyBiomeSet(biomes);
 		return Collections.unmodifiableSet(biomes);
 	}

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/BiomeSourceMixin.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/BiomeSourceMixin.java
@@ -16,8 +16,6 @@
 
 package net.fabricmc.fabric.mixin.biome;
 
-import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -33,11 +31,10 @@ import net.minecraft.world.biome.source.BiomeSource;
 public class BiomeSourceMixin {
 	@Redirect(method = "getBiomes", at = @At(value = "INVOKE", target = "Ljava/util/function/Supplier;get()Ljava/lang/Object;"))
 	private Object getBiomes(Supplier<Set<RegistryEntry<Biome>>> instance) {
-		var biomes = new LinkedHashSet<>(instance.get());
-		fabric_modifyBiomeSet(biomes);
-		return Collections.unmodifiableSet(biomes);
+		return fabric_modifyBiomeSet(instance.get());
 	}
 
-	protected void fabric_modifyBiomeSet(Set<RegistryEntry<Biome>> biomes) {
+	protected Set<RegistryEntry<Biome>> fabric_modifyBiomeSet(Set<RegistryEntry<Biome>> biomes) {
+		return biomes;
 	}
 }

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/TheEndBiomeSourceMixin.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/TheEndBiomeSourceMixin.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.mixin.biome;
 
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -108,14 +110,18 @@ public class TheEndBiomeSourceMixin extends BiomeSourceMixin {
 	}
 
 	@Override
-	protected void fabric_modifyBiomeSet(Set<RegistryEntry<Biome>> biomes) {
+	protected Set<RegistryEntry<Biome>> fabric_modifyBiomeSet(Set<RegistryEntry<Biome>> biomes) {
 		if (!hasCheckedForModifiedSet) {
 			hasCheckedForModifiedSet = true;
 			biomeSetModified = !overrides.get().customBiomes.isEmpty();
 		}
 
 		if (biomeSetModified) {
-			biomes.addAll(overrides.get().customBiomes);
+			var modifiedBiomes = new LinkedHashSet<>(biomes);
+			modifiedBiomes.addAll(overrides.get().customBiomes);
+			return Collections.unmodifiableSet(modifiedBiomes);
 		}
+
+		return biomes;
 	}
 }


### PR DESCRIPTION
`BiomeSource#getBiomes` mixin applies to all biome sources, including one for Overworld. The return value is a set; however one caller in the worldgen code iterates over it: `PlacedFeatureIndexer`. Using a hash set here randomizes the return value, affecting feature placement. Use a linked hash set instead.

Requesting backport for all supported versions.

Fixes #3366