### PR TITLE
23w45a porting fixes

### DIFF
--- a/fabric-dimensions-v1/src/testmod/java/net/fabricmc/fabric/test/dimension/FabricDimensionTest.java
+++ b/fabric-dimensions-v1/src/testmod/java/net/fabricmc/fabric/test/dimension/FabricDimensionTest.java
@@ -22,6 +22,7 @@ import static net.minecraft.server.command.CommandManager.literal;
 
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 
 import net.minecraft.block.Blocks;
 import net.minecraft.command.argument.DimensionArgumentType;
@@ -51,6 +52,7 @@ public class FabricDimensionTest implements ModInitializer {
 	// The dimension options refer to the JSON-file in the dimension subfolder of the data pack,
 	// which will always share its ID with the world that is created from it
 	private static final RegistryKey<DimensionOptions> DIMENSION_KEY = RegistryKey.of(RegistryKeys.DIMENSION, new Identifier("fabric_dimension", "void"));
+	private static final SimpleCommandExceptionType FAILED_EXCEPTION = new SimpleCommandExceptionType(Text.literal("Teleportation failed!"));
 
 	private static RegistryKey<World> WORLD_KEY = RegistryKey.of(RegistryKeys.WORLD, DIMENSION_KEY.getValue());
 
@@ -110,7 +112,7 @@ public class FabricDimensionTest implements ModInitializer {
 		});
 	}
 
-	private int swapTargeted(CommandContext<ServerCommandSource> context) {
+	private int swapTargeted(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
 		ServerPlayerEntity player = context.getSource().getPlayer();
 
 		if (player == null) {
@@ -126,7 +128,7 @@ public class FabricDimensionTest implements ModInitializer {
 			FabricDimensions.teleport(player, modWorld, target);
 
 			if (player.getWorld() != modWorld) {
-				throw new RuntimeException("Teleportation failed!");
+				throw FAILED_EXCEPTION.create();
 			}
 
 			modWorld.setBlockState(new BlockPos(0, 100, 0), Blocks.DIAMOND_BLOCK.getDefaultState());

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricBlockSettings.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricBlockSettings.java
@@ -82,7 +82,12 @@ public class FabricBlockSettings extends AbstractBlock.Settings {
 		this.instrument(otherAccessor.getInstrument());
 		thisAccessor.setReplaceable(otherAccessor.getReplaceable());
 
-		// Not copied in vanilla: field definition order
+		// Vanilla did not copy those fields until 23w45a, which introduced
+		// copyShallow method (maintaining the behavior previously used by the copy method)
+		// and the copy method that copies those fields as well. copyShallow is now
+		// deprecated. To maintain compatibility and since this behavior seems to be the
+		// more proper way, this copies all the fields, not just the shallow ones.
+		// Fields are added by field definition order.
 		this.jumpVelocityMultiplier(otherAccessor.getJumpVelocityMultiplier());
 		this.drops(otherAccessor.getLootTableId());
 		this.allowsSpawning(otherAccessor.getAllowsSpawningPredicate());

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/type/BlockSetTypeBuilder.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/type/BlockSetTypeBuilder.java
@@ -210,6 +210,7 @@ public final class BlockSetTypeBuilder {
 	public static BlockSetTypeBuilder copyOf(BlockSetTypeBuilder builder) {
 		BlockSetTypeBuilder copy = new BlockSetTypeBuilder();
 		copy.openableByHand(builder.openableByHand);
+		copy.openableByWindCharge(builder.openableByWindCharge);
 		copy.buttonActivatedByArrows(builder.buttonActivatedByArrows);
 		copy.pressurePlateActivationRule(builder.pressurePlateActivationRule);
 		copy.soundGroup(builder.soundGroup);
@@ -234,6 +235,7 @@ public final class BlockSetTypeBuilder {
 	public static BlockSetTypeBuilder copyOf(BlockSetType setType) {
 		BlockSetTypeBuilder copy = new BlockSetTypeBuilder();
 		copy.openableByHand(setType.canOpenByHand());
+		copy.openableByWindCharge(setType.canOpenByWindCharge());
 		copy.buttonActivatedByArrows(setType.canButtonBeActivatedByArrows());
 		copy.pressurePlateActivationRule(setType.pressurePlateSensitivity());
 		copy.soundGroup(setType.soundType());

--- a/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.accesswidener
+++ b/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.accesswidener
@@ -129,6 +129,7 @@ transitive-accessible field net/minecraft/client/MinecraftClient attackCooldown 
 transitive-accessible method net/minecraft/block/Blocks createFlowerPotBlock (Lnet/minecraft/block/Block;)Lnet/minecraft/block/Block;
 transitive-accessible method net/minecraft/block/Blocks createLeavesBlock (Lnet/minecraft/sound/BlockSoundGroup;)Lnet/minecraft/block/Block;
 transitive-accessible method net/minecraft/block/Blocks createLogBlock (Lnet/minecraft/block/MapColor;Lnet/minecraft/block/MapColor;)Lnet/minecraft/block/Block;
+transitive-accessible method net/minecraft/block/Blocks createLogBlock (Lnet/minecraft/block/MapColor;Lnet/minecraft/block/MapColor;Lnet/minecraft/sound/BlockSoundGroup;)Lnet/minecraft/block/Block;
 transitive-accessible method net/minecraft/block/Blocks createNetherStemBlock (Lnet/minecraft/block/MapColor;)Lnet/minecraft/block/Block;
 transitive-accessible method net/minecraft/block/Blocks createStoneButtonBlock ()Lnet/minecraft/block/Block;
 transitive-accessible method net/minecraft/block/Blocks createWoodenButtonBlock (Lnet/minecraft/block/BlockSetType;)Lnet/minecraft/block/Block;

--- a/fabric-transitive-access-wideners-v1/template.accesswidener
+++ b/fabric-transitive-access-wideners-v1/template.accesswidener
@@ -124,6 +124,7 @@ transitive-accessible field net/minecraft/client/MinecraftClient attackCooldown 
 transitive-accessible method net/minecraft/block/Blocks createFlowerPotBlock (Lnet/minecraft/block/Block;)Lnet/minecraft/block/Block;
 transitive-accessible method net/minecraft/block/Blocks createLeavesBlock (Lnet/minecraft/sound/BlockSoundGroup;)Lnet/minecraft/block/Block;
 transitive-accessible method net/minecraft/block/Blocks createLogBlock (Lnet/minecraft/block/MapColor;Lnet/minecraft/block/MapColor;)Lnet/minecraft/block/Block;
+transitive-accessible method net/minecraft/block/Blocks createLogBlock (Lnet/minecraft/block/MapColor;Lnet/minecraft/block/MapColor;Lnet/minecraft/sound/BlockSoundGroup;)Lnet/minecraft/block/Block;
 transitive-accessible method net/minecraft/block/Blocks createNetherStemBlock (Lnet/minecraft/block/MapColor;)Lnet/minecraft/block/Block;
 transitive-accessible method net/minecraft/block/Blocks createStoneButtonBlock ()Lnet/minecraft/block/Block;
 transitive-accessible method net/minecraft/block/Blocks createWoodenButtonBlock (Lnet/minecraft/block/BlockSetType;)Lnet/minecraft/block/Block;


### PR DESCRIPTION
- Fixes `openableByWindCharge` not being copied. Testing this the easy way (copying vanilla) turned out to be a little difficult because you have to compare `BlockSetType`, and the ID field has a colon when constructing with our builder.
- Re-adds one TAW that was accidentally removed.
- Updates testmod to use the proper way of throwing.
- Comment update to remain accurate.