### PR TITLE
Fix empty data attachments being saved.

### DIFF
--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentSerializingImpl.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentSerializingImpl.java
@@ -37,7 +37,7 @@ public class AttachmentSerializingImpl {
 
 	@SuppressWarnings("unchecked")
 	public static void serializeAttachmentData(NbtCompound nbt, @Nullable IdentityHashMap<AttachmentType<?>, ?> attachments) {
-		if (attachments == null) {
+		if (attachments == null || attachments.isEmpty()) {
 			return;
 		}
 
@@ -61,10 +61,10 @@ public class AttachmentSerializingImpl {
 		nbt.put(AttachmentTarget.NBT_ATTACHMENT_KEY, compound);
 	}
 
+	@Nullable
 	public static IdentityHashMap<AttachmentType<?>, Object> deserializeAttachmentData(NbtCompound nbt) {
-		var attachments = new IdentityHashMap<AttachmentType<?>, Object>();
-
 		if (nbt.contains(AttachmentTarget.NBT_ATTACHMENT_KEY, NbtElement.COMPOUND_TYPE)) {
+			var attachments = new IdentityHashMap<AttachmentType<?>, Object>();
 			NbtCompound compound = nbt.getCompound(AttachmentTarget.NBT_ATTACHMENT_KEY);
 
 			for (String key : compound.getKeys()) {
@@ -89,9 +89,15 @@ public class AttachmentSerializingImpl {
 							);
 				}
 			}
+
+			if (attachments.isEmpty()) {
+				return null;
+			}
+
+			return attachments;
 		}
 
-		return attachments;
+		return null;
 	}
 
 	public static boolean hasPersistentAttachments(@Nullable IdentityHashMap<AttachmentType<?>, ?> map) {

--- a/fabric-data-attachment-api-v1/src/test/java/net/fabricmc/fabric/test/attachment/CommonAttachmentTests.java
+++ b/fabric-data-attachment-api-v1/src/test/java/net/fabricmc/fabric/test/attachment/CommonAttachmentTests.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
+import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.function.UnaryOperator;
@@ -145,6 +146,25 @@ public class CommonAttachmentTests {
 		// but in practice this is meaningless because on a dedicated server the JVM restarted
 		assertEquals(dummy.identifier(), entry.getKey().identifier());
 		assertEquals(0.5d, entry.getValue());
+	}
+
+	@Test
+	void deserializeNull() {
+		var nbt = new NbtCompound();
+		assertNull(AttachmentSerializingImpl.deserializeAttachmentData(nbt));
+
+		nbt.put(new Identifier("test").toString(), new NbtCompound());
+		assertNull(AttachmentSerializingImpl.deserializeAttachmentData(nbt));
+	}
+
+	@Test
+	void serializeNullOrEmpty() {
+		var nbt = new NbtCompound();
+		AttachmentSerializingImpl.serializeAttachmentData(nbt, null);
+		assertFalse(nbt.contains(AttachmentTarget.NBT_ATTACHMENT_KEY));
+
+		AttachmentSerializingImpl.serializeAttachmentData(nbt, new IdentityHashMap<>());
+		assertFalse(nbt.contains(AttachmentTarget.NBT_ATTACHMENT_KEY));
 	}
 
 	@Test

--- a/fabric-data-attachment-api-v1/src/test/java/net/fabricmc/fabric/test/attachment/CommonAttachmentTests.java
+++ b/fabric-data-attachment-api-v1/src/test/java/net/fabricmc/fabric/test/attachment/CommonAttachmentTests.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
-import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.function.UnaryOperator;


### PR DESCRIPTION
Ensure that empty or null data attachments are never saved or read to nbt.