### PR TITLE
Add mob conversion event

### DIFF
--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.api.entity.event.v1;
 
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.mob.MobEntity;
 
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
@@ -73,6 +74,18 @@ public final class ServerLivingEntityEvents {
 		}
 	});
 
+	/**
+	 * An event that is called when a mob has been converted to another type.
+	 *
+	 * <p>When this event is called, the old instance has not yet been discarded, and the new one has not yet been spawned.
+	 * Mods may use this event to copy some of the old entity's data to the converted one.</p>
+	 */
+	public static final Event<MobConversion> MOB_CONVERSION = EventFactory.createArrayBacked(MobConversion.class, callbacks -> (previous, converted, keepEquiment) -> {
+		for (MobConversion callback : callbacks) {
+			callback.onConversion(previous, converted, keepEquiment);
+		}
+	});
+
 	@FunctionalInterface
 	public interface AllowDamage {
 		/**
@@ -93,7 +106,7 @@ public final class ServerLivingEntityEvents {
 		/**
 		 * Called when a living entity takes fatal damage (before totems of undying can take effect).
 		 *
-		 * @param entity the entity
+		 * @param entity       the entity
 		 * @param damageSource the source of the fatal damage
 		 * @param damageAmount the amount of damage that has killed the entity
 		 * @return true if the death should go ahead, false to cancel the death.
@@ -106,10 +119,21 @@ public final class ServerLivingEntityEvents {
 		/**
 		 * Called when a living entity dies. The death cannot be canceled at this point.
 		 *
-		 * @param entity the entity
+		 * @param entity       the entity
 		 * @param damageSource the source of the fatal damage
 		 */
 		void afterDeath(LivingEntity entity, DamageSource damageSource);
+	}
+
+	@FunctionalInterface
+	public interface MobConversion {
+		/**
+		 * Called when a mob is converted to another type.
+		 *
+		 * @param previous  the previous entity instance
+		 * @param converted the new instance for the converted entity
+		 */
+		void onConversion(MobEntity previous, MobEntity converted, boolean keepEquipment);
 	}
 
 	private ServerLivingEntityEvents() {

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
@@ -80,9 +80,9 @@ public final class ServerLivingEntityEvents {
 	 * <p>When this event is called, the old instance has not yet been discarded, and the new one has not yet been spawned.
 	 * Mods may use this event to copy some of the old entity's data to the converted one.</p>
 	 */
-	public static final Event<MobConversion> MOB_CONVERSION = EventFactory.createArrayBacked(MobConversion.class, callbacks -> (previous, converted, keepEquiment) -> {
+	public static final Event<MobConversion> MOB_CONVERSION = EventFactory.createArrayBacked(MobConversion.class, callbacks -> (previous, converted, keepEquipment) -> {
 		for (MobConversion callback : callbacks) {
-			callback.onConversion(previous, converted, keepEquiment);
+			callback.onConversion(previous, converted, keepEquipment);
 		}
 	});
 

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
@@ -106,7 +106,7 @@ public final class ServerLivingEntityEvents {
 		/**
 		 * Called when a living entity takes fatal damage (before totems of undying can take effect).
 		 *
-		 * @param entity       the entity
+		 * @param entity the entity
 		 * @param damageSource the source of the fatal damage
 		 * @param damageAmount the amount of damage that has killed the entity
 		 * @return true if the death should go ahead, false to cancel the death.
@@ -119,7 +119,7 @@ public final class ServerLivingEntityEvents {
 		/**
 		 * Called when a living entity dies. The death cannot be canceled at this point.
 		 *
-		 * @param entity       the entity
+		 * @param entity the entity
 		 * @param damageSource the source of the fatal damage
 		 */
 		void afterDeath(LivingEntity entity, DamageSource damageSource);
@@ -130,7 +130,7 @@ public final class ServerLivingEntityEvents {
 		/**
 		 * Called when a mob is converted to another type.
 		 *
-		 * @param previous  the previous entity instance
+		 * @param previous the previous entity instance
 		 * @param converted the new instance for the converted entity
 		 */
 		void onConversion(MobEntity previous, MobEntity converted, boolean keepEquipment);

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
@@ -79,6 +79,9 @@ public final class ServerLivingEntityEvents {
 	 *
 	 * <p>When this event is called, the old instance has not yet been discarded, and the new one has not yet been spawned.
 	 * Mods may use this event to copy some of the old entity's data to the converted one.</p>
+	 *
+	 * <p>This event only handles cases where the entity type changes, requiring a new instance. Notably it does not
+	 * cover mooshrooms changing color from lightning, creepers getting charged, or wolves being tamed.</p>
 	 */
 	public static final Event<MobConversion> MOB_CONVERSION = EventFactory.createArrayBacked(MobConversion.class, callbacks -> (previous, converted, keepEquipment) -> {
 		for (MobConversion callback : callbacks) {
@@ -132,6 +135,7 @@ public final class ServerLivingEntityEvents {
 		 *
 		 * @param previous the previous entity instance
 		 * @param converted the new instance for the converted entity
+		 * @param keepEquipment whether the converted entity should keep the previous one's equipment, like armor
 		 */
 		void onConversion(MobEntity previous, MobEntity converted, boolean keepEquipment);
 	}

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/MobEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/MobEntityMixin.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.entity.event;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.mob.MobEntity;
+
+import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
+
+@Mixin(MobEntity.class)
+public class MobEntityMixin {
+	@Inject(method = "convertTo", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;spawnEntity(Lnet/minecraft/entity/Entity;)Z"))
+	private <T extends MobEntity> void afterEntityConverted(EntityType<T> entityType, boolean keepEquipment, CallbackInfoReturnable<T> cir, @Local T converted) {
+		ServerLivingEntityEvents.MOB_CONVERSION.invoker().onConversion((MobEntity) (Object) this, converted, keepEquipment);
+	}
+}

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/MobEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/MobEntityMixin.java
@@ -19,18 +19,18 @@ package net.fabricmc.fabric.mixin.entity.event;
 import com.llamalad7.mixinextras.sugar.Local;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 
-import net.minecraft.entity.EntityType;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.mob.MobEntity;
 
 import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
 
 @Mixin(MobEntity.class)
 public class MobEntityMixin {
-	@Inject(method = "convertTo", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;spawnEntity(Lnet/minecraft/entity/Entity;)Z"))
-	private <T extends MobEntity> void afterEntityConverted(EntityType<T> entityType, boolean keepEquipment, CallbackInfoReturnable<T> cir, @Local T converted) {
-		ServerLivingEntityEvents.MOB_CONVERSION.invoker().onConversion((MobEntity) (Object) this, converted, keepEquipment);
+	@ModifyArg(method = "convertTo", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;spawnEntity(Lnet/minecraft/entity/Entity;)Z"))
+	private Entity afterEntityConverted(Entity converted, @Local(argsOnly = true) boolean keepEquipment) {
+		ServerLivingEntityEvents.MOB_CONVERSION.invoker().onConversion((MobEntity) (Object) this, (MobEntity) converted, keepEquipment);
+		return converted;
 	}
 }

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/PigEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/PigEntityMixin.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.entity.event;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.passive.AnimalEntity;
+import net.minecraft.entity.passive.PigEntity;
+import net.minecraft.world.World;
+
+import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
+
+@Mixin(PigEntity.class)
+abstract class PigEntityMixin extends AnimalEntity {
+	protected PigEntityMixin(EntityType<? extends AnimalEntity> entityType, World world) {
+		super(entityType, world);
+	}
+
+	@ModifyArg(
+			method = "onStruckByLightning",
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ServerWorld;spawnEntity(Lnet/minecraft/entity/Entity;)Z")
+	)
+	private Entity onThunderConversion(Entity converted) {
+		ServerLivingEntityEvents.MOB_CONVERSION.invoker().onConversion(this, (MobEntity) converted, false);
+		return converted;
+	}
+}

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/PigEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/PigEntityMixin.java
@@ -39,7 +39,7 @@ abstract class PigEntityMixin extends AnimalEntity {
 			method = "onStruckByLightning",
 			at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ServerWorld;spawnEntity(Lnet/minecraft/entity/Entity;)Z")
 	)
-	private Entity onThunderConversion(Entity converted) {
+	private Entity afterPiglinConversion(Entity converted) {
 		ServerLivingEntityEvents.MOB_CONVERSION.invoker().onConversion(this, (MobEntity) converted, false);
 		return converted;
 	}

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/TadpoleEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/TadpoleEntityMixin.java
@@ -23,23 +23,23 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.mob.MobEntity;
-import net.minecraft.entity.passive.MerchantEntity;
-import net.minecraft.entity.passive.VillagerEntity;
+import net.minecraft.entity.passive.FishEntity;
+import net.minecraft.entity.passive.TadpoleEntity;
 import net.minecraft.world.World;
 
 import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
 
-@Mixin(VillagerEntity.class)
-abstract class VillagerEntityMixin extends MerchantEntity {
-	VillagerEntityMixin(EntityType<? extends MerchantEntity> entityType, World world) {
+@Mixin(TadpoleEntity.class)
+abstract class TadpoleEntityMixin extends FishEntity {
+	TadpoleEntityMixin(EntityType<? extends FishEntity> entityType, World world) {
 		super(entityType, world);
 	}
 
 	@ModifyArg(
-			method = "onStruckByLightning",
+			method = "growUp",
 			at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ServerWorld;spawnEntityAndPassengers(Lnet/minecraft/entity/Entity;)V")
 	)
-	private Entity afterWitchConversion(Entity converted) {
+	private Entity afterGrowingUpToFrog(Entity converted) {
 		ServerLivingEntityEvents.MOB_CONVERSION.invoker().onConversion(this, (MobEntity) converted, false);
 		return converted;
 	}

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/VillagerEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/VillagerEntityMixin.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.entity.event;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.passive.MerchantEntity;
+import net.minecraft.entity.passive.VillagerEntity;
+import net.minecraft.world.World;
+
+import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
+
+@Mixin(VillagerEntity.class)
+abstract class VillagerEntityMixin extends MerchantEntity {
+	VillagerEntityMixin(EntityType<? extends MerchantEntity> entityType, World world) {
+		super(entityType, world);
+	}
+
+	@ModifyArg(
+			method = "onStruckByLightning",
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ServerWorld;spawnEntityAndPassengers(Lnet/minecraft/entity/Entity;)V")
+	)
+	private Entity onThunderConversion(Entity converted) {
+		ServerLivingEntityEvents.MOB_CONVERSION.invoker().onConversion(this, (MobEntity) converted, false);
+		return converted;
+	}
+}

--- a/fabric-entity-events-v1/src/main/resources/fabric-entity-events-v1.mixins.json
+++ b/fabric-entity-events-v1/src/main/resources/fabric-entity-events-v1.mixins.json
@@ -10,6 +10,7 @@
     "PlayerEntityMixin",
     "PlayerManagerMixin",
     "ServerPlayerEntityMixin",
+    "TadpoleEntityMixin",
     "VillagerEntityMixin",
     "elytra.LivingEntityMixin",
     "elytra.PlayerEntityMixin"

--- a/fabric-entity-events-v1/src/main/resources/fabric-entity-events-v1.mixins.json
+++ b/fabric-entity-events-v1/src/main/resources/fabric-entity-events-v1.mixins.json
@@ -6,9 +6,11 @@
     "EntityMixin",
     "LivingEntityMixin",
     "MobEntityMixin",
+    "PigEntityMixin",
     "PlayerEntityMixin",
     "PlayerManagerMixin",
     "ServerPlayerEntityMixin",
+    "VillagerEntityMixin",
     "elytra.LivingEntityMixin",
     "elytra.PlayerEntityMixin"
   ],

--- a/fabric-entity-events-v1/src/main/resources/fabric-entity-events-v1.mixins.json
+++ b/fabric-entity-events-v1/src/main/resources/fabric-entity-events-v1.mixins.json
@@ -3,13 +3,14 @@
   "package": "net.fabricmc.fabric.mixin.entity.event",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "elytra.LivingEntityMixin",
-    "elytra.PlayerEntityMixin",
     "EntityMixin",
     "LivingEntityMixin",
+    "MobEntityMixin",
     "PlayerEntityMixin",
     "PlayerManagerMixin",
-    "ServerPlayerEntityMixin"
+    "ServerPlayerEntityMixin",
+    "elytra.LivingEntityMixin",
+    "elytra.PlayerEntityMixin"
   ],
   "injectors": {
     "defaultRequire": 1,

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -114,6 +114,10 @@ public final class EntityEventTests implements ModInitializer {
 			LOGGER.info("{} died due to {} damage source", entity.getName().getString(), source.getName());
 		});
 
+		ServerLivingEntityEvents.MOB_CONVERSION.register((previous, converted, keepEquipment) -> {
+			LOGGER.info("{} is being converted to {} [{}]", previous.getName().getString(), converted.getName().getString(), keepEquipment);
+		});
+
 		EntitySleepEvents.ALLOW_SLEEPING.register((player, sleepingPos) -> {
 			// Can't sleep if holds blue wool
 			if (player.getStackInHand(Hand.MAIN_HAND).isOf(Items.BLUE_WOOL)) {


### PR DESCRIPTION
While working on #3476, I was surprised to find there is no event for mob conversion. This is a generally useful mechanic to expose, so this PR adds a notification event to listen for it. There is no "allow" event as mob conversion happens in a variety of contexts, and what it means to "cancel" conversion can mean a lot of very different things.