### PR TITLE
Check for the correct BE type in the lookup API

### DIFF
--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiLookupImpl.java
@@ -153,16 +153,16 @@ public final class BlockApiLookupImpl<A, C> implements BlockApiLookup<A, C> {
 			throw new IllegalArgumentException("Must register at least one BlockEntityType instance with a BlockEntityApiProvider.");
 		}
 
-		BlockApiProvider<A, C> nullCheckedProvider = (world, pos, state, blockEntity, context) -> {
-			if (blockEntity == null) {
-				return null;
-			} else {
-				return provider.find(blockEntity, context);
-			}
-		};
-
 		for (BlockEntityType<?> blockEntityType : blockEntityTypes) {
 			Objects.requireNonNull(blockEntityType, "Encountered null block entity type while registering a block entity API provider mapping.");
+
+			BlockApiProvider<A, C> nullCheckedProvider = (world, pos, state, blockEntity, context) -> {
+				if (blockEntity == null || blockEntity.getType() != blockEntityType) {
+					return null;
+				} else {
+					return provider.find(blockEntity, context);
+				}
+			};
 
 			Block[] blocks = ((BlockEntityTypeAccessor) blockEntityType).getBlocks().toArray(new Block[0]);
 			registerForBlocks(nullCheckedProvider, blocks);


### PR DESCRIPTION
Apologies if this has been raised before - I couldn't see anything obvious, but may have missed some discussion!

The block lookup API's `registerForBlockEntities` method currently just registers the passed provider for each valid block for that block entity type. While this allows for efficient lookup of providers, it doesn't guarantee that we'll only receive block entities of the correct type to our `BlockEntityApiProvider`!

In some situations, the wrong block entity will be present for a particular block (caused by update suppression or a misbehaving mod, e.g. https://github.com/cc-tweaked/CC-Tweaked/issues/1670). This (incorrect) block entity is then passed off to the `BlockEntityApiProvider`. As providers (especially those registered with the generic `registerForBlockEntity`) will often blind-cast to the expected type, we then get class-cast crashes.

The wrong BE being present is definitely a bug (and arguably it would be bettter to catch this early rather than silently failing!). However, I think in this case we should follow vanilla's lead and handle this more gracefully. In this case, we just check whether the correct BE type is present before forwarding it to the user-supplied `BlockEntityApiProvider`.
