### PR TITLE
Make chunk sections only convert vanilla air blocks to AIR

### DIFF
--- a/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/mixin/block/ChunkSectionBlockStateCounterMixin.java
+++ b/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/mixin/block/ChunkSectionBlockStateCounterMixin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.block;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+
+@Mixin(targets = "net/minecraft/world/chunk/ChunkSection$BlockStateCounter")
+public class ChunkSectionBlockStateCounterMixin {
+
+	@Redirect(method = "accept(Lnet/minecraft/block/BlockState;I)V",
+			at = @At(value = "INVOKE" , target = "Lnet/minecraft/block/BlockState;isAir()Z"))
+	private boolean modifyAirCheck(BlockState blockState) {
+		return blockState.isOf(Blocks.AIR) || blockState.isOf(Blocks.CAVE_AIR) || blockState.isOf(Blocks.VOID_AIR);
+	}
+}

--- a/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/mixin/block/ChunkSectionBlockStateCounterMixin.java
+++ b/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/mixin/block/ChunkSectionBlockStateCounterMixin.java
@@ -25,6 +25,10 @@ import net.minecraft.block.Blocks;
 
 @Mixin(targets = "net/minecraft/world/chunk/ChunkSection$BlockStateCounter")
 public class ChunkSectionBlockStateCounterMixin {
+	/**
+	 * Makes Chunk Sections not have isAir = true modded blocks be replaced with AIR against their will.
+	 * Mojang report: https://bugs.mojang.com/browse/MC-232360
+	 */
 	@Redirect(method = "accept(Lnet/minecraft/block/BlockState;I)V",
 			at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;isAir()Z"))
 	private boolean modifyAirCheck(BlockState blockState) {

--- a/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/mixin/block/ChunkSectionBlockStateCounterMixin.java
+++ b/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/mixin/block/ChunkSectionBlockStateCounterMixin.java
@@ -25,9 +25,8 @@ import net.minecraft.block.Blocks;
 
 @Mixin(targets = "net/minecraft/world/chunk/ChunkSection$BlockStateCounter")
 public class ChunkSectionBlockStateCounterMixin {
-
 	@Redirect(method = "accept(Lnet/minecraft/block/BlockState;I)V",
-			at = @At(value = "INVOKE" , target = "Lnet/minecraft/block/BlockState;isAir()Z"))
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;isAir()Z"))
 	private boolean modifyAirCheck(BlockState blockState) {
 		return blockState.isOf(Blocks.AIR) || blockState.isOf(Blocks.CAVE_AIR) || blockState.isOf(Blocks.VOID_AIR);
 	}

--- a/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/mixin/block/ChunkSectionMixin.java
+++ b/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/mixin/block/ChunkSectionMixin.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.block;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.world.chunk.ChunkSection;
+
+@Mixin(ChunkSection.class)
+public class ChunkSectionMixin {
+
+	@Redirect(method = "setBlockState(IIILnet/minecraft/block/BlockState;Z)Lnet/minecraft/block/BlockState;",
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;isAir()Z"))
+	private boolean modifyAirCheck(BlockState blockState) {
+		return blockState.isOf(Blocks.AIR) || blockState.isOf(Blocks.CAVE_AIR) || blockState.isOf(Blocks.VOID_AIR);
+	}
+}

--- a/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/mixin/block/ChunkSectionMixin.java
+++ b/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/mixin/block/ChunkSectionMixin.java
@@ -26,6 +26,10 @@ import net.minecraft.world.chunk.ChunkSection;
 
 @Mixin(ChunkSection.class)
 public class ChunkSectionMixin {
+	/**
+	 * Makes Chunk Sections not have isAir = true modded blocks be replaced with AIR against their will.
+	 * Mojang report: https://bugs.mojang.com/browse/MC-232360
+	 */
 	@Redirect(method = "setBlockState(IIILnet/minecraft/block/BlockState;Z)Lnet/minecraft/block/BlockState;",
 			at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;isAir()Z"))
 	private boolean modifyAirCheck(BlockState blockState) {

--- a/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/mixin/block/ChunkSectionMixin.java
+++ b/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/mixin/block/ChunkSectionMixin.java
@@ -26,7 +26,6 @@ import net.minecraft.world.chunk.ChunkSection;
 
 @Mixin(ChunkSection.class)
 public class ChunkSectionMixin {
-
 	@Redirect(method = "setBlockState(IIILnet/minecraft/block/BlockState;Z)Lnet/minecraft/block/BlockState;",
 			at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;isAir()Z"))
 	private boolean modifyAirCheck(BlockState blockState) {

--- a/fabric-block-api-v1/src/main/resources/fabric-block-api-v1.mixins.json
+++ b/fabric-block-api-v1/src/main/resources/fabric-block-api-v1.mixins.json
@@ -4,7 +4,9 @@
   "compatibilityLevel": "JAVA_17",
   "mixins": [
     "BlockMixin",
-    "BlockStateMixin"
+    "BlockStateMixin",
+    "ChunkSectionBlockStateCounterMixin",
+    "ChunkSectionMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
### The Issue: 
When a chunk section (16x16x16 area) is entirely made of blocks that return true for isAir method, vanilla will convert ALL blocks in that chunk section to Blocks.AIR regardless of what block it is. This does impact CAVE_AIR and VOID_AIR too.

If a mod has a modded air block returning true for isAir, they are getting this nuking behavior above without knowing it because of how hidden and inconsistent this behavior is. There is no use case for wanting this behavior for a block so no need to expose this for modders to opt into since no one will do so.

Vanilla bug report: https://bugs.mojang.com/browse/MC-232360

### Solution 1: Tags:
I thought about this but given how widely and heavily used isAir checks are present in just about most mods, it would be impossible to get everyone to switch all of those checks to a tag check. Never will happen.

### Solution 2: Change the ChunkSection to ignore modded air blocks:
Easiest solution. 2 mixins. And now all modded isAir blocks no longer will be converted into Air automatically by vanilla. It is safe for mods to mark their block as air and get all the isAir compatibility checks they want with other mods. Vanilla air block behavior is unchanged so CAVE_AIR and VOID_AIR still converts to AIR. 

### Why I want this: 
I have Heavy Air and Windy Air block and I want them to be treated like air for all modded and vanilla isAir checks. I just don't want them magically disappearing from a chunk section because someone mined out the last solid block from the section somewhere else. Makes zero logical sense.