### PR TITLE
Fix duplicate resource pack names

### DIFF
--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModNioResourcePack.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModNioResourcePack.java
@@ -94,7 +94,8 @@ public class ModNioResourcePack implements ResourcePack, ModResourcePack {
 
 		if (paths.isEmpty()) return null;
 
-		ModNioResourcePack ret = new ModNioResourcePack(id, mod, paths, type, activationType, modBundled);
+		String packId = subPath == null ? id : id + "_" + subPath;
+		ModNioResourcePack ret = new ModNioResourcePack(packId, mod, paths, type, activationType, modBundled);
 
 		return ret.getNamespaces(type).isEmpty() ? null : ret;
 	}

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModResourcePackCreator.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ModResourcePackCreator.java
@@ -122,7 +122,7 @@ public class ModResourcePackCreator implements ResourcePackProvider {
 					? Text.translatable("pack.name.fabricMod", pack.getFabricModMetadata().getName())
 					: Text.translatable("pack.name.fabricMod.subPack", pack.getFabricModMetadata().getName(), Text.translatable("resourcePack." + subPath + ".name"));
 			ResourcePackProfile profile = ResourcePackProfile.create(
-					subPath == null ? pack.getName() : pack.getName() + "_" + subPath,
+					pack.getName(),
 					displayName,
 					subPath == null,
 					new ModResourcePackFactory(pack),


### PR DESCRIPTION
Fixes a discrepancy between the profile and pack name, which resulted in a duplicate pack name being assigned.