### PR TITLE
Update to loom 1.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 	id "idea"
 	id "maven-publish"
 	id 'jacoco'
-	id "fabric-loom" version "1.5.3" apply false
+	id "fabric-loom" version "1.5.4" apply false
 	id "com.diffplug.spotless" version "6.20.0"
 	id "org.ajoberstar.grgit" version "3.1.0"
 	id "me.modmuss50.remotesign" version "0.4.0" apply false

--- a/build.gradle
+++ b/build.gradle
@@ -153,7 +153,7 @@ allprojects {
 	loom {
 		splitEnvironmentSourceSets()
 		mixin {
-			useLegacyMixinAp = false
+			useLegacyMixinAp = true
 		}
 	}
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 	id "idea"
 	id "maven-publish"
 	id 'jacoco'
-	id "fabric-loom" version "1.4.4" apply false
+	id "fabric-loom" version "1.5.3" apply false
 	id "com.diffplug.spotless" version "6.20.0"
 	id "org.ajoberstar.grgit" version "3.1.0"
 	id "me.modmuss50.remotesign" version "0.4.0" apply false
@@ -152,6 +152,9 @@ allprojects {
 
 	loom {
 		splitEnvironmentSourceSets()
+		mixin {
+			useLegacyMixinAp = false
+		}
 	}
 
 	sourceSets {


### PR DESCRIPTION
Disabling the Mixin AP is quite a large change, with plently of room for things to go wrong, so this will need some good testing.