### PR TITLE
Fix injection point for CoreShaderRegistrationCallback

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/shader/GameRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/shader/GameRendererMixin.java
@@ -24,7 +24,6 @@ import com.mojang.datafixers.util.Pair;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
@@ -42,8 +41,7 @@ import net.fabricmc.fabric.impl.client.rendering.FabricShaderProgram;
 abstract class GameRendererMixin {
 	@Inject(
 			method = "loadPrograms",
-			at = @At(value = "INVOKE", target = "Ljava/util/List;add(Ljava/lang/Object;)Z", remap = false, shift = At.Shift.AFTER),
-			slice = @Slice(from = @At(value = "NEW", target = "net/minecraft/client/gl/ShaderProgram", ordinal = 0)),
+			at = @At(value = "INVOKE", target = "Ljava/util/List;add(Ljava/lang/Object;)Z", remap = false, ordinal = 0),
 			locals = LocalCapture.CAPTURE_FAILHARD
 	)
 	private void registerShaders(ResourceFactory factory, CallbackInfo info, List<?> shaderStages, List<Pair<ShaderProgram, Consumer<ShaderProgram>>> programs) throws IOException {


### PR DESCRIPTION
Relevant issue: https://github.com/FabricMC/fabric/issues/3230

From 1.20.1(?) to 1.20.4, the injection point for the CoreShaderRegistrationCallback event has been broken: it triggers _every time_ vanilla registers a core shader, rather than once during the shader reload cycle. In practice, this means if you rely on the event for loading shaders and use the event as modeled in the test suite, your shader is parsed/validated about _60 times per reload_. An extra implication of this is that if your shader has any unused fields, it will spam console ~60 times telling you to remove it (compared to a single warning per reload, which is what happens in a vanilla environment).

I removed the slice in favor of injecting at the first add call. A potential adjustment might be injecting at the last add call (to load modded shaders after vanilla shaders), but I'm not sure how to hit that inject point without leaving the try/catch block.

### Testing / Replicating

https://github.com/FabricMC/fabric/blob/a462da68c68e109073526be5dd1ae8803e642435/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/HudAndShaderTest.java#L45-L49

Place a print statement in this callback, or register a shader that will intentionally print a warning (such as one with an unused uniform). The print/warning will log approximately 60 times, once per vanilla core shader registration. The callback should only be triggered once, which is what happens after this patch is applied.

---

Thank you in advance for reviews and/or change requests! 💗