### PR TITLE
add `Codec`s for `FluidVariant` and `ResourceAmount<FluidVariant>`

### DIFF
--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariant.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariant.java
@@ -53,15 +53,15 @@ import net.fabricmc.fabric.impl.transfer.fluid.FluidVariantImpl;
 public interface FluidVariant extends TransferVariant<Fluid> {
 	Codec<FluidVariant> CODEC = RecordCodecBuilder.create(instance ->
 			instance.group(
-				Registries.FLUID.getCodec().fieldOf("fluid").forGetter(FluidVariant::getFluid),
-				NbtCompound.CODEC.optionalFieldOf("nbt").forGetter(variant -> Optional.ofNullable(variant.getNbt()))
-		).apply(instance, (fluid, optionalNbt) -> FluidVariant.of(fluid, optionalNbt.orElse(null))));
+					Registries.FLUID.getCodec().fieldOf("fluid").forGetter(FluidVariant::getFluid),
+					NbtCompound.CODEC.optionalFieldOf("nbt").forGetter(variant -> Optional.ofNullable(variant.getNbt()))
+			).apply(instance, (fluid, optionalNbt) -> FluidVariant.of(fluid, optionalNbt.orElse(null))));
 
 	Codec<ResourceAmount<FluidVariant>> AMOUNT_CODEC = RecordCodecBuilder.create(instance ->
-                instance.group(
-                    CODEC.fieldOf("variant").forGetter(ResourceAmount::resource),
-                    Codec.LONG.fieldOf("amount").forGetter(ResourceAmount::amount)
-            ).apply(instance, ResourceAmount::new));
+			instance.group(
+					CODEC.fieldOf("variant").forGetter(ResourceAmount::resource),
+					Codec.LONG.fieldOf("amount").forGetter(ResourceAmount::amount)
+			).apply(instance, ResourceAmount::new));
 
     /**
 	 * Retrieve a blank FluidVariant.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariant.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariant.java
@@ -43,6 +43,12 @@ import net.fabricmc.fabric.impl.transfer.fluid.FluidVariantImpl;
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface FluidVariant extends TransferVariant<Fluid> {
+	public static final Codec<FluidVariant> CODEC = RecordCodecBuilder.create(instance ->
+			instance.group(
+				Registries.FLUID.getCodec().fieldOf("fluid").forGetter(FluidVariant::getFluid),
+				NbtCompound.CODEC.optionalFieldOf("nbt").forGetter(variant -> Optional.ofNullable(variant.getNbt()))
+		).apply(instance, (fluid, optionalNbt) -> FluidVariant.of(fluid, optionalNbt.orElse(null))));
+
 	/**
 	 * Retrieve a blank FluidVariant.
 	 */

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariant.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariant.java
@@ -16,6 +16,13 @@
 
 package net.fabricmc.fabric.api.transfer.v1.fluid;
 
+import java.util.Optional;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import net.minecraft.registry.Registries;
+
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariant.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariant.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
+import net.fabricmc.fabric.api.transfer.v1.storage.base.ResourceAmount;
 import net.minecraft.registry.Registries;
 
 import org.jetbrains.annotations.ApiStatus;
@@ -50,13 +51,19 @@ import net.fabricmc.fabric.impl.transfer.fluid.FluidVariantImpl;
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface FluidVariant extends TransferVariant<Fluid> {
-	public static final Codec<FluidVariant> CODEC = RecordCodecBuilder.create(instance ->
+	Codec<FluidVariant> CODEC = RecordCodecBuilder.create(instance ->
 			instance.group(
 				Registries.FLUID.getCodec().fieldOf("fluid").forGetter(FluidVariant::getFluid),
 				NbtCompound.CODEC.optionalFieldOf("nbt").forGetter(variant -> Optional.ofNullable(variant.getNbt()))
 		).apply(instance, (fluid, optionalNbt) -> FluidVariant.of(fluid, optionalNbt.orElse(null))));
 
-	/**
+	Codec<ResourceAmount<FluidVariant>> AMOUNT_CODEC = RecordCodecBuilder.create(instance ->
+                instance.group(
+                    CODEC.fieldOf("variant").forGetter(ResourceAmount::resource),
+                    Codec.LONG.fieldOf("amount").forGetter(ResourceAmount::amount)
+            ).apply(instance, ResourceAmount::new));
+
+    /**
 	 * Retrieve a blank FluidVariant.
 	 */
 	static FluidVariant blank() {

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/ResourceAmount.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/ResourceAmount.java
@@ -27,4 +27,9 @@ import org.jetbrains.annotations.ApiStatus;
  */
 @ApiStatus.Experimental
 public record ResourceAmount<T> (T resource, long amount) {
+	public static final Codec<ResourceAmount<FluidVariant>> FLUID_VARIANT_CODEC = RecordCodecBuilder.create(instance ->
+			instance.group(
+				FLUID_VARIANT_CODEC.fieldOf("variant").forGetter(ResourceAmount::resource),
+				Codec.LONG.fieldOf("amount").forGetter(ResourceAmount::amount)
+		).apply(instance, ResourceAmount::new));
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/ResourceAmount.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/ResourceAmount.java
@@ -16,10 +16,7 @@
 
 package net.fabricmc.fabric.api.transfer.v1.storage.base;
 
-import com.mojang.serialization.Codec;
-import com.mojang.serialization.codecs.RecordCodecBuilder;
 import org.jetbrains.annotations.ApiStatus;
-import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 
 /**
  * An immutable object storing both a resource and an amount, provided for convenience.
@@ -30,9 +27,4 @@ import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
  */
 @ApiStatus.Experimental
 public record ResourceAmount<T> (T resource, long amount) {
-	public static final Codec<ResourceAmount<FluidVariant>> FLUID_VARIANT_CODEC = RecordCodecBuilder.create(instance ->
-			instance.group(
-				FluidVariant.CODEC.fieldOf("variant").forGetter(ResourceAmount::resource),
-				Codec.LONG.fieldOf("amount").forGetter(ResourceAmount::amount)
-		).apply(instance, ResourceAmount::new));
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/ResourceAmount.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/ResourceAmount.java
@@ -16,7 +16,10 @@
 
 package net.fabricmc.fabric.api.transfer.v1.storage.base;
 
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
 import org.jetbrains.annotations.ApiStatus;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 
 /**
  * An immutable object storing both a resource and an amount, provided for convenience.
@@ -29,7 +32,7 @@ import org.jetbrains.annotations.ApiStatus;
 public record ResourceAmount<T> (T resource, long amount) {
 	public static final Codec<ResourceAmount<FluidVariant>> FLUID_VARIANT_CODEC = RecordCodecBuilder.create(instance ->
 			instance.group(
-				FLUID_VARIANT_CODEC.fieldOf("variant").forGetter(ResourceAmount::resource),
+				FluidVariant.CODEC.fieldOf("variant").forGetter(ResourceAmount::resource),
 				Codec.LONG.fieldOf("amount").forGetter(ResourceAmount::amount)
 		).apply(instance, ResourceAmount::new));
 }

--- a/fabric-transfer-api-v1/src/testmod/java/net/fabricmc/fabric/test/transfer/gametests/CodecsTest.java
+++ b/fabric-transfer-api-v1/src/testmod/java/net/fabricmc/fabric/test/transfer/gametests/CodecsTest.java
@@ -32,7 +32,7 @@ public class CodecsTest {
 
 		JsonElement json = JsonParser.parseString(input);
 
-		DataResult<Pair<ResourceAmount<FluidVariant>, JsonElement>> result = ResourceAmount.FLUID_VARIANT_CODEC.decode(JsonOps.INSTANCE, json);
+		DataResult<Pair<ResourceAmount<FluidVariant>, JsonElement>> result = FluidVariant.AMOUNT_CODEC.decode(JsonOps.INSTANCE, json);
 		context.assertTrue(result.result().isPresent(), "Couldn't decode JSON");
 
 		ResourceAmount<FluidVariant> decoded = result.result().get().getFirst();

--- a/fabric-transfer-api-v1/src/testmod/java/net/fabricmc/fabric/test/transfer/gametests/CodecsTest.java
+++ b/fabric-transfer-api-v1/src/testmod/java/net/fabricmc/fabric/test/transfer/gametests/CodecsTest.java
@@ -36,10 +36,10 @@ public class CodecsTest {
 		context.assertTrue(result.result().isPresent(), "Couldn't decode JSON");
 
 		ResourceAmount<FluidVariant> decoded = result.result().get().getFirst();
-		context.assertTrue(decoded.resource().getFluid() == Fluids.WATER, "Incorrectly decoded fluid");
-		context.assertTrue(decoded.resource().getNbt() != null, "Incorrectly decoded variant NBT");
-		context.assertTrue(!decoded.resource().getNbt().isEmpty(), "Incorrectly decoded variant NBT");
-		context.assertTrue(decoded.amount() == 81000, "Incorrectly decoded resource amount");
+		context.assertTrue(decoded.resource().getFluid() == Fluids.WATER, "Fluid was not water");
+		context.assertTrue(decoded.resource().getNbt() != null, "NBT was null");
+		context.assertTrue(!decoded.resource().getNbt().isEmpty(), "NBT was empty");
+		context.assertTrue(decoded.amount() == 81000, "Amount was not 81000");
 
 		context.complete();
 	}

--- a/fabric-transfer-api-v1/src/testmod/java/net/fabricmc/fabric/test/transfer/gametests/CodecsTest.java
+++ b/fabric-transfer-api-v1/src/testmod/java/net/fabricmc/fabric/test/transfer/gametests/CodecsTest.java
@@ -1,0 +1,46 @@
+package net.fabricmc.fabric.test.transfer.gametests;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.mojang.datafixers.util.Pair;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.JsonOps;
+
+import net.fabricmc.fabric.api.transfer.v1.storage.base.ResourceAmount;
+
+import net.minecraft.fluid.Fluids;
+import net.minecraft.test.GameTest;
+import net.minecraft.test.TestContext;
+
+import net.fabricmc.fabric.api.gametest.v1.FabricGameTest;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
+
+public class CodecsTest {
+	@GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)
+	public void testDecode(TestContext context) {
+		String input = """
+				{
+					"variant": {
+						"fluid": "minecraft:water",
+						"nbt": {
+							"test": 42
+						}
+					},
+					"amount": 81000
+				}
+				""";
+
+		JsonElement json = JsonParser.parseString(input);
+
+		DataResult<Pair<ResourceAmount<FluidVariant>, JsonElement>> result = ResourceAmount.FLUID_VARIANT_CODEC.decode(JsonOps.INSTANCE, json);
+		context.assertTrue(result.result().isPresent(), "Couldn't decode JSON");
+
+		ResourceAmount<FluidVariant> decoded = result.result().get().getFirst();
+		context.assertTrue(decoded.resource().getFluid() == Fluids.WATER, "Incorrectly decoded fluid");
+		context.assertTrue(decoded.resource().getNbt() != null, "Incorrectly decoded variant NBT");
+		context.assertTrue(!decoded.resource().getNbt().isEmpty(), "Incorrectly decoded variant NBT");
+		context.assertTrue(decoded.amount() == 81000, "Incorrectly decoded resource amount");
+
+		context.complete();
+	}
+}

--- a/fabric-transfer-api-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-transfer-api-v1/src/testmod/resources/fabric.mod.json
@@ -18,7 +18,8 @@
     ],
     "fabric-gametest": [
       "net.fabricmc.fabric.test.transfer.gametests.VanillaStorageTests",
-      "net.fabricmc.fabric.test.transfer.gametests.WorldDependentAttributesTest"
+      "net.fabricmc.fabric.test.transfer.gametests.WorldDependentAttributesTest",
+      "net.fabricmc.fabric.test.transfer.gametests.CodecsTest"
     ]
   },
   "mixins": [


### PR DESCRIPTION
Adds `Codec` fields for these two types, which might be useful for the new recipe serializers, which now use `RecipeSerializer#codec` for reading from json, instead of receiving `JsonObject` and reading it imperatively like it was before.