### PR TITLE
[1.20.5] Fix loot table provider not working after 24w09a port

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/loot/FabricLootTableProviderImpl.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/loot/FabricLootTableProviderImpl.java
@@ -58,7 +58,7 @@ public final class FabricLootTableProviderImpl {
 		HashMap<Identifier, LootTable> builders = Maps.newHashMap();
 		HashMap<Identifier, ConditionJsonProvider[]> conditionMap = new HashMap<>();
 
-		return registryLookup.thenApply(lookup -> {
+		return registryLookup.thenCompose(lookup -> {
 			provider.accept(lookup, (identifier, builder) -> {
 				ConditionJsonProvider[] conditions = FabricDataGenHelper.consumeConditions(builder);
 				conditionMap.put(identifier, conditions);


### PR DESCRIPTION
Use `thenCompose` instead of `thenApply` for the loot table provider because `thenCompose` is needed when we return `CompletionStage` (`CompletableFuture`)