### PR TITLE
TooltipDataCallback to allow modders add their own tooltips to existing items

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipComponentCallback.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipComponentCallback.java
@@ -28,7 +28,7 @@ import net.fabricmc.fabric.api.event.EventFactory;
 /**
  * Allows registering a mapping from {@link TooltipData} to {@link TooltipComponent}.
  * This allows custom tooltips for items: first, override {@link Item#getTooltipData} and return a custom {@code TooltipData}, or use
- * {@link TooltipDataCallback} to add {@code TooltipData} to an existing item
+ * {@link TooltipDataCallback} to add {@code TooltipData} to an existing item.
  * Second, register a listener to this event and convert the data to your component implementation if it's an instance of your data class.
  *
  * <p>Note that failure to map some data to a component will throw an exception,

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipComponentCallback.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipComponentCallback.java
@@ -27,7 +27,8 @@ import net.fabricmc.fabric.api.event.EventFactory;
 
 /**
  * Allows registering a mapping from {@link TooltipData} to {@link TooltipComponent}.
- * This allows custom tooltips for items: first, override {@link Item#getTooltipData} and return a custom {@code TooltipData}.
+ * This allows custom tooltips for items: first, override {@link Item#getTooltipData} and return a custom {@code TooltipData}, or use
+ * {@link TooltipDataCallback} to add {@code TooltipData} to an existing item
  * Second, register a listener to this event and convert the data to your component implementation if it's an instance of your data class.
  *
  * <p>Note that failure to map some data to a component will throw an exception,

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipComponentCallback.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipComponentCallback.java
@@ -28,7 +28,7 @@ import net.fabricmc.fabric.api.event.EventFactory;
 /**
  * Allows registering a mapping from {@link TooltipData} to {@link TooltipComponent}.
  * This allows custom tooltips for items: first, override {@link Item#getTooltipData} and return a custom {@code TooltipData}, or use
- * {@link TooltipDataCallback} to add {@code TooltipData} to an existing item.
+ * {@link TooltipDataCallback} to add {@link TooltipData} to an existing item.
  * Second, register a listener to this event and convert the data to your component implementation if it's an instance of your data class.
  *
  * <p>Note that failure to map some data to a component will throw an exception,

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipDataCallback.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipDataCallback.java
@@ -32,10 +32,9 @@ public interface TooltipDataCallback {
 	 * Custom {@code TooltipData} should be registered using {@link TooltipComponentCallback},
 	 * otherwise game will crash when trying to map {@code TooltipData} to {@code TooltipComponent}
 	 */
-	public static final Event<TooltipDataCallback> EVENT = EventFactory.createArrayBacked(TooltipDataCallback.class, callbacks -> (itemStack, tooltipDataList) -> {
-		//MultiTooltipData tooltipData = new MultiTooltipData(callbacks.length);
-		for(TooltipDataCallback callback : callbacks){
-			callback.getTooltipData(itemStack,tooltipDataList);
+	Event<TooltipDataCallback> EVENT = EventFactory.createArrayBacked(TooltipDataCallback.class, callbacks -> (itemStack, tooltipDataList) -> {
+		for (TooltipDataCallback callback : callbacks) {
+			callback.getTooltipData(itemStack, tooltipDataList);
 		}
 	});
 	void getTooltipData(ItemStack itemStack, List<TooltipData> tooltipDataList);

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipDataCallback.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipDataCallback.java
@@ -1,0 +1,29 @@
+package net.fabricmc.fabric.api.client.rendering.v1;
+
+import java.util.List;
+
+import net.minecraft.client.item.TooltipData;
+import net.minecraft.item.ItemStack;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+@FunctionalInterface
+public interface TooltipDataCallback {
+    /**
+     * Allows registering custom TooltipData object for item.
+     * This allows you to add your own tooltips to existing items
+     * Tooltip data rendering should be registered using TooltipComponentCallback,
+     * otherwise game will crash when trying to map TooltipData to TooltipComponent
+     * If you don't need to add tooltip data to this specific itemStack you can return Optional.empty()
+     */
+    public static final Event<TooltipDataCallback> EVENT = EventFactory.createArrayBacked(TooltipDataCallback.class, callbacks -> (itemStack, tooltipDataList) -> {
+        //MultiTooltipData tooltipData = new MultiTooltipData(callbacks.length);
+        for(TooltipDataCallback callback : callbacks){
+            callback.getTooltipData(itemStack,tooltipDataList);
+        }
+    });
+    void getTooltipData(ItemStack itemStack, List<TooltipData> tooltipDataList);
+}
+
+

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipDataCallback.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipDataCallback.java
@@ -29,8 +29,9 @@ public interface TooltipDataCallback {
 	/**
 	 * Allows registering custom {@link TooltipData} object for item.
 	 * This allows you to add your own tooltips to existing items.
-	 * Custom {@code TooltipData} should be registered using {@link TooltipComponentCallback},
-	 * otherwise game will crash when trying to map {@code TooltipData} to {@code TooltipComponent}
+	 *
+	 * <p>Custom {@link TooltipData} should be registered using {@link TooltipComponentCallback},
+	 * otherwise game will crash when trying to map {@link TooltipData} to {@link TooltipComponent}.
 	 */
 	Event<TooltipDataCallback> EVENT = EventFactory.createArrayBacked(TooltipDataCallback.class, callbacks -> (itemStack, tooltipDataList) -> {
 		for (TooltipDataCallback callback : callbacks) {

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipDataCallback.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipDataCallback.java
@@ -41,7 +41,7 @@ public interface TooltipDataCallback {
 	});
 
 	/**
-	 * Add your own {@link TooltipData} to passed list if itemStack matches your requirements
+	 * Add your own {@link TooltipData} to passed list if itemStack matches your requirements.
 	 */
 	void appendTooltipData(ItemStack itemStack, List<TooltipData> tooltipDataList);
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipDataCallback.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipDataCallback.java
@@ -11,11 +11,10 @@ import net.fabricmc.fabric.api.event.EventFactory;
 @FunctionalInterface
 public interface TooltipDataCallback {
     /**
-     * Allows registering custom TooltipData object for item.
-     * This allows you to add your own tooltips to existing items
-     * Tooltip data rendering should be registered using TooltipComponentCallback,
-     * otherwise game will crash when trying to map TooltipData to TooltipComponent
-     * If you don't need to add tooltip data to this specific itemStack you can return Optional.empty()
+     * Allows registering custom {@link TooltipData} object for item.
+     * This allows you to add your own tooltips to existing items.
+     * Custom {@code TooltipData} should be registered using {@link TooltipComponentCallback},
+     * otherwise game will crash when trying to map {@code TooltipData} to {@code TooltipComponent}
      */
     public static final Event<TooltipDataCallback> EVENT = EventFactory.createArrayBacked(TooltipDataCallback.class, callbacks -> (itemStack, tooltipDataList) -> {
         //MultiTooltipData tooltipData = new MultiTooltipData(callbacks.length);

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipDataCallback.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipDataCallback.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.api.client.rendering.v1;
 
 import java.util.List;
@@ -10,19 +26,17 @@ import net.fabricmc.fabric.api.event.EventFactory;
 
 @FunctionalInterface
 public interface TooltipDataCallback {
-    /**
-     * Allows registering custom {@link TooltipData} object for item.
-     * This allows you to add your own tooltips to existing items.
-     * Custom {@code TooltipData} should be registered using {@link TooltipComponentCallback},
-     * otherwise game will crash when trying to map {@code TooltipData} to {@code TooltipComponent}
-     */
-    public static final Event<TooltipDataCallback> EVENT = EventFactory.createArrayBacked(TooltipDataCallback.class, callbacks -> (itemStack, tooltipDataList) -> {
-        //MultiTooltipData tooltipData = new MultiTooltipData(callbacks.length);
-        for(TooltipDataCallback callback : callbacks){
-            callback.getTooltipData(itemStack,tooltipDataList);
-        }
-    });
-    void getTooltipData(ItemStack itemStack, List<TooltipData> tooltipDataList);
+	/**
+	 * Allows registering custom {@link TooltipData} object for item.
+	 * This allows you to add your own tooltips to existing items.
+	 * Custom {@code TooltipData} should be registered using {@link TooltipComponentCallback},
+	 * otherwise game will crash when trying to map {@code TooltipData} to {@code TooltipComponent}
+	 */
+	public static final Event<TooltipDataCallback> EVENT = EventFactory.createArrayBacked(TooltipDataCallback.class, callbacks -> (itemStack, tooltipDataList) -> {
+		//MultiTooltipData tooltipData = new MultiTooltipData(callbacks.length);
+		for(TooltipDataCallback callback : callbacks){
+			callback.getTooltipData(itemStack,tooltipDataList);
+		}
+	});
+	void getTooltipData(ItemStack itemStack, List<TooltipData> tooltipDataList);
 }
-
-

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipDataCallback.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TooltipDataCallback.java
@@ -18,25 +18,30 @@ package net.fabricmc.fabric.api.client.rendering.v1;
 
 import java.util.List;
 
+import net.minecraft.client.gui.tooltip.TooltipComponent;
 import net.minecraft.client.item.TooltipData;
 import net.minecraft.item.ItemStack;
 
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
+/**
+ * Allows registering custom {@link TooltipData} object for item.
+ * This allows you to add your own tooltips to existing items.
+ *
+ * <p>Custom {@link TooltipData} should be registered using {@link TooltipComponentCallback},
+ * otherwise game will crash when trying to map {@link TooltipData} to {@link TooltipComponent}.
+ */
 @FunctionalInterface
 public interface TooltipDataCallback {
-	/**
-	 * Allows registering custom {@link TooltipData} object for item.
-	 * This allows you to add your own tooltips to existing items.
-	 *
-	 * <p>Custom {@link TooltipData} should be registered using {@link TooltipComponentCallback},
-	 * otherwise game will crash when trying to map {@link TooltipData} to {@link TooltipComponent}.
-	 */
 	Event<TooltipDataCallback> EVENT = EventFactory.createArrayBacked(TooltipDataCallback.class, callbacks -> (itemStack, tooltipDataList) -> {
 		for (TooltipDataCallback callback : callbacks) {
-			callback.getTooltipData(itemStack, tooltipDataList);
+			callback.appendTooltipData(itemStack, tooltipDataList);
 		}
 	});
-	void getTooltipData(ItemStack itemStack, List<TooltipData> tooltipDataList);
+
+	/**
+	 * Add your own {@link TooltipData} to passed list if itemStack matches your requirements
+	 */
+	void appendTooltipData(ItemStack itemStack, List<TooltipData> tooltipDataList);
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipComponent.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipComponent.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * You may obtain a matrixCopy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -36,7 +36,7 @@ public class MultiTooltipComponent implements TooltipComponent {
 	private final int width;
 	private final List<TooltipComponent> components;
 
-	public static MultiTooltipComponent of(MultiTooltipData data) {
+	public static MultiTooltipComponent of(List<TooltipData> data) {
 		var l = new ArrayList<TooltipComponent>(data.size());
 
 		for (TooltipData d : data) {
@@ -72,26 +72,23 @@ public class MultiTooltipComponent implements TooltipComponent {
 
 	@Override
 	public void drawText(TextRenderer textRenderer, int x, int y, Matrix4f matrix, VertexConsumerProvider.Immediate vertexConsumers) {
-		int position = 0;
+		Matrix4f matrixCopy = new Matrix4f(matrix);
 
 		for (TooltipComponent c : components) {
-			matrix.translate(0, position, 0);
-			c.drawText(textRenderer, x, y, matrix, vertexConsumers);
-			matrix.translate(0, -position, 0);
-			position += c.getHeight();
+			c.drawText(textRenderer, x, y, matrixCopy, vertexConsumers);
+			matrixCopy.translate(0, c.getHeight(), 0);
 		}
 	}
 
 	@Override
 	public void drawItems(TextRenderer textRenderer, int x, int y, DrawContext context) {
-		int position = 0;
+		context.getMatrices().push();
 
 		for (TooltipComponent c : components) {
-			context.getMatrices().push();
-			context.getMatrices().translate(0, position, 0);
 			c.drawItems(textRenderer, x, y, context);
-			context.getMatrices().pop();
-			position += c.getHeight();
+			context.getMatrices().translate(0, c.getHeight(), 0);
 		}
+
+		context.getMatrices().pop();
 	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipComponent.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipComponent.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.impl.client.rendering.tooltip;
 
 import java.util.ArrayList;
@@ -15,60 +31,60 @@ import net.minecraft.client.render.VertexConsumerProvider;
  * This class renders multiple tooltip components as one
  */
 public class MultiTooltipComponent implements TooltipComponent {
-    private final int height;
-    private final int width;
-    private final List<TooltipComponent> components;
+	private final int height;
+	private final int width;
+	private final List<TooltipComponent> components;
 
-    public static MultiTooltipComponent of(MultiTooltipData data){
-        var l = new ArrayList<TooltipComponent>(data.size());
-        for(var d : data){
-            l.add(TooltipComponent.of(d));
-        }
-        return new MultiTooltipComponent(l);
-    }
+	public static MultiTooltipComponent of(MultiTooltipData data){
+		var l = new ArrayList<TooltipComponent>(data.size());
+		for(var d : data){
+			l.add(TooltipComponent.of(d));
+		}
+		return new MultiTooltipComponent(l);
+	}
 
-    public MultiTooltipComponent(List<TooltipComponent> components) {
-        this.components = components;
-        int height=0;
-        int width=0;
-        for (TooltipComponent component : components) {
-                height += component.getHeight();
-            width = Math.max(width, component.getWidth(MinecraftClient.getInstance().textRenderer));
-        }
-        this.height = height;
-        this.width = width;
-    }
+	public MultiTooltipComponent(List<TooltipComponent> components) {
+		this.components = components;
+		int height=0;
+		int width=0;
+		for (TooltipComponent component : components) {
+				height += component.getHeight();
+			width = Math.max(width, component.getWidth(MinecraftClient.getInstance().textRenderer));
+		}
+		this.height = height;
+		this.width = width;
+	}
 
-    @Override
-    public int getHeight() {
-        return height;
-    }
+	@Override
+	public int getHeight() {
+		return height;
+	}
 
-    @Override
-    public int getWidth(TextRenderer textRenderer) {
-        return width;
-    }
+	@Override
+	public int getWidth(TextRenderer textRenderer) {
+		return width;
+	}
 
-    @Override
-    public void drawText(TextRenderer textRenderer, int x, int y, Matrix4f matrix, VertexConsumerProvider.Immediate vertexConsumers) {
-        int position = 0;
-        for(var c : components){
-            matrix.translate(0,position,0);
-            c.drawText(textRenderer,x,y,matrix,vertexConsumers);
-            matrix.translate(0,-position,0);
-            position+=c.getHeight();
-        }
-    }
+	@Override
+	public void drawText(TextRenderer textRenderer, int x, int y, Matrix4f matrix, VertexConsumerProvider.Immediate vertexConsumers) {
+		int position = 0;
+		for(var c : components){
+			matrix.translate(0,position,0);
+			c.drawText(textRenderer,x,y,matrix,vertexConsumers);
+			matrix.translate(0,-position,0);
+			position+=c.getHeight();
+		}
+	}
 
-    @Override
-    public void drawItems(TextRenderer textRenderer, int x, int y, DrawContext context) {
-        int position = 0;
-        for(var c : components) {
-            context.getMatrices().push();
-            context.getMatrices().translate(0,position,0);
-            c.drawItems(textRenderer,x,y,context);
-            context.getMatrices().pop();
-            position+=c.getHeight();
-        }
-    }
+	@Override
+	public void drawItems(TextRenderer textRenderer, int x, int y, DrawContext context) {
+		int position = 0;
+		for(var c : components) {
+			context.getMatrices().push();
+			context.getMatrices().translate(0,position,0);
+			c.drawItems(textRenderer,x,y,context);
+			context.getMatrices().pop();
+			position+=c.getHeight();
+		}
+	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipComponent.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipComponent.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * You may obtain a matrixCopy of the License at
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipComponent.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipComponent.java
@@ -25,32 +25,37 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.tooltip.TooltipComponent;
+import net.minecraft.client.item.TooltipData;
 import net.minecraft.client.render.VertexConsumerProvider;
 
 /**
- * This class renders multiple tooltip components as one
+ * This class renders multiple tooltip components as one.
  */
 public class MultiTooltipComponent implements TooltipComponent {
 	private final int height;
 	private final int width;
 	private final List<TooltipComponent> components;
 
-	public static MultiTooltipComponent of(MultiTooltipData data){
+	public static MultiTooltipComponent of(MultiTooltipData data) {
 		var l = new ArrayList<TooltipComponent>(data.size());
-		for(var d : data){
+
+		for (TooltipData d : data) {
 			l.add(TooltipComponent.of(d));
 		}
+
 		return new MultiTooltipComponent(l);
 	}
 
 	public MultiTooltipComponent(List<TooltipComponent> components) {
 		this.components = components;
-		int height=0;
-		int width=0;
+		int height = 0;
+		int width = 0;
+
 		for (TooltipComponent component : components) {
-				height += component.getHeight();
+			height += component.getHeight();
 			width = Math.max(width, component.getWidth(MinecraftClient.getInstance().textRenderer));
 		}
+
 		this.height = height;
 		this.width = width;
 	}
@@ -68,23 +73,25 @@ public class MultiTooltipComponent implements TooltipComponent {
 	@Override
 	public void drawText(TextRenderer textRenderer, int x, int y, Matrix4f matrix, VertexConsumerProvider.Immediate vertexConsumers) {
 		int position = 0;
-		for(var c : components){
-			matrix.translate(0,position,0);
-			c.drawText(textRenderer,x,y,matrix,vertexConsumers);
-			matrix.translate(0,-position,0);
-			position+=c.getHeight();
+
+		for (TooltipComponent c : components) {
+			matrix.translate(0, position, 0);
+			c.drawText(textRenderer, x, y, matrix, vertexConsumers);
+			matrix.translate(0, -position, 0);
+			position += c.getHeight();
 		}
 	}
 
 	@Override
 	public void drawItems(TextRenderer textRenderer, int x, int y, DrawContext context) {
 		int position = 0;
-		for(var c : components) {
+
+		for (TooltipComponent c : components) {
 			context.getMatrices().push();
-			context.getMatrices().translate(0,position,0);
-			c.drawItems(textRenderer,x,y,context);
+			context.getMatrices().translate(0, position, 0);
+			c.drawItems(textRenderer, x, y, context);
 			context.getMatrices().pop();
-			position+=c.getHeight();
+			position += c.getHeight();
 		}
 	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipComponent.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipComponent.java
@@ -1,0 +1,74 @@
+package net.fabricmc.fabric.impl.client.rendering.tooltip;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.joml.Matrix4f;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.tooltip.TooltipComponent;
+import net.minecraft.client.render.VertexConsumerProvider;
+
+/**
+ * This class renders multiple tooltip components as one
+ */
+public class MultiTooltipComponent implements TooltipComponent {
+    private final int height;
+    private final int width;
+    private final List<TooltipComponent> components;
+
+    public static MultiTooltipComponent of(MultiTooltipData data){
+        var l = new ArrayList<TooltipComponent>(data.size());
+        for(var d : data){
+            l.add(TooltipComponent.of(d));
+        }
+        return new MultiTooltipComponent(l);
+    }
+
+    public MultiTooltipComponent(List<TooltipComponent> components) {
+        this.components = components;
+        int height=0;
+        int width=0;
+        for (TooltipComponent component : components) {
+                height += component.getHeight();
+            width = Math.max(width, component.getWidth(MinecraftClient.getInstance().textRenderer));
+        }
+        this.height = height;
+        this.width = width;
+    }
+
+    @Override
+    public int getHeight() {
+        return height;
+    }
+
+    @Override
+    public int getWidth(TextRenderer textRenderer) {
+        return width;
+    }
+
+    @Override
+    public void drawText(TextRenderer textRenderer, int x, int y, Matrix4f matrix, VertexConsumerProvider.Immediate vertexConsumers) {
+        int position = 0;
+        for(var c : components){
+            matrix.translate(0,position,0);
+            c.drawText(textRenderer,x,y,matrix,vertexConsumers);
+            matrix.translate(0,-position,0);
+            position+=c.getHeight();
+        }
+    }
+
+    @Override
+    public void drawItems(TextRenderer textRenderer, int x, int y, DrawContext context) {
+        int position = 0;
+        for(var c : components) {
+            context.getMatrices().push();
+            context.getMatrices().translate(0,position,0);
+            c.drawItems(textRenderer,x,y,context);
+            context.getMatrices().pop();
+            position+=c.getHeight();
+        }
+    }
+}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipComponentRegister.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipComponentRegister.java
@@ -22,10 +22,11 @@ import net.fabricmc.fabric.api.client.rendering.v1.TooltipComponentCallback;
 public class MultiTooltipComponentRegister implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
-		TooltipComponentCallback.EVENT.register((tooltipData)->{
-			if(tooltipData instanceof MultiTooltipData multiTooltipData){
+		TooltipComponentCallback.EVENT.register((tooltipData) -> {
+			if (tooltipData instanceof MultiTooltipData multiTooltipData) {
 				return MultiTooltipComponent.of(multiTooltipData);
 			}
+
 			return null;
 		});
 	}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipComponentRegister.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipComponentRegister.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.impl.client.rendering.tooltip;
 
 import net.fabricmc.api.ClientModInitializer;

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipComponentRegister.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipComponentRegister.java
@@ -1,0 +1,16 @@
+package net.fabricmc.fabric.impl.client.rendering.tooltip;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.rendering.v1.TooltipComponentCallback;
+
+public class MultiTooltipComponentRegister implements ClientModInitializer {
+	@Override
+	public void onInitializeClient() {
+		TooltipComponentCallback.EVENT.register((tooltipData)->{
+			if(tooltipData instanceof MultiTooltipData multiTooltipData){
+				return MultiTooltipComponent.of(multiTooltipData);
+			}
+			return null;
+		});
+	}
+}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipComponentRegister.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipComponentRegister.java
@@ -24,7 +24,7 @@ public class MultiTooltipComponentRegister implements ClientModInitializer {
 	public void onInitializeClient() {
 		TooltipComponentCallback.EVENT.register((tooltipData) -> {
 			if (tooltipData instanceof MultiTooltipData multiTooltipData) {
-				return MultiTooltipComponent.of(multiTooltipData);
+				return MultiTooltipComponent.of(multiTooltipData.tooltipData());
 			}
 
 			return null;

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipData.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipData.java
@@ -1,0 +1,15 @@
+package net.fabricmc.fabric.impl.client.rendering.tooltip;
+
+import net.minecraft.client.item.TooltipData;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+/**
+ * This class stores multiple TooltipData object to their further mapping to MultiTooltipComponent
+ */
+public class MultiTooltipData extends ArrayList<TooltipData> implements TooltipData {
+    public MultiTooltipData(int length) {
+        super(length);
+    }
+}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipData.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipData.java
@@ -17,14 +17,14 @@
 package net.fabricmc.fabric.impl.client.rendering.tooltip;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import net.minecraft.client.item.TooltipData;
+
+import javax.tools.Tool;
 
 /**
  * This class stores multiple TooltipData object to their further mapping to MultiTooltipComponent.
  */
-public class MultiTooltipData extends ArrayList<TooltipData> implements TooltipData {
-	public MultiTooltipData(int length) {
-		super(length);
-	}
+public record MultiTooltipData(List<TooltipData> tooltipData) implements TooltipData {
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipData.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipData.java
@@ -21,7 +21,7 @@ import java.util.ArrayList;
 import net.minecraft.client.item.TooltipData;
 
 /**
- * This class stores multiple TooltipData object to their further mapping to MultiTooltipComponent
+ * This class stores multiple TooltipData object to their further mapping to MultiTooltipComponent.
  */
 public class MultiTooltipData extends ArrayList<TooltipData> implements TooltipData {
 	public MultiTooltipData(int length) {

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipData.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipData.java
@@ -16,12 +16,9 @@
 
 package net.fabricmc.fabric.impl.client.rendering.tooltip;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import net.minecraft.client.item.TooltipData;
-
-import javax.tools.Tool;
 
 /**
  * This class stores multiple TooltipData object to their further mapping to MultiTooltipComponent.

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipData.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/tooltip/MultiTooltipData.java
@@ -1,15 +1,30 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.impl.client.rendering.tooltip;
 
-import net.minecraft.client.item.TooltipData;
-
 import java.util.ArrayList;
-import java.util.Optional;
+
+import net.minecraft.client.item.TooltipData;
 
 /**
  * This class stores multiple TooltipData object to their further mapping to MultiTooltipComponent
  */
 public class MultiTooltipData extends ArrayList<TooltipData> implements TooltipData {
-    public MultiTooltipData(int length) {
-        super(length);
-    }
+	public MultiTooltipData(int length) {
+		super(length);
+	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/HandledScreenMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/HandledScreenMixin.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.fabric.mixin.client.rendering;
 
-
 import java.util.Optional;
 
 import org.spongepowered.asm.mixin.Mixin;
@@ -32,15 +31,17 @@ import net.fabricmc.fabric.impl.client.rendering.tooltip.MultiTooltipData;
 
 @Mixin(HandledScreen.class)
 class HandledScreenMixin {
-	@Redirect(method = "drawMouseoverTooltip",at = @At(value = "INVOKE",target = "Lnet/minecraft/item/ItemStack;getTooltipData()Ljava/util/Optional;"))
-	Optional<TooltipData> addMultiData(ItemStack stack){
-		var original = stack.getTooltipData();
+	@Redirect(method = "drawMouseoverTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getTooltipData()Ljava/util/Optional;"))
+	Optional<TooltipData> addMultiData(ItemStack stack) {
+		Optional<TooltipData> original = stack.getTooltipData();
 		var mutlidata = new MultiTooltipData(1);
 		original.ifPresent(mutlidata::add);
-		TooltipDataCallback.EVENT.invoker().getTooltipData(stack,mutlidata);
-		if(mutlidata.size() == 0){
+		TooltipDataCallback.EVENT.invoker().getTooltipData(stack, mutlidata);
+
+		if (mutlidata.size() == 0) {
 			return Optional.empty();
 		}
+
 		return Optional.of(mutlidata);
 	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/HandledScreenMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/HandledScreenMixin.java
@@ -1,30 +1,46 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.client.rendering;
 
 
-import net.fabricmc.fabric.api.client.rendering.v1.TooltipDataCallback;
-import net.fabricmc.fabric.impl.client.rendering.tooltip.MultiTooltipData;
-
-import net.minecraft.client.gui.screen.ingame.HandledScreen;
-import net.minecraft.client.item.TooltipData;
-import net.minecraft.item.ItemStack;
+import java.util.Optional;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
-import java.util.Optional;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.item.TooltipData;
+import net.minecraft.item.ItemStack;
+
+import net.fabricmc.fabric.api.client.rendering.v1.TooltipDataCallback;
+import net.fabricmc.fabric.impl.client.rendering.tooltip.MultiTooltipData;
 
 @Mixin(HandledScreen.class)
 class HandledScreenMixin {
-    @Redirect(method = "drawMouseoverTooltip",at = @At(value = "INVOKE",target = "Lnet/minecraft/item/ItemStack;getTooltipData()Ljava/util/Optional;"))
-    Optional<TooltipData> addMultiData(ItemStack stack){
-        var original = stack.getTooltipData();
-        var mutlidata = new MultiTooltipData(1);
-        original.ifPresent(mutlidata::add);
-        TooltipDataCallback.EVENT.invoker().getTooltipData(stack,mutlidata);
+	@Redirect(method = "drawMouseoverTooltip",at = @At(value = "INVOKE",target = "Lnet/minecraft/item/ItemStack;getTooltipData()Ljava/util/Optional;"))
+	Optional<TooltipData> addMultiData(ItemStack stack){
+		var original = stack.getTooltipData();
+		var mutlidata = new MultiTooltipData(1);
+		original.ifPresent(mutlidata::add);
+		TooltipDataCallback.EVENT.invoker().getTooltipData(stack,mutlidata);
 		if(mutlidata.size() == 0){
 			return Optional.empty();
 		}
 		return Optional.of(mutlidata);
-    }
+	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/HandledScreenMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/HandledScreenMixin.java
@@ -39,7 +39,7 @@ class HandledScreenMixin {
 		original.ifPresent(multiData.tooltipData()::add);
 		TooltipDataCallback.EVENT.invoker().appendTooltipData(stack, multiData.tooltipData());
 
-		if (multiData.tooltipData().size() == 0) {
+		if (multiData.tooltipData().isEmpty()) {
 			return original;
 		}
 

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/HandledScreenMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/HandledScreenMixin.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
@@ -36,14 +35,14 @@ class HandledScreenMixin {
 	@Redirect(method = "drawMouseoverTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getTooltipData()Ljava/util/Optional;"))
 	Optional<TooltipData> addMultiData(ItemStack stack) {
 		Optional<TooltipData> original = stack.getTooltipData();
-		var multidata = new MultiTooltipData(new ArrayList<>());
-		original.ifPresent(multidata.tooltipData()::add);
-		TooltipDataCallback.EVENT.invoker().appendTooltipData(stack, multidata.tooltipData());
+		var multiData = new MultiTooltipData(new ArrayList<>());
+		original.ifPresent(multiData.tooltipData()::add);
+		TooltipDataCallback.EVENT.invoker().appendTooltipData(stack, multiData.tooltipData());
 
-		if (multidata.tooltipData().size() <= 1) {
+		if (multiData.tooltipData().size() <= 1) {
 			return original;
 		}
 
-		return Optional.of(multidata);
+		return Optional.of(multiData);
 	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/HandledScreenMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/HandledScreenMixin.java
@@ -16,10 +16,12 @@
 
 package net.fabricmc.fabric.mixin.client.rendering;
 
+import java.util.ArrayList;
 import java.util.Optional;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
@@ -34,14 +36,14 @@ class HandledScreenMixin {
 	@Redirect(method = "drawMouseoverTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getTooltipData()Ljava/util/Optional;"))
 	Optional<TooltipData> addMultiData(ItemStack stack) {
 		Optional<TooltipData> original = stack.getTooltipData();
-		var mutlidata = new MultiTooltipData(1);
-		original.ifPresent(mutlidata::add);
-		TooltipDataCallback.EVENT.invoker().getTooltipData(stack, mutlidata);
+		var multidata = new MultiTooltipData(new ArrayList<>());
+		original.ifPresent(multidata.tooltipData()::add);
+		TooltipDataCallback.EVENT.invoker().appendTooltipData(stack, multidata.tooltipData());
 
-		if (mutlidata.size() == 0) {
-			return Optional.empty();
+		if (multidata.tooltipData().size() <= 1) {
+			return original;
 		}
 
-		return Optional.of(mutlidata);
+		return Optional.of(multidata);
 	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/HandledScreenMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/HandledScreenMixin.java
@@ -39,8 +39,12 @@ class HandledScreenMixin {
 		original.ifPresent(multiData.tooltipData()::add);
 		TooltipDataCallback.EVENT.invoker().appendTooltipData(stack, multiData.tooltipData());
 
-		if (multiData.tooltipData().size() <= 1) {
+		if (multiData.tooltipData().size() == 0) {
 			return original;
+		}
+
+		if (multiData.tooltipData().size() == 1){
+			return Optional.of(multiData.tooltipData().get(0));
 		}
 
 		return Optional.of(multiData);

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/HandledScreenMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/HandledScreenMixin.java
@@ -1,0 +1,30 @@
+package net.fabricmc.fabric.mixin.client.rendering;
+
+
+import net.fabricmc.fabric.api.client.rendering.v1.TooltipDataCallback;
+import net.fabricmc.fabric.impl.client.rendering.tooltip.MultiTooltipData;
+
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.item.TooltipData;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.Optional;
+
+@Mixin(HandledScreen.class)
+class HandledScreenMixin {
+    @Redirect(method = "drawMouseoverTooltip",at = @At(value = "INVOKE",target = "Lnet/minecraft/item/ItemStack;getTooltipData()Ljava/util/Optional;"))
+    Optional<TooltipData> addMultiData(ItemStack stack){
+        var original = stack.getTooltipData();
+        var mutlidata = new MultiTooltipData(1);
+        original.ifPresent(mutlidata::add);
+        TooltipDataCallback.EVENT.invoker().getTooltipData(stack,mutlidata);
+		if(mutlidata.size() == 0){
+			return Optional.empty();
+		}
+		return Optional.of(mutlidata);
+    }
+}

--- a/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
+++ b/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
@@ -12,6 +12,7 @@
     "EntityModelLayersAccessor",
     "EntityModelsMixin",
     "EntityRenderersMixin",
+    "HandledScreenMixin",
     "InGameHudMixin",
     "ItemColorsMixin",
     "LivingEntityRendererAccessor",

--- a/fabric-rendering-v1/src/client/resources/fabric.mod.json
+++ b/fabric-rendering-v1/src/client/resources/fabric.mod.json
@@ -19,6 +19,11 @@
     "fabricloader": ">=0.4.0",
     "fabric-api-base": "*"
   },
+  "entrypoints": {
+    "client": [
+      "net.fabricmc.fabric.impl.client.rendering.tooltip.MultiTooltipComponentRegister"
+    ]
+  },
   "description": "Hooks and registries for rendering-related things.",
   "mixins": [
     "fabric-rendering-v1.mixins.json"

--- a/fabric-rendering-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-rendering-v1/src/testmod/resources/fabric.mod.json
@@ -15,7 +15,10 @@
       "net.fabricmc.fabric.test.rendering.client.FeatureRendererTest",
       "net.fabricmc.fabric.test.rendering.client.TooltipComponentTests",
       "net.fabricmc.fabric.test.rendering.client.DimensionalRenderingTest",
-      "net.fabricmc.fabric.test.rendering.client.HudAndShaderTest"
+      "net.fabricmc.fabric.test.rendering.client.HudAndShaderTest",
+      "net.fabricmc.fabric.test.rendering.client.tooltip.BundleFullnessTooltipTest",
+      "net.fabricmc.fabric.test.rendering.client.tooltip.DurabilityTooltipTest",
+      "net.fabricmc.fabric.test.rendering.client.tooltip.FoodTooltipTest"
     ]
   }
 }

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/tooltip/BundleFullnessTooltipTest.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/tooltip/BundleFullnessTooltipTest.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.fabric.test.rendering.client.tooltip;
 
-
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.tooltip.TooltipComponent;
@@ -32,20 +31,21 @@ public class BundleFullnessTooltipTest implements ClientModInitializer {
 	public void onInitializeClient() {
 		TooltipDataCallback.EVENT.register((itemStack, tooltipDataList) -> {
 			if (itemStack.getItem() instanceof BundleItem bundle) {
-				tooltipDataList.add(0,new BundleCustomTooltipData(BundleItem.getAmountFilled(itemStack)));
+				tooltipDataList.add(0, new BundleCustomTooltipData(BundleItem.getAmountFilled(itemStack)));
 			}
 		});
 		TooltipComponentCallback.EVENT.register(data -> {
-			if(data instanceof BundleCustomTooltipData bundleCustomTooltipData)
+			if (data instanceof BundleCustomTooltipData bundleCustomTooltipData) {
 				return new BundleFullnessTooltipComponent(bundleCustomTooltipData.fullness);
+			}
+
 			return null;
 		});
 	}
 
 	private static class BundleCustomTooltipData implements TooltipData {
 		private final float fullness;
-
-		public BundleCustomTooltipData(float fullness) {
+		BundleCustomTooltipData(float fullness) {
 			this.fullness = fullness;
 		}
 	}
@@ -56,7 +56,7 @@ public class BundleFullnessTooltipTest implements ClientModInitializer {
 		private static final int GAP = 2;
 		private final float fullness;
 
-		public BundleFullnessTooltipComponent(float fullness) {
+		BundleFullnessTooltipComponent(float fullness) {
 			this.fullness = fullness;
 		}
 
@@ -69,12 +69,13 @@ public class BundleFullnessTooltipTest implements ClientModInitializer {
 		public int getWidth(TextRenderer textRenderer) {
 			return BAR_WIDTH;
 		}
+
 		@Override
 		public void drawItems(TextRenderer textRenderer, int x, int y, DrawContext context) {
 			context.getMatrices().push();
-			context.getMatrices().translate(x,y,0);
-			context.fill(0,0,BAR_WIDTH,BAR_HEIGHT,0xFF3F007F);
-			context.fill(0,0, (int) (BAR_WIDTH*fullness),BAR_HEIGHT,0xFF7F00FF);
+			context.getMatrices().translate(x, y, 0);
+			context.fill(0, 0, BAR_WIDTH, BAR_HEIGHT, 0xFF3F007F);
+			context.fill(0, 0, (int) (BAR_WIDTH * fullness), BAR_HEIGHT, 0xFF7F00FF);
 			context.getMatrices().pop();
 		}
 	}

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/tooltip/BundleFullnessTooltipTest.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/tooltip/BundleFullnessTooltipTest.java
@@ -1,7 +1,21 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.test.rendering.client.tooltip;
 
-
-import net.fabricmc.fabric.api.client.rendering.v1.TooltipDataCallback;
 
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
@@ -11,56 +25,57 @@ import net.minecraft.item.BundleItem;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.rendering.v1.TooltipComponentCallback;
+import net.fabricmc.fabric.api.client.rendering.v1.TooltipDataCallback;
 
 public class BundleFullnessTooltipTest implements ClientModInitializer {
-    @Override
-    public void onInitializeClient() {
-        TooltipDataCallback.EVENT.register((itemStack, tooltipDataList) -> {
-            if (itemStack.getItem() instanceof BundleItem bundle) {
-                tooltipDataList.add(0,new BundleCustomTooltipData(BundleItem.getAmountFilled(itemStack)));
-            }
-        });
-        TooltipComponentCallback.EVENT.register(data -> {
-            if(data instanceof BundleCustomTooltipData bundleCustomTooltipData)
-                return new BundleFullnessTooltipComponent(bundleCustomTooltipData.fullness);
-            return null;
-        });
-    }
+	@Override
+	public void onInitializeClient() {
+		TooltipDataCallback.EVENT.register((itemStack, tooltipDataList) -> {
+			if (itemStack.getItem() instanceof BundleItem bundle) {
+				tooltipDataList.add(0,new BundleCustomTooltipData(BundleItem.getAmountFilled(itemStack)));
+			}
+		});
+		TooltipComponentCallback.EVENT.register(data -> {
+			if(data instanceof BundleCustomTooltipData bundleCustomTooltipData)
+				return new BundleFullnessTooltipComponent(bundleCustomTooltipData.fullness);
+			return null;
+		});
+	}
 
-    private static class BundleCustomTooltipData implements TooltipData {
-        private final float fullness;
+	private static class BundleCustomTooltipData implements TooltipData {
+		private final float fullness;
 
-        public BundleCustomTooltipData(float fullness) {
-            this.fullness = fullness;
-        }
-    }
+		public BundleCustomTooltipData(float fullness) {
+			this.fullness = fullness;
+		}
+	}
 
-    private static class BundleFullnessTooltipComponent implements TooltipComponent {
-        private static final int BAR_WIDTH = 40;
-        private static final int BAR_HEIGHT = 10;
-        private static final int GAP = 2;
-        private final float fullness;
+	private static class BundleFullnessTooltipComponent implements TooltipComponent {
+		private static final int BAR_WIDTH = 40;
+		private static final int BAR_HEIGHT = 10;
+		private static final int GAP = 2;
+		private final float fullness;
 
-        public BundleFullnessTooltipComponent(float fullness) {
-            this.fullness = fullness;
-        }
+		public BundleFullnessTooltipComponent(float fullness) {
+			this.fullness = fullness;
+		}
 
-        @Override
-        public int getHeight() {
-            return BAR_HEIGHT + GAP;
-        }
+		@Override
+		public int getHeight() {
+			return BAR_HEIGHT + GAP;
+		}
 
-        @Override
-        public int getWidth(TextRenderer textRenderer) {
-            return BAR_WIDTH;
-        }
-        @Override
-        public void drawItems(TextRenderer textRenderer, int x, int y, DrawContext context) {
-            context.getMatrices().push();
-            context.getMatrices().translate(x,y,0);
-            context.fill(0,0,BAR_WIDTH,BAR_HEIGHT,0xFF3F007F);
-            context.fill(0,0, (int) (BAR_WIDTH*fullness),BAR_HEIGHT,0xFF7F00FF);
-            context.getMatrices().pop();
-        }
-    }
+		@Override
+		public int getWidth(TextRenderer textRenderer) {
+			return BAR_WIDTH;
+		}
+		@Override
+		public void drawItems(TextRenderer textRenderer, int x, int y, DrawContext context) {
+			context.getMatrices().push();
+			context.getMatrices().translate(x,y,0);
+			context.fill(0,0,BAR_WIDTH,BAR_HEIGHT,0xFF3F007F);
+			context.fill(0,0, (int) (BAR_WIDTH*fullness),BAR_HEIGHT,0xFF7F00FF);
+			context.getMatrices().pop();
+		}
+	}
 }

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/tooltip/BundleFullnessTooltipTest.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/tooltip/BundleFullnessTooltipTest.java
@@ -1,0 +1,66 @@
+package net.fabricmc.fabric.test.rendering.client.tooltip;
+
+
+import net.fabricmc.fabric.api.client.rendering.v1.TooltipDataCallback;
+
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.tooltip.TooltipComponent;
+import net.minecraft.client.item.TooltipData;
+import net.minecraft.item.BundleItem;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.rendering.v1.TooltipComponentCallback;
+
+public class BundleFullnessTooltipTest implements ClientModInitializer {
+    @Override
+    public void onInitializeClient() {
+        TooltipDataCallback.EVENT.register((itemStack, tooltipDataList) -> {
+            if (itemStack.getItem() instanceof BundleItem bundle) {
+                tooltipDataList.add(0,new BundleCustomTooltipData(BundleItem.getAmountFilled(itemStack)));
+            }
+        });
+        TooltipComponentCallback.EVENT.register(data -> {
+            if(data instanceof BundleCustomTooltipData bundleCustomTooltipData)
+                return new BundleFullnessTooltipComponent(bundleCustomTooltipData.fullness);
+            return null;
+        });
+    }
+
+    private static class BundleCustomTooltipData implements TooltipData {
+        private final float fullness;
+
+        public BundleCustomTooltipData(float fullness) {
+            this.fullness = fullness;
+        }
+    }
+
+    private static class BundleFullnessTooltipComponent implements TooltipComponent {
+        private static final int BAR_WIDTH = 40;
+        private static final int BAR_HEIGHT = 10;
+        private static final int GAP = 2;
+        private final float fullness;
+
+        public BundleFullnessTooltipComponent(float fullness) {
+            this.fullness = fullness;
+        }
+
+        @Override
+        public int getHeight() {
+            return BAR_HEIGHT + GAP;
+        }
+
+        @Override
+        public int getWidth(TextRenderer textRenderer) {
+            return BAR_WIDTH;
+        }
+        @Override
+        public void drawItems(TextRenderer textRenderer, int x, int y, DrawContext context) {
+            context.getMatrices().push();
+            context.getMatrices().translate(x,y,0);
+            context.fill(0,0,BAR_WIDTH,BAR_HEIGHT,0xFF3F007F);
+            context.fill(0,0, (int) (BAR_WIDTH*fullness),BAR_HEIGHT,0xFF7F00FF);
+            context.getMatrices().pop();
+        }
+    }
+}

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/tooltip/DurabilityTooltipTest.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/tooltip/DurabilityTooltipTest.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.fabric.test.rendering.client.tooltip;
 
-
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.tooltip.TooltipComponent;
@@ -26,7 +25,6 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.rendering.v1.TooltipComponentCallback;
 import net.fabricmc.fabric.api.client.rendering.v1.TooltipDataCallback;
 
-
 public class DurabilityTooltipTest implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
@@ -35,9 +33,12 @@ public class DurabilityTooltipTest implements ClientModInitializer {
 				tooltipDataList.add(new DamagedItemData(itemStack.getDamage(), itemStack.getMaxDamage()));
 			}
 		});
+
 		TooltipComponentCallback.EVENT.register(data -> {
-			if(data instanceof DamagedItemData damagedItemData)
+			if (data instanceof DamagedItemData damagedItemData) {
 				return new DurabilityModTooltipComponent(damagedItemData);
+			}
+
 			return null;
 		});
 	}
@@ -51,7 +52,7 @@ public class DurabilityTooltipTest implements ClientModInitializer {
 		private static final int GAP = 2;
 		private final DamagedItemData damage;
 
-		public DurabilityModTooltipComponent(DamagedItemData data) {
+		DurabilityModTooltipComponent(DamagedItemData data) {
 			this.damage = data;
 		}
 
@@ -64,13 +65,14 @@ public class DurabilityTooltipTest implements ClientModInitializer {
 		public int getWidth(TextRenderer textRenderer) {
 			return BAR_WIDTH;
 		}
+
 		@Override
 		public void drawItems(TextRenderer textRenderer, int x, int y, DrawContext context) {
 			context.getMatrices().push();
-			context.getMatrices().translate(x,y,0);
+			context.getMatrices().translate(x, y, 0);
 			float width = 1-(float) this.damage.durability / this.damage.maxDurability;
-			context.fill(0,0,BAR_WIDTH,BAR_HEIGHT,0xFFFF0000);
-			context.fill(0,0, (int) (BAR_WIDTH*width),BAR_HEIGHT,0xFF00FF00);
+			context.fill(0, 0, BAR_WIDTH, BAR_HEIGHT, 0xFFFF0000);
+			context.fill(0, 0, (int) (BAR_WIDTH * width), BAR_HEIGHT, 0xFF00FF00);
 			context.getMatrices().pop();
 		}
 	}

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/tooltip/DurabilityTooltipTest.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/tooltip/DurabilityTooltipTest.java
@@ -1,0 +1,62 @@
+package net.fabricmc.fabric.test.rendering.client.tooltip;
+
+
+import net.fabricmc.fabric.api.client.rendering.v1.TooltipDataCallback;
+
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.tooltip.TooltipComponent;
+import net.minecraft.client.item.TooltipData;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.rendering.v1.TooltipComponentCallback;
+
+
+public class DurabilityTooltipTest implements ClientModInitializer {
+    @Override
+    public void onInitializeClient() {
+        TooltipDataCallback.EVENT.register((itemStack, tooltipDataList) -> {
+            if (itemStack.isDamageable()) {
+                tooltipDataList.add(new DamagedItemData(itemStack.getDamage(), itemStack.getMaxDamage()));
+            }
+        });
+        TooltipComponentCallback.EVENT.register(data -> {
+            if(data instanceof DamagedItemData damagedItemData)
+                return new DurabilityModTooltipComponent(damagedItemData);
+            return null;
+        });
+    }
+
+    public record DamagedItemData(int durability, int maxDurability) implements TooltipData {
+    }
+
+    private static class DurabilityModTooltipComponent implements TooltipComponent {
+        private static final int BAR_WIDTH = 40;
+        private static final int BAR_HEIGHT = 10;
+        private static final int GAP = 2;
+        private final DamagedItemData damage;
+
+        public DurabilityModTooltipComponent(DamagedItemData data) {
+            this.damage = data;
+        }
+
+        @Override
+        public int getHeight() {
+            return BAR_HEIGHT + GAP;
+        }
+
+        @Override
+        public int getWidth(TextRenderer textRenderer) {
+            return BAR_WIDTH;
+        }
+        @Override
+        public void drawItems(TextRenderer textRenderer, int x, int y, DrawContext context) {
+            context.getMatrices().push();
+            context.getMatrices().translate(x,y,0);
+            float width = 1-(float) this.damage.durability / this.damage.maxDurability;
+            context.fill(0,0,BAR_WIDTH,BAR_HEIGHT,0xFFFF0000);
+            context.fill(0,0, (int) (BAR_WIDTH*width),BAR_HEIGHT,0xFF00FF00);
+            context.getMatrices().pop();
+        }
+    }
+}

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/tooltip/DurabilityTooltipTest.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/tooltip/DurabilityTooltipTest.java
@@ -1,7 +1,21 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.test.rendering.client.tooltip;
 
-
-import net.fabricmc.fabric.api.client.rendering.v1.TooltipDataCallback;
 
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
@@ -10,53 +24,54 @@ import net.minecraft.client.item.TooltipData;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.rendering.v1.TooltipComponentCallback;
+import net.fabricmc.fabric.api.client.rendering.v1.TooltipDataCallback;
 
 
 public class DurabilityTooltipTest implements ClientModInitializer {
-    @Override
-    public void onInitializeClient() {
-        TooltipDataCallback.EVENT.register((itemStack, tooltipDataList) -> {
-            if (itemStack.isDamageable()) {
-                tooltipDataList.add(new DamagedItemData(itemStack.getDamage(), itemStack.getMaxDamage()));
-            }
-        });
-        TooltipComponentCallback.EVENT.register(data -> {
-            if(data instanceof DamagedItemData damagedItemData)
-                return new DurabilityModTooltipComponent(damagedItemData);
-            return null;
-        });
-    }
+	@Override
+	public void onInitializeClient() {
+		TooltipDataCallback.EVENT.register((itemStack, tooltipDataList) -> {
+			if (itemStack.isDamageable()) {
+				tooltipDataList.add(new DamagedItemData(itemStack.getDamage(), itemStack.getMaxDamage()));
+			}
+		});
+		TooltipComponentCallback.EVENT.register(data -> {
+			if(data instanceof DamagedItemData damagedItemData)
+				return new DurabilityModTooltipComponent(damagedItemData);
+			return null;
+		});
+	}
 
-    public record DamagedItemData(int durability, int maxDurability) implements TooltipData {
-    }
+	public record DamagedItemData(int durability, int maxDurability) implements TooltipData {
+	}
 
-    private static class DurabilityModTooltipComponent implements TooltipComponent {
-        private static final int BAR_WIDTH = 40;
-        private static final int BAR_HEIGHT = 10;
-        private static final int GAP = 2;
-        private final DamagedItemData damage;
+	private static class DurabilityModTooltipComponent implements TooltipComponent {
+		private static final int BAR_WIDTH = 40;
+		private static final int BAR_HEIGHT = 10;
+		private static final int GAP = 2;
+		private final DamagedItemData damage;
 
-        public DurabilityModTooltipComponent(DamagedItemData data) {
-            this.damage = data;
-        }
+		public DurabilityModTooltipComponent(DamagedItemData data) {
+			this.damage = data;
+		}
 
-        @Override
-        public int getHeight() {
-            return BAR_HEIGHT + GAP;
-        }
+		@Override
+		public int getHeight() {
+			return BAR_HEIGHT + GAP;
+		}
 
-        @Override
-        public int getWidth(TextRenderer textRenderer) {
-            return BAR_WIDTH;
-        }
-        @Override
-        public void drawItems(TextRenderer textRenderer, int x, int y, DrawContext context) {
-            context.getMatrices().push();
-            context.getMatrices().translate(x,y,0);
-            float width = 1-(float) this.damage.durability / this.damage.maxDurability;
-            context.fill(0,0,BAR_WIDTH,BAR_HEIGHT,0xFFFF0000);
-            context.fill(0,0, (int) (BAR_WIDTH*width),BAR_HEIGHT,0xFF00FF00);
-            context.getMatrices().pop();
-        }
-    }
+		@Override
+		public int getWidth(TextRenderer textRenderer) {
+			return BAR_WIDTH;
+		}
+		@Override
+		public void drawItems(TextRenderer textRenderer, int x, int y, DrawContext context) {
+			context.getMatrices().push();
+			context.getMatrices().translate(x,y,0);
+			float width = 1-(float) this.damage.durability / this.damage.maxDurability;
+			context.fill(0,0,BAR_WIDTH,BAR_HEIGHT,0xFFFF0000);
+			context.fill(0,0, (int) (BAR_WIDTH*width),BAR_HEIGHT,0xFF00FF00);
+			context.getMatrices().pop();
+		}
+	}
 }

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/tooltip/FoodTooltipTest.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/tooltip/FoodTooltipTest.java
@@ -1,0 +1,69 @@
+package net.fabricmc.fabric.test.rendering.client.tooltip;
+
+
+import net.fabricmc.fabric.api.client.rendering.v1.TooltipDataCallback;
+
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.tooltip.TooltipComponent;
+import net.minecraft.client.item.TooltipData;
+import net.minecraft.item.FoodComponent;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.rendering.v1.TooltipComponentCallback;
+
+public class FoodTooltipTest implements ClientModInitializer {
+    @Override
+    public void onInitializeClient() {
+        TooltipDataCallback.EVENT.register((itemStack, tooltipDataList) -> {
+            if (itemStack.getItem().getFoodComponent() != null) {
+                var foodData = new FoodItemData(itemStack.getItem().getFoodComponent());
+                tooltipDataList.add(foodData);
+            }
+        });
+        TooltipComponentCallback.EVENT.register(data -> {
+            if(data instanceof FoodItemData foodItemData)
+                return new FoodModTooltip(foodItemData);
+            return null;
+        });
+    }
+
+
+    private static class FoodItemData implements TooltipData {
+        public final int hunger;
+
+        public FoodItemData(FoodComponent foodComponent) {
+            this.hunger = foodComponent.getHunger();
+        }
+    }
+
+    private static class FoodModTooltip implements TooltipComponent {
+        private final FoodItemData food;
+        private static final int SIZE=8;
+        private static final int GAP=2;
+
+        public FoodModTooltip(FoodItemData foodItemData) {
+            this.food = foodItemData;
+        }
+
+        @Override
+        public int getHeight() {
+            return (SIZE+GAP);
+        }
+
+        @Override
+        public int getWidth(TextRenderer textRenderer) {
+            return (SIZE+GAP)*food.hunger-GAP;
+        }
+        @Override
+        public void drawItems(TextRenderer textRenderer, int x, int y, DrawContext context) {
+            context.getMatrices().push();
+            context.getMatrices().translate(x,y,0);
+            for(int i=0;i<food.hunger;i++){
+                context.fill(0,0,SIZE,SIZE,0xFFFFFF00);
+                context.getMatrices().translate(GAP+SIZE,0,0);
+            }
+            context.getMatrices().pop();
+        }
+    }
+}

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/tooltip/FoodTooltipTest.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/tooltip/FoodTooltipTest.java
@@ -1,7 +1,21 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.test.rendering.client.tooltip;
 
-
-import net.fabricmc.fabric.api.client.rendering.v1.TooltipDataCallback;
 
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
@@ -11,59 +25,60 @@ import net.minecraft.item.FoodComponent;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.rendering.v1.TooltipComponentCallback;
+import net.fabricmc.fabric.api.client.rendering.v1.TooltipDataCallback;
 
 public class FoodTooltipTest implements ClientModInitializer {
-    @Override
-    public void onInitializeClient() {
-        TooltipDataCallback.EVENT.register((itemStack, tooltipDataList) -> {
-            if (itemStack.getItem().getFoodComponent() != null) {
-                var foodData = new FoodItemData(itemStack.getItem().getFoodComponent());
-                tooltipDataList.add(foodData);
-            }
-        });
-        TooltipComponentCallback.EVENT.register(data -> {
-            if(data instanceof FoodItemData foodItemData)
-                return new FoodModTooltip(foodItemData);
-            return null;
-        });
-    }
+	@Override
+	public void onInitializeClient() {
+		TooltipDataCallback.EVENT.register((itemStack, tooltipDataList) -> {
+			if (itemStack.getItem().getFoodComponent() != null) {
+				var foodData = new FoodItemData(itemStack.getItem().getFoodComponent());
+				tooltipDataList.add(foodData);
+			}
+		});
+		TooltipComponentCallback.EVENT.register(data -> {
+			if(data instanceof FoodItemData foodItemData)
+				return new FoodModTooltip(foodItemData);
+			return null;
+		});
+	}
 
 
-    private static class FoodItemData implements TooltipData {
-        public final int hunger;
+	private static class FoodItemData implements TooltipData {
+		public final int hunger;
 
-        public FoodItemData(FoodComponent foodComponent) {
-            this.hunger = foodComponent.getHunger();
-        }
-    }
+		public FoodItemData(FoodComponent foodComponent) {
+			this.hunger = foodComponent.getHunger();
+		}
+	}
 
-    private static class FoodModTooltip implements TooltipComponent {
-        private final FoodItemData food;
-        private static final int SIZE=8;
-        private static final int GAP=2;
+	private static class FoodModTooltip implements TooltipComponent {
+		private final FoodItemData food;
+		private static final int SIZE=8;
+		private static final int GAP=2;
 
-        public FoodModTooltip(FoodItemData foodItemData) {
-            this.food = foodItemData;
-        }
+		public FoodModTooltip(FoodItemData foodItemData) {
+			this.food = foodItemData;
+		}
 
-        @Override
-        public int getHeight() {
-            return (SIZE+GAP);
-        }
+		@Override
+		public int getHeight() {
+			return (SIZE+GAP);
+		}
 
-        @Override
-        public int getWidth(TextRenderer textRenderer) {
-            return (SIZE+GAP)*food.hunger-GAP;
-        }
-        @Override
-        public void drawItems(TextRenderer textRenderer, int x, int y, DrawContext context) {
-            context.getMatrices().push();
-            context.getMatrices().translate(x,y,0);
-            for(int i=0;i<food.hunger;i++){
-                context.fill(0,0,SIZE,SIZE,0xFFFFFF00);
-                context.getMatrices().translate(GAP+SIZE,0,0);
-            }
-            context.getMatrices().pop();
-        }
-    }
+		@Override
+		public int getWidth(TextRenderer textRenderer) {
+			return (SIZE+GAP)*food.hunger-GAP;
+		}
+		@Override
+		public void drawItems(TextRenderer textRenderer, int x, int y, DrawContext context) {
+			context.getMatrices().push();
+			context.getMatrices().translate(x,y,0);
+			for(int i=0;i<food.hunger;i++){
+				context.fill(0,0,SIZE,SIZE,0xFFFFFF00);
+				context.getMatrices().translate(GAP+SIZE,0,0);
+			}
+			context.getMatrices().pop();
+		}
+	}
 }

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/tooltip/FoodTooltipTest.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/tooltip/FoodTooltipTest.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.fabric.test.rendering.client.tooltip;
 
-
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.tooltip.TooltipComponent;
@@ -36,48 +35,52 @@ public class FoodTooltipTest implements ClientModInitializer {
 				tooltipDataList.add(foodData);
 			}
 		});
+
 		TooltipComponentCallback.EVENT.register(data -> {
-			if(data instanceof FoodItemData foodItemData)
+			if (data instanceof FoodItemData foodItemData) {
 				return new FoodModTooltip(foodItemData);
+			}
+
 			return null;
 		});
 	}
 
-
 	private static class FoodItemData implements TooltipData {
 		public final int hunger;
-
-		public FoodItemData(FoodComponent foodComponent) {
+		FoodItemData(FoodComponent foodComponent) {
 			this.hunger = foodComponent.getHunger();
 		}
 	}
 
 	private static class FoodModTooltip implements TooltipComponent {
 		private final FoodItemData food;
-		private static final int SIZE=8;
-		private static final int GAP=2;
+		private static final int SIZE = 8;
+		private static final int GAP = 2;
 
-		public FoodModTooltip(FoodItemData foodItemData) {
+		FoodModTooltip(FoodItemData foodItemData) {
 			this.food = foodItemData;
 		}
 
 		@Override
 		public int getHeight() {
-			return (SIZE+GAP);
+			return (SIZE + GAP);
 		}
 
 		@Override
 		public int getWidth(TextRenderer textRenderer) {
-			return (SIZE+GAP)*food.hunger-GAP;
+			return (SIZE + GAP) * food.hunger - GAP;
 		}
+
 		@Override
 		public void drawItems(TextRenderer textRenderer, int x, int y, DrawContext context) {
 			context.getMatrices().push();
-			context.getMatrices().translate(x,y,0);
-			for(int i=0;i<food.hunger;i++){
-				context.fill(0,0,SIZE,SIZE,0xFFFFFF00);
-				context.getMatrices().translate(GAP+SIZE,0,0);
+			context.getMatrices().translate(x, y, 0);
+
+			for (int i = 0; i < food.hunger; i++) {
+				context.fill(0, 0, SIZE, SIZE, 0xFFFFFF00);
+				context.getMatrices().translate(GAP + SIZE, 0, 0);
 			}
+
 			context.getMatrices().pop();
 		}
 	}


### PR DESCRIPTION
I recently was developing feature that added "sell" and "purchase" tooltips for blocks with that functionality. The problem is that these toolips were added by different mods, one for selling, one for purchasing. And to make these mods compatible i had to develop small separate library, and package it to both mods. And i haven't even tested compatibility with other mods that may change tooltips.
The only tooltip related events I found are for adding text lines to tooltip and registering tooltip component.
So I propose new event the Fabric API - TooltipDataCallback(ItemStack, List<TooltipData>).
Also i added three example mods to showcase what this can add [(Fabric discord message link)](https://discord.com/channels/507304429255393322/566276937035546624/1170469767669350450)