### PR TITLE
Cooking recipes working with count.

### DIFF
--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/mixin/recipe/cooking/AbstractFurnaceBlockEntityMixin.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/mixin/recipe/cooking/AbstractFurnaceBlockEntityMixin.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.recipe.cooking;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.block.entity.AbstractFurnaceBlockEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.RecipeEntry;
+import net.minecraft.registry.DynamicRegistryManager;
+
+/**
+ * A Mixin class to ensure that furnaces can use the functionality provided from recipes involving multiple output items
+ * (not item types, just multiple of the same item).
+ */
+@Mixin(AbstractFurnaceBlockEntity.class)
+public abstract class AbstractFurnaceBlockEntityMixin {
+	/**
+	 * A wrapper altering the result of a smelting recipe when outputting into a partially filled output slot. 1.20.4
+	 * functionality increments the output by 1. This wrapper instead increases the count by the amount defined in the
+	 * recipe.
+	 *
+	 * <p>Assumes that the increment will be valid and does not stop recipe if it would go over. E.g. an increment of
+	 * 65 would always be performed, if not stopped by other logic prior to this.
+	 *
+	 * @param outputStack the instance of the itemstack to increment, in the furnace's output slot.
+	 * @param increment the original incremented amount (1.20.4 this is always 1).
+	 * @param incrementItemStack the method responsible for increasing the item stack count.
+	 * @param registryManager the registry manager to access for the recipe
+	 * @param recipe the (!= null) recipe.
+	 */
+	@WrapOperation(
+			method = "craftRecipe",
+			at = @At(
+					value = "INVOKE",
+					target = "Lnet/minecraft/item/ItemStack;increment(I)V"
+			)
+	)
+	private static void incrementByRecipe(ItemStack outputStack, int increment, Operation<Void> incrementItemStack, DynamicRegistryManager registryManager, RecipeEntry<?> recipe) {
+		incrementItemStack.call(
+				outputStack,
+				recipe.value()
+						.getResult(registryManager)
+						.getCount());
+	}
+
+	/**
+	 * Modifies the return value of {@code ItemStack.getCount()} in the specified function to be compatible with
+	 * multiple item output. In Vanilla (1.20.4), this is used in the original function to check whether the furnace
+	 * output stack has enough space to accommodate the new items. It assumes this is always equal to 1 and so checks
+	 * whether the current number of items is less than the maximum number.
+	 *
+	 * <p>This mixin modifies the original "count" result so that it checks against the count modified for the number added
+	 * by the recipe - 1. This ensures identical functionality for vanilla recipes (where count == 1), while ensuring
+	 * that the crafting will not occur if there is no space for multiple items.
+	 *
+	 * @param itemStack2Count the original in the furnace output slot.
+	 * @param recipeResult the ItemStack resulting from the current smelting recipe.
+	 * @return a new count that represents the item stack size after the current recipe is performed (minus 1)
+	 */
+	@ModifyExpressionValue(
+			method = "canAcceptRecipeOutput",
+			at = @At(
+					value = "INVOKE",
+					target = "Lnet/minecraft/item/ItemStack;getCount()I"
+			)
+	)
+	private static int correctFutureAmountByRecipe(int itemStack2Count, @Local(ordinal = 0) ItemStack recipeResult) {
+		return itemStack2Count + recipeResult.getCount() - 1;
+	}
+}

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/mixin/recipe/cooking/CookingRecipeSerializerMixin.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/mixin/recipe/cooking/CookingRecipeSerializerMixin.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.recipe.cooking;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.CookingRecipeSerializer;
+import net.minecraft.util.dynamic.Codecs;
+
+/**
+ * A Mixin class to allow cooking recipes to interpret different Json formats for the "result" item.
+ *
+ * <p>In Vanilla (1.20.4), cooking recipes can deserialise the following Json format for their result:
+ * <pre>
+ * "result": "minecraft:example"
+ * </pre>
+ *
+ * <p>With this mixin, the following format is added as a valid option.
+ * <pre>
+ * "result": {
+ *     "item": "minecraft:example",     (required)
+ *     "count": 1                       (optional)
+ * }
+ * </pre>
+ *
+ * <p>Additionally, the mixin alters cooking recipes to always prefer to be serialised in the following manner:
+ * <pre>
+ * "result": {
+ *     "item": minecraft:example",
+ *     "count": 1
+ * }
+ * </pre>
+ */
+@Mixin(CookingRecipeSerializer.class)
+public abstract class CookingRecipeSerializerMixin {
+	/**
+	 * Redirects the original MapCodec to include an alternative (and now primary) Codec that allows for both identifier
+	 * and counting of furnace recipe items.
+	 *
+	 * <p>If you wanted to alter this to allow users to extend the additional Codec, you could instead read the codec from
+	 * a more customisable data source.
+	 * @param originalCodec the original Codec for Item strings.
+	 * @param fieldName     the name of the field that was used to build the MapCodec. In 1.20.4 this was "result"
+	 * @param toMapCodec    the method call that transforms originalCodec to a MapCodec using field name. Here it is
+	 *                      applied after the new primary Codec is inserted.
+	 * @return a new MapCodec, built with the same field name, with an inserted Codec for additional
+	 *         serialisation/deserialisation functionality.
+	 */
+	@WrapOperation(
+			method = "method_53766(ILnet/minecraft/recipe/AbstractCookingRecipe$RecipeFactory;Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;",
+			at = @At(
+					value = "INVOKE",
+					target = "Lcom/mojang/serialization/Codec;fieldOf(Ljava/lang/String;)Lcom/mojang/serialization/MapCodec;", // Lcom/mojang/serialization/Codec;fieldOf(Ljava/lang/String;)Lcom/mojang/serialization/MapCodec;
+					ordinal = 1,
+					remap = false
+			)
+	)
+	private static MapCodec<? extends ItemStack> addAlternativeCodec(Codec<? extends ItemStack> originalCodec, String fieldName, Operation<MapCodec<? extends ItemStack>> toMapCodec) {
+		return toMapCodec.call(
+				Codecs.alternatively(
+						ItemStack.RECIPE_RESULT_CODEC, // doesn't work with nbt - a custom codec would be required here
+						originalCodec
+				),
+				fieldName);
+	}
+}

--- a/fabric-recipe-api-v1/src/main/resources/fabric-recipe-api-v1.mixins.json
+++ b/fabric-recipe-api-v1/src/main/resources/fabric-recipe-api-v1.mixins.json
@@ -5,7 +5,9 @@
   "mixins": [
     "ingredient.IngredientMixin",
     "ingredient.PacketEncoderMixin",
-    "ingredient.ShapelessRecipeMixin"
+    "ingredient.ShapelessRecipeMixin",
+    "cooking.AbstractFurnaceBlockEntityMixin",
+    "cooking.CookingRecipeSerializerMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/fabric-recipe-api-v1/src/testmod/resources/data/minecraft/recipes/iron_ingot_from_smelting_deepslate_iron_ore.json
+++ b/fabric-recipe-api-v1/src/testmod/resources/data/minecraft/recipes/iron_ingot_from_smelting_deepslate_iron_ore.json
@@ -1,0 +1,13 @@
+{
+  "type": "minecraft:smelting",
+  "group": "iron_ingot",
+  "ingredient": {
+    "item": "minecraft:deepslate_iron_ore"
+  },
+  "result": {
+    "item": "minecraft:iron_ingot",
+    "count": 3
+  },
+  "experience": 0,
+  "cookingtime": 1
+}


### PR DESCRIPTION
Alters the processing of cooking recipes so that they accept the following JSON formats for deserialising recipe results:

Vanilla
```
"result": "minecraft:example"
```
Additional (Added by this pull request)
```
"result": {
    "item": minecraft:example",      (required)
    "count": 1                       (optional)
 }
```

Serialisation of recipe results is altered from the vanilla format to the additional object format.

There has been fruitful discussion on NBT recipe additions in the following thread:
[Add result NBT and count to crafting and smelting recipes](https://github.com/FabricMC/fabric/issues/3068)
This modification adds the Mojang crafting result Codec to the cooking result deserialisation Codec. Should a Codec that also accepts NBT be produced for crafting, it should be a simple matter to edit `CookingRecipeSerializerMixin` to use that instead. This should give you NBT smithing recipes for (nearly, see below) free.

Suggested modifications should NBT recipes be enabled:
(Yarn names) `canAcceptRecipeOutput` in `AbstractFurnaceBlockEntity.class` does not check NBT data when checking whether a recipe is valid. In order to avoid unintended gain/loss of NBT data for recipes, this function would need to check NBT of the outputs too.