### PR TITLE
Fix FabricBlockSettings copyOf missing settings

### DIFF
--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricBlockSettings.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricBlockSettings.java
@@ -69,10 +69,18 @@ public class FabricBlockSettings extends AbstractBlock.Settings {
 		thisAccessor.setDynamicBounds(otherAccessor.getDynamicBounds());
 		thisAccessor.setOpaque(otherAccessor.getOpaque());
 		thisAccessor.setIsAir(otherAccessor.getIsAir());
+		thisAccessor.setBurnable(otherAccessor.getBurnable());
+		thisAccessor.setLiquid(otherAccessor.getLiquid());
+		thisAccessor.setForceNotSolid(otherAccessor.getForceNotSolid());
+		thisAccessor.setForceSolid(otherAccessor.getForceSolid());
+		this.pistonBehavior(otherAccessor.getPistonBehavior());
 		thisAccessor.setToolRequired(otherAccessor.isToolRequired());
 		thisAccessor.setOffsetter(otherAccessor.getOffsetter());
 		thisAccessor.setBlockBreakParticles(otherAccessor.getBlockBreakParticles());
 		thisAccessor.setRequiredFeatures(otherAccessor.getRequiredFeatures());
+		this.emissiveLighting(otherAccessor.getEmissiveLightingPredicate());
+		this.instrument(otherAccessor.getInstrument());
+		thisAccessor.setReplaceable(otherAccessor.getReplaceable());
 
 		// Not copied in vanilla: field definition order
 		this.jumpVelocityMultiplier(otherAccessor.getJumpVelocityMultiplier());
@@ -82,7 +90,6 @@ public class FabricBlockSettings extends AbstractBlock.Settings {
 		this.suffocates(otherAccessor.getSuffocationPredicate());
 		this.blockVision(otherAccessor.getBlockVisionPredicate());
 		this.postProcess(otherAccessor.getPostProcessPredicate());
-		this.emissiveLighting(otherAccessor.getEmissiveLightingPredicate());
 	}
 
 	public static FabricBlockSettings create() {

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/AbstractBlockSettingsAccessor.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/AbstractBlockSettingsAccessor.java
@@ -26,6 +26,8 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.MapColor;
+import net.minecraft.block.enums.Instrument;
+import net.minecraft.block.piston.PistonBehavior;
 import net.minecraft.entity.EntityType;
 import net.minecraft.resource.featuretoggle.FeatureSet;
 import net.minecraft.sound.BlockSoundGroup;
@@ -106,6 +108,27 @@ public interface AbstractBlockSettingsAccessor {
 	@Accessor
 	FeatureSet getRequiredFeatures();
 
+	@Accessor
+	boolean getBurnable();
+
+	@Accessor
+	boolean getLiquid();
+
+	@Accessor
+	boolean getForceNotSolid();
+
+	@Accessor
+	boolean getForceSolid();
+
+	@Accessor
+	PistonBehavior getPistonBehavior();
+
+	@Accessor
+	Instrument getInstrument();
+
+	@Accessor
+	boolean getReplaceable();
+
 	/* SETTERS */
 	@Accessor
 	void setCollidable(boolean collidable);
@@ -139,4 +162,19 @@ public interface AbstractBlockSettingsAccessor {
 
 	@Accessor
 	void setOffsetter(Optional<AbstractBlock.Offsetter> offsetter);
+
+	@Accessor
+	void setBurnable(boolean burnable);
+
+	@Accessor
+	void setLiquid(boolean liquid);
+
+	@Accessor
+	void setForceNotSolid(boolean forceNotSolid);
+
+	@Accessor
+	void setForceSolid(boolean forceSolid);
+
+	@Accessor
+	void setReplaceable(boolean replaceable);
 }


### PR DESCRIPTION
Fixes FabricBlockSettings' copyOf method missing several new settings introduced as a result of the removal of Materials.

Specifically `burnable`, `liquid`, `forceNotSolid`, `forceSolid`, `pistonBehavior`, `instrument`, and `replaceable`. These are all copied by the vanilla `BlockSettings.copy` as well.
The `emissiveLightingPredicate` is also now copied in vanilla, so I moved the copy of that to reflect that change.

This should probably also be backported to 1.20.1, and frontported to 1.20.3 (at least for now, until it gets fully json'd away)