### PR TITLE
Fix local login query response handler not working

### DIFF
--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/server/ServerLoginNetworkAddon.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/server/ServerLoginNetworkAddon.java
@@ -147,7 +147,7 @@ public final class ServerLoginNetworkAddon extends AbstractNetworkAddon<ServerLo
 		}
 
 		boolean understood = originalBuf != null;
-		@Nullable ServerLoginNetworking.LoginQueryResponseHandler handler = ServerNetworkingImpl.LOGIN.getHandler(channel);
+		@Nullable ServerLoginNetworking.LoginQueryResponseHandler handler = this.getHandler(channel);
 
 		if (handler == null) {
 			return false;

--- a/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/login/NetworkingLoginQueryTest.java
+++ b/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/login/NetworkingLoginQueryTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.FutureTask;
 
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerLoginNetworkHandler;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.Util;
 
 import net.fabricmc.api.ModInitializer;
@@ -29,10 +30,12 @@ import net.fabricmc.fabric.api.networking.v1.PacketSender;
 import net.fabricmc.fabric.api.networking.v1.ServerLoginConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerLoginNetworking;
 import net.fabricmc.fabric.test.networking.NetworkingTestmods;
-import net.fabricmc.fabric.test.networking.play.NetworkingPlayPacketTest;
 
 public final class NetworkingLoginQueryTest implements ModInitializer {
 	private static final boolean useLoginDelayTest = System.getProperty("fabric-networking-api-v1.loginDelayTest") != null;
+
+	public static final Identifier GLOBAL_TEST_CHANNEL = NetworkingTestmods.id("global_test_channel");
+	public static final Identifier LOCAL_TEST_CHANNEL = NetworkingTestmods.id("local_test_channel");
 
 	@Override
 	public void onInitialize() {
@@ -40,9 +43,9 @@ public final class NetworkingLoginQueryTest implements ModInitializer {
 		ServerLoginConnectionEvents.QUERY_START.register(this::delaySimply);
 
 		// login delaying example
-		ServerLoginNetworking.registerGlobalReceiver(NetworkingPlayPacketTest.TEST_CHANNEL, (server, handler, understood, buf, synchronizer, sender) -> {
+		ServerLoginNetworking.registerGlobalReceiver(GLOBAL_TEST_CHANNEL, (server, handler, understood, buf, synchronizer, sender) -> {
 			if (understood) {
-				NetworkingTestmods.LOGGER.info("Understood response from client in {}", NetworkingPlayPacketTest.TEST_CHANNEL);
+				NetworkingTestmods.LOGGER.info("Understood response from client in {}", GLOBAL_TEST_CHANNEL);
 
 				if (useLoginDelayTest) {
 					FutureTask<?> future = new FutureTask<>(() -> {
@@ -59,8 +62,20 @@ public final class NetworkingLoginQueryTest implements ModInitializer {
 					synchronizer.waitFor(future);
 				}
 			} else {
-				NetworkingTestmods.LOGGER.info("Client did not understand response query message with channel name {}", NetworkingPlayPacketTest.TEST_CHANNEL);
+				NetworkingTestmods.LOGGER.info("Client did not understand response query message with channel name {}", GLOBAL_TEST_CHANNEL);
 			}
+		});
+
+		ServerLoginConnectionEvents.QUERY_START.register((handler, server, sender, synchronizer) -> {
+			ServerLoginNetworking.registerReceiver(handler, LOCAL_TEST_CHANNEL, (server1, handler1, understood, buf, synchronizer1, responseSender) -> {
+				if (understood) {
+					NetworkingTestmods.LOGGER.info("Understood response from client in {}", LOCAL_TEST_CHANNEL);
+				} else {
+					NetworkingTestmods.LOGGER.info("Client did not understand response query message with channel name {}", LOCAL_TEST_CHANNEL);
+				}
+			});
+
+			sender.sendPacket(LOCAL_TEST_CHANNEL, PacketByteBufs.create());
 		});
 	}
 
@@ -81,6 +96,6 @@ public final class NetworkingLoginQueryTest implements ModInitializer {
 
 	private void onLoginStart(ServerLoginNetworkHandler networkHandler, MinecraftServer server, PacketSender sender, ServerLoginNetworking.LoginSynchronizer synchronizer) {
 		// Send a dummy query when the client starts accepting queries.
-		sender.sendPacket(NetworkingPlayPacketTest.TEST_CHANNEL, PacketByteBufs.empty()); // dummy packet
+		sender.sendPacket(GLOBAL_TEST_CHANNEL, PacketByteBufs.empty()); // dummy packet
 	}
 }

--- a/fabric-networking-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/networking/client/login/NetworkingLoginQueryClientTest.java
+++ b/fabric-networking-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/networking/client/login/NetworkingLoginQueryClientTest.java
@@ -19,16 +19,23 @@ package net.fabricmc.fabric.test.networking.client.login;
 import java.util.concurrent.CompletableFuture;
 
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.networking.v1.ClientLoginConnectionEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientLoginNetworking;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
-import net.fabricmc.fabric.test.networking.play.NetworkingPlayPacketTest;
+import net.fabricmc.fabric.test.networking.login.NetworkingLoginQueryTest;
 
 public final class NetworkingLoginQueryClientTest implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
 		// Send a dummy response to the server in return, by registering here we essentially say we understood the server's query
-		ClientLoginNetworking.registerGlobalReceiver(NetworkingPlayPacketTest.TEST_CHANNEL, (client, handler, buf, listenerAdder) -> {
+		ClientLoginNetworking.registerGlobalReceiver(NetworkingLoginQueryTest.GLOBAL_TEST_CHANNEL, (client, handler, buf, listenerAdder) -> {
 			return CompletableFuture.completedFuture(PacketByteBufs.empty());
+		});
+
+		ClientLoginConnectionEvents.QUERY_START.register((handler, client) -> {
+			ClientLoginNetworking.registerReceiver(NetworkingLoginQueryTest.LOCAL_TEST_CHANNEL, (client1, handler1, buf, listenerAdder) -> {
+				return CompletableFuture.completedFuture(PacketByteBufs.empty());
+			});
 		});
 	}
 }


### PR DESCRIPTION
Closes https://github.com/FabricMC/fabric/issues/3494

Happens all the way from the start of the Networking API v1, though with the issue only encountered now means that no one actually uses the local handler registry, so not sure if we need to release a fix for all the versions.