### PR TITLE
Fix custom ingredient serialization with allowEmpty

### DIFF
--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/CustomIngredientImpl.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/CustomIngredientImpl.java
@@ -23,10 +23,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
-import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
-import com.mojang.serialization.DynamicOps;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.item.ItemStack;
@@ -133,34 +131,5 @@ public class CustomIngredientImpl extends Ingredient {
 
 	private <T> T coerceIngredient() {
 		return (T) customIngredient;
-	}
-
-	public static <T> Codec<T> first(Codec<T> first, Codec<T> second) {
-		return new First<>(first, second);
-	}
-
-	// Decode/encode the first codec, if that fails return the result of the second.
-	record First<T>(Codec<T> first, Codec<T> second) implements Codec<T> {
-		@Override
-		public <T1> DataResult<Pair<T, T1>> decode(DynamicOps<T1> ops, T1 input) {
-			DataResult<Pair<T, T1>> firstResult = first.decode(ops, input);
-
-			if (firstResult.result().isPresent()) {
-				return firstResult;
-			}
-
-			return second.decode(ops, input);
-		}
-
-		@Override
-		public <T1> DataResult<T1> encode(T input, DynamicOps<T1> ops, T1 prefix) {
-			DataResult<T1> firstResult = first.encode(input, ops, prefix);
-
-			if (firstResult.result().isPresent()) {
-				return firstResult;
-			}
-
-			return second.encode(input, ops, prefix);
-		}
 	}
 }

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/CustomIngredientImpl.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/CustomIngredientImpl.java
@@ -56,9 +56,6 @@ public class CustomIngredientImpl extends Ingredient {
 			serializer -> DataResult.success(serializer.getIdentifier())
 	);
 
-	public static final Codec<CustomIngredient> ALLOW_EMPTY_INGREDIENT_CODECS = CODEC.dispatch(TYPE_KEY, CustomIngredient::getSerializer, serializer -> serializer.getCodec(true));
-	public static final Codec<CustomIngredient> DISALLOW_EMPTY_INGREDIENT_CODECS = CODEC.dispatch(TYPE_KEY, CustomIngredient::getSerializer, serializer -> serializer.getCodec(false));
-
 	public static void registerSerializer(CustomIngredientSerializer<?> serializer) {
 		Objects.requireNonNull(serializer.getIdentifier(), "CustomIngredientSerializer identifier may not be null.");
 

--- a/fabric-recipe-api-v1/src/testmod/java/net/fabricmc/fabric/test/recipe/ingredient/SerializationTests.java
+++ b/fabric-recipe-api-v1/src/testmod/java/net/fabricmc/fabric/test/recipe/ingredient/SerializationTests.java
@@ -21,6 +21,7 @@ import java.util.List;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
+import com.mojang.serialization.Codec;
 import com.mojang.serialization.JsonOps;
 
 import net.minecraft.item.Items;
@@ -31,7 +32,7 @@ import net.minecraft.test.TestContext;
 import net.minecraft.util.Util;
 
 import net.fabricmc.fabric.api.gametest.v1.FabricGameTest;
-import net.fabricmc.fabric.impl.recipe.ingredient.builtin.AllIngredient;
+import net.fabricmc.fabric.api.recipe.v1.ingredient.DefaultCustomIngredients;
 
 public class SerializationTests {
 	/**
@@ -64,19 +65,28 @@ public class SerializationTests {
 	}
 
 	/**
-	 * Check that we can serialise a custom ingredient.
+	 * Check that we can serialise and deserialize a custom ingredient.
 	 */
 	@GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)
 	public void testCustomIngredientSerialization(TestContext context) {
-		String ingredientJson = """
-				{"ingredients":[{"item":"minecraft:stone"}],"fabric:type":"fabric:all"}
-				""".trim();
+		for (boolean allowEmpty : List.of(false, true)) {
+			String ingredientJson = """
+					{"ingredients":[{"item":"minecraft:stone"}],"fabric:type":"fabric:all"}
+					""".trim();
 
-		var ingredient = new AllIngredient(List.of(
-				Ingredient.ofItems(Items.STONE)
-		));
-		String json = ingredient.toVanilla().toJson(false).toString();
-		context.assertTrue(json.equals(ingredientJson), "Unexpected json: " + json);
+			var ingredient = DefaultCustomIngredients.all(
+					Ingredient.ofItems(Items.STONE)
+			);
+			JsonElement json = ingredient.toJson(allowEmpty);
+			context.assertTrue(json.toString().equals(ingredientJson), "Unexpected json: " + json);
+			// Make sure that we can deserialize it
+			Codec<Ingredient> ingredientCodec = allowEmpty ? Ingredient.ALLOW_EMPTY_CODEC : Ingredient.DISALLOW_EMPTY_CODEC;
+			Ingredient deserialized = Util.getResult(
+					ingredientCodec.parse(JsonOps.INSTANCE, json), JsonParseException::new
+			);
+			context.assertTrue(deserialized.getCustomIngredient() != null, "Custom ingredient was not deserialized");
+			context.assertTrue(deserialized.getCustomIngredient().getSerializer() == ingredient.getCustomIngredient().getSerializer(), "Serializer did not match");
+		}
 		context.complete();
 	}
 }

--- a/fabric-recipe-api-v1/src/testmod/java/net/fabricmc/fabric/test/recipe/ingredient/SerializationTests.java
+++ b/fabric-recipe-api-v1/src/testmod/java/net/fabricmc/fabric/test/recipe/ingredient/SerializationTests.java
@@ -74,7 +74,7 @@ public class SerializationTests {
 					{"ingredients":[{"item":"minecraft:stone"}],"fabric:type":"fabric:all"}
 					""".trim();
 
-			var ingredient = DefaultCustomIngredients.all(
+			Ingredient ingredient = DefaultCustomIngredients.all(
 					Ingredient.ofItems(Items.STONE)
 			);
 			JsonElement json = ingredient.toJson(allowEmpty);
@@ -87,6 +87,7 @@ public class SerializationTests {
 			context.assertTrue(deserialized.getCustomIngredient() != null, "Custom ingredient was not deserialized");
 			context.assertTrue(deserialized.getCustomIngredient().getSerializer() == ingredient.getCustomIngredient().getSerializer(), "Serializer did not match");
 		}
+
 		context.complete();
 	}
 }


### PR DESCRIPTION
@jaredlll08 told me that custom ingredients did not serialize correctly with the `allowEmpty` codec. This is because the serialization code in our modified codec actually tried to serialize using the vanilla codec first, which fails when the ingredient is empty if `allowEmpty` is false **but succeeds if `allowEmpty` is true, thus writing an empty array `[]`**. I rewrote this using an `either` codec, cleaning up the code a bit and fixing the bug.