### PR TITLE
[1.20.5] Fix HopperBlockEntityMixin not applying.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,13 @@ def metaProjects = [
 	'fabric-api-catalog'
 ]
 
+def debugArgs = [
+	"-enableassertions",
+	"-Dmixin.debug.verify=true",
+	//"-Dmixin.debug.strict=true",
+	"-Dmixin.debug.countInjections=true",
+]
+
 import net.fabricmc.loom.util.gradle.SourceSetHelper
 import groovy.json.JsonSlurper
 import org.apache.commons.codec.digest.DigestUtils
@@ -204,7 +211,7 @@ allprojects {
 	}
 
 	loom.runs.configureEach {
-		vmArg("-enableassertions")
+		vmArgs(debugArgs)
 	}
 
 	allprojects.each { p ->
@@ -518,8 +525,8 @@ tasks.register('runProductionAutoTestClient', JavaExec) {
 		jvmArgs(
 				"-Dfabric.addMods=${remapJar.archiveFile.get().asFile.absolutePath}${File.pathSeparator}${remapTestmodJar.archiveFile.get().asFile.absolutePath}",
 				"-Dfabric.autoTest",
-				"-enableassertions"
 				)
+		jvmArgs(debugArgs)
 	}
 }
 
@@ -550,8 +557,8 @@ tasks.register('runProductionAutoTestServer', JavaExec) {
 		jvmArgs(
 				"-Dfabric.addMods=${remapJar.archiveFile.get().asFile.absolutePath}${File.pathSeparator}${remapTestmodJar.archiveFile.get().asFile.absolutePath}",
 				"-Dfabric.autoTest",
-				"-enableassertions"
 				)
+		jvmArgs(debugArgs)
 
 		args("nogui")
 	}

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/mixin/transfer/HopperBlockEntityMixin.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/mixin/transfer/HopperBlockEntityMixin.java
@@ -16,14 +16,13 @@
 
 package net.fabricmc.fabric.mixin.transfer;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-import net.minecraft.block.BlockState;
-import net.minecraft.block.HopperBlock;
 import net.minecraft.block.entity.Hopper;
 import net.minecraft.block.entity.HopperBlockEntity;
 import net.minecraft.inventory.Inventory;
@@ -42,27 +41,29 @@ import net.fabricmc.fabric.api.transfer.v1.storage.StorageUtil;
  */
 @Mixin(HopperBlockEntity.class)
 public class HopperBlockEntityMixin {
+	@Shadow
+	private Direction facing;
+
 	@Inject(
 			at = @At(
 					value = "INVOKE_ASSIGN",
-					target = "Lnet/minecraft/block/entity/HopperBlockEntity;getOutputInventory(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;)Lnet/minecraft/inventory/Inventory;"
+					target = "Lnet/minecraft/block/entity/HopperBlockEntity;getOutputInventory(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/entity/HopperBlockEntity;)Lnet/minecraft/inventory/Inventory;"
 			),
-			method = "insert(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;Lnet/minecraft/inventory/Inventory;)Z",
-			locals = LocalCapture.CAPTURE_FAILHARD,
+			method = "insert",
 			cancellable = true
 	)
-	private static void hookInsert(World world, BlockPos pos, BlockState state, Inventory inventory, CallbackInfoReturnable<Boolean> cir, Inventory targetInventory) {
+	private static void hookInsert(World world, BlockPos pos, HopperBlockEntity blockEntity, CallbackInfoReturnable<Boolean> cir, @Local Inventory targetInventory) {
 		// Let vanilla handle the transfer if it found an inventory.
 		if (targetInventory != null) return;
 
 		// Otherwise inject our transfer logic.
-		Direction direction = state.get(HopperBlock.FACING);
+		Direction direction = ((HopperBlockEntityMixin) (Object) blockEntity).facing.getOpposite();
 		BlockPos targetPos = pos.offset(direction);
 		Storage<ItemVariant> target = ItemStorage.SIDED.find(world, targetPos, direction.getOpposite());
 
 		if (target != null) {
 			long moved = StorageUtil.move(
-					InventoryStorage.of(inventory, direction),
+					InventoryStorage.of(blockEntity, direction),
 					target,
 					iv -> true,
 					1,
@@ -75,13 +76,12 @@ public class HopperBlockEntityMixin {
 	@Inject(
 			at = @At(
 					value = "INVOKE_ASSIGN",
-					target = "Lnet/minecraft/block/entity/HopperBlockEntity;getInputInventory(Lnet/minecraft/world/World;Lnet/minecraft/block/entity/Hopper;)Lnet/minecraft/inventory/Inventory;"
+					target = "Lnet/minecraft/block/entity/HopperBlockEntity;getInputInventory(Lnet/minecraft/world/World;Lnet/minecraft/block/entity/Hopper;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;)Lnet/minecraft/inventory/Inventory;"
 			),
 			method = "extract(Lnet/minecraft/world/World;Lnet/minecraft/block/entity/Hopper;)Z",
-			locals = LocalCapture.CAPTURE_FAILHARD,
 			cancellable = true
 	)
-	private static void hookExtract(World world, Hopper hopper, CallbackInfoReturnable<Boolean> cir, Inventory inputInventory) {
+	private static void hookExtract(World world, Hopper hopper, CallbackInfoReturnable<Boolean> cir, @Local Inventory inputInventory) {
 		// Let vanilla handle the transfer if it found an inventory.
 		if (inputInventory != null) return;
 

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/mixin/transfer/HopperBlockEntityMixin.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/mixin/transfer/HopperBlockEntityMixin.java
@@ -57,7 +57,7 @@ public class HopperBlockEntityMixin {
 		if (targetInventory != null) return;
 
 		// Otherwise inject our transfer logic.
-		Direction direction = ((HopperBlockEntityMixin) (Object) blockEntity).facing.getOpposite();
+		Direction direction = ((HopperBlockEntityMixin) (Object) blockEntity).facing;
 		BlockPos targetPos = pos.offset(direction);
 		Storage<ItemVariant> target = ItemStorage.SIDED.find(world, targetPos, direction.getOpposite());
 

--- a/fabric-transfer-api-v1/src/main/resources/fabric-transfer-api-v1.mixins.json
+++ b/fabric-transfer-api-v1/src/main/resources/fabric-transfer-api-v1.mixins.json
@@ -15,5 +15,8 @@
     "JukeboxBlockEntityMixin",
     "LockableContainerBlockEntityMixin",
     "SimpleInventoryMixin"
-  ]
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
 }


### PR DESCRIPTION
Enable some runtime mixin validation, more work to be done to get it all working later.