### PR TITLE
feat: add fabric-api-bom and fabric-api-catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ def ENV = System.getenv()
 version = project.version + "+" + (ENV.GITHUB_RUN_NUMBER ? "" : "local-") + getBranch()
 logger.lifecycle("Building Fabric: " + version)
 
+def metaProjects = ['deprecated', 'fabric-api-bom', 'fabric-api-catalog']
 
 import net.fabricmc.loom.util.gradle.SourceSetHelper
 import groovy.json.JsonSlurper
@@ -132,7 +133,7 @@ allprojects {
 		setupRepositories(repositories)
 	}
 
-	if (it.name == "deprecated") {
+	if (metaProjects.contains(it.name)) {
 		return
 	}
 
@@ -200,7 +201,7 @@ allprojects {
 	}
 
 	allprojects.each { p ->
-		if (project.name == "deprecated") {
+		if (metaProjects.contains(project.name)) {
 			return
 		}
 
@@ -332,7 +333,7 @@ remapTestmodJar {
 	def testModJarTasks = []
 
 	subprojects {
-		if (it.name == "deprecated" || !(it.file("src/testmod").exists() || it.file("src/testmodClient").exists())) {
+		if (metaProjects.contains(it.name) || !(it.file("src/testmod").exists() || it.file("src/testmodClient").exists())) {
 			return
 		}
 
@@ -374,7 +375,7 @@ javadoc {
 	}
 
 	allprojects.each {
-		if (it.name == "deprecated") {
+		if (metaProjects.contains(it.name)) {
 			return
 		}
 
@@ -592,7 +593,7 @@ def addPomMetadataInformation(Project project, MavenPom pom) {
 }
 
 subprojects {
-	if (it.name == "deprecated") {
+	if (metaProjects.contains(it.name)) {
 		return
 	}
 
@@ -705,7 +706,7 @@ void setupRepositories(RepositoryHandler repositories) {
 }
 
 subprojects.each {
-	if (it.name == "deprecated") {
+	if (metaProjects.contains(it.name)) {
 		return
 	}
 
@@ -718,7 +719,7 @@ def devOnlyModules = ["fabric-gametest-api-v1",]
 dependencies {
 	afterEvaluate {
 		subprojects.each {
-			if (it.name == "deprecated") {
+			if (metaProjects.contains(it.name)) {
 				return
 			}
 
@@ -734,7 +735,7 @@ dependencies {
 remapJar {
 	afterEvaluate {
 		subprojects.each {
-			if (it.name in devOnlyModules || it.name == "deprecated") {
+			if (it.name in devOnlyModules || metaProjects.contains(it.name)) {
 				return
 			}
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,11 @@ def ENV = System.getenv()
 version = project.version + "+" + (ENV.GITHUB_RUN_NUMBER ? "" : "local-") + getBranch()
 logger.lifecycle("Building Fabric: " + version)
 
-def metaProjects = ['deprecated', 'fabric-api-bom', 'fabric-api-catalog']
+def metaProjects = [
+	'deprecated',
+	'fabric-api-bom',
+	'fabric-api-catalog'
+]
 
 import net.fabricmc.loom.util.gradle.SourceSetHelper
 import groovy.json.JsonSlurper

--- a/fabric-api-bom/build.gradle
+++ b/fabric-api-bom/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+	id 'java-platform'
+}
+
+version = rootProject.version
+
+publishing.publications {
+	register('mavenJava', MavenPublication) {
+		from(components['javaPlatform'])
+	}
+}
+
+tasks.withType(GenerateModuleMetadata) {
+	// todo: RemoteSignJar fails when this is false (as set by parent build script)
+	enabled = true
+}
+
+dependencies {
+	constraints {
+		for (proj in rootProject.allprojects) {
+			if (proj == project) { // the bom itself
+				continue
+			}
+			if (proj.name == 'fabric-api-catalog') {
+				continue
+			}
+
+			api(project(proj.path))
+		}
+	}
+}

--- a/fabric-api-catalog/build.gradle
+++ b/fabric-api-catalog/build.gradle
@@ -6,7 +6,7 @@ version = rootProject.version
 
 publishing.publications {
 	register('mavenJava', MavenPublication) {
-		from(components['versionCatalog'])
+		from components.versionCatalog
 	}
 }
 
@@ -21,7 +21,7 @@ tasks.register('configureCatalog') {
 		doConfigureCatalog()
 	}
 }
-tasks.generateCatalogAsToml {
+tasks.named('generateCatalogAsToml') {
 	dependsOn('configureCatalog')
 }
 

--- a/fabric-api-catalog/build.gradle
+++ b/fabric-api-catalog/build.gradle
@@ -1,0 +1,57 @@
+plugins {
+	id 'version-catalog'
+}
+
+version = rootProject.version
+
+publishing.publications {
+	register('mavenJava', MavenPublication) {
+		from(components['versionCatalog'])
+	}
+}
+
+tasks.withType(GenerateModuleMetadata) {
+	// todo: RemoteSignJar fails when this is false (as set by parent build script)
+	enabled = true
+}
+
+// Avoid configuration ordering issues by creating the catalog entries during task execution time
+tasks.register('configureCatalog') {
+	doFirst {
+		doConfigureCatalog()
+	}
+}
+tasks.generateCatalogAsToml {
+	dependsOn('configureCatalog')
+}
+
+def doConfigureCatalog() {
+	for (proj in rootProject.allprojects) {
+		if (proj == project) { // the catalog itself
+			continue
+		}
+
+		String catalogName = proj.name
+		if (catalogName == 'fabric-api-base') {
+			catalogName = 'base'
+		} else if (catalogName == 'fabric-api-bom') {
+			catalogName = 'bom'
+		} else if (catalogName == 'deprecated') {
+			catalogName = 'deprecated-fabric-api'
+		} else if (catalogName == 'fabric-api') {
+			catalogName = 'fabric-api'
+		} else {
+			catalogName = catalogName.substring('fabric-'.length())
+		}
+
+		if (proj.parent != null && proj.parent.name == 'deprecated') {
+			catalogName = 'deprecated-' + catalogName
+		}
+
+		catalog {
+			versionCatalog {
+				library(catalogName, "net.fabricmc.fabric-api:${proj.name}:${proj.version}")
+			}
+		}
+	}
+}

--- a/gradle/module-validation.gradle
+++ b/gradle/module-validation.gradle
@@ -8,7 +8,7 @@ import groovy.json.JsonSlurper
  */
 
 subprojects {
-	if (it.name == "deprecated") {
+	if (it.name == "deprecated" || it.name == "fabric-api-bom" || it.name == "fabric-api-catalog") {
 		return
 	}
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,6 +11,9 @@ pluginManagement {
 
 rootProject.name = "fabric-api"
 
+include 'fabric-api-bom'
+include 'fabric-api-catalog'
+
 include 'fabric-api-base'
 
 include 'fabric-api-lookup-api-v1'


### PR DESCRIPTION
This adds two new publications, a [BOM](https://docs.gradle.org/current/userguide/platforms.html#sub:bom_import) (`fabric-api-bom`) and a [version catalog](https://docs.gradle.org/current/userguide/platforms.html#sec:importing-published-catalog) (`fabric-api-catalog`).

**Example use of the BOM**

This will also work with `include` configuration in loom 1.5+
```kotlin
dependencies {
  modImplementation(platform("net.fabricmc.fabric-api:fabric-api-bom:VERSION"))
  modImplementation("net.fabricmc.fabric-api:fabric-api-lookup-api-v1") // version is from BOM
}
```

**Example use of the catalog**

`settings.gradle(.kts)`:
```kotlin
dependencyResolutionManagement {
  repositories {
    maven("https://maven.fabricmc.net/")
  }
  versionCatalogs {
    create("fabricApiLibs") {
      from("net.fabricmc.fabric-api:fabric-api-catalog:VERSION")
    }
  }
}
```

`build.gradle(.kts)`:
```kotlin
dependencies {
  modImplementation(platform(fabricApiLibs.bom)) // if you want to use the BOM too
  modImplementation(fabricApiLibs.api.lookup.api.v1)

  // deprecated modules in own group
  modImplementation(fabricApiLibs.deprecated.command.api.v1)
}
```

**Future ideas**
For modules that depend on others, we could also include a bundle in the catalog that has flattened dependencies (for use with `include`).