### PR TITLE
Deprecate FabricBlockSettings & FabricItemSettings.

### DIFF
--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/FabricApiLookupTest.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/FabricApiLookupTest.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.test.lookup;
 
 import org.jetbrains.annotations.NotNull;
 
+import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
@@ -28,7 +29,6 @@ import net.minecraft.util.math.Direction;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup;
-import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
 import net.fabricmc.fabric.test.lookup.api.ItemApis;
 import net.fabricmc.fabric.test.lookup.api.ItemInsertable;
@@ -41,17 +41,17 @@ public class FabricApiLookupTest implements ModInitializer {
 	public static final String MOD_ID = "fabric-lookup-api-v1-testmod";
 	// Chute - Block without model that transfers item from the container above to the container below.
 	// It's meant to work with unsided containers: chests, dispensers, droppers and hoppers.
-	public static final ChuteBlock CHUTE_BLOCK = new ChuteBlock(FabricBlockSettings.create());
+	public static final ChuteBlock CHUTE_BLOCK = new ChuteBlock(AbstractBlock.Settings.create());
 	public static final BlockItem CHUTE_ITEM = new BlockItem(CHUTE_BLOCK, new Item.Settings());
 	public static BlockEntityType<ChuteBlockEntity> CHUTE_BLOCK_ENTITY_TYPE;
 	// Cobble gen - Block without model that can generate infinite cobblestone when placed above a chute.
 	// It's meant to test BlockApiLookup#registerSelf.
-	public static final CobbleGenBlock COBBLE_GEN_BLOCK = new CobbleGenBlock(FabricBlockSettings.create());
+	public static final CobbleGenBlock COBBLE_GEN_BLOCK = new CobbleGenBlock(AbstractBlock.Settings.create());
 	public static final BlockItem COBBLE_GEN_ITEM = new BlockItem(COBBLE_GEN_BLOCK, new Item.Settings());
 	public static BlockEntityType<CobbleGenBlockEntity> COBBLE_GEN_BLOCK_ENTITY_TYPE;
 	// Testing for item api lookups is done in the `item` package.
 
-	public static final InspectorBlock INSPECTOR_BLOCK = new InspectorBlock(FabricBlockSettings.create());
+	public static final InspectorBlock INSPECTOR_BLOCK = new InspectorBlock(AbstractBlock.Settings.create());
 	public static final BlockItem INSPECTOR_ITEM = new BlockItem(INSPECTOR_BLOCK, new Item.Settings());
 
 	@Override

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
@@ -30,6 +30,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.Hand;
 
+import net.fabricmc.fabric.impl.item.FabricItemInternals;
+
 /**
  * General-purpose Fabric-provided extensions for {@link Item} subclasses.
  *
@@ -135,5 +137,33 @@ public interface FabricItem {
 	 */
 	default @Nullable FoodComponent getFoodComponent(ItemStack stack) {
 		return ((Item) this).getFoodComponent();
+	}
+
+	/**
+	 * Fabric-provided extensions for {@link Item.Settings}.
+	 * This interface is automatically implemented on all item settings via Mixin and interface injection.
+	 */
+	interface Settings {
+		/**
+		 * Sets the equipment slot provider of the item.
+		 *
+		 * @param equipmentSlotProvider the equipment slot provider
+		 * @return this builder
+		 */
+		default Item.Settings equipmentSlot(EquipmentSlotProvider equipmentSlotProvider) {
+			FabricItemInternals.computeExtraData((Item.Settings) this).equipmentSlot(equipmentSlotProvider);
+			return (Item.Settings) this;
+		}
+
+		/**
+		 * Sets the custom damage handler of the item.
+		 * Note that this is only called on an ItemStack if {@link ItemStack#isDamageable()} returns true.
+		 *
+		 * @see CustomDamageHandler
+		 */
+		default Item.Settings customDamage(CustomDamageHandler handler) {
+			FabricItemInternals.computeExtraData((Item.Settings) this).customDamage(handler);
+			return (Item.Settings) this;
+		}
 	}
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItemSettings.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItemSettings.java
@@ -25,19 +25,18 @@ import net.minecraft.util.Rarity;
 import net.fabricmc.fabric.impl.item.FabricItemInternals;
 
 /**
- * Fabric's version of Item.Settings. Adds additional methods and hooks
- * not found in the original class.
- *
- * <p>To use it, simply replace {@code new Item.Settings()} with
- * {@code new FabricItemSettings()}.
+ * @deprecated replace with {@link Item.Settings}
  */
+@Deprecated
 public class FabricItemSettings extends Item.Settings {
 	/**
 	 * Sets the equipment slot provider of the item.
 	 *
 	 * @param equipmentSlotProvider the equipment slot provider
 	 * @return this builder
+	 * @deprecated replace with {@link FabricItem.Settings#equipmentSlot(EquipmentSlotProvider)}
 	 */
+	@Deprecated
 	public FabricItemSettings equipmentSlot(EquipmentSlotProvider equipmentSlotProvider) {
 		FabricItemInternals.computeExtraData(this).equipmentSlot(equipmentSlotProvider);
 		return this;
@@ -47,6 +46,7 @@ public class FabricItemSettings extends Item.Settings {
 	 * Sets the custom damage handler of the item.
 	 * Note that this is only called on an ItemStack if {@link ItemStack#isDamageable()} returns true.
 	 *
+	 * @deprecated replace with {@link FabricItem.Settings#customDamage(CustomDamageHandler)}
 	 * @see CustomDamageHandler
 	 */
 	public FabricItemSettings customDamage(CustomDamageHandler handler) {

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemSettingsMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemSettingsMixin.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.item;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import net.minecraft.item.Item;
+
+import net.fabricmc.fabric.api.item.v1.FabricItem;
+
+@Mixin(Item.Settings.class)
+public class ItemSettingsMixin implements FabricItem.Settings {
+}

--- a/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.mixins.json
+++ b/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.mixins.json
@@ -12,6 +12,7 @@
     "FoxEntityMixin",
     "HungerManagerMixin",
     "ItemMixin",
+    "ItemSettingsMixin",
     "ItemStackMixin",
     "LivingEntityMixin",
     "RecipeMixin",

--- a/fabric-item-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-item-api-v1/src/main/resources/fabric.mod.json
@@ -31,6 +31,7 @@
     "fabric-api:module-lifecycle": "stable",
     "loom:injected_interfaces": {
       "net/minecraft/class_1792": ["net/fabricmc/fabric/api/item/v1/FabricItem"],
+      "net/minecraft/class_1792\u0024class_1793": ["net/fabricmc/fabric/api/item/v1/FabricItem\u0024Settings"],
       "net/minecraft/class_1799": ["net/fabricmc/fabric/api/item/v1/FabricItemStack"]
     }
   }

--- a/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/CustomDamageTest.java
+++ b/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/CustomDamageTest.java
@@ -30,7 +30,6 @@ import net.minecraft.util.Identifier;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.item.v1.CustomDamageHandler;
-import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
 import net.fabricmc.fabric.api.registry.FabricBrewingRecipeRegistry;
 import net.fabricmc.fabric.api.registry.FuelRegistry;
 
@@ -57,7 +56,7 @@ public class CustomDamageTest implements ModInitializer {
 
 	public static class WeirdPick extends PickaxeItem {
 		protected WeirdPick() {
-			super(ToolMaterials.GOLD, 1, -2.8F, new FabricItemSettings().customDamage(WEIRD_DAMAGE_HANDLER));
+			super(ToolMaterials.GOLD, 1, -2.8F, new Item.Settings().customDamage(WEIRD_DAMAGE_HANDLER));
 		}
 
 		@Override

--- a/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/FabricItemSettingsTests.java
+++ b/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/FabricItemSettingsTests.java
@@ -35,7 +35,7 @@ public class FabricItemSettingsTests implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		// Registers an item with a custom equipment slot.
-		Item testItem = new Item(new FabricItemSettings().equipmentSlot(stack -> EquipmentSlot.CHEST));
+		Item testItem = new Item(new Item.Settings().equipmentSlot(stack -> EquipmentSlot.CHEST));
 		Registry.register(Registries.ITEM, new Identifier("fabric-item-api-v1-testmod", "test_item"), testItem);
 
 		final List<String> missingMethods = new ArrayList<>();

--- a/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/FoodGameInitializer.java
+++ b/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/FoodGameInitializer.java
@@ -26,11 +26,10 @@ import net.minecraft.registry.Registry;
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
 
 public final class FoodGameInitializer implements ModInitializer {
-	public static final Item DAMAGE = Registry.register(Registries.ITEM, new Identifier("fabric-item-api-v1-testmod", "damage_food"), new DamageFood(new FabricItemSettings().maxDamage(20)));
-	public static final Item NAME = Registry.register(Registries.ITEM, new Identifier("fabric-item-api-v1-testmod", "name_food"), new NameFood(new FabricItemSettings()));
+	public static final Item DAMAGE = Registry.register(Registries.ITEM, new Identifier("fabric-item-api-v1-testmod", "damage_food"), new DamageFood(new Item.Settings().maxDamage(20)));
+	public static final Item NAME = Registry.register(Registries.ITEM, new Identifier("fabric-item-api-v1-testmod", "name_food"), new NameFood(new Item.Settings()));
 
 	@Override
 	public void onInitialize() {

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricBlockSettings.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricBlockSettings.java
@@ -35,15 +35,9 @@ import net.fabricmc.fabric.mixin.object.builder.AbstractBlockAccessor;
 import net.fabricmc.fabric.mixin.object.builder.AbstractBlockSettingsAccessor;
 
 /**
- * Fabric's version of Block.Settings. Adds additional methods and hooks
- * not found in the original class.
- *
- * <p>Make note that this behaves slightly different from the
- * vanilla counterpart, copying some settings that vanilla does not.
- *
- * <p>To use it, simply replace Block.Settings.of() with
- * FabricBlockSettings.of().
+ * @deprecated replace with {@link AbstractBlock.Settings}
  */
+@Deprecated
 public class FabricBlockSettings extends AbstractBlock.Settings {
 	protected FabricBlockSettings() {
 		super();
@@ -97,56 +91,72 @@ public class FabricBlockSettings extends AbstractBlock.Settings {
 		this.postProcess(otherAccessor.getPostProcessPredicate());
 	}
 
+	/**
+	 * @deprecated replace with {@link AbstractBlock.Settings#create()}
+	 */
+	@Deprecated
 	public static FabricBlockSettings create() {
 		return new FabricBlockSettings();
 	}
 
 	/**
-	 * @deprecated Use {@link FabricBlockSettings#create()} instead.
+	 * @deprecated replace with {@link AbstractBlock.Settings#create()}
 	 */
 	@Deprecated
 	public static FabricBlockSettings of() {
 		return create();
 	}
 
+	/**
+	 * @deprecated replace with {@link AbstractBlock.Settings#copy(AbstractBlock)}
+	 */
 	public static FabricBlockSettings copyOf(AbstractBlock block) {
 		return new FabricBlockSettings(((AbstractBlockAccessor) block).getSettings());
 	}
 
+	/**
+	 * @deprecated replace with {@link AbstractBlock.Settings#copy(AbstractBlock)}
+	 */
 	public static FabricBlockSettings copyOf(AbstractBlock.Settings settings) {
 		return new FabricBlockSettings(settings);
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings noCollision() {
 		super.noCollision();
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings nonOpaque() {
 		super.nonOpaque();
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings slipperiness(float value) {
 		super.slipperiness(value);
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings velocityMultiplier(float velocityMultiplier) {
 		super.velocityMultiplier(velocityMultiplier);
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings jumpVelocityMultiplier(float jumpVelocityMultiplier) {
 		super.jumpVelocityMultiplier(jumpVelocityMultiplier);
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings sounds(BlockSoundGroup group) {
 		super.sounds(group);
@@ -161,89 +171,105 @@ public class FabricBlockSettings extends AbstractBlock.Settings {
 		return this.luminance(levelFunction);
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings luminance(ToIntFunction<BlockState> luminanceFunction) {
 		super.luminance(luminanceFunction);
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings strength(float hardness, float resistance) {
 		super.strength(hardness, resistance);
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings breakInstantly() {
 		super.breakInstantly();
 		return this;
 	}
 
+	@Deprecated
+	@Override
 	public FabricBlockSettings strength(float strength) {
 		super.strength(strength);
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings ticksRandomly() {
 		super.ticksRandomly();
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings dynamicBounds() {
 		super.dynamicBounds();
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings dropsNothing() {
 		super.dropsNothing();
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings dropsLike(Block block) {
 		super.dropsLike(block);
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings air() {
 		super.air();
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings allowsSpawning(AbstractBlock.TypedContextPredicate<EntityType<?>> predicate) {
 		super.allowsSpawning(predicate);
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings solidBlock(AbstractBlock.ContextPredicate predicate) {
 		super.solidBlock(predicate);
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings suffocates(AbstractBlock.ContextPredicate predicate) {
 		super.suffocates(predicate);
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings blockVision(AbstractBlock.ContextPredicate predicate) {
 		super.blockVision(predicate);
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings postProcess(AbstractBlock.ContextPredicate predicate) {
 		super.postProcess(predicate);
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings emissiveLighting(AbstractBlock.ContextPredicate predicate) {
 		super.emissiveLighting(predicate);
@@ -253,90 +279,105 @@ public class FabricBlockSettings extends AbstractBlock.Settings {
 	/**
 	 * Make the block require tool to drop and slows down mining speed if the incorrect tool is used.
 	 */
+	@Deprecated
 	@Override
 	public FabricBlockSettings requiresTool() {
 		super.requiresTool();
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings mapColor(MapColor color) {
 		super.mapColor(color);
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings hardness(float hardness) {
 		super.hardness(hardness);
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings resistance(float resistance) {
 		super.resistance(resistance);
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings offset(AbstractBlock.OffsetType offsetType) {
 		super.offset(offsetType);
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings noBlockBreakParticles() {
 		super.noBlockBreakParticles();
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings requires(FeatureFlag... features) {
 		super.requires(features);
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings mapColor(Function<BlockState, MapColor> mapColorProvider) {
 		super.mapColor(mapColorProvider);
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings burnable() {
 		super.burnable();
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings liquid() {
 		super.liquid();
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings solid() {
 		super.solid();
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings notSolid() {
 		super.notSolid();
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings pistonBehavior(PistonBehavior pistonBehavior) {
 		super.pistonBehavior(pistonBehavior);
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings instrument(Instrument instrument) {
 		super.instrument(instrument);
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public FabricBlockSettings replaceable() {
 		super.replaceable();
@@ -354,11 +395,16 @@ public class FabricBlockSettings extends AbstractBlock.Settings {
 		return this;
 	}
 
+	/**
+	 * @deprecated replace with {@link AbstractBlock.Settings#luminance(ToIntFunction)}
+	 */
+	@Deprecated
 	public FabricBlockSettings luminance(int luminance) {
 		this.luminance(ignored -> luminance);
 		return this;
 	}
 
+	@Deprecated
 	public FabricBlockSettings drops(Identifier dropTableId) {
 		((AbstractBlockSettingsAccessor) this).setLootTableId(dropTableId);
 		return this;
@@ -367,7 +413,7 @@ public class FabricBlockSettings extends AbstractBlock.Settings {
 	/* FABRIC DELEGATE WRAPPERS */
 
 	/**
-	 * @deprecated Please migrate to {@link FabricBlockSettings#mapColor(MapColor)}
+	 * @deprecated Please migrate to {@link AbstractBlock.Settings#mapColor(MapColor)}
 	 */
 	@Deprecated
 	public FabricBlockSettings materialColor(MapColor color) {
@@ -375,17 +421,22 @@ public class FabricBlockSettings extends AbstractBlock.Settings {
 	}
 
 	/**
-	 * @deprecated Please migrate to {@link FabricBlockSettings#mapColor(DyeColor)}
+	 * @deprecated Please migrate to {@link AbstractBlock.Settings#mapColor(DyeColor)}
 	 */
 	@Deprecated
 	public FabricBlockSettings materialColor(DyeColor color) {
 		return this.mapColor(color);
 	}
 
+	/**
+	 * @deprecated Please migrate to {@link AbstractBlock.Settings#mapColor(DyeColor)}
+	 */
+	@Deprecated
 	public FabricBlockSettings mapColor(DyeColor color) {
 		return this.mapColor(color.getMapColor());
 	}
 
+	@Deprecated
 	public FabricBlockSettings collidable(boolean collidable) {
 		((AbstractBlockSettingsAccessor) this).setCollidable(collidable);
 		return this;

--- a/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/TealSignTest.java
+++ b/fabric-object-builder-api-v1/src/testmod/java/net/fabricmc/fabric/test/object/builder/TealSignTest.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.test.object.builder;
 
+import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.BlockSetType;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
@@ -36,7 +37,6 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
 import net.fabricmc.fabric.api.object.builder.v1.block.type.BlockSetTypeBuilder;
 import net.fabricmc.fabric.api.object.builder.v1.block.type.WoodTypeBuilder;
@@ -45,25 +45,25 @@ public class TealSignTest implements ModInitializer {
 	public static final Identifier TEAL_TYPE_ID = ObjectBuilderTestConstants.id("teal");
 	public static final BlockSetType TEAL_BLOCK_SET_TYPE = BlockSetTypeBuilder.copyOf(BlockSetType.OAK).build(TEAL_TYPE_ID);
 	public static final WoodType TEAL_WOOD_TYPE = WoodTypeBuilder.copyOf(WoodType.OAK).build(TEAL_TYPE_ID, TEAL_BLOCK_SET_TYPE);
-	public static final SignBlock TEAL_SIGN = new SignBlock(TEAL_WOOD_TYPE, FabricBlockSettings.copy(Blocks.OAK_SIGN)) {
+	public static final SignBlock TEAL_SIGN = new SignBlock(TEAL_WOOD_TYPE, AbstractBlock.Settings.copy(Blocks.OAK_SIGN)) {
 		@Override
 		public TealSign createBlockEntity(BlockPos pos, BlockState state) {
 			return new TealSign(pos, state);
 		}
 	};
-	public static final WallSignBlock TEAL_WALL_SIGN = new WallSignBlock(TEAL_WOOD_TYPE, FabricBlockSettings.copy(Blocks.OAK_SIGN)) {
+	public static final WallSignBlock TEAL_WALL_SIGN = new WallSignBlock(TEAL_WOOD_TYPE, AbstractBlock.Settings.copy(Blocks.OAK_SIGN)) {
 		@Override
 		public TealSign createBlockEntity(BlockPos pos, BlockState state) {
 			return new TealSign(pos, state);
 		}
 	};
-	public static final HangingSignBlock TEAL_HANGING_SIGN = new HangingSignBlock(TEAL_WOOD_TYPE, FabricBlockSettings.copy(Blocks.OAK_HANGING_SIGN)) {
+	public static final HangingSignBlock TEAL_HANGING_SIGN = new HangingSignBlock(TEAL_WOOD_TYPE, AbstractBlock.Settings.copy(Blocks.OAK_HANGING_SIGN)) {
 		@Override
 		public TealHangingSign createBlockEntity(BlockPos pos, BlockState state) {
 			return new TealHangingSign(pos, state);
 		}
 	};
-	public static final WallHangingSignBlock TEAL_WALL_HANGING_SIGN = new WallHangingSignBlock(TEAL_WOOD_TYPE, FabricBlockSettings.copy(Blocks.OAK_HANGING_SIGN)) {
+	public static final WallHangingSignBlock TEAL_WALL_HANGING_SIGN = new WallHangingSignBlock(TEAL_WOOD_TYPE, AbstractBlock.Settings.copy(Blocks.OAK_HANGING_SIGN)) {
 		@Override
 		public TealHangingSign createBlockEntity(BlockPos pos, BlockState state) {
 			return new TealHangingSign(pos, state);

--- a/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/Registration.java
+++ b/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/Registration.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.test.renderer;
 
+import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.entity.BlockEntityType;
@@ -24,16 +25,15 @@ import net.minecraft.item.Item;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 
-import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
 
 public final class Registration {
-	public static final FrameBlock FRAME_BLOCK = register("frame", new FrameBlock(FabricBlockSettings.copyOf(Blocks.IRON_BLOCK).nonOpaque()));
-	public static final FrameBlock FRAME_MULTIPART_BLOCK = register("frame_multipart", new FrameBlock(FabricBlockSettings.copyOf(Blocks.IRON_BLOCK).nonOpaque()));
-	public static final FrameBlock FRAME_VARIANT_BLOCK = register("frame_variant", new FrameBlock(FabricBlockSettings.copyOf(Blocks.IRON_BLOCK).nonOpaque()));
-	public static final Block PILLAR_BLOCK = register("pillar", new Block(FabricBlockSettings.create()));
-	public static final Block OCTAGONAL_COLUMN_BLOCK = register("octagonal_column", new Block(FabricBlockSettings.create().nonOpaque().strength(1.8F)));
-	public static final Block RIVERSTONE_BLOCK = register("riverstone", new Block(FabricBlockSettings.copyOf(Blocks.STONE)));
+	public static final FrameBlock FRAME_BLOCK = register("frame", new FrameBlock(AbstractBlock.Settings.copy(Blocks.IRON_BLOCK).nonOpaque()));
+	public static final FrameBlock FRAME_MULTIPART_BLOCK = register("frame_multipart", new FrameBlock(AbstractBlock.Settings.copy(Blocks.IRON_BLOCK).nonOpaque()));
+	public static final FrameBlock FRAME_VARIANT_BLOCK = register("frame_variant", new FrameBlock(AbstractBlock.Settings.copy(Blocks.IRON_BLOCK).nonOpaque()));
+	public static final Block PILLAR_BLOCK = register("pillar", new Block(AbstractBlock.Settings.create()));
+	public static final Block OCTAGONAL_COLUMN_BLOCK = register("octagonal_column", new Block(AbstractBlock.Settings.create().nonOpaque().strength(1.8F)));
+	public static final Block RIVERSTONE_BLOCK = register("riverstone", new Block(AbstractBlock.Settings.copy(Blocks.STONE)));
 
 	public static final FrameBlock[] FRAME_BLOCKS = new FrameBlock[] {
 			FRAME_BLOCK,

--- a/fabric-transitive-access-wideners-v1/src/testmod/java/net/fabricmc/fabric/test/access/SignBlockEntityTest.java
+++ b/fabric-transitive-access-wideners-v1/src/testmod/java/net/fabricmc/fabric/test/access/SignBlockEntityTest.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.test.access;
 
+import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.SignBlock;
@@ -32,18 +33,17 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
 
 public final class SignBlockEntityTest implements ModInitializer {
 	public static final String MOD_ID = "fabric-transitive-access-wideners-v1-testmod";
-	public static final SignBlock TEST_SIGN = new SignBlock(WoodType.OAK, FabricBlockSettings.copy(Blocks.OAK_SIGN)) {
+	public static final SignBlock TEST_SIGN = new SignBlock(WoodType.OAK, AbstractBlock.Settings.copy(Blocks.OAK_SIGN)) {
 		@Override
 		public BlockEntity createBlockEntity(BlockPos pos, BlockState state) {
 			return new TestSign(pos, state);
 		}
 	};
-	public static final WallSignBlock TEST_WALL_SIGN = new WallSignBlock(WoodType.OAK, FabricBlockSettings.copy(Blocks.OAK_SIGN)) {
+	public static final WallSignBlock TEST_WALL_SIGN = new WallSignBlock(WoodType.OAK, AbstractBlock.Settings.copy(Blocks.OAK_SIGN)) {
 		@Override
 		public BlockEntity createBlockEntity(BlockPos pos, BlockState state) {
 			return new TestSign(pos, state);


### PR DESCRIPTION
- Deprecate FabricBlockSettings & FabricItemSettings.
- Add injected FabricItem.Settings interface replacing FabricItemSettings functionality. 
- The existing vanilla Block Settings should provide most if not all of the functionality that FabricBlockSettings provided