### PR TITLE
Fix Doubles not being editable in the game-rule menu

### DIFF
--- a/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/api/gamerule/v1/rule/DoubleRule.java
+++ b/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/api/gamerule/v1/rule/DoubleRule.java
@@ -113,7 +113,12 @@ public final class DoubleRule extends GameRules.Rule<DoubleRule> implements Vali
 		try {
 			final double d = Double.parseDouble(value);
 
-			return this.inBounds(d);
+			if (!this.inBounds(d)) {
+				return false;
+			}
+
+			this.value = d;
+			return true;
 		} catch (NumberFormatException ignored) {
 			return false;
 		}

--- a/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/api/gamerule/v1/rule/ValidateableRule.java
+++ b/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/api/gamerule/v1/rule/ValidateableRule.java
@@ -23,9 +23,10 @@ package net.fabricmc.fabric.api.gamerule.v1.rule;
 public interface ValidateableRule {
 	/**
 	 * Validates if a rule can accept the input.
+	 * If valid, the input will be set as the rule's value.
 	 *
 	 * @param value the value to validate
-	 * @return true if the value can be accepted.
+	 * @return true if the value was accepted.
 	 */
 	boolean validate(String value);
 }


### PR DESCRIPTION
Hi,

Currently, game-rules of type Double are impossible to edit using the "Edit Gamerules" screen on world creation; any change to those rules is discarded upon exiting the screen.

This is due to `DoubleRule.validate` not updating the rule's value when called by the `DoubleRuleWidget`. For other gamerule types, this is how their widget update their value.

I have tested the fix in this PR on 1.20.2 using the artifacts generated on my fork. However the issue dates from furher back; at least since 1.19.4 where I first identified the issue. If this is accepted, I'd be interested in a backport of this fix to that version.

