### PR TITLE
Update to loader 0.15

### DIFF
--- a/deprecated/fabric-command-api-v1/src/main/resources/fabric.mod.json
+++ b/deprecated/fabric-command-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.10.5",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*",
     "fabric-command-api-v2": "*"
   },

--- a/deprecated/fabric-command-api-v1/src/main/resources/fabric.mod.json
+++ b/deprecated/fabric-command-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*",
     "fabric-command-api-v2": "*"
   },

--- a/deprecated/fabric-commands-v0/src/main/resources/fabric.mod.json
+++ b/deprecated/fabric-commands-v0/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*",
     "fabric-command-api-v2": "*"
   },

--- a/deprecated/fabric-commands-v0/src/main/resources/fabric.mod.json
+++ b/deprecated/fabric-commands-v0/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.4.0",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*",
     "fabric-command-api-v2": "*"
   },

--- a/deprecated/fabric-containers-v0/src/main/resources/fabric-containers-v0.accurate.mixins.json
+++ b/deprecated/fabric-containers-v0/src/main/resources/fabric-containers-v0.accurate.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": false,
   "package": "net.fabricmc.fabric.mixin.container",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "ServerPlayerEntityMixin"
   ],

--- a/deprecated/fabric-containers-v0/src/main/resources/fabric-containers-v0.mixins.json
+++ b/deprecated/fabric-containers-v0/src/main/resources/fabric-containers-v0.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": false,
   "package": "net.fabricmc.fabric.mixin.container",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "ServerPlayerEntityAccessor"
   ],

--- a/deprecated/fabric-containers-v0/src/main/resources/fabric.mod.json
+++ b/deprecated/fabric-containers-v0/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.4.0",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*",
     "fabric-networking-api-v1": "*"
   },

--- a/deprecated/fabric-containers-v0/src/main/resources/fabric.mod.json
+++ b/deprecated/fabric-containers-v0/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*",
     "fabric-networking-api-v1": "*"
   },

--- a/deprecated/fabric-events-lifecycle-v0/src/main/resources/fabric.mod.json
+++ b/deprecated/fabric-events-lifecycle-v0/src/main/resources/fabric.mod.json
@@ -24,7 +24,7 @@
     ]
   },
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*",
     "fabric-item-api-v1": "*",
     "fabric-lifecycle-events-v1": "*"

--- a/deprecated/fabric-events-lifecycle-v0/src/main/resources/fabric.mod.json
+++ b/deprecated/fabric-events-lifecycle-v0/src/main/resources/fabric.mod.json
@@ -24,7 +24,7 @@
     ]
   },
   "depends": {
-    "fabricloader": ">=0.4.0",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*",
     "fabric-item-api-v1": "*",
     "fabric-lifecycle-events-v1": "*"

--- a/deprecated/fabric-keybindings-v0/src/client/resources/fabric.mod.json
+++ b/deprecated/fabric-keybindings-v0/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-key-binding-api-v1": "*"
   },
   "description": "Keybinding registry API.",

--- a/deprecated/fabric-keybindings-v0/src/client/resources/fabric.mod.json
+++ b/deprecated/fabric-keybindings-v0/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.4.0",
+    "fabricloader": ">=0.15.0",
     "fabric-key-binding-api-v1": "*"
   },
   "description": "Keybinding registry API.",

--- a/deprecated/fabric-models-v0/src/client/resources/fabric.mod.json
+++ b/deprecated/fabric-models-v0/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*",
     "fabric-model-loading-api-v1": "*"
   },

--- a/deprecated/fabric-models-v0/src/client/resources/fabric.mod.json
+++ b/deprecated/fabric-models-v0/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.4.0",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*",
     "fabric-model-loading-api-v1": "*"
   },

--- a/deprecated/fabric-renderer-registries-v1/src/client/resources/fabric.mod.json
+++ b/deprecated/fabric-renderer-registries-v1/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "minecraft": ">=1.15-alpha.19.39.a",
     "fabric-api-base": "*",
     "fabric-rendering-v1": "*"

--- a/deprecated/fabric-renderer-registries-v1/src/client/resources/fabric.mod.json
+++ b/deprecated/fabric-renderer-registries-v1/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.4.0",
+    "fabricloader": ">=0.15.0",
     "minecraft": ">=1.15-alpha.19.39.a",
     "fabric-api-base": "*",
     "fabric-rendering-v1": "*"

--- a/deprecated/fabric-rendering-data-attachment-v1/src/main/resources/fabric.mod.json
+++ b/deprecated/fabric-rendering-data-attachment-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.4.0",
+    "fabricloader": ">=0.15.0",
     "fabric-block-view-api-v2": "*"
   },
   "description": "Thread-safe hooks for block entity data use during terrain rendering.",

--- a/deprecated/fabric-rendering-data-attachment-v1/src/main/resources/fabric.mod.json
+++ b/deprecated/fabric-rendering-data-attachment-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-block-view-api-v2": "*"
   },
   "description": "Thread-safe hooks for block entity data use during terrain rendering.",

--- a/deprecated/fabric-rendering-v0/src/client/resources/fabric.mod.json
+++ b/deprecated/fabric-rendering-v0/src/client/resources/fabric.mod.json
@@ -21,7 +21,7 @@
     ]
   },
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "minecraft": ">=1.15-alpha.19.39.a",
     "fabric-api-base": "*",
     "fabric-rendering-v1": "*"

--- a/deprecated/fabric-rendering-v0/src/client/resources/fabric.mod.json
+++ b/deprecated/fabric-rendering-v0/src/client/resources/fabric.mod.json
@@ -21,7 +21,7 @@
     ]
   },
   "depends": {
-    "fabricloader": ">=0.4.0",
+    "fabricloader": ">=0.15.0",
     "minecraft": ">=1.15-alpha.19.39.a",
     "fabric-api-base": "*",
     "fabric-rendering-v1": "*"

--- a/fabric-api-base/src/main/resources/fabric.mod.json
+++ b/fabric-api-base/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0"
+    "fabricloader": ">=0.15.1"
   },
   "description": "Contains the essentials for Fabric API modules.",
   "custom": {

--- a/fabric-api-base/src/main/resources/fabric.mod.json
+++ b/fabric-api-base/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.4.0"
+    "fabricloader": ">=0.15.0"
   },
   "description": "Contains the essentials for Fabric API modules.",
   "custom": {

--- a/fabric-api-lookup-api-v1/src/main/resources/fabric-api-lookup-api-v1.mixins.json
+++ b/fabric-api-lookup-api-v1/src/main/resources/fabric-api-lookup-api-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.lookup",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "BlockEntityTypeAccessor",
     "ServerWorldMixin"

--- a/fabric-api-lookup-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-api-lookup-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*",
     "fabric-lifecycle-events-v1": "*"
   },

--- a/fabric-api-lookup-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-api-lookup-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.9.2",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*",
     "fabric-lifecycle-events-v1": "*"
   },

--- a/fabric-biome-api-v1/src/main/resources/fabric-biome-api-v1.mixins.json
+++ b/fabric-biome-api-v1/src/main/resources/fabric-biome-api-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.biome",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "BiomeSourceMixin",
     "ChunkNoiseSamplerMixin",

--- a/fabric-biome-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-biome-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "minecraft": ">=1.16.2"
   },
   "description": "Hooks for adding biomes to the default world generator.",

--- a/fabric-biome-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-biome-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.9.2",
+    "fabricloader": ">=0.15.0",
     "minecraft": ">=1.16.2"
   },
   "description": "Hooks for adding biomes to the default world generator.",

--- a/fabric-block-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-block-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.14.9"
+    "fabricloader": ">=0.15.0"
   },
   "entrypoints": {
   },

--- a/fabric-block-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-block-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0"
+    "fabricloader": ">=0.15.1"
   },
   "entrypoints": {
   },

--- a/fabric-block-view-api-v2/src/main/resources/fabric.mod.json
+++ b/fabric-block-view-api-v2/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0"
+    "fabricloader": ">=0.15.1"
   },
   "description": "Hooks for block views",
   "mixins": [

--- a/fabric-block-view-api-v2/src/main/resources/fabric.mod.json
+++ b/fabric-block-view-api-v2/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.14.21"
+    "fabricloader": ">=0.15.0"
   },
   "description": "Hooks for block views",
   "mixins": [

--- a/fabric-blockrenderlayer-v1/src/client/resources/fabric-blockrenderlayer-v1.mixins.json
+++ b/fabric-blockrenderlayer-v1/src/client/resources/fabric-blockrenderlayer-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.blockrenderlayer",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "RenderLayersMixin"
   ],

--- a/fabric-blockrenderlayer-v1/src/client/resources/fabric.mod.json
+++ b/fabric-blockrenderlayer-v1/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "minecraft": ">=1.15-alpha.19.38.b",
     "fabric-api-base": "*"
   },

--- a/fabric-blockrenderlayer-v1/src/client/resources/fabric.mod.json
+++ b/fabric-blockrenderlayer-v1/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.6.2",
+    "fabricloader": ">=0.15.0",
     "minecraft": ">=1.15-alpha.19.38.b",
     "fabric-api-base": "*"
   },

--- a/fabric-client-tags-api-v1/src/client/resources/fabric.mod.json
+++ b/fabric-client-tags-api-v1/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.14.6"
+    "fabricloader": ">=0.15.0"
   },
   "description": "Adds the ability to load tags from the local mods.",
   "custom": {

--- a/fabric-client-tags-api-v1/src/client/resources/fabric.mod.json
+++ b/fabric-client-tags-api-v1/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0"
+    "fabricloader": ">=0.15.1"
   },
   "description": "Adds the ability to load tags from the local mods.",
   "custom": {

--- a/fabric-command-api-v2/src/client/resources/fabric-command-api-v2.client.mixins.json
+++ b/fabric-command-api-v2/src/client/resources/fabric-command-api-v2.client.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.command.client",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "ClientCommandSourceMixin",
     "ClientPlayNetworkHandlerMixin"

--- a/fabric-command-api-v2/src/main/resources/fabric-command-api-v2.mixins.json
+++ b/fabric-command-api-v2/src/main/resources/fabric-command-api-v2.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.command",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "ArgumentTypesAccessor",
     "CommandManagerMixin",

--- a/fabric-command-api-v2/src/main/resources/fabric.mod.json
+++ b/fabric-command-api-v2/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*",
     "minecraft": ">1.19-alpha.22.11.a"
   },

--- a/fabric-command-api-v2/src/main/resources/fabric.mod.json
+++ b/fabric-command-api-v2/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.10.5",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*",
     "minecraft": ">1.19-alpha.22.11.a"
   },

--- a/fabric-content-registries-v0/src/main/resources/fabric-content-registries-v0.mixins.json
+++ b/fabric-content-registries-v0/src/main/resources/fabric-content-registries-v0.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.content.registry",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "AxeItemAccessor",
     "FarmerWorkTaskAccessor",

--- a/fabric-content-registries-v0/src/main/resources/fabric.mod.json
+++ b/fabric-content-registries-v0/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*",
     "fabric-lifecycle-events-v1": "*",
     "fabric-resource-loader-v0": "*"

--- a/fabric-content-registries-v0/src/main/resources/fabric.mod.json
+++ b/fabric-content-registries-v0/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.12.0",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*",
     "fabric-lifecycle-events-v1": "*",
     "fabric-resource-loader-v0": "*"

--- a/fabric-convention-tags-v1/src/datagen/resources/fabric.mod.json
+++ b/fabric-convention-tags-v1/src/datagen/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.4.0",
+    "fabricloader": ">=0.15.0",
     "minecraft": ">=1.18.2"
   },
   "description": "Contains common tags used by mods for vanilla things.",

--- a/fabric-convention-tags-v1/src/datagen/resources/fabric.mod.json
+++ b/fabric-convention-tags-v1/src/datagen/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "minecraft": ">=1.18.2"
   },
   "description": "Contains common tags used by mods for vanilla things.",

--- a/fabric-convention-tags-v1/src/main/resources/fabric.mod.json
+++ b/fabric-convention-tags-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.4.0",
+    "fabricloader": ">=0.15.0",
     "minecraft": ">=1.18.2"
   },
   "description": "Contains common tags used by mods for vanilla things.",

--- a/fabric-convention-tags-v1/src/main/resources/fabric.mod.json
+++ b/fabric-convention-tags-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "minecraft": ">=1.18.2"
   },
   "description": "Contains common tags used by mods for vanilla things.",

--- a/fabric-crash-report-info-v1/src/main/resources/fabric-crash-report-info-v1.mixins.json
+++ b/fabric-crash-report-info-v1/src/main/resources/fabric-crash-report-info-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.crash.report.info",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "SystemDetailsMixin"
   ],

--- a/fabric-crash-report-info-v1/src/main/resources/fabric.mod.json
+++ b/fabric-crash-report-info-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0"
+    "fabricloader": ">=0.15.1"
   },
   "description": "Adds Fabric-related debug info to crash reports.",
   "mixins": [

--- a/fabric-crash-report-info-v1/src/main/resources/fabric.mod.json
+++ b/fabric-crash-report-info-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.13.0"
+    "fabricloader": ">=0.15.0"
   },
   "description": "Adds Fabric-related debug info to crash reports.",
   "mixins": [

--- a/fabric-data-generation-api-v1/src/client/resources/fabric-data-generation-api-v1.client.mixins.json
+++ b/fabric-data-generation-api-v1/src/client/resources/fabric-data-generation-api-v1.client.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.datagen.client",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "MinecraftClientMixin"
   ],

--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.datagen",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "loot.BlockLootTableGeneratorMixin",
     "DataProviderMixin",

--- a/fabric-data-generation-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.14.10"
+    "fabricloader": ">=0.15.0"
   },
   "description": "Allows for automatic data generation.",
   "mixins": [

--- a/fabric-data-generation-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0"
+    "fabricloader": ">=0.15.1"
   },
   "description": "Allows for automatic data generation.",
   "mixins": [

--- a/fabric-dimensions-v1/src/main/resources/fabric-dimensions-v1.mixins.json
+++ b/fabric-dimensions-v1/src/main/resources/fabric-dimensions-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.dimension",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "EntityMixin",
     "RegistryCodecsMixin",

--- a/fabric-dimensions-v1/src/main/resources/fabric.mod.json
+++ b/fabric-dimensions-v1/src/main/resources/fabric.mod.json
@@ -15,7 +15,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.12.0",
+    "fabricloader": ">=0.15.0",
     "minecraft": ">=1.16-rc.3",
     "fabric-api-base": "*"
   },

--- a/fabric-dimensions-v1/src/main/resources/fabric.mod.json
+++ b/fabric-dimensions-v1/src/main/resources/fabric.mod.json
@@ -15,7 +15,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "minecraft": ">=1.16-rc.3",
     "fabric-api-base": "*"
   },

--- a/fabric-entity-events-v1/src/client/resources/fabric-entity-events-v1.client.mixins.json
+++ b/fabric-entity-events-v1/src/client/resources/fabric-entity-events-v1.client.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.client.entity.event",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "elytra.ClientPlayerEntityMixin"
   ],

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/ServerPlayerEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/ServerPlayerEntityMixin.java
@@ -54,7 +54,7 @@ import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
 @Mixin(ServerPlayerEntity.class)
 abstract class ServerPlayerEntityMixin extends LivingEntityMixin {
 	@Shadow
-	public abstract ServerWorld method_51469();
+	public abstract ServerWorld getServerWorld();
 
 	/**
 	 * Minecraft by default does not call Entity#onKilledOther for a ServerPlayerEntity being killed.
@@ -67,8 +67,8 @@ abstract class ServerPlayerEntityMixin extends LivingEntityMixin {
 
 		// If the damage source that killed the player was an entity, then fire the event.
 		if (attacker != null) {
-			attacker.onKilledOther(this.method_51469(), (ServerPlayerEntity) (Object) this);
-			ServerEntityCombatEvents.AFTER_KILLED_OTHER_ENTITY.invoker().afterKilledOtherEntity(this.method_51469(), attacker, (ServerPlayerEntity) (Object) this);
+			attacker.onKilledOther(this.getServerWorld(), (ServerPlayerEntity) (Object) this);
+			ServerEntityCombatEvents.AFTER_KILLED_OTHER_ENTITY.invoker().afterKilledOtherEntity(this.getServerWorld(), attacker, (ServerPlayerEntity) (Object) this);
 		}
 	}
 
@@ -83,7 +83,7 @@ abstract class ServerPlayerEntityMixin extends LivingEntityMixin {
 	 */
 	@Inject(method = "worldChanged(Lnet/minecraft/server/world/ServerWorld;)V", at = @At("TAIL"))
 	private void afterWorldChanged(ServerWorld origin, CallbackInfo ci) {
-		ServerEntityWorldChangeEvents.AFTER_PLAYER_CHANGE_WORLD.invoker().afterChangeWorld((ServerPlayerEntity) (Object) this, origin, this.method_51469());
+		ServerEntityWorldChangeEvents.AFTER_PLAYER_CHANGE_WORLD.invoker().afterChangeWorld((ServerPlayerEntity) (Object) this, origin, this.getServerWorld());
 	}
 
 	@Inject(method = "copyFrom", at = @At("TAIL"))

--- a/fabric-entity-events-v1/src/main/resources/fabric-entity-events-v1.mixins.json
+++ b/fabric-entity-events-v1/src/main/resources/fabric-entity-events-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.entity.event",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "elytra.LivingEntityMixin",
     "elytra.PlayerEntityMixin",

--- a/fabric-entity-events-v1/src/main/resources/fabric.mod.json
+++ b/fabric-entity-events-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.8.2"
+    "fabricloader": ">=0.15.0"
   },
   "description": "Events to hook into entities.",
   "mixins": [

--- a/fabric-entity-events-v1/src/main/resources/fabric.mod.json
+++ b/fabric-entity-events-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0"
+    "fabricloader": ">=0.15.1"
   },
   "description": "Events to hook into entities.",
   "mixins": [

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -60,7 +60,7 @@ public final class EntityEventTests implements ModInitializer {
 		Registry.register(Registries.ITEM, new Identifier("fabric-entity-events-v1-testmod", "diamond_elytra"), DIAMOND_ELYTRA);
 
 		ServerEntityCombatEvents.AFTER_KILLED_OTHER_ENTITY.register((world, entity, killed) -> {
-			LOGGER.info("Entity Killed: {}", killed);
+			LOGGER.info("Entity {} Killed: {}", entity, killed);
 		});
 
 		ServerEntityWorldChangeEvents.AFTER_PLAYER_CHANGE_WORLD.register((player, origin, destination) -> {

--- a/fabric-events-interaction-v0/src/client/resources/fabric-events-interaction-v0.client.mixins.json
+++ b/fabric-events-interaction-v0/src/client/resources/fabric-events-interaction-v0.client.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.event.interaction.client",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "ClientPlayerInteractionManagerMixin",
     "KeyBindingAccessor",

--- a/fabric-events-interaction-v0/src/main/resources/fabric-events-interaction-v0.mixins.json
+++ b/fabric-events-interaction-v0/src/main/resources/fabric-events-interaction-v0.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.event.interaction",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "PlayerAdvancementTrackerMixin",
     "ServerPlayerEntityMixin",

--- a/fabric-events-interaction-v0/src/main/resources/fabric.mod.json
+++ b/fabric-events-interaction-v0/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.4.0",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*",
     "minecraft": ">=1.15-alpha.19.37.a"
   },

--- a/fabric-events-interaction-v0/src/main/resources/fabric.mod.json
+++ b/fabric-events-interaction-v0/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*",
     "minecraft": ">=1.15-alpha.19.37.a"
   },

--- a/fabric-game-rule-api-v1/src/client/resources/fabric-game-rule-api-v1.client.mixins.json
+++ b/fabric-game-rule-api-v1/src/client/resources/fabric-game-rule-api-v1.client.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.gamerule.client",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "EditGameRulesScreenAccessor",
     "EditGameRulesScreenRuleListWidgetMixin",

--- a/fabric-game-rule-api-v1/src/main/resources/fabric-game-rule-api-v1.mixins.json
+++ b/fabric-game-rule-api-v1/src/main/resources/fabric-game-rule-api-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.gamerule",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "GameRulesBooleanRuleAccessor",
     "GameRuleCommandAccessor",

--- a/fabric-game-rule-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-game-rule-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0"
+    "fabricloader": ">=0.15.1"
   },
   "description": "Allows registration of custom game rules.",
   "mixins": [

--- a/fabric-game-rule-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-game-rule-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.8.2"
+    "fabricloader": ">=0.15.0"
   },
   "description": "Allows registration of custom game rules.",
   "mixins": [

--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/mixin/gametest/server/MainMixin.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/mixin/gametest/server/MainMixin.java
@@ -37,7 +37,7 @@ public class MainMixin {
 	}
 
 	// Inject after resourcePackManager is stored
-	@Inject(method = "main", cancellable = true, at = @At(value = "INVOKE", shift = At.Shift.BY, by = 2, target = "Lnet/minecraft/resource/VanillaDataPackProvider;createManager(Lnet/minecraft/world/level/storage/LevelStorage$Session;)Lnet/minecraft/resource/ResourcePackManager;"))
+	@Inject(method = "main", cancellable = true, at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/resource/VanillaDataPackProvider;createManager(Lnet/minecraft/world/level/storage/LevelStorage$Session;)Lnet/minecraft/resource/ResourcePackManager;"))
 	private static void main(String[] args, CallbackInfo info, @Local LevelStorage.Session session, @Local ResourcePackManager resourcePackManager) {
 		if (FabricGameTestHelper.ENABLED) {
 			FabricGameTestHelper.runHeadlessServer(session, resourcePackManager);

--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/mixin/gametest/server/MainMixin.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/mixin/gametest/server/MainMixin.java
@@ -16,39 +16,29 @@
 
 package net.fabricmc.fabric.mixin.gametest.server;
 
-import java.io.File;
-import java.nio.file.Path;
-
-import com.mojang.serialization.Dynamic;
-import joptsimple.OptionParser;
-import joptsimple.OptionSet;
-import joptsimple.OptionSpec;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import net.minecraft.resource.ResourcePackManager;
 import net.minecraft.server.Main;
-import net.minecraft.server.dedicated.EulaReader;
-import net.minecraft.server.dedicated.ServerPropertiesLoader;
-import net.minecraft.util.ApiServices;
 import net.minecraft.world.level.storage.LevelStorage;
 
 import net.fabricmc.fabric.impl.gametest.FabricGameTestHelper;
 
 @Mixin(Main.class)
 public class MainMixin {
-	@Redirect(method = "main", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/dedicated/EulaReader;isEulaAgreedTo()Z"))
-	private static boolean isEulaAgreedTo(EulaReader reader) {
-		return FabricGameTestHelper.ENABLED || reader.isEulaAgreedTo();
+	@ModifyExpressionValue(method = "main", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/dedicated/EulaReader;isEulaAgreedTo()Z"))
+	private static boolean isEulaAgreedTo(boolean isEulaAgreedTo) {
+		return FabricGameTestHelper.ENABLED || isEulaAgreedTo;
 	}
 
 	// Inject after resourcePackManager is stored
-	@Inject(method = "main", cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD, at = @At(value = "INVOKE", shift = At.Shift.BY, by = 2, target = "Lnet/minecraft/resource/VanillaDataPackProvider;createManager(Lnet/minecraft/world/level/storage/LevelStorage$Session;)Lnet/minecraft/resource/ResourcePackManager;"))
-	private static void main(String[] args, CallbackInfo info, OptionParser optionParser, OptionSpec optionSpec, OptionSpec optionSpec2, OptionSpec optionSpec3, OptionSpec optionSpec4, OptionSpec optionSpec5, OptionSpec optionSpec6, OptionSpec optionSpec7, OptionSpec optionSpec8, OptionSpec optionSpec9, OptionSpec optionSpec10, OptionSpec optionSpec11, OptionSpec optionSpec12, OptionSpec optionSpec13, OptionSpec optionSpec14, OptionSpec optionSpec15, OptionSet optionSet, Path path2, ServerPropertiesLoader serverPropertiesLoader, Path path3, EulaReader eulaReader, File file, ApiServices apiServices, String string, LevelStorage levelStorage, LevelStorage.Session session, Dynamic dynamic, Dynamic dynamic2, boolean bl, ResourcePackManager resourcePackManager) {
+	@Inject(method = "main", cancellable = true, at = @At(value = "INVOKE", shift = At.Shift.BY, by = 2, target = "Lnet/minecraft/resource/VanillaDataPackProvider;createManager(Lnet/minecraft/world/level/storage/LevelStorage$Session;)Lnet/minecraft/resource/ResourcePackManager;"))
+	private static void main(String[] args, CallbackInfo info, @Local LevelStorage.Session session, @Local ResourcePackManager resourcePackManager) {
 		if (FabricGameTestHelper.ENABLED) {
 			FabricGameTestHelper.runHeadlessServer(session, resourcePackManager);
 			info.cancel();  // Do not progress in starting the normal dedicated server

--- a/fabric-gametest-api-v1/src/main/resources/fabric-gametest-api-v1.mixins.json
+++ b/fabric-gametest-api-v1/src/main/resources/fabric-gametest-api-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.gametest",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "ArgumentTypesMixin",
     "CommandManagerMixin",

--- a/fabric-gametest-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-gametest-api-v1/src/main/resources/fabric.mod.json
@@ -21,7 +21,7 @@
     ]
   },
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-resource-loader-v0": "*"
   },
   "description": "Allows registration of custom game tests.",

--- a/fabric-gametest-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-gametest-api-v1/src/main/resources/fabric.mod.json
@@ -21,6 +21,7 @@
     ]
   },
   "depends": {
+    "fabricloader": ">=0.15.0",
     "fabric-resource-loader-v0": "*"
   },
   "description": "Allows registration of custom game tests.",

--- a/fabric-item-api-v1/src/client/resources/fabric-item-api-v1.client.mixins.json
+++ b/fabric-item-api-v1/src/client/resources/fabric-item-api-v1.client.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.item.client",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "ClientPlayerInteractionManagerMixin",
     "HeldItemRendererMixin",

--- a/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.mixins.json
+++ b/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.item",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "AbstractFurnaceBlockEntityMixin",
     "ArmorItemMixin",

--- a/fabric-item-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-item-api-v1/src/main/resources/fabric.mod.json
@@ -23,7 +23,7 @@
     }
   ],
   "depends": {
-    "fabricloader": ">=0.4.0",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*"
   },
   "description": "Hooks for items",

--- a/fabric-item-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-item-api-v1/src/main/resources/fabric.mod.json
@@ -23,7 +23,7 @@
     }
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*"
   },
   "description": "Hooks for items",

--- a/fabric-item-api-v1/src/testmod/resources/fabric-item-api-tests-v1.mixins.json
+++ b/fabric-item-api-v1/src/testmod/resources/fabric-item-api-tests-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.test.item.mixin",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "BrewingRecipeRegistryAccessor"
   ],

--- a/fabric-item-group-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-item-group-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*",
     "fabric-resource-loader-v0": "*"
   },

--- a/fabric-item-group-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-item-group-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.14.9",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*",
     "fabric-resource-loader-v0": "*"
   },

--- a/fabric-key-binding-api-v1/src/client/resources/fabric-key-binding-api-v1.mixins.json
+++ b/fabric-key-binding-api-v1/src/client/resources/fabric-key-binding-api-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.client.keybinding",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "KeyBindingAccessor",
     "GameOptionsMixin"

--- a/fabric-key-binding-api-v1/src/client/resources/fabric.mod.json
+++ b/fabric-key-binding-api-v1/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.4.0"
+    "fabricloader": ">=0.15.0"
   },
   "description": "Key Binding registry API.",
   "mixins": [

--- a/fabric-key-binding-api-v1/src/client/resources/fabric.mod.json
+++ b/fabric-key-binding-api-v1/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0"
+    "fabricloader": ">=0.15.1"
   },
   "description": "Key Binding registry API.",
   "mixins": [

--- a/fabric-lifecycle-events-v1/src/client/resources/fabric-lifecycle-events-v1.client.mixins.json
+++ b/fabric-lifecycle-events-v1/src/client/resources/fabric-lifecycle-events-v1.client.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.event.lifecycle.client",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "ClientChunkManagerMixin",
     "ClientPlayNetworkHandlerMixin",

--- a/fabric-lifecycle-events-v1/src/main/resources/fabric-lifecycle-events-v1.mixins.json
+++ b/fabric-lifecycle-events-v1/src/main/resources/fabric-lifecycle-events-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.event.lifecycle",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "DataPackContentsMixin",
     "LivingEntityMixin",

--- a/fabric-lifecycle-events-v1/src/main/resources/fabric.mod.json
+++ b/fabric-lifecycle-events-v1/src/main/resources/fabric.mod.json
@@ -31,7 +31,7 @@
     }
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*"
   },
   "description": "Events for the game's lifecycle.",

--- a/fabric-lifecycle-events-v1/src/main/resources/fabric.mod.json
+++ b/fabric-lifecycle-events-v1/src/main/resources/fabric.mod.json
@@ -31,7 +31,7 @@
     }
   ],
   "depends": {
-    "fabricloader": ">=0.4.0",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*"
   },
   "description": "Events for the game's lifecycle.",

--- a/fabric-loot-api-v2/src/main/resources/fabric-loot-api-v2.mixins.json
+++ b/fabric-loot-api-v2/src/main/resources/fabric-loot-api-v2.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.loot",
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "LootManagerMixin",
     "LootPoolAccessor",

--- a/fabric-loot-api-v2/src/main/resources/fabric.mod.json
+++ b/fabric-loot-api-v2/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.4.0",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*",
     "fabric-resource-loader-v0": "*"
   },

--- a/fabric-loot-api-v2/src/main/resources/fabric.mod.json
+++ b/fabric-loot-api-v2/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*",
     "fabric-resource-loader-v0": "*"
   },

--- a/fabric-message-api-v1/src/main/resources/fabric-message-api-v1.mixins.json
+++ b/fabric-message-api-v1/src/main/resources/fabric-message-api-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.message",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "MinecraftServerMixin",
     "PlayerManagerMixin"

--- a/fabric-message-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-message-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.10.5",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*"
   },
   "description": "Adds message-related hooks.",

--- a/fabric-message-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-message-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*"
   },
   "description": "Adds message-related hooks.",

--- a/fabric-mining-level-api-v1/src/main/resources/fabric-mining-level-api-v1.mixins.json
+++ b/fabric-mining-level-api-v1/src/main/resources/fabric-mining-level-api-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.mininglevel",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "MiningToolItemMixin",
     "ShearsItemMixin",

--- a/fabric-mining-level-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-mining-level-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*",
     "fabric-lifecycle-events-v1": "*",
     "fabric-resource-loader-v0": "*"

--- a/fabric-mining-level-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-mining-level-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.4.0",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*",
     "fabric-lifecycle-events-v1": "*",
     "fabric-resource-loader-v0": "*"

--- a/fabric-model-loading-api-v1/src/client/resources/fabric.mod.json
+++ b/fabric-model-loading-api-v1/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.14.21",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*"
   },
   "breaks": {

--- a/fabric-model-loading-api-v1/src/client/resources/fabric.mod.json
+++ b/fabric-model-loading-api-v1/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*"
   },
   "breaks": {

--- a/fabric-networking-api-v1/src/client/resources/fabric-networking-api-v1.client.mixins.json
+++ b/fabric-networking-api-v1/src/client/resources/fabric-networking-api-v1.client.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.networking.client",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "accessor.ClientCommonNetworkHandlerAccessor",
     "accessor.ClientConfigurationNetworkHandlerAccessor",

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/ClientConnectionMixin.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/ClientConnectionMixin.java
@@ -30,7 +30,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
@@ -103,13 +102,11 @@ abstract class ClientConnectionMixin implements ChannelInfoHolder {
 		}
 	}
 
-	@ModifyVariable(method = "handleDisconnection", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/listener/PacketListener;onDisconnected(Lnet/minecraft/text/Text;)V"))
-	private PacketListener disconnectAddon(PacketListener packetListener) {
+	@Inject(method = "handleDisconnection", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/listener/PacketListener;onDisconnected(Lnet/minecraft/text/Text;)V"))
+	private void disconnectAddon(CallbackInfo ci) {
 		if (packetListener instanceof NetworkHandlerExtensions extension) {
 			extension.getAddon().handleDisconnect();
 		}
-
-		return packetListener;
 	}
 
 	@Inject(method = "sendInternal", at = @At(value = "INVOKE", target = "Lio/netty/channel/ChannelFuture;addListener(Lio/netty/util/concurrent/GenericFutureListener;)Lio/netty/channel/ChannelFuture;", remap = false), locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true)

--- a/fabric-networking-api-v1/src/main/resources/fabric-networking-api-v1.mixins.json
+++ b/fabric-networking-api-v1/src/main/resources/fabric-networking-api-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.networking",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "ClientConnectionMixin",
     "CommandManagerMixin",

--- a/fabric-networking-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-networking-api-v1/src/main/resources/fabric.mod.json
@@ -25,7 +25,7 @@
   },
   "accessWidener": "fabric-networking-api-v1.accesswidener",
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*"
   },
   "description": "Low-level, vanilla protocol oriented networking hooks.",

--- a/fabric-networking-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-networking-api-v1/src/main/resources/fabric.mod.json
@@ -25,7 +25,7 @@
   },
   "accessWidener": "fabric-networking-api-v1.accesswidener",
   "depends": {
-    "fabricloader": ">=0.4.0",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*"
   },
   "description": "Low-level, vanilla protocol oriented networking hooks.",

--- a/fabric-object-builder-api-v1/src/client/resources/fabric-object-builder-v1.client.mixins.json
+++ b/fabric-object-builder-api-v1/src/client/resources/fabric-object-builder-v1.client.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.object.builder.client",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "EntityModelLayersMixin",
     "HangingSignEditScreenMixin",

--- a/fabric-object-builder-api-v1/src/main/resources/fabric-object-builder-v1.mixins.json
+++ b/fabric-object-builder-api-v1/src/main/resources/fabric-object-builder-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.object.builder",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "AbstractBlockAccessor",
     "AbstractBlockSettingsAccessor",

--- a/fabric-object-builder-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-object-builder-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*"
   },
   "description": "Builders for objects vanilla has locked down.",

--- a/fabric-object-builder-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-object-builder-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.8.2",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*"
   },
   "description": "Builders for objects vanilla has locked down.",

--- a/fabric-particles-v1/src/client/resources/fabric-particles-v1.client.mixins.json
+++ b/fabric-particles-v1/src/client/resources/fabric-particles-v1.client.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.client.particle",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "BlockDustParticleMixin",
     "ParticleManagerMixin",

--- a/fabric-particles-v1/src/main/resources/fabric.mod.json
+++ b/fabric-particles-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.14.21"
+    "fabricloader": ">=0.15.0"
   },
   "description": "Hooks for registering custom particles.",
   "mixins": [

--- a/fabric-particles-v1/src/main/resources/fabric.mod.json
+++ b/fabric-particles-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0"
+    "fabricloader": ">=0.15.1"
   },
   "description": "Hooks for registering custom particles.",
   "mixins": [

--- a/fabric-recipe-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-recipe-api-v1/src/main/resources/fabric.mod.json
@@ -20,7 +20,7 @@
   ],
   "accessWidener": "fabric-recipe-api-v1.accesswidener",
   "depends": {
-    "fabricloader": ">=0.14.10",
+    "fabricloader": ">=0.15.0",
     "fabric-networking-api-v1": "*"
   },
   "entrypoints": {

--- a/fabric-recipe-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-recipe-api-v1/src/main/resources/fabric.mod.json
@@ -20,7 +20,7 @@
   ],
   "accessWidener": "fabric-recipe-api-v1.accesswidener",
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-networking-api-v1": "*"
   },
   "entrypoints": {

--- a/fabric-registry-sync-v0/src/client/resources/fabric-registry-sync-v0.client.mixins.json
+++ b/fabric-registry-sync-v0/src/client/resources/fabric-registry-sync-v0.client.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.registry.sync.client",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "BlockColorsMixin",
     "ItemColorsMixin",

--- a/fabric-registry-sync-v0/src/main/resources/fabric-registry-sync-v0.mixins.json
+++ b/fabric-registry-sync-v0/src/main/resources/fabric-registry-sync-v0.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.registry.sync",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "BootstrapMixin",
     "ChunkSerializerMixin",

--- a/fabric-registry-sync-v0/src/main/resources/fabric.mod.json
+++ b/fabric-registry-sync-v0/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*",
     "fabric-networking-api-v1": "*"
   },

--- a/fabric-registry-sync-v0/src/main/resources/fabric.mod.json
+++ b/fabric-registry-sync-v0/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.13.2",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*",
     "fabric-networking-api-v1": "*"
   },

--- a/fabric-renderer-api-v1/src/client/resources/fabric-renderer-api-v1.debughud.mixins.json
+++ b/fabric-renderer-api-v1/src/client/resources/fabric-renderer-api-v1.debughud.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": false,
   "package": "net.fabricmc.fabric.mixin.renderer.client.debughud",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "DebugHudMixin"
   ],

--- a/fabric-renderer-api-v1/src/client/resources/fabric-renderer-api-v1.mixins.json
+++ b/fabric-renderer-api-v1/src/client/resources/fabric-renderer-api-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.renderer",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "client.BakedModelMixin",
     "client.MultipartBakedModelMixin",

--- a/fabric-renderer-api-v1/src/client/resources/fabric.mod.json
+++ b/fabric-renderer-api-v1/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "minecraft": ">=1.15-alpha.19.39.a",
     "fabric-api-base": "*"
   },

--- a/fabric-renderer-api-v1/src/client/resources/fabric.mod.json
+++ b/fabric-renderer-api-v1/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.6.2",
+    "fabricloader": ">=0.15.0",
     "minecraft": ">=1.15-alpha.19.39.a",
     "fabric-api-base": "*"
   },

--- a/fabric-renderer-indigo/src/client/resources/fabric-renderer-indigo.mixins.json
+++ b/fabric-renderer-indigo/src/client/resources/fabric-renderer-indigo.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.client.indigo.renderer",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "plugin": "net.fabricmc.fabric.impl.client.indigo.IndigoMixinConfigPlugin",
   "mixins": [
   ],

--- a/fabric-renderer-indigo/src/client/resources/fabric.mod.json
+++ b/fabric-renderer-indigo/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.6.2",
+    "fabricloader": ">=0.15.0",
     "minecraft": ">=1.15-alpha.19.39.a",
     "fabric-api-base": "*",
     "fabric-renderer-api-v1": "*"

--- a/fabric-renderer-indigo/src/client/resources/fabric.mod.json
+++ b/fabric-renderer-indigo/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "minecraft": ">=1.15-alpha.19.39.a",
     "fabric-api-base": "*",
     "fabric-renderer-api-v1": "*"

--- a/fabric-rendering-fluids-v1/src/client/resources/fabric-rendering-fluids-v1.mixins.json
+++ b/fabric-rendering-fluids-v1/src/client/resources/fabric-rendering-fluids-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.client.rendering.fluid",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "FluidRendererMixin"
   ],

--- a/fabric-rendering-fluids-v1/src/main/resources/fabric.mod.json
+++ b/fabric-rendering-fluids-v1/src/main/resources/fabric.mod.json
@@ -15,7 +15,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.4.0",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*"
   },
   "description": "Hooks for registering fluid renders.",

--- a/fabric-rendering-fluids-v1/src/main/resources/fabric.mod.json
+++ b/fabric-rendering-fluids-v1/src/main/resources/fabric.mod.json
@@ -15,7 +15,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*"
   },
   "description": "Hooks for registering fluid renders.",

--- a/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
+++ b/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.client.rendering",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "ArmorFeatureRendererMixin",
     "BlockColorsMixin",

--- a/fabric-rendering-v1/src/client/resources/fabric.mod.json
+++ b/fabric-rendering-v1/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*"
   },
   "description": "Hooks and registries for rendering-related things.",

--- a/fabric-rendering-v1/src/client/resources/fabric.mod.json
+++ b/fabric-rendering-v1/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.4.0",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*"
   },
   "description": "Hooks and registries for rendering-related things.",

--- a/fabric-resource-conditions-api-v1/src/main/resources/fabric-resource-conditions-api-v1.mixins.json
+++ b/fabric-resource-conditions-api-v1/src/main/resources/fabric-resource-conditions-api-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.resource.conditions",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "DataPackContentsMixin",
     "DataProviderMixin",

--- a/fabric-resource-conditions-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-resource-conditions-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0"
+    "fabricloader": ">=0.15.1"
   },
   "description": "Allows conditionally loading resources.",
   "mixins": [

--- a/fabric-resource-conditions-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-resource-conditions-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.9.2"
+    "fabricloader": ">=0.15.0"
   },
   "description": "Allows conditionally loading resources.",
   "mixins": [

--- a/fabric-resource-loader-v0/src/client/resources/fabric-resource-loader-v0.client.mixins.json
+++ b/fabric-resource-loader-v0/src/client/resources/fabric-resource-loader-v0.client.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.resource.loader.client",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "VanillaResourcePackProviderMixin",
     "DefaultClientResourcePackProviderMixin",

--- a/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
+++ b/fabric-resource-loader-v0/src/main/resources/fabric-resource-loader-v0.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.resource.loader",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "KeyedResourceReloadListenerMixin",
     "LifecycledResourceManagerImplMixin",

--- a/fabric-resource-loader-v0/src/main/resources/fabric.mod.json
+++ b/fabric-resource-loader-v0/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0"
+    "fabricloader": ">=0.15.1"
   },
   "description": "Asset and data resource loading.",
   "mixins": [

--- a/fabric-resource-loader-v0/src/main/resources/fabric.mod.json
+++ b/fabric-resource-loader-v0/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.13.0"
+    "fabricloader": ">=0.15.0"
   },
   "description": "Asset and data resource loading.",
   "mixins": [

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/GameRendererMixin.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/GameRendererMixin.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.mixin.screen;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -23,13 +24,11 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.render.GameRenderer;
-import net.minecraft.client.util.math.MatrixStack;
 
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 
@@ -42,8 +41,8 @@ abstract class GameRendererMixin {
 	@Unique
 	private Screen renderingScreen;
 
-	@Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;renderWithTooltip(Lnet/minecraft/client/gui/DrawContext;IIF)V"), locals = LocalCapture.CAPTURE_FAILHARD)
-	private void onBeforeRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo ci, boolean b1, int mouseX, int mouseY, MatrixStack matrixStack, DrawContext drawContext) {
+	@Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;renderWithTooltip(Lnet/minecraft/client/gui/DrawContext;IIF)V"))
+	private void onBeforeRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo ci, @Local(ordinal = 0) int mouseX, @Local(ordinal = 0) int mouseY, @Local DrawContext drawContext) {
 		// Store the screen in a variable in case someone tries to change the screen during this before render event.
 		// If someone changes the screen, the after render event will likely have class cast exceptions or an NPE.
 		this.renderingScreen = this.client.currentScreen;
@@ -51,8 +50,8 @@ abstract class GameRendererMixin {
 	}
 
 	// This injection should end up in the try block so exceptions are caught
-	@Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;renderWithTooltip(Lnet/minecraft/client/gui/DrawContext;IIF)V", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD)
-	private void onAfterRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo ci, boolean b1, int mouseX, int mouseY, MatrixStack matrixStack, DrawContext drawContext) {
+	@Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;renderWithTooltip(Lnet/minecraft/client/gui/DrawContext;IIF)V", shift = At.Shift.AFTER))
+	private void onAfterRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo ci, @Local(ordinal = 0) int mouseX, @Local(ordinal = 0) int mouseY, @Local DrawContext drawContext) {
 		ScreenEvents.afterRender(this.renderingScreen).invoker().afterRender(this.renderingScreen, drawContext, mouseX, mouseY, tickDelta);
 		// Finally set the currently rendering screen to null
 		this.renderingScreen = null;

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/GameRendererMixin.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/GameRendererMixin.java
@@ -16,16 +16,11 @@
 
 package net.fabricmc.fabric.mixin.screen;
 
-import com.llamalad7.mixinextras.sugar.Local;
-import org.spongepowered.asm.mixin.Final;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.render.GameRenderer;
@@ -34,26 +29,10 @@ import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 
 @Mixin(GameRenderer.class)
 abstract class GameRendererMixin {
-	@Shadow
-	@Final
-	private MinecraftClient client;
-
-	@Unique
-	private Screen renderingScreen;
-
-	@Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;renderWithTooltip(Lnet/minecraft/client/gui/DrawContext;IIF)V"))
-	private void onBeforeRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo ci, @Local(ordinal = 0) int mouseX, @Local(ordinal = 1) int mouseY, @Local DrawContext drawContext) {
-		// Store the screen in a variable in case someone tries to change the screen during this before render event.
-		// If someone changes the screen, the after render event will likely have class cast exceptions or an NPE.
-		this.renderingScreen = this.client.currentScreen;
-		ScreenEvents.beforeRender(this.renderingScreen).invoker().beforeRender(this.renderingScreen, drawContext, mouseX, mouseY, tickDelta);
-	}
-
-	// This injection should end up in the try block so exceptions are caught
-	@Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;renderWithTooltip(Lnet/minecraft/client/gui/DrawContext;IIF)V", shift = At.Shift.AFTER))
-	private void onAfterRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo ci, @Local(ordinal = 0) int mouseX, @Local(ordinal = 1) int mouseY, @Local DrawContext drawContext) {
-		ScreenEvents.afterRender(this.renderingScreen).invoker().afterRender(this.renderingScreen, drawContext, mouseX, mouseY, tickDelta);
-		// Finally set the currently rendering screen to null
-		this.renderingScreen = null;
+	@WrapOperation(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;renderWithTooltip(Lnet/minecraft/client/gui/DrawContext;IIF)V"))
+	private void onRenderScreen(Screen currentScreen, DrawContext drawContext, int mouseX, int mouseY, float tickDelta, Operation<Void> operation) {
+		ScreenEvents.beforeRender(currentScreen).invoker().beforeRender(currentScreen, drawContext, mouseX, mouseY, tickDelta);
+		operation.call(currentScreen, drawContext, mouseX, mouseY, tickDelta);
+		ScreenEvents.afterRender(currentScreen).invoker().afterRender(currentScreen, drawContext, mouseX, mouseY, tickDelta);
 	}
 }

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/GameRendererMixin.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/GameRendererMixin.java
@@ -42,7 +42,7 @@ abstract class GameRendererMixin {
 	private Screen renderingScreen;
 
 	@Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;renderWithTooltip(Lnet/minecraft/client/gui/DrawContext;IIF)V"))
-	private void onBeforeRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo ci, @Local(ordinal = 0) int mouseX, @Local(ordinal = 0) int mouseY, @Local DrawContext drawContext) {
+	private void onBeforeRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo ci, @Local(ordinal = 0) int mouseX, @Local(ordinal = 1) int mouseY, @Local DrawContext drawContext) {
 		// Store the screen in a variable in case someone tries to change the screen during this before render event.
 		// If someone changes the screen, the after render event will likely have class cast exceptions or an NPE.
 		this.renderingScreen = this.client.currentScreen;
@@ -51,7 +51,7 @@ abstract class GameRendererMixin {
 
 	// This injection should end up in the try block so exceptions are caught
 	@Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;renderWithTooltip(Lnet/minecraft/client/gui/DrawContext;IIF)V", shift = At.Shift.AFTER))
-	private void onAfterRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo ci, @Local(ordinal = 0) int mouseX, @Local(ordinal = 0) int mouseY, @Local DrawContext drawContext) {
+	private void onAfterRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo ci, @Local(ordinal = 0) int mouseX, @Local(ordinal = 1) int mouseY, @Local DrawContext drawContext) {
 		ScreenEvents.afterRender(this.renderingScreen).invoker().afterRender(this.renderingScreen, drawContext, mouseX, mouseY, tickDelta);
 		// Finally set the currently rendering screen to null
 		this.renderingScreen = null;

--- a/fabric-screen-api-v1/src/client/resources/fabric-screen-api-v1.mixins.json
+++ b/fabric-screen-api-v1/src/client/resources/fabric-screen-api-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.screen",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "GameRendererMixin",
     "MinecraftClientMixin",

--- a/fabric-screen-api-v1/src/client/resources/fabric.mod.json
+++ b/fabric-screen-api-v1/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.8.2",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*"
   },
   "description": "Adds screen related hooks.",

--- a/fabric-screen-api-v1/src/client/resources/fabric.mod.json
+++ b/fabric-screen-api-v1/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*"
   },
   "description": "Adds screen related hooks.",

--- a/fabric-screen-handler-api-v1/src/main/resources/fabric-screen-handler-api-v1.mixins.json
+++ b/fabric-screen-handler-api-v1/src/main/resources/fabric-screen-handler-api-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.screenhandler",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "NamedScreenHandlerFactoryMixin",
     "ServerPlayerEntityMixin"

--- a/fabric-screen-handler-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-screen-handler-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-base": "*",
     "fabric-networking-api-v1": "*"
   },

--- a/fabric-screen-handler-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-screen-handler-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.8.0",
+    "fabricloader": ">=0.15.0",
     "fabric-api-base": "*",
     "fabric-networking-api-v1": "*"
   },

--- a/fabric-sound-api-v1/src/client/resources/fabric.mod.json
+++ b/fabric-sound-api-v1/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "minecraft": ">=1.19.2"
   },
   "description": "Hooks for modifying Minecraft's sound system.",

--- a/fabric-sound-api-v1/src/client/resources/fabric.mod.json
+++ b/fabric-sound-api-v1/src/client/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.14.9",
+    "fabricloader": ">=0.15.0",
     "minecraft": ">=1.19.2"
   },
   "description": "Hooks for modifying Minecraft's sound system.",

--- a/fabric-transfer-api-v1/src/main/resources/fabric-transfer-api-v1.mixins.json
+++ b/fabric-transfer-api-v1/src/main/resources/fabric-transfer-api-v1.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.mixin.transfer",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "AbstractFurnaceBlockEntityMixin",
     "BucketItemAccessor",

--- a/fabric-transfer-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-transfer-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "fabric-api-lookup-api-v1": "*",
     "fabric-rendering-fluids-v1": "*"
   },

--- a/fabric-transfer-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-transfer-api-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.9.2",
+    "fabricloader": ">=0.15.0",
     "fabric-api-lookup-api-v1": "*",
     "fabric-rendering-fluids-v1": "*"
   },

--- a/fabric-transfer-api-v1/src/testmod/resources/fabric-transfer-api-v1-testmod.mixins.json
+++ b/fabric-transfer-api-v1/src/testmod/resources/fabric-transfer-api-v1-testmod.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.fabricmc.fabric.test.transfer.mixin",
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "AbstractFurnaceBlockEntityAccessor"
   ]

--- a/fabric-transitive-access-wideners-v1/src/main/resources/fabric.mod.json
+++ b/fabric-transitive-access-wideners-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.12.12"
+    "fabricloader": ">=0.15.0"
   },
   "description": "Contains transitive access wideners that provide access to otherwise inaccessible Minecraft code.",
   "accessWidener": "fabric-transitive-access-wideners-v1.accesswidener",

--- a/fabric-transitive-access-wideners-v1/src/main/resources/fabric.mod.json
+++ b/fabric-transitive-access-wideners-v1/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0"
+    "fabricloader": ">=0.15.1"
   },
   "description": "Contains transitive access wideners that provide access to otherwise inaccessible Minecraft code.",
   "accessWidener": "fabric-transitive-access-wideners-v1.accesswidener",

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ fabric.loom.multiProjectOptimisation=true
 version=0.91.1
 minecraft_version=1.20.3-pre4
 yarn_version=+build.1
-loader_version=0.14.23
+loader_version=0.15.0
 installer_version=0.11.1
 
 prerelease=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ fabric.loom.multiProjectOptimisation=true
 version=0.91.1
 minecraft_version=1.20.4-rc1
 yarn_version=+build.1
-loader_version=0.15.0
+loader_version=0.15.1
 installer_version=0.11.1
 
 prerelease=true

--- a/gradle/module-validation.gradle
+++ b/gradle/module-validation.gradle
@@ -73,5 +73,13 @@ class ValidateModuleTask extends DefaultTask {
 			default:
 				throw new GradleException("Module ${project} has an invalid module lifecycle ${json.custom.get('fabric-api:module-lifecycle')}")
 		}
+
+		if (json.depends == null) {
+			throw new GradleException("Module ${project} does not have a depends value!")
+		}
+
+		if (json.depends.fabricloader != ">=${project.loader_version}") {
+			throw new GradleException("Module ${project} does not have a valid fabricloader value! Got \"${json.depends.fabricloader}\" but expected \">=${project.loader_version}\"")
+		}
 	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,7 +19,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.14.23",
+    "fabricloader": ">=0.15.0",
     "java": ">=17",
     "minecraft": ">=1.20.3- <1.20.4-"
   },

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,7 +19,7 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
+    "fabricloader": ">=0.15.1",
     "java": ">=17",
     "minecraft": ">=1.20.3- <1.20.5-"
   },


### PR DESCRIPTION
Ensure all modules depend on the version of loader they are built against, a number of modules had mixins that depended on the "legacy" local cpature behaviour, I have replaced those broken with @Local

Going forward all modules will depend on the loader version that FAPI is built against.

I will combine this PR with a Gradle + other deps update as well, due to the need to update all modules.