### PR TITLE
Improve handling of empty item groups in the creative menu

### DIFF
--- a/fabric-item-group-api-v1/src/client/java/net/fabricmc/fabric/mixin/itemgroup/client/CreativeInventoryScreenMixin.java
+++ b/fabric-item-group-api-v1/src/client/java/net/fabricmc/fabric/mixin/itemgroup/client/CreativeInventoryScreenMixin.java
@@ -93,13 +93,10 @@ public abstract class CreativeInventoryScreenMixin<T extends ScreenHandler> exte
 
 	private void fabric_updateSelection() {
 		if (!fabric_isGroupVisible(selectedTab)) {
-			ItemGroups.getGroups().stream()
+			ItemGroups.getGroups()
+					.stream()
 					.filter(this::fabric_isGroupVisible)
-					.min((a, b) -> {
-						if (a.isSpecial() && !b.isSpecial()) return 1;
-						if (!a.isSpecial() && b.isSpecial()) return -1;
-						return 0;
-					})
+					.min((a, b) -> Boolean.compare(a.isSpecial(), b.isSpecial()))
 					.ifPresent(this::setSelectedTab);
 		}
 	}
@@ -144,7 +141,7 @@ public abstract class CreativeInventoryScreenMixin<T extends ScreenHandler> exte
 	}
 
 	private boolean fabric_isGroupVisible(ItemGroup itemGroup) {
-		return fabric_currentPage == fabric_getPage(itemGroup);
+		return itemGroup.shouldDisplay() && fabric_currentPage == fabric_getPage(itemGroup);
 	}
 
 	private static int fabric_getPage(ItemGroup itemGroup) {

--- a/fabric-item-group-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/group/ItemGroupTest.java
+++ b/fabric-item-group-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/group/ItemGroupTest.java
@@ -19,11 +19,7 @@ package net.fabricmc.fabric.test.item.group;
 import com.google.common.base.Supplier;
 
 import net.minecraft.block.Blocks;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemGroup;
-import net.minecraft.item.ItemGroups;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
+import net.minecraft.item.*;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
@@ -69,6 +65,10 @@ public class ItemGroupTest implements ModInitializer {
 
 		// Add a differently damaged pickaxe to all groups
 		ItemGroupEvents.MODIFY_ENTRIES_ALL.register((group, content) -> {
+			if (group.getIcon() == ItemStack.EMPTY) { // Leave the empty groups empty
+				return;
+			}
+
 			ItemStack minDmgPickaxe = new ItemStack(Items.DIAMOND_PICKAXE);
 			minDmgPickaxe.setDamage(1);
 			content.prepend(minDmgPickaxe);
@@ -77,6 +77,17 @@ public class ItemGroupTest implements ModInitializer {
 			maxDmgPickaxe.setDamage(maxDmgPickaxe.getMaxDamage() - 1);
 			content.add(maxDmgPickaxe);
 		});
+
+		// Regression test for #3566
+		for (int j = 0; j < 20; j++) {
+			Registry.register(
+					Registries.ITEM_GROUP,
+					new Identifier(MOD_ID, "empty_group_" + j),
+					FabricItemGroup.builder()
+							.displayName(Text.literal("Empty Item Group: " + j))
+							.build()
+			);
+		}
 
 		for (int i = 0; i < 100; i++) {
 			final int index = i;

--- a/fabric-item-group-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/group/ItemGroupTest.java
+++ b/fabric-item-group-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/group/ItemGroupTest.java
@@ -19,7 +19,11 @@ package net.fabricmc.fabric.test.item.group;
 import com.google.common.base.Supplier;
 
 import net.minecraft.block.Blocks;
-import net.minecraft.item.*;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.item.ItemGroups;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;


### PR DESCRIPTION
Fixes #3566. The bug was caused by item groups being distributed into pages without checking if they could even be displayed. This PR waits until they have been initialized to do that, and relegates non-displayable groups to the end of the list, making it so that old behavior functions correctly. Testmod has been augmented with a regression test.

By coincidence, another bug was fixed wherein empty item groups could sometimes be selected when switching pages.