### PR TITLE
Fix OpenScreenPayload title being decoded but not encoded

### DIFF
--- a/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/impl/screenhandler/Networking.java
+++ b/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/impl/screenhandler/Networking.java
@@ -103,6 +103,7 @@ public final class Networking implements ModInitializer {
 		private void write(RegistryByteBuf buf) {
 			buf.writeIdentifier(this.identifier);
 			buf.writeByte(this.syncId);
+			TextCodecs.REGISTRY_PACKET_CODEC.encode(buf, this.title);
 			this.innerCodec.encode(buf, this.data);
 		}
 


### PR DESCRIPTION
This PR fixes an issue where the client gets kicked from the server due to not being able to decode the OpenScreenPayload. This is caused by the screen title never being sent.

There's also another issue that relates to this one. It's caused by the random mod loading order which I'm not sure of how to fix. Therefore I will open up a new issue soon.