### PR TITLE
Allow `FabricCodecDataProvider` to access dynamic registries

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricCodecDataProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricCodecDataProvider.java
@@ -52,7 +52,7 @@ public abstract class FabricCodecDataProvider<T> implements DataProvider {
 	/**
 	 * @deprecated Please use {@link FabricCodecDataProvider#FabricCodecDataProvider(FabricDataOutput, CompletableFuture, DataOutput.OutputType, String, Codec)}.
 	 */
-	@Deprecated(forRemoval = true)
+	@Deprecated()
 	protected FabricCodecDataProvider(FabricDataOutput dataOutput, DataOutput.OutputType outputType, String directoryName, Codec<T> codec) {
 		this.pathResolver = dataOutput.getResolver(outputType, directoryName);
 		this.registriesFuture = null;
@@ -107,7 +107,7 @@ public abstract class FabricCodecDataProvider<T> implements DataProvider {
 	 * @param provider A consumer that accepts an {@link Identifier} and a value to register.
 	 * @deprecated Please use {@link FabricCodecDataProvider#configure(BiConsumer, RegistryWrapper.WrapperLookup)}.
 	 */
-	@Deprecated(forRemoval = true)
+	@Deprecated()
 	protected void configure(BiConsumer<Identifier, T> provider) {
 		throw new UnsupportedOperationException("Override this method.");
 	}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricCodecDataProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricCodecDataProvider.java
@@ -109,6 +109,7 @@ public abstract class FabricCodecDataProvider<T> implements DataProvider {
 	 */
 	@Deprecated(forRemoval = true)
 	protected void configure(BiConsumer<Identifier, T> provider) {
+		throw new UnsupportedOperationException("Override this method.");
 	}
 
 	/**
@@ -118,6 +119,7 @@ public abstract class FabricCodecDataProvider<T> implements DataProvider {
 	 */
 	protected void configure(BiConsumer<Identifier, T> provider, RegistryWrapper.WrapperLookup lookup) {
 		// TODO: Make abstract once the deprecated method is removed.
+		throw new UnsupportedOperationException("Override this method.");
 	}
 
 	private JsonElement convert(Identifier id, T value) {

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricCodecDataProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricCodecDataProvider.java
@@ -19,18 +19,20 @@ package net.fabricmc.fabric.api.datagen.v1.provider;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
 import com.google.gson.JsonElement;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
+import com.mojang.serialization.DynamicOps;
 import com.mojang.serialization.JsonOps;
-import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.data.DataOutput;
 import net.minecraft.data.DataProvider;
 import net.minecraft.data.DataWriter;
+import net.minecraft.registry.RegistryOps;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.util.Identifier;
 
@@ -38,28 +40,53 @@ import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
 
 /**
- * Extend this class and implement {@link FabricCodecDataProvider#configure}.
+ * Extend this class and implement {@link FabricCodecDataProvider#configure(BiConsumer, RegistryWrapper.WrapperLookup)}.
  *
  * <p>Register an instance of the class with {@link FabricDataGenerator.Pack#addProvider} in a {@link net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint}.
  */
 public abstract class FabricCodecDataProvider<T> implements DataProvider {
 	private final DataOutput.PathResolver pathResolver;
-	@Nullable
 	private final CompletableFuture<RegistryWrapper.WrapperLookup> registriesFuture;
 	private final Codec<T> codec;
 
+	/**
+	 * @deprecated Please use {@link FabricCodecDataProvider#FabricCodecDataProvider(FabricDataOutput, CompletableFuture, DataOutput.OutputType, String, Codec)}.
+	 */
+	@Deprecated(forRemoval = true)
 	protected FabricCodecDataProvider(FabricDataOutput dataOutput, DataOutput.OutputType outputType, String directoryName, Codec<T> codec) {
-		this(dataOutput, null, outputType, directoryName, codec);
+		this.pathResolver = dataOutput.getResolver(outputType, directoryName);
+		this.registriesFuture = null;
+		this.codec = codec;
 	}
 
-	protected FabricCodecDataProvider(FabricDataOutput dataOutput, @Nullable CompletableFuture<RegistryWrapper.WrapperLookup> registriesFuture, DataOutput.OutputType outputType, String directoryName, Codec<T> codec) {
+	protected FabricCodecDataProvider(FabricDataOutput dataOutput, CompletableFuture<RegistryWrapper.WrapperLookup> registriesFuture, DataOutput.OutputType outputType, String directoryName, Codec<T> codec) {
 		this.pathResolver = dataOutput.getResolver(outputType, directoryName);
-		this.registriesFuture = registriesFuture;
+		this.registriesFuture = Objects.requireNonNull(registriesFuture);
 		this.codec = codec;
 	}
 
 	@Override
 	public CompletableFuture<?> run(DataWriter writer) {
+		// TODO: Remove the null check once the deprecated method and constructor are removed.
+		if (this.registriesFuture != null) {
+			return this.registriesFuture.thenCompose(lookup -> {
+				Map<Identifier, JsonElement> entries = new HashMap<>();
+				RegistryOps<JsonElement> ops = RegistryOps.of(JsonOps.INSTANCE, lookup);
+
+				BiConsumer<Identifier, T> provider = (id, value) -> {
+					JsonElement json = this.convert(id, value, ops);
+					JsonElement existingJson = entries.put(id, json);
+
+					if (existingJson != null) {
+						throw new IllegalArgumentException("Duplicate entry " + id);
+					}
+				};
+
+				this.configure(provider, lookup);
+				return this.write(writer, entries);
+			});
+		}
+
 		Map<Identifier, JsonElement> entries = new HashMap<>();
 		BiConsumer<Identifier, T> provider = (id, value) -> {
 			JsonElement json = this.convert(id, value);
@@ -70,13 +97,6 @@ public abstract class FabricCodecDataProvider<T> implements DataProvider {
 			}
 		};
 
-		if (this.registriesFuture != null) {
-			return this.registriesFuture.thenCompose(lookup -> {
-				this.configure(provider, lookup);
-				return this.write(writer, entries);
-			});
-		}
-
 		this.configure(provider);
 		return this.write(writer, entries);
 	}
@@ -85,7 +105,9 @@ public abstract class FabricCodecDataProvider<T> implements DataProvider {
 	 * Implement this method to register entries to generate.
 	 *
 	 * @param provider A consumer that accepts an {@link Identifier} and a value to register.
+	 * @deprecated Please use {@link FabricCodecDataProvider#configure(BiConsumer, RegistryWrapper.WrapperLookup)}.
 	 */
+	@Deprecated(forRemoval = true)
 	protected void configure(BiConsumer<Identifier, T> provider) {}
 
 	/**
@@ -93,10 +115,16 @@ public abstract class FabricCodecDataProvider<T> implements DataProvider {
 	 * @param provider A consumer that accepts an {@link Identifier} and a value to register.
 	 * @param lookup A lookup for registries.
 	 */
-	protected void configure(BiConsumer<Identifier, T> provider, RegistryWrapper.WrapperLookup lookup) {}
+	protected void configure(BiConsumer<Identifier, T> provider, RegistryWrapper.WrapperLookup lookup) {
+		// TODO: Make abstract once the deprecated method is removed.
+	}
 
 	private JsonElement convert(Identifier id, T value) {
-		DataResult<JsonElement> dataResult = this.codec.encodeStart(JsonOps.INSTANCE, value);
+		return this.convert(id, value, JsonOps.INSTANCE);
+	}
+
+	private JsonElement convert(Identifier id, T value, DynamicOps<JsonElement> ops) {
+		DataResult<JsonElement> dataResult = this.codec.encodeStart(ops, value);
 		return dataResult.get()
 				.mapRight(partial -> "Invalid entry %s: %s".formatted(id, partial.message()))
 				.orThrow();

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricCodecDataProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricCodecDataProvider.java
@@ -108,7 +108,8 @@ public abstract class FabricCodecDataProvider<T> implements DataProvider {
 	 * @deprecated Please use {@link FabricCodecDataProvider#configure(BiConsumer, RegistryWrapper.WrapperLookup)}.
 	 */
 	@Deprecated(forRemoval = true)
-	protected void configure(BiConsumer<Identifier, T> provider) {}
+	protected void configure(BiConsumer<Identifier, T> provider) {
+	}
 
 	/**
 	 * Implement this method to register entries to generate using a {@link RegistryWrapper.WrapperLookup}.


### PR DESCRIPTION
This PR allows `FabricCodecDataProvider` to access the dynamic registries if it is passed in the constructor. Now, I have a couple of issues with this implementation myself because I didn't want to cause a breaking change, the biggest one being that if you do not override the correct method in your subclass, it won't generate any files. Using the `FabricCodecDataProvider#FabricCodecDataProvider(FabricDataOutput, CompletableFuture, DataOutput.OutputType, String, Codec)}` constructor and then the `FabricCodecDataProvider#configure(BiConsumer)` method won't generate anything as it's never called.

This could all be avoided by always requiring a `CompletableFuture<RegistryWrapper.WrapperLookup>` in the constructor and by adding said `RegistryWrapper.WrapperLookup` to the `configure` method, but that would be a breaking change. We would end up with a much more graceful implementation though.