### PR TITLE
[1.20.5] Misc networking cleanup

### DIFF
--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientCommonNetworkAddon.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientCommonNetworkAddon.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.networking.client;
+
+import java.util.Collections;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientCommonNetworkHandler;
+import net.minecraft.network.ClientConnection;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.impl.networking.AbstractChanneledNetworkAddon;
+import net.fabricmc.fabric.impl.networking.GlobalReceiverRegistry;
+import net.fabricmc.fabric.impl.networking.NetworkingImpl;
+import net.fabricmc.fabric.impl.networking.RegistrationPayload;
+
+abstract class ClientCommonNetworkAddon<H, T extends ClientCommonNetworkHandler> extends AbstractChanneledNetworkAddon<H> {
+	protected final T handler;
+	protected final MinecraftClient client;
+
+	protected boolean isServerReady = false;
+
+	protected ClientCommonNetworkAddon(GlobalReceiverRegistry<H> receiver, ClientConnection connection, String description, T handler, MinecraftClient client) {
+		super(receiver, connection, description);
+		this.handler = handler;
+		this.client = client;
+	}
+
+	public void onServerReady() {
+		this.isServerReady = true;
+	}
+
+	@Override
+	protected void handleRegistration(Identifier channelName) {
+		// If we can already send packets, immediately send the register packet for this channel
+		if (this.isServerReady) {
+			final RegistrationPayload payload = this.createRegistrationPayload(RegistrationPayload.REGISTER, Collections.singleton(channelName));
+
+			if (payload != null) {
+				this.sendPacket(payload);
+			}
+		}
+	}
+
+	@Override
+	protected void handleUnregistration(Identifier channelName) {
+		// If we can already send packets, immediately send the unregister packet for this channel
+		if (this.isServerReady) {
+			final RegistrationPayload payload = this.createRegistrationPayload(RegistrationPayload.UNREGISTER, Collections.singleton(channelName));
+
+			if (payload != null) {
+				this.sendPacket(payload);
+			}
+		}
+	}
+
+	@Override
+	protected boolean isReservedChannel(Identifier channelName) {
+		return NetworkingImpl.isReservedCommonChannel(channelName);
+	}
+
+	@Override
+	protected void schedule(Runnable task) {
+		client.execute(task);
+	}
+}

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientConfigurationNetworkAddon.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientConfigurationNetworkAddon.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.fabric.impl.networking.client;
 
-import java.util.Collections;
 import java.util.List;
 
 import net.minecraft.client.MinecraftClient;
@@ -31,23 +30,17 @@ import net.fabricmc.fabric.api.client.networking.v1.ClientConfigurationConnectio
 import net.fabricmc.fabric.api.client.networking.v1.ClientConfigurationNetworking;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.networking.v1.PacketSender;
-import net.fabricmc.fabric.impl.networking.AbstractChanneledNetworkAddon;
 import net.fabricmc.fabric.impl.networking.ChannelInfoHolder;
-import net.fabricmc.fabric.impl.networking.NetworkingImpl;
 import net.fabricmc.fabric.impl.networking.RegistrationPayload;
 import net.fabricmc.fabric.mixin.networking.client.accessor.ClientCommonNetworkHandlerAccessor;
 import net.fabricmc.fabric.mixin.networking.client.accessor.ClientConfigurationNetworkHandlerAccessor;
 
-public final class ClientConfigurationNetworkAddon extends AbstractChanneledNetworkAddon<ClientConfigurationNetworking.ConfigurationPayloadHandler<?>> {
-	private final ClientConfigurationNetworkHandler handler;
-	private final MinecraftClient client;
+public final class ClientConfigurationNetworkAddon extends ClientCommonNetworkAddon<ClientConfigurationNetworking.ConfigurationPayloadHandler<?>, ClientConfigurationNetworkHandler> {
 	private final ContextImpl context;
 	private boolean sentInitialRegisterPacket;
 
 	public ClientConfigurationNetworkAddon(ClientConfigurationNetworkHandler handler, MinecraftClient client) {
-		super(ClientNetworkingImpl.CONFIGURATION, ((ClientCommonNetworkHandlerAccessor) handler).getConnection(), "ClientPlayNetworkAddon for " + ((ClientConfigurationNetworkHandlerAccessor) handler).getProfile().getName());
-		this.handler = handler;
-		this.client = client;
+		super(ClientNetworkingImpl.CONFIGURATION, ((ClientCommonNetworkHandlerAccessor) handler).getConnection(), "ClientPlayNetworkAddon for " + ((ClientConfigurationNetworkHandlerAccessor) handler).getProfile().getName(), handler, client);
 		this.context = new ContextImpl(this);
 
 		// Must register pending channels via lateinit
@@ -57,10 +50,6 @@ public final class ClientConfigurationNetworkAddon extends AbstractChanneledNetw
 	@Override
 	protected void invokeInitEvent() {
 		ClientConfigurationConnectionEvents.INIT.invoker().onConfigurationInit(this.handler, this.client);
-	}
-
-	public void onServerReady() {
-		// Do nothing for now
 	}
 
 	@Override
@@ -79,12 +68,6 @@ public final class ClientConfigurationNetworkAddon extends AbstractChanneledNetw
 	}
 
 	// impl details
-
-	@Override
-	protected void schedule(Runnable task) {
-		MinecraftClient.getInstance().execute(task);
-	}
-
 	@Override
 	public Packet<?> createPacket(CustomPayload packet) {
 		return ClientPlayNetworking.createC2SPacket(packet);
@@ -100,30 +83,6 @@ public final class ClientConfigurationNetworkAddon extends AbstractChanneledNetw
 		C2SConfigurationChannelEvents.UNREGISTER.invoker().onChannelUnregister(this.handler, this, this.client, ids);
 	}
 
-	@Override
-	protected void handleRegistration(Identifier channelName) {
-		// If we can already send packets, immediately send the register packet for this channel
-		if (this.sentInitialRegisterPacket) {
-			final RegistrationPayload payload = this.createRegistrationPayload(RegistrationPayload.REGISTER, Collections.singleton(channelName));
-
-			if (payload != null) {
-				this.sendPacket(payload);
-			}
-		}
-	}
-
-	@Override
-	protected void handleUnregistration(Identifier channelName) {
-		// If we can already send packets, immediately send the unregister packet for this channel
-		if (this.sentInitialRegisterPacket) {
-			final RegistrationPayload payload = this.createRegistrationPayload(RegistrationPayload.UNREGISTER, Collections.singleton(channelName));
-
-			if (payload != null) {
-				this.sendPacket(payload);
-			}
-		}
-	}
-
 	public void handleReady() {
 		ClientConfigurationConnectionEvents.READY.invoker().onConfigurationReady(this.handler, this.client);
 		ClientNetworkingImpl.setClientConfigurationAddon(null);
@@ -132,11 +91,6 @@ public final class ClientConfigurationNetworkAddon extends AbstractChanneledNetw
 	@Override
 	protected void invokeDisconnectEvent() {
 		ClientConfigurationConnectionEvents.DISCONNECT.invoker().onConfigurationDisconnect(this.handler, this.client);
-	}
-
-	@Override
-	protected boolean isReservedChannel(Identifier channelName) {
-		return NetworkingImpl.isReservedCommonChannel(channelName);
 	}
 
 	public ChannelInfoHolder getChannelInfoHolder() {

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/AbstractChanneledNetworkAddon.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/AbstractChanneledNetworkAddon.java
@@ -146,7 +146,6 @@ public abstract class AbstractChanneledNetworkAddon<H> extends AbstractNetworkAd
 		}
 
 		this.sendableChannels.add(id);
-		schedule(() -> this.invokeRegisterEvent(Collections.singletonList(id)));
 	}
 
 	void unregister(List<Identifier> ids) {

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/AbstractChanneledNetworkAddon.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/AbstractChanneledNetworkAddon.java
@@ -44,8 +44,8 @@ import net.fabricmc.fabric.api.networking.v1.PacketSender;
 public abstract class AbstractChanneledNetworkAddon<H> extends AbstractNetworkAddon<H> implements PacketSender, CommonPacketHandler {
 	// The maximum number of channels that a connecting client can register.
 	private static final int MAX_CHANNELS = Integer.getInteger("fabric.networking.maxChannels", 8192);
-	// The maximum length of a channel name a connecting client can use.
-	private static final int MAX_CHANNEL_NAME_LENGTH = Integer.getInteger("fabric.networking.maxChannelNameLength", 128);
+	// The maximum length of a channel name a connecting client can use, 128 is the default and minimum value.
+	private static final int MAX_CHANNEL_NAME_LENGTH = Math.max(Integer.getInteger("fabric.networking.maxChannelNameLength", GlobalReceiverRegistry.DEFAULT_CHANNEL_NAME_MAX_LENGTH), GlobalReceiverRegistry.DEFAULT_CHANNEL_NAME_MAX_LENGTH);
 
 	protected final ClientConnection connection;
 	protected final GlobalReceiverRegistry<H> receiver;

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/AbstractChanneledNetworkAddon.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/AbstractChanneledNetworkAddon.java
@@ -42,6 +42,11 @@ import net.fabricmc.fabric.api.networking.v1.PacketSender;
  * @param <H> the channel handler type
  */
 public abstract class AbstractChanneledNetworkAddon<H> extends AbstractNetworkAddon<H> implements PacketSender, CommonPacketHandler {
+	// The maximum number of channels that a connecting client can register.
+	private static final int MAX_CHANNELS = Integer.getInteger("fabric.networking.maxChannels", 8192);
+	// The maximum length of a channel name a connecting client can use.
+	private static final int MAX_CHANNEL_NAME_LENGTH = Integer.getInteger("fabric.networking.maxChannelNameLength", 128);
+
 	protected final ClientConnection connection;
 	protected final GlobalReceiverRegistry<H> receiver;
 	protected final Set<Identifier> sendableChannels;
@@ -127,8 +132,21 @@ public abstract class AbstractChanneledNetworkAddon<H> extends AbstractNetworkAd
 	}
 
 	void register(List<Identifier> ids) {
-		this.sendableChannels.addAll(ids);
+		ids.forEach(this::registerChannel);
 		schedule(() -> this.invokeRegisterEvent(ids));
+	}
+
+	private void registerChannel(Identifier id) {
+		if (this.sendableChannels.size() >= MAX_CHANNELS) {
+			throw new IllegalArgumentException("Cannot register more than " + MAX_CHANNELS + " channels");
+		}
+
+		if (id.toString().length() > MAX_CHANNEL_NAME_LENGTH) {
+			throw new IllegalArgumentException("Channel name is too long");
+		}
+
+		this.sendableChannels.add(id);
+		schedule(() -> this.invokeRegisterEvent(Collections.singletonList(id)));
 	}
 
 	void unregister(List<Identifier> ids) {

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/GlobalReceiverRegistry.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/GlobalReceiverRegistry.java
@@ -216,6 +216,10 @@ public final class GlobalReceiverRegistry<H> {
 		if (payloadTypeRegistry.get(channelName) == null) {
 			throw new IllegalArgumentException(String.format("Cannot register handler as no payload type has been registered with name \"%s\" for %s %s", channelName, side, phase));
 		}
+
+		if (channelName.toString().length() >= 128) {
+			throw new IllegalArgumentException(String.format("Cannot register handler for channel with name \"%s\" as it exceeds the maximum length of 128 characters", channelName));
+		}
 	}
 
 	public NetworkPhase getPhase() {

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/GlobalReceiverRegistry.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/GlobalReceiverRegistry.java
@@ -34,6 +34,7 @@ import net.minecraft.network.NetworkSide;
 import net.minecraft.util.Identifier;
 
 public final class GlobalReceiverRegistry<H> {
+	public static final int DEFAULT_CHANNEL_NAME_MAX_LENGTH = 128;
 	private static final Logger LOGGER = LoggerFactory.getLogger(GlobalReceiverRegistry.class);
 
 	private final NetworkSide side;
@@ -217,7 +218,7 @@ public final class GlobalReceiverRegistry<H> {
 			throw new IllegalArgumentException(String.format("Cannot register handler as no payload type has been registered with name \"%s\" for %s %s", channelName, side, phase));
 		}
 
-		if (channelName.toString().length() >= 128) {
+		if (channelName.toString().length() > DEFAULT_CHANNEL_NAME_MAX_LENGTH) {
 			throw new IllegalArgumentException(String.format("Cannot register handler for channel with name \"%s\" as it exceeds the maximum length of 128 characters", channelName));
 		}
 	}

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/server/ServerConfigurationNetworkAddon.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/server/ServerConfigurationNetworkAddon.java
@@ -32,7 +32,6 @@ import net.fabricmc.fabric.api.networking.v1.PacketSender;
 import net.fabricmc.fabric.api.networking.v1.S2CConfigurationChannelEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerConfigurationConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerConfigurationNetworking;
-import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.impl.networking.AbstractChanneledNetworkAddon;
 import net.fabricmc.fabric.impl.networking.ChannelInfoHolder;
 import net.fabricmc.fabric.impl.networking.NetworkingImpl;
@@ -117,7 +116,7 @@ public final class ServerConfigurationNetworkAddon extends AbstractChanneledNetw
 
 	@Override
 	public Packet<?> createPacket(CustomPayload packet) {
-		return ServerPlayNetworking.createS2CPacket(packet);
+		return ServerConfigurationNetworking.createS2CPacket(packet);
 	}
 
 	@Override


### PR DESCRIPTION
- Deduplicate some logic in the client play/common network addon. 
- (Slight breaking change) limit the lenght of a network channel name to 128.
- Set a limit of 8192 channel, can be configured by a system prop.