### PR TITLE
Improve 24w05a port

### DIFF
--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentSerializingImpl.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentSerializingImpl.java
@@ -82,7 +82,7 @@ public class AttachmentSerializingImpl {
 
 				if (codec != null) {
 					RegistryOps<NbtElement> registryOps = RegistryOps.of(NbtOps.INSTANCE, wrapperLookup);
-					codec.parse(NbtOps.INSTANCE, compound.get(key))
+					codec.parse(registryOps, compound.get(key))
 							.get()
 							.ifRight(partial -> {
 								LOGGER.warn("Couldn't deserialize attachment " + type.identifier() + ", skipping. Error:");

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricBlockLootTableProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricBlockLootTableProvider.java
@@ -32,6 +32,7 @@ import net.minecraft.loot.LootTable;
 import net.minecraft.loot.LootTables;
 import net.minecraft.loot.context.LootContextTypes;
 import net.minecraft.registry.Registries;
+import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.resource.featuretoggle.FeatureFlags;
 import net.minecraft.util.Identifier;
 
@@ -47,10 +48,12 @@ import net.fabricmc.fabric.impl.datagen.loot.FabricLootTableProviderImpl;
 public abstract class FabricBlockLootTableProvider extends BlockLootTableGenerator implements FabricLootTableProvider {
 	private final FabricDataOutput output;
 	private final Set<Identifier> excludedFromStrictValidation = new HashSet<>();
+	private final CompletableFuture<RegistryWrapper.WrapperLookup> registryLookup;
 
-	protected FabricBlockLootTableProvider(FabricDataOutput dataOutput) {
+	protected FabricBlockLootTableProvider(FabricDataOutput dataOutput, CompletableFuture<RegistryWrapper.WrapperLookup> registryLookup) {
 		super(Collections.emptySet(), FeatureFlags.FEATURE_MANAGER.getFeatureSet());
 		this.output = dataOutput;
+		this.registryLookup = registryLookup;
 	}
 
 	/**
@@ -107,7 +110,7 @@ public abstract class FabricBlockLootTableProvider extends BlockLootTableGenerat
 
 	@Override
 	public CompletableFuture<?> run(DataWriter writer) {
-		return FabricLootTableProviderImpl.run(writer, this, LootContextTypes.BLOCK, output);
+		return FabricLootTableProviderImpl.run(writer, this, LootContextTypes.BLOCK, output, registryLookup);
 	}
 
 	@Override

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricCodecDataProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricCodecDataProvider.java
@@ -82,10 +82,6 @@ public abstract class FabricCodecDataProvider<T> implements DataProvider {
 	 */
 	protected abstract void configure(BiConsumer<Identifier, T> provider, RegistryWrapper.WrapperLookup lookup);
 
-	private JsonElement convert(Identifier id, T value) {
-		return this.convert(id, value, JsonOps.INSTANCE);
-	}
-
 	private JsonElement convert(Identifier id, T value, DynamicOps<JsonElement> ops) {
 		DataResult<JsonElement> dataResult = this.codec.encodeStart(ops, value);
 		return dataResult.get()

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/SimpleFabricLootTableProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/SimpleFabricLootTableProvider.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 import net.minecraft.data.DataWriter;
 import net.minecraft.loot.context.LootContextType;
 import net.minecraft.loot.context.LootContextTypes;
+import net.minecraft.registry.RegistryWrapper;
 
 import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
@@ -32,16 +33,18 @@ import net.fabricmc.fabric.impl.datagen.loot.FabricLootTableProviderImpl;
  */
 public abstract class SimpleFabricLootTableProvider implements FabricLootTableProvider {
 	protected final FabricDataOutput output;
+	private final CompletableFuture<RegistryWrapper.WrapperLookup> registryLookup;
 	protected final LootContextType lootContextType;
 
-	public SimpleFabricLootTableProvider(FabricDataOutput output, LootContextType lootContextType) {
+	public SimpleFabricLootTableProvider(FabricDataOutput output, CompletableFuture<RegistryWrapper.WrapperLookup> registryLookup, LootContextType lootContextType) {
 		this.output = output;
+		this.registryLookup = registryLookup;
 		this.lootContextType = lootContextType;
 	}
 
 	@Override
 	public CompletableFuture<?> run(DataWriter writer) {
-		return FabricLootTableProviderImpl.run(writer, this, lootContextType, output);
+		return FabricLootTableProviderImpl.run(writer, this, lootContextType, output, registryLookup);
 	}
 
 	@Override

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
@@ -356,8 +356,8 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 	}
 
 	private static class TestAdvancementProvider extends FabricAdvancementProvider {
-		private TestAdvancementProvider(FabricDataOutput output) {
-			super(output);
+		private TestAdvancementProvider(FabricDataOutput output, CompletableFuture<RegistryWrapper.WrapperLookup> registryLookup) {
+			super(output, registryLookup);
 		}
 
 		@Override
@@ -386,8 +386,8 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 	}
 
 	private static class TestBlockLootTableProvider extends FabricBlockLootTableProvider {
-		private TestBlockLootTableProvider(FabricDataOutput output) {
-			super(output);
+		private TestBlockLootTableProvider(FabricDataOutput output, CompletableFuture<RegistryWrapper.WrapperLookup> registryLookup) {
+			super(output, registryLookup);
 		}
 
 		@Override
@@ -401,8 +401,8 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 	}
 
 	private static class TestBarterLootTableProvider extends SimpleFabricLootTableProvider {
-		private TestBarterLootTableProvider(FabricDataOutput output) {
-			super(output, LootContextTypes.BARTER);
+		private TestBarterLootTableProvider(FabricDataOutput output, CompletableFuture<RegistryWrapper.WrapperLookup> registryLookup) {
+			super(output, registryLookup, LootContextTypes.BARTER);
 		}
 
 		@Override


### PR DESCRIPTION
- Fix wrong ops being used in `AttachmentSerializingImpl`
- **Breaking change**: advancement and loot table providers now require passing `WraperLookup` future.