### PR TITLE
Add a system property for a custom output directory for gametest structures

### DIFF
--- a/fabric-gametest-api-v1/build.gradle
+++ b/fabric-gametest-api-v1/build.gradle
@@ -2,6 +2,17 @@ version = getSubprojectVersion(project)
 
 loom {
 	accessWidenerPath = file("src/main/resources/fabric-gametest-api-v1.accesswidener")
+
+	runs {
+		testmodClient {
+			client()
+			name = "Testmod Client"
+			vmArg "-Dfabric-api.gametest.structures.output-dir=${file("src/testmod/resources/data/fabric-gametest-api-v1-testmod/gametest/structures")}"
+
+			ideConfigGenerated = true
+			source sourceSets.testmodClient
+		}
+	}
 }
 
 moduleDependencies(project, [

--- a/fabric-gametest-api-v1/build.gradle
+++ b/fabric-gametest-api-v1/build.gradle
@@ -9,7 +9,7 @@ loom {
 			name = "Testmod Client"
 			vmArg "-Dfabric-api.gametest.structures.output-dir=${file("src/testmod/resources/data/fabric-gametest-api-v1-testmod/gametest/structures")}"
 
-			ideConfigGenerated = true
+			ideConfigGenerated = false
 			source sourceSets.testmodClient
 		}
 	}

--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/mixin/gametest/TestCommandMixin.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/mixin/gametest/TestCommandMixin.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.gametest;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import net.minecraft.server.command.TestCommand;
+
+@Mixin(TestCommand.class)
+public class TestCommandMixin {
+	@Unique
+	private static final String OUTPUT_DIR = System.getProperty("fabric-api.gametest.structures.output-dir");
+
+	@ModifyArg(
+		method = "executeExport(Lnet/minecraft/server/command/ServerCommandSource;Ljava/lang/String;)I",
+		at = @At(
+			value = "INVOKE",
+			target = "Ljava/nio/file/Paths;get(Ljava/lang/String;[Ljava/lang/String;)Ljava/nio/file/Path;"
+		)
+	)
+	private static String useCustomOutputDirectory(String first) {
+		if (OUTPUT_DIR != null) {
+			return OUTPUT_DIR;
+		}
+		return first;
+	}
+}

--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/mixin/gametest/TestCommandMixin.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/mixin/gametest/TestCommandMixin.java
@@ -29,16 +29,17 @@ public class TestCommandMixin {
 	private static final String OUTPUT_DIR = System.getProperty("fabric-api.gametest.structures.output-dir");
 
 	@ModifyArg(
-		method = "executeExport(Lnet/minecraft/server/command/ServerCommandSource;Ljava/lang/String;)I",
-		at = @At(
-			value = "INVOKE",
-			target = "Ljava/nio/file/Paths;get(Ljava/lang/String;[Ljava/lang/String;)Ljava/nio/file/Path;"
-		)
+			method = "executeExport(Lnet/minecraft/server/command/ServerCommandSource;Ljava/lang/String;)I",
+			at = @At(
+					value = "INVOKE",
+					target = "Ljava/nio/file/Paths;get(Ljava/lang/String;[Ljava/lang/String;)Ljava/nio/file/Path;"
+			)
 	)
 	private static String useCustomOutputDirectory(String first) {
 		if (OUTPUT_DIR != null) {
 			return OUTPUT_DIR;
 		}
+
 		return first;
 	}
 }

--- a/fabric-gametest-api-v1/src/main/resources/fabric-gametest-api-v1.mixins.json
+++ b/fabric-gametest-api-v1/src/main/resources/fabric-gametest-api-v1.mixins.json
@@ -7,6 +7,7 @@
     "CommandManagerMixin",
     "MinecraftServerMixin",
     "StructureTemplateManagerMixin",
+    "TestCommandMixin",
     "TestFunctionsMixin",
     "TestServerMixin"
   ],


### PR DESCRIPTION
This PR adds a system property to specify the output directory for gametest structures, so you don't have to move them manually after exporting them using the `test export` command. If the property is not specified, it still uses the default `gameteststructures` directory in your run directory.

Example `build.gradle`:
```gradle
loom {
	runs {
		gametestClient {
			inherit client
			name "GameTest Client"
			vmArg "-Dfabric-api.gametest.structures.output-dir=${file("src/gametest/resources/data/mod_id/gametest/structures")}"

			source sourceSets.gametest
		}
	}
}
```
This then exports the structures to `src/gametest/resources/data/mod_id/gametest/structures`, which can then read by Fabric API again when running your tests. I require the entire path to be specified, as [modmuss talked about additional search directories in Discord](https://discord.com/channels/507304429255393322/566276937035546624/1192157128744505536) too. On top of that, the `test` command does not allow you to specify identifiers, so the mod id has to be included in the path.