### PR TITLE
Expose a function for querying the non-default fluid renderer

### DIFF
--- a/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/api/client/render/fluid/v1/FluidRenderHandlerRegistry.java
+++ b/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/api/client/render/fluid/v1/FluidRenderHandlerRegistry.java
@@ -42,6 +42,15 @@ public interface FluidRenderHandlerRegistry {
 	FluidRenderHandler get(Fluid fluid);
 
 	/**
+	 * Get a {@link FluidRenderHandler} for a given Fluid, if it is not the
+	 * default implementation. Supports vanilla and Fabric fluids.
+	 *
+	 * @param fluid The Fluid.
+	 * @return The FluidRenderHandler.
+	 */
+	FluidRenderHandler getOverride(Fluid fluid);
+
+	/**
 	 * Register a {@link FluidRenderHandler} for a given Fluid.
 	 *
 	 * <p>Note that most fluids have a still and a flowing type, and a

--- a/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/api/client/render/fluid/v1/FluidRenderHandlerRegistry.java
+++ b/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/api/client/render/fluid/v1/FluidRenderHandlerRegistry.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.client.render.fluid.v1;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.LeavesBlock;
 import net.minecraft.block.TransparentBlock;
@@ -48,6 +50,7 @@ public interface FluidRenderHandlerRegistry {
 	 * @param fluid The Fluid.
 	 * @return The FluidRenderHandler.
 	 */
+	@Nullable
 	FluidRenderHandler getOverride(Fluid fluid);
 
 	/**

--- a/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/api/client/render/fluid/v1/FluidRenderHandlerRegistry.java
+++ b/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/api/client/render/fluid/v1/FluidRenderHandlerRegistry.java
@@ -41,6 +41,7 @@ public interface FluidRenderHandlerRegistry {
 	 * @param fluid The Fluid.
 	 * @return The FluidRenderHandler.
 	 */
+	@Nullable
 	FluidRenderHandler get(Fluid fluid);
 
 	/**

--- a/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/fluid/FluidRenderHandlerRegistryImpl.java
+++ b/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/fluid/FluidRenderHandlerRegistryImpl.java
@@ -57,6 +57,7 @@ public class FluidRenderHandlerRegistryImpl implements FluidRenderHandlerRegistr
 	}
 
 	@Override
+	@Nullable
 	public FluidRenderHandler get(Fluid fluid) {
 		return handlers.get(fluid);
 	}

--- a/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/fluid/FluidRenderHandlerRegistryImpl.java
+++ b/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/fluid/FluidRenderHandlerRegistryImpl.java
@@ -59,6 +59,7 @@ public class FluidRenderHandlerRegistryImpl implements FluidRenderHandlerRegistr
 		return handlers.get(fluid);
 	}
 
+	@Override
 	public FluidRenderHandler getOverride(Fluid fluid) {
 		return modHandlers.get(fluid);
 	}

--- a/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/fluid/FluidRenderHandlerRegistryImpl.java
+++ b/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/fluid/FluidRenderHandlerRegistryImpl.java
@@ -108,10 +108,10 @@ public class FluidRenderHandlerRegistryImpl implements FluidRenderHandlerRegistr
 			}
 		};
 
-		register(Fluids.WATER, waterHandler);
-		register(Fluids.FLOWING_WATER, waterHandler);
-		register(Fluids.LAVA, lavaHandler);
-		register(Fluids.FLOWING_LAVA, lavaHandler);
+		handlers.put(Fluids.WATER, waterHandler);
+		handlers.put(Fluids.FLOWING_WATER, waterHandler);
+		handlers.put(Fluids.LAVA, lavaHandler);
+		handlers.put(Fluids.FLOWING_LAVA, lavaHandler);
 		handlers.putAll(modHandlers);
 
 		SpriteAtlasTexture texture = MinecraftClient.getInstance()

--- a/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/fluid/FluidRenderHandlerRegistryImpl.java
+++ b/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/fluid/FluidRenderHandlerRegistryImpl.java
@@ -19,6 +19,8 @@ package net.fabricmc.fabric.impl.client.rendering.fluid;
 import java.util.IdentityHashMap;
 import java.util.Map;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.LeavesBlock;
@@ -60,6 +62,7 @@ public class FluidRenderHandlerRegistryImpl implements FluidRenderHandlerRegistr
 	}
 
 	@Override
+	@Nullable
 	public FluidRenderHandler getOverride(Fluid fluid) {
 		return modHandlers.get(fluid);
 	}

--- a/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/fluid/FluidRendererMixin.java
+++ b/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/fluid/FluidRendererMixin.java
@@ -85,7 +85,7 @@ public class FluidRendererMixin {
 	@Unique
 	private void tessellateViaHandler(BlockRenderView view, BlockPos pos, VertexConsumer vertexConsumer, BlockState blockState, FluidState fluidState, CallbackInfo info) {
 		FluidRendererHookContainer ctr = fabric_renderHandler.get();
-		FluidRenderHandler handler = ((FluidRenderHandlerRegistryImpl) FluidRenderHandlerRegistry.INSTANCE).getOverride(fluidState.getFluid());
+		FluidRenderHandler handler = FluidRenderHandlerRegistry.INSTANCE.get(fluidState.getFluid());
 
 		ctr.view = view;
 		ctr.pos = pos;


### PR DESCRIPTION
This pull request exposes the existing functionality located at `FluidRenderHandlerRegistryImpl#getOverride` so that other mods can use it without depending on internals.

The reason for this is because Sodium (see [issue](https://github.com/CaffeineMC/sodium-fabric/issues/2298)) implements its own "default" for fluids, which allows it to use per-vertex colors to create a smooth gradient across the water surface. Since it's currently not possible to detect whether the default implementation is being returned by Fabric API, we can't know when to override it with our own in rendering.

I'm not sure if this is the best solution, but it seems _relatively_ harmless as far as changes go.