### PR TITLE
Extend Data Attachment API to ProtoChunk

### DIFF
--- a/fabric-data-attachment-api-v1/build.gradle
+++ b/fabric-data-attachment-api-v1/build.gradle
@@ -7,5 +7,6 @@ moduleDependencies(project, [
 ])
 
 testDependencies(project, [
-	':fabric-lifecycle-events-v1'
+	':fabric-lifecycle-events-v1',
+	':fabric-biome-api-v1'
 ])

--- a/fabric-data-attachment-api-v1/src/client/java/net/fabricmc/fabric/mixin/attachment/client/ClientPlayNetworkHandlerMixin.java
+++ b/fabric-data-attachment-api-v1/src/client/java/net/fabricmc/fabric/mixin/attachment/client/ClientPlayNetworkHandlerMixin.java
@@ -38,7 +38,7 @@ abstract class ClientPlayNetworkHandlerMixin {
 		/*
 		 * The KEEP_ATTRIBUTES flag is not set on a death respawn, and set in all other cases
 		 */
-		AttachmentTargetImpl.copyOnRespawn(oldPlayer, newPlayer, !packet.hasFlag(PlayerRespawnS2CPacket.KEEP_ATTRIBUTES));
+		AttachmentTargetImpl.transfer(oldPlayer, newPlayer, !packet.hasFlag(PlayerRespawnS2CPacket.KEEP_ATTRIBUTES));
 		init.call(newPlayer);
 	}
 }

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentTarget.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentTarget.java
@@ -28,14 +28,14 @@ import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.Entity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.world.chunk.Chunk;
-import net.minecraft.world.chunk.WorldChunk;
+import net.minecraft.world.chunk.ChunkStatus;
 
 /**
  * Marks all objects on which data can be attached using {@link AttachmentType}s.
  *
- * <p>Fabric implements this on {@link Entity}, {@link BlockEntity}, {@link ServerWorld} and {@link WorldChunk} via mixin.</p>
+ * <p>Fabric implements this on {@link Entity}, {@link BlockEntity}, {@link ServerWorld} and {@link Chunk} via mixin.</p>
  *
- * <p>Note about {@link BlockEntity} and {@link WorldChunk} targets: these objects need to be notified of changes to their
+ * <p>Note about {@link BlockEntity} and {@link Chunk} targets: these objects need to be notified of changes to their
  * state (using {@link BlockEntity#markDirty()} and {@link Chunk#setNeedsSaving(boolean)} respectively), otherwise the modifications will not take effect properly.
  * The {@link #setAttached(AttachmentType, Object)} method handles this automatically, but this needs to be done manually
  * when attached data is mutable, for example:
@@ -54,6 +54,12 @@ import net.minecraft.world.chunk.WorldChunk;
  * undesirable behavior, the API completely removes attachments from the result of {@link BlockEntity#toInitialChunkDataNbt()},
  * which takes care of all vanilla types. However, modded block entities may be coded differently, so be wary of this
  * when attaching data to modded block entities.
+ * </p>
+ *
+ * <p>
+ * Note about {@link Chunk} targets with {@link ChunkStatus#EMPTY}: These chunks are not saved unless the generation
+ * progresses to at least {@link ChunkStatus#STRUCTURE_STARTS}. Therefore, persistent attachments to those chunks may not
+ * be saved. The {@link #setAttached(AttachmentType, Object)} method will log a warning when this is attempted.
  * </p>
  */
 @ApiStatus.Experimental

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentType.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentType.java
@@ -23,8 +23,6 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityType;
-import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.chunk.Chunk;
@@ -32,6 +30,7 @@ import net.minecraft.world.chunk.ProtoChunk;
 import net.minecraft.world.chunk.WorldChunk;
 
 import net.fabricmc.fabric.api.entity.event.v1.ServerEntityWorldChangeEvents;
+import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
 
 /**
@@ -49,7 +48,7 @@ import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
  * an attachment that keeps a reference to an {@link Entity} or {@link ProtoChunk} instance can and will break unexpectedly. If,
  * for whatever reason, keeping a reference to the target is absolutely necessary, be sure to implement custom copying logic.
  * For {@link Entity} targets, use {@link ServerPlayerEvents#COPY_FROM}, {@link ServerEntityWorldChangeEvents#AFTER_ENTITY_CHANGE_WORLD},
- * and a mixin into {@link MobEntity#convertTo(EntityType, boolean)}. For {@link Chunk} targets, mixin into
+ * and {@link ServerLivingEntityEvents#MOB_CONVERSION}. For {@link Chunk} targets, mixin into
  * {@link WorldChunk#WorldChunk(ServerWorld, ProtoChunk, WorldChunk.EntityLoader)}.
  * </p>
  *

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentType.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentType.java
@@ -25,7 +25,11 @@ import org.jetbrains.annotations.Nullable;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Identifier;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.ProtoChunk;
+import net.minecraft.world.chunk.WorldChunk;
 
 import net.fabricmc.fabric.api.entity.event.v1.ServerEntityWorldChangeEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
@@ -39,13 +43,15 @@ import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
  * immutable types. More generally, different attachments <i>must not</i> share mutable state, and it is <i>strongly advised</i>
  * for attachments not to hold internal references to their target. See the following note on entity targets.</p>
  *
- * <p>Note on {@link Entity} targets: in several instances, the name needs to copy data from one {@link Entity} to another.
- * These are player respawning, mob conversion, return from the End and cross-world entity teleportation. By default,
- * attachments are simply copied wholesale, up to {@link #copyOnDeath()}. Since one entity instance is discarded,
- * an attachment that keeps a reference to an {@link Entity} instance can and will break unexpectedly. If,
- * for whatever reason, keeping to reference to the target entity is absolutely necessary, be sure to use
- * {@link ServerPlayerEvents#COPY_FROM}, {@link ServerEntityWorldChangeEvents#AFTER_ENTITY_CHANGE_WORLD}
- * and a mixin into {@link MobEntity#convertTo(EntityType, boolean)} to implement custom copying logic.</p>
+ * <p>Note on {@link Entity} and {@link Chunk} targets: in several instances, the game needs to copy data from one instance to another.
+ * These are player respawning, mob conversion, return from the End, cross-world entity teleportation, and conversion of a {@link ProtoChunk} to
+ * {@link WorldChunk}. By default, attachments are simply copied wholesale, up to {@link #copyOnDeath()}. Since one instance is discarded,
+ * an attachment that keeps a reference to an {@link Entity} or {@link ProtoChunk} instance can and will break unexpectedly. If,
+ * for whatever reason, keeping a reference to the target is absolutely necessary, be sure to implement custom copying logic.
+ * For {@link Entity} targets, use {@link ServerPlayerEvents#COPY_FROM}, {@link ServerEntityWorldChangeEvents#AFTER_ENTITY_CHANGE_WORLD},
+ * and a mixin into {@link MobEntity#convertTo(EntityType, boolean)}. For {@link Chunk} targets, mixin into
+ * {@link WorldChunk#WorldChunk(ServerWorld, ProtoChunk, WorldChunk.EntityLoader)}.
+ * </p>
  *
  * @param <A> type of the attached data. It is encouraged for this to be an immutable type.
  */

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentEntrypoint.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentEntrypoint.java
@@ -25,14 +25,14 @@ public class AttachmentEntrypoint implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		ServerPlayerEvents.COPY_FROM.register((oldPlayer, newPlayer, alive) ->
-				AttachmentTargetImpl.copyOnRespawn(oldPlayer, newPlayer, !alive)
+				AttachmentTargetImpl.transfer(oldPlayer, newPlayer, !alive)
 		);
 		ServerEntityWorldChangeEvents.AFTER_ENTITY_CHANGE_WORLD.register(((originalEntity, newEntity, origin, destination) ->
-				AttachmentTargetImpl.copyOnRespawn(originalEntity, newEntity, false))
+				AttachmentTargetImpl.transfer(originalEntity, newEntity, false))
 		);
 		// using the corresponding player event is unnecessary as no new instance is created
 		ServerLivingEntityEvents.MOB_CONVERSION.register((previous, converted, keepEquipment) ->
-				AttachmentTargetImpl.copyOnRespawn(previous, converted, true)
+				AttachmentTargetImpl.transfer(previous, converted, true)
 		);
 	}
 }

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentEntrypoint.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentEntrypoint.java
@@ -16,12 +16,17 @@
 
 package net.fabricmc.fabric.impl.attachment;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.entity.event.v1.ServerEntityWorldChangeEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
 
 public class AttachmentEntrypoint implements ModInitializer {
+	public static final Logger LOGGER = LoggerFactory.getLogger("fabric-data-attachment-api-v1");
+
 	@Override
 	public void onInitialize() {
 		ServerPlayerEvents.COPY_FROM.register((oldPlayer, newPlayer, alive) ->

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentTargetImpl.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentTargetImpl.java
@@ -27,11 +27,11 @@ import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
 
 public interface AttachmentTargetImpl extends AttachmentTarget {
 	/**
-	 * Copies attachements fromt the original to the target. This is uese when a ProtoChunks is converted to a
-	 * WorldChunks, and when an entity is respawned and a new instance is created. For entity respawns, it is
-	 * triggered on player respawn, entity conversion, return from the End or cross-world entity teleportation.
+	 * Copies attachments from the original to the target. This is used when a ProtoChunk is converted to a
+	 * WorldChunk, and when an entity is respawned and a new instance is created. For entity respawns, it is
+	 * triggered on player respawn, entity conversion, return from the End, or cross-world entity teleportation.
 	 * In the first two cases, only the attachments with {@link AttachmentType#copyOnDeath()} will be transferred.
-	 */
+	*/
 	@SuppressWarnings("unchecked")
 	static void transfer(AttachmentTarget original, AttachmentTarget target, boolean isDeath) {
 		Map<AttachmentType<?>, ?> attachments = ((AttachmentTargetImpl) original).fabric_getAttachments();

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentTargetImpl.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentTargetImpl.java
@@ -27,12 +27,13 @@ import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
 
 public interface AttachmentTargetImpl extends AttachmentTarget {
 	/**
-	 * Copies entity attachments when it is respawned and a new instance is created.
-	 * Is triggered on player respawn, entity conversion, return from the End or cross-world entity teleportation.
+	 * Copies attachements fromt the original to the target. This is uese when a ProtoChunks is converted to a
+	 * WorldChunks, and when an entity is respawned and a new instance is created. For entity respawns, it is
+	 * triggered on player respawn, entity conversion, return from the End or cross-world entity teleportation.
 	 * In the first two cases, only the attachments with {@link AttachmentType#copyOnDeath()} will be transferred.
 	 */
 	@SuppressWarnings("unchecked")
-	static void copyOnRespawn(AttachmentTarget original, AttachmentTarget target, boolean isDeath) {
+	static void transfer(AttachmentTarget original, AttachmentTarget target, boolean isDeath) {
 		Map<AttachmentType<?>, ?> attachments = ((AttachmentTargetImpl) original).fabric_getAttachments();
 
 		if (attachments == null) {

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
@@ -27,8 +27,10 @@ import net.minecraft.entity.Entity;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.ChunkStatus;
 
 import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
+import net.fabricmc.fabric.impl.attachment.AttachmentEntrypoint;
 import net.fabricmc.fabric.impl.attachment.AttachmentSerializingImpl;
 import net.fabricmc.fabric.impl.attachment.AttachmentTargetImpl;
 
@@ -55,6 +57,10 @@ abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
 			((BlockEntity) thisObject).markDirty();
 		} else if (thisObject instanceof Chunk) {
 			((Chunk) thisObject).setNeedsSaving(true);
+
+			if (type.isPersistent() && ((Chunk) thisObject).getStatus().equals(ChunkStatus.EMPTY)) {
+				AttachmentEntrypoint.LOGGER.warn("Attaching persistent attachment {} to chunk with chunk status EMPTY. Attachment might be discarded.", type.identifier());
+			}
 		}
 
 		if (value == null) {

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
@@ -27,13 +27,12 @@ import net.minecraft.entity.Entity;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
-import net.minecraft.world.chunk.WorldChunk;
 
 import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
 import net.fabricmc.fabric.impl.attachment.AttachmentSerializingImpl;
 import net.fabricmc.fabric.impl.attachment.AttachmentTargetImpl;
 
-@Mixin({BlockEntity.class, Entity.class, World.class, WorldChunk.class})
+@Mixin({BlockEntity.class, Entity.class, World.class, Chunk.class})
 abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
 	@Nullable
 	private IdentityHashMap<AttachmentType<?>, Object> fabric_dataAttachments = null;
@@ -54,7 +53,7 @@ abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
 
 		if (thisObject instanceof BlockEntity) {
 			((BlockEntity) thisObject).markDirty();
-		} else if (thisObject instanceof WorldChunk) {
+		} else if (thisObject instanceof Chunk) {
 			((Chunk) thisObject).setNeedsSaving(true);
 		}
 

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/ChunkSerializerMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/ChunkSerializerMixin.java
@@ -27,7 +27,7 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.ChunkSerializer;
 import net.minecraft.world.chunk.Chunk;
-import net.minecraft.world.chunk.ChunkStatus;
+import net.minecraft.world.chunk.ProtoChunk;
 import net.minecraft.world.chunk.WorldChunk;
 import net.minecraft.world.poi.PointOfInterestStorage;
 
@@ -42,7 +42,19 @@ abstract class ChunkSerializerMixin {
 			),
 			method = "deserialize"
 	)
-	private static WorldChunk readChunkAttachments(WorldChunk chunk, ServerWorld world, PointOfInterestStorage poiStorage, ChunkPos chunkPos, NbtCompound nbt) {
+	private static WorldChunk readWorldChunkAttachments(WorldChunk chunk, ServerWorld world, PointOfInterestStorage poiStorage, ChunkPos chunkPos, NbtCompound nbt) {
+		((AttachmentTargetImpl) chunk).fabric_readAttachmentsFromNbt(nbt);
+		return chunk;
+	}
+
+	@ModifyExpressionValue(
+			at = @At(
+					value = "NEW",
+					target = "net/minecraft/world/chunk/ProtoChunk"
+			),
+			method = "deserialize"
+	)
+	private static ProtoChunk readProtoChunkAttachments(ProtoChunk chunk, ServerWorld world, PointOfInterestStorage poiStorage, ChunkPos chunkPos, NbtCompound nbt) {
 		((AttachmentTargetImpl) chunk).fabric_readAttachmentsFromNbt(nbt);
 		return chunk;
 	}
@@ -52,8 +64,6 @@ abstract class ChunkSerializerMixin {
 			method = "serialize"
 	)
 	private static void writeChunkAttachments(ServerWorld world, Chunk chunk, CallbackInfoReturnable<NbtCompound> cir) {
-		if (chunk.getStatus().getChunkType() == ChunkStatus.ChunkType.LEVELCHUNK) {
-			((AttachmentTargetImpl) chunk).fabric_writeAttachmentsToNbt(cir.getReturnValue());
-		}
+		((AttachmentTargetImpl) chunk).fabric_writeAttachmentsToNbt(cir.getReturnValue());
 	}
 }

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WorldChunkMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WorldChunkMixin.java
@@ -1,0 +1,24 @@
+package net.fabricmc.fabric.mixin.attachment;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.world.chunk.ProtoChunk;
+import net.minecraft.world.chunk.WorldChunk;
+
+import net.fabricmc.fabric.api.attachment.v1.AttachmentTarget;
+import net.fabricmc.fabric.impl.attachment.AttachmentTargetImpl;
+
+@Mixin(WorldChunk.class)
+public class WorldChunkMixin {
+	@Inject(
+			method = "<init>(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/world/chunk/ProtoChunk;Lnet/minecraft/world/chunk/WorldChunk$EntityLoader;)V",
+			at = @At("TAIL")
+	)
+	public void transferProtoChunkAttachement(ServerWorld world, ProtoChunk protoChunk, WorldChunk.EntityLoader entityLoader, CallbackInfo ci) {
+		AttachmentTargetImpl.transfer(protoChunk, (AttachmentTarget) this, false);
+	}
+}

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WorldChunkMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WorldChunkMixin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.attachment;
 
 import org.spongepowered.asm.mixin.Mixin;

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WrapperProtoChunkMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WrapperProtoChunkMixin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.attachment;
 
 import java.util.Map;

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WrapperProtoChunkMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WrapperProtoChunkMixin.java
@@ -1,0 +1,59 @@
+package net.fabricmc.fabric.mixin.attachment;
+
+import java.util.Map;
+
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.world.chunk.WorldChunk;
+import net.minecraft.world.chunk.WrapperProtoChunk;
+
+import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
+import net.fabricmc.fabric.impl.attachment.AttachmentTargetImpl;
+
+@Mixin(WrapperProtoChunk.class)
+public class WrapperProtoChunkMixin implements AttachmentTargetImpl {
+	@Shadow
+	@Final
+	private WorldChunk wrapped;
+
+	@Override
+	@Nullable
+	public <T> T getAttached(AttachmentType<T> type) {
+		return this.wrapped.getAttached(type);
+	}
+
+	@Override
+	@Nullable
+	public <T> T setAttached(AttachmentType<T> type, @Nullable T value) {
+		return this.wrapped.setAttached(type, value);
+	}
+
+	@Override
+	public boolean hasAttached(AttachmentType<?> type) {
+		return this.wrapped.hasAttached(type);
+	}
+
+	@Override
+	public void fabric_writeAttachmentsToNbt(NbtCompound nbt) {
+		((AttachmentTargetImpl) this.wrapped).fabric_writeAttachmentsToNbt(nbt);
+	}
+
+	@Override
+	public void fabric_readAttachmentsFromNbt(NbtCompound nbt) {
+		((AttachmentTargetImpl) this.wrapped).fabric_readAttachmentsFromNbt(nbt);
+	}
+
+	@Override
+	public boolean fabric_hasPersistentAttachments() {
+		return ((AttachmentTargetImpl) this.wrapped).fabric_hasPersistentAttachments();
+	}
+
+	@Override
+	public Map<AttachmentType<?>, ?> fabric_getAttachments() {
+		return ((AttachmentTargetImpl) this.wrapped).fabric_getAttachments();
+	}
+}

--- a/fabric-data-attachment-api-v1/src/main/resources/fabric-data-attachment-api-v1.mixins.json
+++ b/fabric-data-attachment-api-v1/src/main/resources/fabric-data-attachment-api-v1.mixins.json
@@ -8,7 +8,9 @@
     "BlockEntityUpdateS2CPacketMixin",
     "ChunkSerializerMixin",
     "EntityMixin",
-    "ServerWorldMixin"
+    "ServerWorldMixin",
+    "WorldChunkMixin",
+    "WrapperProtoChunkMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/fabric-data-attachment-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-data-attachment-api-v1/src/main/resources/fabric.mod.json
@@ -37,7 +37,7 @@
     "fabric-api:module-lifecycle": "experimental",
     "loom:injected_interfaces": {
       "net/minecraft/class_2586": ["net/fabricmc/fabric/api/attachment/v1/AttachmentTarget"],
-      "net/minecraft/class_2818": ["net/fabricmc/fabric/api/attachment/v1/AttachmentTarget"],
+      "net/minecraft/class_2791": ["net/fabricmc/fabric/api/attachment/v1/AttachmentTarget"],
       "net/minecraft/class_1297": ["net/fabricmc/fabric/api/attachment/v1/AttachmentTarget"],
       "net/minecraft/class_3218": ["net/fabricmc/fabric/api/attachment/v1/AttachmentTarget"]
     }

--- a/fabric-data-attachment-api-v1/src/test/java/net/fabricmc/fabric/test/attachment/CommonAttachmentTests.java
+++ b/fabric-data-attachment-api-v1/src/test/java/net/fabricmc/fabric/test/attachment/CommonAttachmentTests.java
@@ -48,6 +48,7 @@ import net.minecraft.nbt.NbtElement;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.chunk.ProtoChunk;
 import net.minecraft.world.chunk.WorldChunk;
 
 import net.fabricmc.fabric.api.attachment.v1.AttachmentRegistry;
@@ -82,8 +83,9 @@ public class CommonAttachmentTests {
 		Entity entity = mock(Entity.class, CALLS_REAL_METHODS);
 		BlockEntity blockEntity = mock(BlockEntity.class, CALLS_REAL_METHODS);
 		WorldChunk worldChunk = mock(WorldChunk.class, CALLS_REAL_METHODS);
+		ProtoChunk protoChunk = mock(ProtoChunk.class, CALLS_REAL_METHODS);
 
-		for (AttachmentTarget target : new AttachmentTarget[]{serverWorld, entity, blockEntity, worldChunk}) {
+		for (AttachmentTarget target : new AttachmentTarget[]{serverWorld, entity, blockEntity, worldChunk, protoChunk}) {
 			testForTarget(target, basic);
 		}
 	}
@@ -161,8 +163,8 @@ public class CommonAttachmentTests {
 		Entity respawnTarget = mock(Entity.class, CALLS_REAL_METHODS);
 		Entity nonRespawnTarget = mock(Entity.class, CALLS_REAL_METHODS);
 
-		AttachmentTargetImpl.copyOnRespawn(original, respawnTarget, true);
-		AttachmentTargetImpl.copyOnRespawn(original, nonRespawnTarget, false);
+		AttachmentTargetImpl.transfer(original, respawnTarget, true);
+		AttachmentTargetImpl.transfer(original, nonRespawnTarget, false);
 		assertTrue(respawnTarget.hasAttached(copiedOnRespawn));
 		assertFalse(respawnTarget.hasAttached(notCopiedOnRespawn));
 		assertTrue(nonRespawnTarget.hasAttached(copiedOnRespawn));

--- a/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
+++ b/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
@@ -50,14 +50,14 @@ public class AttachmentTestMod implements ModInitializer {
 			new Identifier(MOD_ID, "persistent"),
 			Codec.STRING
 	);
-	public static final AttachmentType<String> FEATURE_ATTACHMENT = AttachmentRegistry.createPersistent(
-			new Identifier(MOD_ID, "feature"),
-			Codec.STRING
+	public static final AttachmentType<String> FEATURE_ATTACHMENT = AttachmentRegistry.create(
+			new Identifier(MOD_ID, "feature")
 	);
 
 	public static final ChunkPos FAR_CHUNK_POS = new ChunkPos(30, 0);
 
 	private boolean firstLaunch = true;
+	public static boolean featurePlaced = false;
 
 	@Override
 	public void onInitialize() {
@@ -78,7 +78,14 @@ public class AttachmentTestMod implements ModInitializer {
 
 			if (firstLaunch) {
 				LOGGER.info("First launch, testing attachment by feature");
-				if (!"feature".equals(chunk.getAttached(FEATURE_ATTACHMENT))) throw new AssertionError("Feature did not write write attachment to ProtoChunk");
+
+				if (featurePlaced) {
+					if (!"feature".equals(chunk.getAttached(FEATURE_ATTACHMENT))) {
+						throw new AssertionError("Feature did not write attachment to ProtoChunk");
+					}
+				} else {
+					LOGGER.warn("Feature not placed, could not test writing during worldgen");
+				}
 
 				LOGGER.info("setting up persistent attachments");
 

--- a/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
+++ b/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
@@ -69,7 +69,6 @@ public class AttachmentTestMod implements ModInitializer {
 				RegistryKey.of(RegistryKeys.PLACED_FEATURE, new Identifier(MOD_ID, "set_attachment"))
 		);
 
-
 		ServerLifecycleEvents.SERVER_STARTED.register(server -> {
 			ServerWorld overworld;
 			WorldChunk chunk;

--- a/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
+++ b/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
@@ -76,7 +76,8 @@ public class AttachmentTestMod implements ModInitializer {
 				if (!"chunk_data".equals(wrapperProtoChunk.getAttached(PERSISTENT))) throw new AssertionError("Attachement is not accessible through WrapperProtoChunk");
 
 				Chunk farChunk = overworld.getChunkManager().getChunk(FAR_CHUNK_POS.x, FAR_CHUNK_POS.z, ChunkStatus.EMPTY, true);
-				if (farChunk instanceof WrapperProtoChunk){
+
+				if (farChunk instanceof WrapperProtoChunk) {
 					LOGGER.warn("Far chunk alread generated, can't test persistence in ProtoChunk.");
 				} else {
 					if (!"protochunk_data".equals(farChunk.getAttached(PERSISTENT))) throw new AssertionError("ProtoChunk attachement did not persist");

--- a/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/SetAttachmentFeature.java
+++ b/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/SetAttachmentFeature.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.test.attachment;
 
 import com.mojang.serialization.Codec;
 
+import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ProtoChunk;
 import net.minecraft.world.chunk.WrapperProtoChunk;
@@ -34,11 +35,16 @@ public class SetAttachmentFeature extends Feature<DefaultFeatureConfig> {
 	public boolean generate(FeatureContext<DefaultFeatureConfig> context) {
 		Chunk chunk = context.getWorld().getChunk(context.getOrigin());
 
-		if (!(chunk instanceof ProtoChunk) || chunk instanceof WrapperProtoChunk) {
-			AttachmentTestMod.LOGGER.warn("Feature not attaching to ProtoChunk");
+		if (chunk.getPos().equals(new ChunkPos(0, 0))) {
+			AttachmentTestMod.featurePlaced = true;
+
+			if (!(chunk instanceof ProtoChunk) || chunk instanceof WrapperProtoChunk) {
+				AttachmentTestMod.LOGGER.warn("Feature not attaching to ProtoChunk");
+			}
+
+			chunk.setAttached(AttachmentTestMod.FEATURE_ATTACHMENT, "feature");
 		}
 
-		chunk.setAttached(AttachmentTestMod.FEATURE_ATTACHMENT, "feature");
 		return true;
 	}
 }

--- a/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/SetAttachmentFeature.java
+++ b/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/SetAttachmentFeature.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.attachment;
+
+import com.mojang.serialization.Codec;
+
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.ProtoChunk;
+import net.minecraft.world.chunk.WrapperProtoChunk;
+import net.minecraft.world.gen.feature.DefaultFeatureConfig;
+import net.minecraft.world.gen.feature.Feature;
+import net.minecraft.world.gen.feature.util.FeatureContext;
+
+public class SetAttachmentFeature extends Feature<DefaultFeatureConfig> {
+	public SetAttachmentFeature(Codec<DefaultFeatureConfig> codec) {
+		super(codec);
+	}
+
+	@Override
+	public boolean generate(FeatureContext<DefaultFeatureConfig> context) {
+		Chunk chunk = context.getWorld().getChunk(context.getOrigin());
+		if (!(chunk instanceof ProtoChunk) || chunk instanceof WrapperProtoChunk) {
+			AttachmentTestMod.LOGGER.warn("Feature not attaching to ProtoChunk");
+		}
+
+		chunk.setAttached(AttachmentTestMod.FEATURE_ATTACHMENT, "feature");
+		return true;
+	}
+}

--- a/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/SetAttachmentFeature.java
+++ b/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/SetAttachmentFeature.java
@@ -33,6 +33,7 @@ public class SetAttachmentFeature extends Feature<DefaultFeatureConfig> {
 	@Override
 	public boolean generate(FeatureContext<DefaultFeatureConfig> context) {
 		Chunk chunk = context.getWorld().getChunk(context.getOrigin());
+
 		if (!(chunk instanceof ProtoChunk) || chunk instanceof WrapperProtoChunk) {
 			AttachmentTestMod.LOGGER.warn("Feature not attaching to ProtoChunk");
 		}

--- a/fabric-data-attachment-api-v1/src/testmod/resources/data/fabric-data-attachment-api-v1-testmod/worldgen/placed_feature/set_attachment.json
+++ b/fabric-data-attachment-api-v1/src/testmod/resources/data/fabric-data-attachment-api-v1-testmod/worldgen/placed_feature/set_attachment.json
@@ -1,0 +1,7 @@
+{
+  "feature": {
+    "type": "fabric-data-attachment-api-v1-testmod:set_attachment",
+    "config": {}
+  },
+  "placement": []
+}

--- a/fabric-data-attachment-api-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-data-attachment-api-v1/src/testmod/resources/fabric.mod.json
@@ -7,7 +7,8 @@
   "license": "Apache-2.0",
   "depends": {
     "fabric-data-attachment-api-v1": "*",
-    "fabric-lifecycle-events-v1": "*"
+    "fabric-lifecycle-events-v1": "*",
+    "fabric-biome-api-v1": "*"
   },
   "entrypoints": {
     "main": [


### PR DESCRIPTION
This PR extends the Data Attachment API to allow data attachments on `ProtoChunk`s, rather than just `WorldChunk`s. Data on a `ProtoChunk` is kept when it is converted to a `WorldChunk`. This allows storing custom data during worldgen and reading it during gameplay.

### Individual changes:
- Move the interface injection from `WorldChunk` to `Chunk`.
- Transfer the attachment of a `ProtoChunk` to a `WorldChunk` in the `WorldChunk` constructor.
  - I've reused the `copyOnRespawn` helper method for that and renamed it to `transfer` to better match its extended use.
- A separate mixin to `WrapperProtoChunk` that simply forwards the calls to the wrapped `WorldChunk`.

### What still needs to be decided:
- [X] Should `WrapperProtoChunk.setAttached` adhere to the `propagateToWrapped` flag? -> We ignore the flag and always write to the `WorldChunk`.
- [X] What should happen when trying to attach a persistent attachment to a `ProtoChunk` with chunk status `EMPTY`? Since those aren't saved, the attachment would get lost too. Options are:
  - ~~Save empty `ProtoChunks` when an attachment is present. (I would still need to investigate how to do that.)~~
  - ~~Throw an exception when trying to attach a persistent attachment (but allow non-persistent attachments).~~
  -> We log a warning. The javadoc documents this behavior. 

### Tests:
I've extended the testmod to test saving data to a `ProtoChunk`s.
- A custom configured feature that writes an attachment to the `ProtoChunk` if it is in the [0, 0] chunk, then testing whether the attachment is present in the WorldChunk after world-load. This tests both writing to `ProtoChunk`s and the `WorldChunk` conversion. 
- To test persistence in `ProtoChunk`s, I'm adding an attachment to a far chunk. This requires this chunk to not be generated beforehand.