### PR TITLE
Send `c:register` packet for play phase instead of config

### DIFF
--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/CommonPacketsImpl.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/CommonPacketsImpl.java
@@ -25,6 +25,7 @@ import net.minecraft.server.network.ServerPlayerConfigurationTask;
 
 import net.fabricmc.fabric.api.networking.v1.ServerConfigurationConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerConfigurationNetworking;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.impl.networking.server.ServerConfigurationNetworkAddon;
 import net.fabricmc.fabric.impl.networking.server.ServerNetworkingImpl;
 
@@ -95,7 +96,7 @@ public class CommonPacketsImpl {
 
 		@Override
 		public void sendPacket(Consumer<Packet<?>> sender) {
-			addon.sendPacket(addon.createRegisterPayload());
+			addon.sendPacket(new CommonRegisterPayload(addon.getNegotiatedVersion(), CommonRegisterPayload.PLAY_PHASE, ServerPlayNetworking.getGlobalReceivers()));
 		}
 
 		@Override

--- a/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/play/NetworkingPlayPacketTest.java
+++ b/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/play/NetworkingPlayPacketTest.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import org.apache.commons.lang3.Validate;
 
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.listener.ClientPlayPacketListener;
@@ -43,6 +44,7 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.networking.v1.FabricPacket;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.networking.v1.PacketType;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.test.networking.NetworkingTestmods;
 
@@ -132,6 +134,10 @@ public final class NetworkingPlayPacketTest implements ModInitializer {
 					sendToUnknownChannel(player);
 				}
 			}
+		});
+
+		ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> {
+			Validate.isTrue(ServerPlayNetworking.canSend(handler, OverlayPacket.PACKET_TYPE));
 		});
 	}
 

--- a/fabric-networking-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/networking/client/play/NetworkingPlayPacketClientTest.java
+++ b/fabric-networking-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/networking/client/play/NetworkingPlayPacketClientTest.java
@@ -25,7 +25,6 @@ import net.minecraft.util.Identifier;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
-import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.networking.v1.PacketSender;
@@ -37,7 +36,7 @@ public final class NetworkingPlayPacketClientTest implements ClientModInitialize
 
 	@Override
 	public void onInitializeClient() {
-		ClientPlayConnectionEvents.INIT.register((handler, client) -> ClientPlayNetworking.registerReceiver(NetworkingPlayPacketTest.OverlayPacket.PACKET_TYPE, this));
+		ClientPlayNetworking.registerGlobalReceiver(NetworkingPlayPacketTest.OverlayPacket.PACKET_TYPE, this);
 
 		ClientCommandRegistrationCallback.EVENT.register((dispatcher, dedicated) -> dispatcher.register(
 				ClientCommandManager.literal("clientnetworktestcommand")


### PR DESCRIPTION
Closes #3541 

The graph on https://github.com/FabricMC/fabric/pull/3244 says that it sends `c:register` for the play phase but sends for the config phase instead. 
The channel IDs for the config phase have already been sent with the `minecraft:register` payload.