### PR TITLE
Enhance Lookup API

### DIFF
--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiLookup.java
@@ -214,8 +214,12 @@ public interface BlockApiLookup<A, C> {
 
 		A api = preliminary().invoker().find(world, pos, state, blockEntity, context);
 		if (api != null) return api;
-		api = getSpecificFor(state.getBlock()).invoker().find(world, pos, state, blockEntity, context);
-		if (api != null) return api;
+
+		if (blockSpecific().containsKey(state.getBlock())) {
+			api = getSpecificFor(state.getBlock()).invoker().find(world, pos, state, blockEntity, context);
+			if (api != null) return api;
+		}
+
 		return fallback().invoker().find(world, pos, state, blockEntity, context);
 	}
 
@@ -319,10 +323,14 @@ public interface BlockApiLookup<A, C> {
 
 	@Nullable BlockApiProvider<A, C> getProvider(Block block);
 
+	/**
+	 * It is queried before {@link #blockSpecific()} and {@link #fallback()}.
+	 */
 	Event<BlockApiProvider<A, C>> preliminary();
 
 	/**
-	 * This is for query existing providers. To register new providers, see {@link #getSpecificFor(Block)}.
+	 * <p>It's queried after {@link #preliminary()} while before {@link #fallback()}.</p>
+	 * <p>This is for query existing providers. To register new providers, see {@link #getSpecificFor(Block)}.</p>
 	 *
 	 * @return The map that stores providers for different blocks. If a block doesn't have any specific provider, there is no entry about it in the map ({@code blockSpecific().get(block) == null}).
 	 */
@@ -335,6 +343,9 @@ public interface BlockApiLookup<A, C> {
 	 */
 	@NotNull Event<BlockApiProvider<A, C>> getSpecificFor(Block block);
 
+	/**
+	 * It's queried after {@link #preliminary()} and {@link #blockSpecific()}.
+	 */
 	Event<BlockApiProvider<A, C>> fallback();
 
 	@FunctionalInterface

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiLookup.java
@@ -330,18 +330,18 @@ public interface BlockApiLookup<A, C> {
 
 	/**
 	 * <p>It's queried after {@link #preliminary()} while before {@link #fallback()}.</p>
-	 * <p>This is for query existing providers. To register new providers, see {@link #getSpecificFor(Block)}.</p>
+	 * <p>This is for query existing providers. To register new providers, see {@link #getSpecificFor}.</p>
 	 *
 	 * @return The map that stores providers for different blocks. If a block doesn't have any specific provider, there is no entry about it in the map ({@code blockSpecific().get(block) == null}).
 	 */
-	@UnmodifiableView Map<Block, Event<BlockApiProvider<A, C>>> blockSpecific();
+	@UnmodifiableView Map<@NotNull Block, @NotNull Event<BlockApiProvider<A, C>>> blockSpecific();
 
 	/**
 	 * This is for registering new providers. To query existing providers, see {@link #blockSpecific()}.
 	 *
-	 * @return The event for registering providers for the block. If there has not been any provider yet, a new event will be created and put into {@link #blockSpecific()}.
+	 * @return The event for registering providers for the block. If there has not been any provider for it yet, a new event will be created and put into {@link #blockSpecific()}.
 	 */
-	@NotNull Event<BlockApiProvider<A, C>> getSpecificFor(Block block);
+	@NotNull Event<BlockApiProvider<A, C>> getSpecificFor(@NotNull Block block);
 
 	/**
 	 * It's queried after {@link #preliminary()} and {@link #blockSpecific()}.

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiLookup.java
@@ -16,10 +16,13 @@
 
 package net.fabricmc.fabric.api.lookup.v1.block;
 
+import java.util.Map;
 import java.util.function.BiFunction;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -29,6 +32,7 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
+import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.impl.lookup.block.BlockApiLookupImpl;
 
 /**
@@ -152,7 +156,16 @@ public interface BlockApiLookup<A, C> {
 	static <A, C> BlockApiLookup<A, C> get(Identifier lookupId, Class<A> apiClass, Class<C> contextClass) {
 		return BlockApiLookupImpl.get(lookupId, apiClass, contextClass);
 	}
-
+	@SuppressWarnings("unchecked")
+	static <A, C> BlockApiLookup<A, C> getUnchecked(Identifier lookupId, Class<?> apiClass, Class<?> contextClass) {
+		return get(lookupId,(Class<A> )apiClass,( Class<C>)contextClass);
+	}
+	@SafeVarargs
+	static <A,C,B extends BlockEntity> void registerForBlockEntities(BlockApiLookup<A,C > lookup, BiFunction<? super B,? super C, ? extends @Nullable A> provider, BlockEntityType<? extends B>... blockEntityTypes) {
+		for (BlockEntityType<? extends B> blockEntityType : blockEntityTypes) {
+			lookup.registerForBlockEntity(blockEntityType,provider);
+		}
+	}
 	/**
 	 * Attempt to retrieve an API from a block in the world.
 	 * Consider using {@link BlockApiCache} if you are doing frequent queries at the same position.
@@ -165,7 +178,7 @@ public interface BlockApiLookup<A, C> {
 	 * @return The retrieved API, or {@code null} if no API was found.
 	 */
 	@Nullable
-	default A find(World world, BlockPos pos, C context) {
+	default A find(@NotNull World world,@NotNull  BlockPos pos, C context) {
 		return find(world, pos, null, null, context);
 	}
 
@@ -181,7 +194,26 @@ public interface BlockApiLookup<A, C> {
 	 * @return The retrieved API, or {@code null} if no API was found.
 	 */
 	@Nullable
-	A find(World world, BlockPos pos, @Nullable BlockState state, @Nullable BlockEntity blockEntity, C context);
+default 	A find(@NotNull World world,@NotNull  BlockPos pos, @Nullable BlockState state, @Nullable BlockEntity blockEntity, C context) {
+		if (blockEntity == null) {
+			if (state == null) {
+				state = world.getBlockState(pos);
+			}
+
+			if (state.hasBlockEntity()) {
+				blockEntity = world.getBlockEntity(pos);
+			}
+		} else {
+			if (state == null) {
+				state = blockEntity.getCachedState();
+			}
+		}
+		A api = preliminary().invoker().find(world, pos, state, blockEntity, context);
+		if (api!=null)return api;
+		api = getSpecificFor(state.getBlock()).invoker().find(world, pos, state, blockEntity, context);
+		if (api!=null)return api;
+		return fallback().invoker().find(world, pos, state, blockEntity, context);
+	}
 
 	/**
 	 * Expose the API for the passed block entities directly implementing it.
@@ -193,6 +225,8 @@ public interface BlockApiLookup<A, C> {
 	 */
 	void registerSelf(BlockEntityType<?>... blockEntityTypes);
 
+
+
 	/**
 	 * Expose the API for the passed blocks.
 	 * The mapping from the parameters of the query to the API is handled by the passed {@link BlockApiProvider}.
@@ -200,7 +234,11 @@ public interface BlockApiLookup<A, C> {
 	 * @param provider The provider.
 	 * @param blocks The blocks.
 	 */
-	void registerForBlocks(BlockApiProvider<A, C> provider, Block... blocks);
+default 	void registerForBlocks(BlockApiProvider<A, C> provider, Block... blocks) {
+	for (Block block : blocks) {
+		getSpecificFor(block).register(provider);
+	}
+}
 
 	/**
 	 * Expose the API for instances of the passed block entity type.
@@ -215,11 +253,13 @@ public interface BlockApiLookup<A, C> {
 	 * @param provider The provider: returns an API if available in the passed block entity with the passed context,
 	 *                 or {@code null} if no API is available.
 	 * @param blockEntityType The block entity type.
+	 * @deprecated see {@link #registerForBlockEntity(BlockEntityType, BiFunction)}
 	 */
-	@SuppressWarnings("unchecked")
+	@Deprecated
 	default <T extends BlockEntity> void registerForBlockEntity(BiFunction<? super T, C, @Nullable A> provider, BlockEntityType<T> blockEntityType) {
-		registerForBlockEntities((blockEntity, context) -> provider.apply((T) blockEntity, context), blockEntityType);
+		registerForBlockEntity(blockEntityType,provider);
 	}
+	<B extends BlockEntity> void registerForBlockEntity(@NotNull BlockEntityType<? extends B> blockEntityType, @NotNull BiFunction<? super B,? super C,? extends  @Nullable  A> provider);
 
 	/**
 	 * Expose the API for instances of the passed block entity types.
@@ -233,16 +273,23 @@ public interface BlockApiLookup<A, C> {
 	 *
 	 * @param provider The provider.
 	 * @param blockEntityTypes The block entity types.
+	 * @deprecated see {@link #registerForBlockEntities(BlockApiLookup, BiFunction, BlockEntityType[])}
 	 */
-	void registerForBlockEntities(BlockEntityApiProvider<A, C> provider, BlockEntityType<?>... blockEntityTypes);
+	@Deprecated
+	default void registerForBlockEntities(BlockEntityApiProvider<A, C> provider, BlockEntityType<?>... blockEntityTypes) {
+		registerForBlockEntities(this,provider::find,blockEntityTypes);
+	}
 
 	/**
 	 * Expose the API for all queries: the provider will be invoked if no object was found using the block or block entity providers.
 	 * This may have a big performance impact on all queries, use cautiously.
 	 *
 	 * @param fallbackProvider The fallback provider.
+	 * @see  #fallback()
 	 */
-	void registerFallback(BlockApiProvider<A, C> fallbackProvider);
+default 	void registerFallback(@NotNull BlockApiProvider<A, C> fallbackProvider){
+	fallback().register(fallbackProvider);
+}
 
 	/**
 	 * Return the identifier of this lookup.
@@ -262,9 +309,27 @@ public interface BlockApiLookup<A, C> {
 	/**
 	 * Return the provider for the passed block (registered with one of the {@code register} functions), or null if none was registered (yet).
 	 * Queries should go through {@link #find}, only use this to inspect registered providers!
+	 * @deprecated see {@link #getSpecificFor(Block)}
 	 */
-	@Nullable
-	BlockApiProvider<A, C> getProvider(Block block);
+	@Deprecated(forRemoval = true)
+
+	@Nullable	BlockApiProvider<A, C> getProvider(Block block);
+
+	Event<BlockApiProvider<A, C>> preliminary();
+
+	/**
+	 * This is for query existing providers. To register new providers, see {@link #getSpecificFor(Block)}.
+	 * @return The map that stores providers for different blocks. If a block doesn't have any specific provider, there is no entry about it in the map ({@code blockSpecific().get(block) == null}).
+	 */
+	@UnmodifiableView Map<Block, Event<BlockApiProvider<A, C>>> blockSpecific();
+
+	/**
+	 * This is for registering new providers. To query existing providers, see {@link #blockSpecific()}.
+	 * @return The event for registering providers for the block. If there has not been any provider yet, a new event will be created and put into {@link #blockSpecific()}.
+	 */
+	@NotNull Event<BlockApiProvider<A, C>> getSpecificFor(Block block);
+
+	Event<BlockApiProvider<A, C>> fallback();
 
 	@FunctionalInterface
 	interface BlockApiProvider<A, C> {
@@ -278,10 +343,14 @@ public interface BlockApiLookup<A, C> {
 		 * @param context Additional context passed to the query.
 		 * @return An API of type {@code A}, or {@code null} if no API is available.
 		 */
-		@Nullable
-		A find(World world, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity, C context);
+
+		@Nullable	A find(@NotNull World world,@NotNull  BlockPos pos,@NotNull  BlockState state, @Nullable BlockEntity blockEntity, C context);
 	}
 
+	/**
+	 * @deprecated use {@link BiFunction}{@code <BlockEntity, C, A>} instead
+	 */
+	@Deprecated
 	@FunctionalInterface
 	interface BlockEntityApiProvider<A, C> {
 		/**

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/custom/ApiProviderMap.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/custom/ApiProviderMap.java
@@ -35,7 +35,7 @@ import net.fabricmc.fabric.impl.lookup.custom.ApiProviderHashMap;
  * @param <V> The value type of the map.
  */
 @ApiStatus.NonExtendable
-public interface ApiProviderMap<K, V>  {
+public interface ApiProviderMap<K, V> {
 	/**
 	 * Create a new instance.
 	 */
@@ -58,7 +58,7 @@ public interface ApiProviderMap<K, V>  {
 	 *
 	 * @throws NullPointerException If the key or the provider is null.
 	 */
-@Nullable	V putIfAbsent(K key, V provider);
+	@Nullable V putIfAbsent(K key, V provider);
 
-	@UnmodifiableView Map<K,V> asMap();
+	@UnmodifiableView Map<K, V> asMap();
 }

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/custom/ApiProviderMap.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/custom/ApiProviderMap.java
@@ -60,5 +60,8 @@ public interface ApiProviderMap<K, V> {
 	 */
 	@Nullable V putIfAbsent(K key, V provider);
 
+	/**
+	 * @return A read-only {@link Map} view of this instance. All modification operations will throw {@link UnsupportedOperationException}, except {@link Map#putIfAbsent(Object, Object)}.
+	 */
 	@UnmodifiableView Map<K, V> asMap();
 }

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/custom/ApiProviderMap.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/custom/ApiProviderMap.java
@@ -49,8 +49,7 @@ public interface ApiProviderMap<K, V> {
 	 *
 	 * @throws NullPointerException If the key is null.
 	 */
-	@Nullable
-	V get(K key);
+	@Nullable V get(K key);
 
 	/**
 	 * If the specified key is not already associated with a provider,

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/custom/ApiProviderMap.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/custom/ApiProviderMap.java
@@ -16,8 +16,11 @@
 
 package net.fabricmc.fabric.api.lookup.v1.custom;
 
+import java.util.Map;
+
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
 
 import net.fabricmc.fabric.impl.lookup.custom.ApiProviderHashMap;
 
@@ -32,7 +35,7 @@ import net.fabricmc.fabric.impl.lookup.custom.ApiProviderHashMap;
  * @param <V> The value type of the map.
  */
 @ApiStatus.NonExtendable
-public interface ApiProviderMap<K, V> {
+public interface ApiProviderMap<K, V>  {
 	/**
 	 * Create a new instance.
 	 */
@@ -55,5 +58,7 @@ public interface ApiProviderMap<K, V> {
 	 *
 	 * @throws NullPointerException If the key or the provider is null.
 	 */
-	V putIfAbsent(K key, V provider);
+@Nullable	V putIfAbsent(K key, V provider);
+
+	@UnmodifiableView Map<K,V> asMap();
 }

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/entity/EntityApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/entity/EntityApiLookup.java
@@ -193,14 +193,31 @@ public interface EntityApiLookup<A, C> {
 	 * Queries should go through {@link #find}, only use this to inspect registered providers!
 	 */
 	@Deprecated(forRemoval = true)
-	@Nullable EntityApiProvider<A, C> getProvider(EntityType<?> entityType);
+	@Nullable EntityApiProvider<A, C> getProvider(@NotNull EntityType<?> entityType);
 
+	/**
+	 * It is queried before {@link #typeSpecific()} and {@link #fallback()}.
+	 */
 	Event<EntityApiProvider<A, C>> preliminary();
 
-	@UnmodifiableView Map<EntityType<?>, Event<EntityApiProvider<A, C>>> typeSpecific();
+	/**
+	 * <p>It's queried after {@link #preliminary()} while before {@link #fallback()}.</p>
+	 * <p>This is for query existing providers. To register new providers, see {@link #getSpecificFor}.</p>
+	 *
+	 * @return The map that stores providers for different entity types. If an entity type doesn't have any specific provider, there is no entry about it in the map ({@code blockSpecific().get(entityType) == null}).
+	 */
+	@UnmodifiableView Map<@NotNull EntityType<?>, @NotNull Event<EntityApiProvider<A, C>>> typeSpecific();
 
+	/**
+	 * This is for registering new providers. To query existing providers, see {@link #typeSpecific()}.
+	 *
+	 * @return The event for registering providers for the entity type. If there has not been any provider for it yet, a new event will be created and put into {@link #typeSpecific()}.
+	 */
 	@NotNull Event<EntityApiProvider<A, C>> getSpecificFor(EntityType<?> type);
 
+	/**
+	 * It's queried after {@link #preliminary()} and {@link #typeSpecific()}.
+	 */
 	Event<EntityApiProvider<A, C>> fallback();
 
 	interface EntityApiProvider<A, C> {

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
@@ -16,7 +16,11 @@
 
 package net.fabricmc.fabric.api.lookup.v1.item;
 
+import java.util.Map;
+import java.util.Objects;
+
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.item.Item;
@@ -24,6 +28,7 @@ import net.minecraft.item.ItemConvertible;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
 
+import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup;
 import net.fabricmc.fabric.impl.lookup.item.ItemApiLookupImpl;
 
@@ -96,14 +101,19 @@ public interface ItemApiLookup<A, C> {
 	/**
 	 * Retrieve the {@link ItemApiLookup} associated with an identifier, or create it if it didn't exist yet.
 	 *
-	 * @param lookupId The unique identifier of the lookup.
-	 * @param apiClass The class of the API.
+	 * @param lookupId     The unique identifier of the lookup.
+	 * @param apiClass     The class of the API.
 	 * @param contextClass The class of the additional context.
 	 * @return The unique lookup with the passed lookupId.
 	 * @throws IllegalArgumentException If another {@code apiClass} or another {@code contextClass} was already registered with the same identifier.
 	 */
 	static <A, C> ItemApiLookup<A, C> get(Identifier lookupId, Class<A> apiClass, Class<C> contextClass) {
 		return ItemApiLookupImpl.get(lookupId, apiClass, contextClass);
+	}
+
+	@SuppressWarnings("unchecked")
+	static <A, C> ItemApiLookup<A, C> getUnchecked(Identifier lookupId, Class<?> apiClass, Class<?> contextClass) {
+		return get(lookupId, (Class<A>) apiClass, (Class<C>) contextClass);
 	}
 
 	/**
@@ -115,35 +125,62 @@ public interface ItemApiLookup<A, C> {
 	 * <br>While providers may capture a reference to the stack, it is expected that they do not modify it directly.
 	 *
 	 * @param itemStack The item stack.
-	 * @param context Additional context for the query, defined by type parameter C.
+	 * @param context   Additional context for the query, defined by type parameter C.
 	 * @return The retrieved API, or {@code null} if no API was found.
 	 */
 	@Nullable
-	A find(ItemStack itemStack, C context);
+	default A find(@NotNull ItemStack itemStack, C context) {
+		A api = preliminary().invoker().find(itemStack, context);
+		if (api != null) return api;
 
-	/**
-	 * Expose the API for the passed items directly implementing it.
-	 *
-	 * @param items Items for which to expose the API.
-	 * @throws IllegalArgumentException If the API class is not assignable from a class of one of the items.
-	 */
-	void registerSelf(ItemConvertible... items);
+		if (itemSpecific().containsKey(itemStack.getItem())) {
+			api = getSpecificFor(itemStack.getItem()).invoker().find(itemStack, context);
+			if (api != null) return api;
+		}
 
-	/**
-	 * Expose the API for the passed items.
-	 * The mapping from the parameters of the query to the API is handled by the passed {@link ItemApiProvider}.
-	 *
-	 * @param provider The provider.
-	 * @param items The items.
-	 */
-	void registerForItems(ItemApiProvider<A, C> provider, ItemConvertible... items);
+		return fallback().invoker().find(itemStack, context);
+	}
+
+	@SuppressWarnings("unchecked")
+	default void registerSelf(ItemConvertible @NotNull ... items) {
+		for (ItemConvertible itemConvertible : items) {
+			Item item = itemConvertible.asItem();
+
+			if (!apiClass().isAssignableFrom(item.getClass())) {
+				String errorMessage = String.format(
+						"Failed to register self-implementing items. API class %s is not assignable from item class %s.",
+						apiClass().getCanonicalName(),
+						item.getClass().getCanonicalName()
+				);
+				throw new IllegalArgumentException(errorMessage);
+			}
+		}
+
+		registerForItems((itemStack, context) -> (A) itemStack.getItem(), items);
+	}
+
+	default void registerForItems(@NotNull ItemApiProvider<A, C> provider, ItemConvertible @NotNull ... items) {
+		Objects.requireNonNull(provider, "ItemApiProvider may not be null.");
+
+		if (items.length == 0) {
+			throw new IllegalArgumentException("Must register at least one ItemConvertible instance with an ItemApiProvider.");
+		}
+
+		for (ItemConvertible itemConvertible : items) {
+			Item item = itemConvertible.asItem();
+			Objects.requireNonNull(item, "Item convertible in item form may not be null.");
+			getSpecificFor(item).register(provider);
+		}
+	}
 
 	/**
 	 * Expose the API for all queries: the fallbacks providers will be invoked if no object was found using the regular providers.
 	 *
 	 * @param fallbackProvider The fallback provider.
 	 */
-	void registerFallback(ItemApiProvider<A, C> fallbackProvider);
+	default void registerFallback(@NotNull ItemApiProvider<A, C> fallbackProvider) {
+		fallback().register(fallbackProvider);
+	}
 
 	/**
 	 * Return the identifier of this lookup.
@@ -167,6 +204,14 @@ public interface ItemApiLookup<A, C> {
 	@Nullable
 	ItemApiProvider<A, C> getProvider(Item item);
 
+	Event<ItemApiProvider<A, C>> preliminary();
+
+	Map<Item, Event<ItemApiProvider<A, C>>> itemSpecific();
+
+	@NotNull Event<ItemApiProvider<A, C>> getSpecificFor(@NotNull Item item);
+
+	Event<ItemApiProvider<A, C>> fallback();
+
 	@FunctionalInterface
 	interface ItemApiProvider<A, C> {
 		/**
@@ -178,10 +223,10 @@ public interface ItemApiLookup<A, C> {
 		 * <br>While providers may capture a reference to the stack, it is expected that they do not modify it directly.
 		 *
 		 * @param itemStack The item stack.
-		 * @param context Additional context passed to the query.
+		 * @param context   Additional context passed to the query.
 		 * @return An API of type {@code A}, or {@code null} if no API is available.
 		 */
-		@Nullable
-		A find(ItemStack itemStack, C context);
+
+		@Nullable A find(@NotNull ItemStack itemStack, C context);
 	}
 }

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
@@ -142,7 +142,7 @@ public interface ItemApiLookup<A, C> {
 	}
 
 	@SuppressWarnings("unchecked")
-	default void registerSelf(ItemConvertible @NotNull... items) {
+	default void registerSelf(ItemConvertible... items) {
 		for (ItemConvertible itemConvertible : items) {
 			Item item = itemConvertible.asItem();
 
@@ -159,7 +159,7 @@ public interface ItemApiLookup<A, C> {
 		registerForItems((itemStack, context) -> (A) itemStack.getItem(), items);
 	}
 
-	default void registerForItems(@NotNull ItemApiProvider<A, C> provider, ItemConvertible @NotNull... items) {
+	default void registerForItems(@NotNull ItemApiProvider<A, C> provider, ItemConvertible... items) {
 		Objects.requireNonNull(provider, "ItemApiProvider may not be null.");
 
 		if (items.length == 0) {
@@ -200,17 +200,35 @@ public interface ItemApiLookup<A, C> {
 	/**
 	 * Return the provider for the passed item (registered with one of the {@code register} functions), or null if none was registered (yet).
 	 * Queries should go through {@link #find}, only use this to inspect registered providers!
+	 *
 	 * @deprecated see {@link #getSpecificFor(Item)}
 	 */
 	@Deprecated(forRemoval = true)
-	@Nullable ItemApiProvider<A, C> getProvider(Item item);
+	@Nullable ItemApiProvider<A, C> getProvider(@NotNull Item item);
 
+	/**
+	 * It is queried before {@link #itemSpecific()} and {@link #fallback()}.
+	 */
 	Event<ItemApiProvider<A, C>> preliminary();
 
-	Map<Item, Event<ItemApiProvider<A, C>>> itemSpecific();
+	/**
+	 * <p>It's queried after {@link #preliminary()} while before {@link #fallback()}.</p>
+	 * <p>This is for query existing providers. To register new providers, see {@link #getSpecificFor}.</p>
+	 *
+	 * @return The map that stores providers for different items. If an item doesn't have any specific provider, there is no entry about it in the map ({@code blockSpecific().get(item) == null}).
+	 */
+	Map<@NotNull Item, @NotNull Event<ItemApiProvider<A, C>>> itemSpecific();
 
+	/**
+	 * This is for registering new providers. To query existing providers, see {@link #itemSpecific()}.
+	 *
+	 * @return The event for registering providers for the item. If there has not been any provider for it yet, a new event will be created and put into {@link #itemSpecific()}.
+	 */
 	@NotNull Event<ItemApiProvider<A, C>> getSpecificFor(@NotNull Item item);
 
+	/**
+	 * It's queried after {@link #preliminary()} and {@link #itemSpecific()}.
+	 */
 	Event<ItemApiProvider<A, C>> fallback();
 
 	@FunctionalInterface

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
@@ -200,9 +200,10 @@ public interface ItemApiLookup<A, C> {
 	/**
 	 * Return the provider for the passed item (registered with one of the {@code register} functions), or null if none was registered (yet).
 	 * Queries should go through {@link #find}, only use this to inspect registered providers!
+	 * @deprecated see {@link #getSpecificFor(Item)}
 	 */
-	@Nullable
-	ItemApiProvider<A, C> getProvider(Item item);
+	@Deprecated(forRemoval = true)
+	@Nullable ItemApiProvider<A, C> getProvider(Item item);
 
 	Event<ItemApiProvider<A, C>> preliminary();
 

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
@@ -142,7 +142,7 @@ public interface ItemApiLookup<A, C> {
 	}
 
 	@SuppressWarnings("unchecked")
-	default void registerSelf(ItemConvertible @NotNull ... items) {
+	default void registerSelf(ItemConvertible @NotNull... items) {
 		for (ItemConvertible itemConvertible : items) {
 			Item item = itemConvertible.asItem();
 
@@ -159,7 +159,7 @@ public interface ItemApiLookup<A, C> {
 		registerForItems((itemStack, context) -> (A) itemStack.getItem(), items);
 	}
 
-	default void registerForItems(@NotNull ItemApiProvider<A, C> provider, ItemConvertible @NotNull ... items) {
+	default void registerForItems(@NotNull ItemApiProvider<A, C> provider, ItemConvertible @NotNull... items) {
 		Objects.requireNonNull(provider, "ItemApiProvider may not be null.");
 
 		if (items.length == 0) {

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/package-info.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/package-info.java
@@ -37,7 +37,7 @@
  *     <li>It also allows registering APIs for blocks, because for the query to work the API must be registered first.
  *     Registration primarily happens through {@link net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup#registerSelf registerSelf()},
  *     {@link net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup#registerForBlocks registerForBlocks()}
- *     and {@link net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup#registerForBlockEntities registerForBlockEntities()}.</li>
+ *     and {@link net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup#registerForBlockEntities(net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup, java.util.function.BiFunction, net.minecraft.block.entity.BlockEntityType[]) registerForBlockEntities}.</li>
  * 	   <li>{@code BlockApiLookup} instances can be accessed through {@link net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup#get BlockApiLookup#get()}.
  *     For optimal performance, it is better to store them in a {@code public static final} field instead of querying them multiple times.</li>
  *     <li>See {@link net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup BlockApiLookup} for example code.</li>

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiCacheImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiCacheImpl.java
@@ -80,10 +80,13 @@ public final class BlockApiCacheImpl<A, C> implements BlockApiCache<A, C> {
 			lastState = state;
 		}
 
-		// Query the provider
+		// Query the preliminary provider
+		A instance = lookup.preliminary().invoker().find(world, pos, state, cachedBlockEntity, context);
+		if (instance != null) return instance;
 
+		// Query the providers
 		if (cachedProviders != null) {
-			A instance = cachedProviders.invoker().find(world, pos, state, cachedBlockEntity, context);
+			instance = cachedProviders.invoker().find(world, pos, state, cachedBlockEntity, context);
 
 			if (instance != null) {
 				return instance;

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiCacheImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiCacheImpl.java
@@ -84,13 +84,14 @@ public final class BlockApiCacheImpl<A, C> implements BlockApiCache<A, C> {
 
 		if (cachedProviders != null) {
 			A instance = cachedProviders.invoker().find(world, pos, state, cachedBlockEntity, context);
+
 			if (instance != null) {
 				return instance;
 			}
 		}
 
 		// Query the fallback providers
-		return lookup.fallback().invoker().find(world,pos,state,cachedBlockEntity,context);
+		return lookup.fallback().invoker().find(world, pos, state, cachedBlockEntity, context);
 	}
 
 	@Override

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiLookupImpl.java
@@ -156,12 +156,12 @@ public final class BlockApiLookupImpl<A, C> implements BlockApiLookup<A, C> {
 	}
 
 	@Override
-	public @UnmodifiableView Map<Block, Event<BlockApiProvider<A, C>>> blockSpecific() {
+	public @UnmodifiableView Map<@NotNull Block, @NotNull Event<BlockApiProvider<A, C>>> blockSpecific() {
 		return blockSpecific.asMap();
 	}
 
 	@Override
-	public @NotNull Event<BlockApiProvider<A, C>> getSpecificFor(Block block) {
+	public @NotNull Event<BlockApiProvider<A, C>> getSpecificFor(@NotNull Block block) {
 		Event<BlockApiProvider<A, C>> event = blockSpecific.get(block);
 
 		if (event == null) {

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiLookupImpl.java
@@ -17,22 +17,29 @@
 package net.fabricmc.fabric.impl.lookup.block;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BiFunction;
 
+import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
+import com.google.common.collect.Multimaps;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.registry.Registries;
-import net.minecraft.world.World;
 
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
 import net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup;
 import net.fabricmc.fabric.api.lookup.v1.custom.ApiLookupMap;
 import net.fabricmc.fabric.api.lookup.v1.custom.ApiProviderMap;
@@ -46,11 +53,36 @@ public final class BlockApiLookupImpl<A, C> implements BlockApiLookup<A, C> {
 	public static <A, C> BlockApiLookup<A, C> get(Identifier lookupId, Class<A> apiClass, Class<C> contextClass) {
 		return (BlockApiLookup<A, C>) LOOKUPS.getLookup(lookupId, apiClass, contextClass);
 	}
-
+	@ApiStatus.Internal
+	public static <A,C>  Event<BlockApiProvider<A,C>> newEvent() {
+		return EventFactory.createArrayBacked(BlockApiProvider.class, providers -> (world, pos, state, blockEntity, context) -> {
+			for (BlockApiProvider<A, C> provider : providers) {
+				A api = provider.find(world, pos, state, blockEntity, context);
+				if (api!=null)return api;
+			}
+			return null;
+		});
+	}
 	private final Identifier identifier;
 	private final Class<A> apiClass;
 	private final Class<C> contextClass;
+	/**
+	 * @deprecated see {@link #blockSpecific}
+	 */
+	@Deprecated(forRemoval = true)
 	private final ApiProviderMap<Block, BlockApiProvider<A, C>> providerMap = ApiProviderMap.create();
+	private final Event<BlockApiProvider<A,C>> preliminary = newEvent();
+	private final ApiProviderMap<Block,Event<BlockApiProvider<A,C>>> blockSpecific = ApiProviderMap.create();
+	/**
+	 * It can't reflect phase order.
+	 */
+	@ApiStatus.Experimental
+	private final Multimap<Block,BlockApiProvider<A, C>> blockSpecificProviders = Multimaps.synchronizedMultimap(MultimapBuilder.hashKeys().arrayListValues().build());
+	private final Event<BlockApiProvider<A,C>> fallback = newEvent();
+	/**
+	 * It can't reflect phase order.
+	 */
+	@ApiStatus.Experimental
 	private final List<BlockApiProvider<A, C>> fallbackProviders = new CopyOnWriteArrayList<>();
 
 	@SuppressWarnings("unchecked")
@@ -58,52 +90,6 @@ public final class BlockApiLookupImpl<A, C> implements BlockApiLookup<A, C> {
 		this.identifier = identifier;
 		this.apiClass = (Class<A>) apiClass;
 		this.contextClass = (Class<C>) contextClass;
-	}
-
-	@Nullable
-	@Override
-	public A find(World world, BlockPos pos, @Nullable BlockState state, @Nullable BlockEntity blockEntity, C context) {
-		Objects.requireNonNull(world, "World may not be null.");
-		Objects.requireNonNull(pos, "BlockPos may not be null.");
-		// Providers have the final say whether a null context is allowed.
-
-		// Get the block state and the block entity
-		if (blockEntity == null) {
-			if (state == null) {
-				state = world.getBlockState(pos);
-			}
-
-			if (state.hasBlockEntity()) {
-				blockEntity = world.getBlockEntity(pos);
-			}
-		} else {
-			if (state == null) {
-				state = blockEntity.getCachedState();
-			}
-		}
-
-		@Nullable
-		BlockApiProvider<A, C> provider = getProvider(state.getBlock());
-		A instance = null;
-
-		if (provider != null) {
-			instance = provider.find(world, pos, state, blockEntity, context);
-		}
-
-		if (instance != null) {
-			return instance;
-		}
-
-		// Query the fallback providers
-		for (BlockApiProvider<A, C> fallbackProvider : fallbackProviders) {
-			instance = fallbackProvider.find(world, pos, state, blockEntity, context);
-
-			if (instance != null) {
-				return instance;
-			}
-		}
-
-		return null;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -124,55 +110,12 @@ public final class BlockApiLookupImpl<A, C> implements BlockApiLookup<A, C> {
 				throw new IllegalArgumentException(errorMessage);
 			}
 		}
-
-		registerForBlockEntities((blockEntity, context) -> (A) blockEntity, blockEntityTypes);
+		BlockApiLookup.registerForBlockEntities(this,(blockEntity, context) -> (A) blockEntity, blockEntityTypes );
 	}
 
 	@Override
-	public void registerForBlocks(BlockApiProvider<A, C> provider, Block... blocks) {
-		Objects.requireNonNull(provider, "BlockApiProvider may not be null.");
-
-		if (blocks.length == 0) {
-			throw new IllegalArgumentException("Must register at least one Block instance with a BlockApiProvider.");
-		}
-
-		for (Block block : blocks) {
-			Objects.requireNonNull(block, "Encountered null block while registering a block API provider mapping.");
-
-			if (providerMap.putIfAbsent(block, provider) != null) {
-				LOGGER.warn("Encountered duplicate API provider registration for block: " + Registries.BLOCK.getId(block));
-			}
-		}
-	}
-
-	@Override
-	public void registerForBlockEntities(BlockEntityApiProvider<A, C> provider, BlockEntityType<?>... blockEntityTypes) {
-		Objects.requireNonNull(provider, "BlockEntityApiProvider may not be null.");
-
-		if (blockEntityTypes.length == 0) {
-			throw new IllegalArgumentException("Must register at least one BlockEntityType instance with a BlockEntityApiProvider.");
-		}
-
-		BlockApiProvider<A, C> nullCheckedProvider = (world, pos, state, blockEntity, context) -> {
-			if (blockEntity == null) {
-				return null;
-			} else {
-				return provider.find(blockEntity, context);
-			}
-		};
-
-		for (BlockEntityType<?> blockEntityType : blockEntityTypes) {
-			Objects.requireNonNull(blockEntityType, "Encountered null block entity type while registering a block entity API provider mapping.");
-
-			Block[] blocks = ((BlockEntityTypeAccessor) blockEntityType).getBlocks().toArray(new Block[0]);
-			registerForBlocks(nullCheckedProvider, blocks);
-		}
-	}
-
-	@Override
-	public void registerFallback(BlockApiProvider<A, C> fallbackProvider) {
-		Objects.requireNonNull(fallbackProvider, "BlockApiProvider may not be null.");
-
+	public void registerFallback(@NotNull BlockApiProvider<A, C> fallbackProvider) {
+BlockApiLookup.super.registerFallback(fallbackProvider);
 		fallbackProviders.add(fallbackProvider);
 	}
 
@@ -191,13 +134,49 @@ public final class BlockApiLookupImpl<A, C> implements BlockApiLookup<A, C> {
 		return contextClass;
 	}
 
+	@SuppressWarnings("removal")//though just override while no invoke, idea still warns
 	@Override
-	@Nullable
-	public BlockApiProvider<A, C> getProvider(Block block) {
-		return providerMap.get(block);
+	@Deprecated(forRemoval = true)
+
+	public @Nullable BlockApiProvider<A, C> getProvider(Block block) {
+		for (BlockApiProvider<A, C> provider : blockSpecificProviders.get(block)) {
+			return provider;
+		}
+		return null;
 	}
 
-	public List<BlockApiProvider<A, C>> getFallbackProviders() {
+	public @UnmodifiableView List<BlockApiProvider<A, C>> getFallbackProviders() {
 		return fallbackProviders;
+	}
+
+	@Override
+	public Event<BlockApiProvider<A, C>> preliminary() {
+		return preliminary;
+	}
+
+	@Override
+	public @UnmodifiableView Map<Block, Event<BlockApiProvider<A, C>>> blockSpecific() {
+		return blockSpecific.asMap();
+	}
+	@Override
+	public @NotNull Event<BlockApiProvider<A, C>> getSpecificFor(Block block) {
+		var event = blockSpecific.get(block);
+		if (event==null){
+			event=newEvent();
+			blockSpecific.putIfAbsent(block,event);
+		}
+		return event;
+	}
+	@Override
+	public Event<BlockApiProvider<A, C>> fallback() {
+		return fallback;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <B extends BlockEntity> void registerForBlockEntity(@NotNull BlockEntityType<? extends B> blockEntityType, @NotNull BiFunction<? super B, ? super C,? extends @Nullable A> provider) {
+		for (Block block : ((BlockEntityTypeAccessor) blockEntityType).getBlocks().toArray(new Block[0])) {
+			getSpecificFor(block).register((world, pos, state, blockEntity, context) -> provider.apply((B)blockEntity,context));
+		}
 	}
 }

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiLookupImpl.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiFunction;
 
-import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import org.jetbrains.annotations.ApiStatus;
@@ -71,13 +71,15 @@ public final class BlockApiLookupImpl<A, C> implements BlockApiLookup<A, C> {
 	private final Event<BlockApiProvider<A, C>> preliminary = newEvent();
 	private final ApiProviderMap<Block, Event<BlockApiProvider<A, C>>> blockSpecific = ApiProviderMap.create();
 	/**
-	 * It can't reflect phase order.
+	 * It can't reflect phase order.<br/>
+	 * It's just for {@link #getProvider}. It should be removed in the future.
 	 */
 	@ApiStatus.Experimental
-	private final Multimap<Block, BlockApiProvider<A, C>> blockSpecificProviders = Multimaps.synchronizedMultimap(HashMultimap.create());
+	private final Multimap<Block, BlockApiProvider<A, C>> blockSpecificProviders = Multimaps.synchronizedMultimap(ArrayListMultimap.create());
 	private final Event<BlockApiProvider<A, C>> fallback = newEvent();
 	/**
-	 * It can't reflect phase order.
+	 * It can't reflect phase order.<br/>
+	 * It's just for {@link #getFallbackProviders()}. It should be removed in the future.
 	 */
 	@ApiStatus.Experimental
 	private final List<BlockApiProvider<A, C>> fallbackProviders = new CopyOnWriteArrayList<>();
@@ -143,6 +145,7 @@ public final class BlockApiLookupImpl<A, C> implements BlockApiLookup<A, C> {
 		return null;
 	}
 
+	@Deprecated(forRemoval = true)
 	public @UnmodifiableView List<BlockApiProvider<A, C>> getFallbackProviders() {
 		return fallbackProviders;
 	}
@@ -162,8 +165,8 @@ public final class BlockApiLookupImpl<A, C> implements BlockApiLookup<A, C> {
 		Event<BlockApiProvider<A, C>> event = blockSpecific.get(block);
 
 		if (event == null) {
-			event = newEvent();
-			blockSpecific.putIfAbsent(block, event);
+			blockSpecific.putIfAbsent(block, newEvent());
+			event = Objects.requireNonNull(blockSpecific.get(block));
 		}
 
 		return event;

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiLookupImpl.java
@@ -22,8 +22,8 @@ import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiFunction;
 
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.Multimaps;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -74,7 +74,7 @@ public final class BlockApiLookupImpl<A, C> implements BlockApiLookup<A, C> {
 	 * It can't reflect phase order.
 	 */
 	@ApiStatus.Experimental
-	private final Multimap<Block, BlockApiProvider<A, C>> blockSpecificProviders = Multimaps.synchronizedMultimap(MultimapBuilder.hashKeys().arrayListValues().build());
+	private final Multimap<Block, BlockApiProvider<A, C>> blockSpecificProviders = Multimaps.synchronizedMultimap(HashMultimap.create());
 	private final Event<BlockApiProvider<A, C>> fallback = newEvent();
 	/**
 	 * It can't reflect phase order.

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/custom/ApiProviderHashMap.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/custom/ApiProviderHashMap.java
@@ -16,27 +16,87 @@
 
 package net.fabricmc.fabric.impl.lookup.custom;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
 
 import net.fabricmc.fabric.api.lookup.v1.custom.ApiProviderMap;
 
-public final class ApiProviderHashMap<K, V> implements ApiProviderMap<K, V> {
+public final class ApiProviderHashMap<K, V> implements ApiProviderMap<K, V>, @UnmodifiableView Map<K,V> {
 	private volatile Map<K, V> lookups = new Reference2ReferenceOpenHashMap<>();
+
+	@Override
+	public int size() {
+		return lookups.size();
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return lookups.isEmpty();
+	}
+
+	@Override
+	public boolean containsKey(Object key) {
+		return lookups.containsKey(key);
+	}
+
+	@Override
+	public boolean containsValue(Object value) {
+		return lookups.containsValue(value);
+	}
 
 	@Nullable
 	@Override
-	public V get(K key) {
+	public V get(Object key) {
 		Objects.requireNonNull(key, "Key may not be null.");
 
 		return lookups.get(key);
 	}
+	@Override
+	public @Nullable V put(K key, V value) {
+		throw new UnsupportedOperationException();
+	}
 
 	@Override
-	public synchronized V putIfAbsent(K key, V provider) {
+	public V remove(Object key) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void putAll(@NotNull Map<? extends K, ? extends V> m) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void clear() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public @NotNull Set<K> keySet() {
+		return Collections.unmodifiableSet(lookups.keySet());
+	}
+
+	@Override
+	public @NotNull Collection<V> values() {
+		return Collections.unmodifiableCollection(lookups.values());
+	}
+
+
+	@Override
+	public @NotNull Set<Entry<K, V>> entrySet() {
+		return Collections.unmodifiableSet(lookups.entrySet());
+	}
+
+	@Override
+	public synchronized @Nullable V putIfAbsent(K key, V provider) {
 		Objects.requireNonNull(key, "Key may not be null.");
 		Objects.requireNonNull(provider, "Provider may not be null.");
 
@@ -46,5 +106,10 @@ public final class ApiProviderHashMap<K, V> implements ApiProviderMap<K, V> {
 		lookups = lookupsCopy;
 
 		return result;
+	}
+
+	@Override
+	public @UnmodifiableView Map<K, V> asMap() {
+		return this;
 	}
 }

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/custom/ApiProviderHashMap.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/custom/ApiProviderHashMap.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.UnmodifiableView;
 
 import net.fabricmc.fabric.api.lookup.v1.custom.ApiProviderMap;
 
-public final class ApiProviderHashMap<K, V> implements ApiProviderMap<K, V>, @UnmodifiableView Map<K,V> {
+public final class ApiProviderHashMap<K, V> implements ApiProviderMap<K, V>, @UnmodifiableView Map<K, V> {
 	private volatile Map<K, V> lookups = new Reference2ReferenceOpenHashMap<>();
 
 	@Override
@@ -59,6 +59,7 @@ public final class ApiProviderHashMap<K, V> implements ApiProviderMap<K, V>, @Un
 
 		return lookups.get(key);
 	}
+
 	@Override
 	public @Nullable V put(K key, V value) {
 		throw new UnsupportedOperationException();
@@ -88,7 +89,6 @@ public final class ApiProviderHashMap<K, V> implements ApiProviderMap<K, V>, @Un
 	public @NotNull Collection<V> values() {
 		return Collections.unmodifiableCollection(lookups.values());
 	}
-
 
 	@Override
 	public @NotNull Set<Entry<K, V>> entrySet() {

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/entity/EntityApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/entity/EntityApiLookupImpl.java
@@ -147,7 +147,7 @@ public class EntityApiLookupImpl<A, C> implements EntityApiLookup<A, C> {
 	@SuppressWarnings("removal")
 	@Override
 	@Deprecated(forRemoval = true)
-	public @Nullable EntityApiProvider<A, C> getProvider(EntityType<?> entityType) {
+	public @Nullable EntityApiProvider<A, C> getProvider(@NotNull EntityType<?> entityType) {
 		for (EntityApiProvider<A, C> provider : typeSpecificProviders.get(entityType)) {
 			return provider;
 		}
@@ -161,7 +161,7 @@ public class EntityApiLookupImpl<A, C> implements EntityApiLookup<A, C> {
 	}
 
 	@Override
-	public @UnmodifiableView Map<EntityType<?>, Event<EntityApiProvider<A, C>>> typeSpecific() {
+	public @UnmodifiableView Map<@NotNull EntityType<?>, @NotNull Event<EntityApiProvider<A, C>>> typeSpecific() {
 		return typeSpecific.asMap();
 	}
 

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
@@ -16,20 +16,22 @@
 
 package net.fabricmc.fabric.impl.lookup.item;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.Map;
 
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.minecraft.item.Item;
-import net.minecraft.item.ItemConvertible;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
-import net.minecraft.registry.Registries;
 
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
 import net.fabricmc.fabric.api.lookup.v1.custom.ApiLookupMap;
 import net.fabricmc.fabric.api.lookup.v1.custom.ApiProviderMap;
 import net.fabricmc.fabric.api.lookup.v1.item.ItemApiLookup;
@@ -43,87 +45,36 @@ public class ItemApiLookupImpl<A, C> implements ItemApiLookup<A, C> {
 		return (ItemApiLookup<A, C>) LOOKUPS.getLookup(lookupId, apiClass, contextClass);
 	}
 
+	public static <A, C> Event<ItemApiProvider<A, C>> newEvent() {
+		return EventFactory.createArrayBacked(ItemApiProvider.class, providers -> (itemStack, context) -> {
+			for (ItemApiProvider<A, C> provider : providers) {
+				A api = provider.find(itemStack, context);
+				if (api != null) return api;
+			}
+
+			return null;
+		});
+	}
 	private final Identifier identifier;
 	private final Class<A> apiClass;
 	private final Class<C> contextClass;
-	private final ApiProviderMap<Item, ItemApiProvider<A, C>> providerMap = ApiProviderMap.create();
-	private final List<ItemApiProvider<A, C>> fallbackProviders = new CopyOnWriteArrayList<>();
+	private final Event<ItemApiProvider<A, C>> preliminary = newEvent();
+	/**
+	 * It can't reflect phase order.
+	 */
+	private final ApiProviderMap<Item, Event<ItemApiProvider<A, C>>> itemSpecific = ApiProviderMap.create();
+	/**
+	 * It can't reflect phase order.
+	 */
+	@ApiStatus.Experimental
+	private final Multimap<Item, ItemApiProvider<A, C>> itemSpecificProviders = Multimaps.synchronizedMultimap(HashMultimap.create());
+	private final Event<ItemApiProvider<A, C>> fallback = newEvent();
 
 	@SuppressWarnings("unchecked")
 	private ItemApiLookupImpl(Identifier identifier, Class<?> apiClass, Class<?> contextClass) {
 		this.identifier = identifier;
 		this.apiClass = (Class<A>) apiClass;
 		this.contextClass = (Class<C>) contextClass;
-	}
-
-	@Override
-	public @Nullable A find(ItemStack itemStack, C context) {
-		Objects.requireNonNull(itemStack, "ItemStack may not be null.");
-
-		@Nullable
-		ItemApiProvider<A, C> provider = providerMap.get(itemStack.getItem());
-
-		if (provider != null) {
-			A instance = provider.find(itemStack, context);
-
-			if (instance != null) {
-				return instance;
-			}
-		}
-
-		for (ItemApiProvider<A, C> fallbackProvider : fallbackProviders) {
-			A instance = fallbackProvider.find(itemStack, context);
-
-			if (instance != null) {
-				return instance;
-			}
-		}
-
-		return null;
-	}
-
-	@SuppressWarnings("unchecked")
-	@Override
-	public void registerSelf(ItemConvertible... items) {
-		for (ItemConvertible itemConvertible : items) {
-			Item item = itemConvertible.asItem();
-
-			if (!apiClass.isAssignableFrom(item.getClass())) {
-				String errorMessage = String.format(
-						"Failed to register self-implementing items. API class %s is not assignable from item class %s.",
-						apiClass.getCanonicalName(),
-						item.getClass().getCanonicalName()
-				);
-				throw new IllegalArgumentException(errorMessage);
-			}
-		}
-
-		registerForItems((itemStack, context) -> (A) itemStack.getItem(), items);
-	}
-
-	@Override
-	public void registerForItems(ItemApiProvider<A, C> provider, ItemConvertible... items) {
-		Objects.requireNonNull(provider, "ItemApiProvider may not be null.");
-
-		if (items.length == 0) {
-			throw new IllegalArgumentException("Must register at least one ItemConvertible instance with an ItemApiProvider.");
-		}
-
-		for (ItemConvertible itemConvertible : items) {
-			Item item = itemConvertible.asItem();
-			Objects.requireNonNull(item, "Item convertible in item form may not be null.");
-
-			if (providerMap.putIfAbsent(item, provider) != null) {
-				LOGGER.warn("Encountered duplicate API provider registration for item: " + Registries.ITEM.getId(item));
-			}
-		}
-	}
-
-	@Override
-	public void registerFallback(ItemApiProvider<A, C> fallbackProvider) {
-		Objects.requireNonNull(fallbackProvider, "ItemApiProvider may not be null.");
-
-		fallbackProviders.add(fallbackProvider);
 	}
 
 	@Override
@@ -143,7 +94,39 @@ public class ItemApiLookupImpl<A, C> implements ItemApiLookup<A, C> {
 
 	@Override
 	@Nullable
+	@Deprecated(forRemoval = true)
 	public ItemApiProvider<A, C> getProvider(Item item) {
-		return providerMap.get(item);
+		for (ItemApiProvider<A, C> provider : itemSpecificProviders.get(item)) {
+			return provider;
+		}
+
+		return null;
+	}
+
+	@Override
+	public Event<ItemApiProvider<A, C>> preliminary() {
+		return preliminary;
+	}
+
+	@Override
+	public Map<Item, Event<ItemApiProvider<A, C>>> itemSpecific() {
+		return itemSpecific.asMap();
+	}
+
+	@Override
+	public @NotNull Event<ItemApiProvider<A, C>> getSpecificFor(@NotNull Item item) {
+		Event<ItemApiProvider<A, C>> event = itemSpecific.get(item);
+
+		if (event == null) {
+			event = newEvent();
+			itemSpecific.putIfAbsent(item, event);
+		}
+
+		return event;
+	}
+
+	@Override
+	public Event<ItemApiProvider<A, C>> fallback() {
+		return fallback;
 	}
 }

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
@@ -60,9 +60,6 @@ public class ItemApiLookupImpl<A, C> implements ItemApiLookup<A, C> {
 	private final Class<A> apiClass;
 	private final Class<C> contextClass;
 	private final Event<ItemApiProvider<A, C>> preliminary = newEvent();
-	/**
-	 * It can't reflect phase order.
-	 */
 	private final ApiProviderMap<Item, Event<ItemApiProvider<A, C>>> itemSpecific = ApiProviderMap.create();
 	/**
 	 * It can't reflect phase order.
@@ -93,10 +90,10 @@ public class ItemApiLookupImpl<A, C> implements ItemApiLookup<A, C> {
 		return contextClass;
 	}
 
+	@SuppressWarnings("removal") // ide always warns
 	@Override
-	@Nullable
 	@Deprecated(forRemoval = true)
-	public ItemApiProvider<A, C> getProvider(Item item) {
+	public @Nullable ItemApiProvider<A, C> getProvider(Item item) {
 		for (ItemApiProvider<A, C> provider : itemSpecificProviders.get(item)) {
 			return provider;
 		}

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
@@ -17,8 +17,9 @@
 package net.fabricmc.fabric.impl.lookup.item;
 
 import java.util.Map;
+import java.util.Objects;
 
-import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import org.jetbrains.annotations.ApiStatus;
@@ -62,10 +63,11 @@ public class ItemApiLookupImpl<A, C> implements ItemApiLookup<A, C> {
 	private final Event<ItemApiProvider<A, C>> preliminary = newEvent();
 	private final ApiProviderMap<Item, Event<ItemApiProvider<A, C>>> itemSpecific = ApiProviderMap.create();
 	/**
-	 * It can't reflect phase order.
+	 * It can't reflect phase order.<br/>
+	 * It's just for {@link #getProvider}. It should be removed in the future.
 	 */
 	@ApiStatus.Experimental
-	private final Multimap<Item, ItemApiProvider<A, C>> itemSpecificProviders = Multimaps.synchronizedMultimap(HashMultimap.create());
+	private final Multimap<Item, ItemApiProvider<A, C>> itemSpecificProviders = Multimaps.synchronizedMultimap(ArrayListMultimap.create());
 	private final Event<ItemApiProvider<A, C>> fallback = newEvent();
 
 	@SuppressWarnings("unchecked")
@@ -90,7 +92,7 @@ public class ItemApiLookupImpl<A, C> implements ItemApiLookup<A, C> {
 		return contextClass;
 	}
 
-	@SuppressWarnings("removal") // ide always warns
+	@SuppressWarnings("removal") // IDE always warns
 	@Override
 	@Deprecated(forRemoval = true)
 	public @Nullable ItemApiProvider<A, C> getProvider(Item item) {
@@ -116,8 +118,8 @@ public class ItemApiLookupImpl<A, C> implements ItemApiLookup<A, C> {
 		Event<ItemApiProvider<A, C>> event = itemSpecific.get(item);
 
 		if (event == null) {
-			event = newEvent();
-			itemSpecific.putIfAbsent(item, event);
+			itemSpecific.putIfAbsent(item, newEvent());
+			event = Objects.requireNonNull(itemSpecific.get(item));
 		}
 
 		return event;

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
@@ -95,7 +95,7 @@ public class ItemApiLookupImpl<A, C> implements ItemApiLookup<A, C> {
 	@SuppressWarnings("removal") // IDE always warns
 	@Override
 	@Deprecated(forRemoval = true)
-	public @Nullable ItemApiProvider<A, C> getProvider(Item item) {
+	public @Nullable ItemApiProvider<A, C> getProvider(@NotNull Item item) {
 		for (ItemApiProvider<A, C> provider : itemSpecificProviders.get(item)) {
 			return provider;
 		}
@@ -109,7 +109,7 @@ public class ItemApiLookupImpl<A, C> implements ItemApiLookup<A, C> {
 	}
 
 	@Override
-	public Map<Item, Event<ItemApiProvider<A, C>>> itemSpecific() {
+	public Map<@NotNull Item, @NotNull Event<ItemApiProvider<A, C>>> itemSpecific() {
 		return itemSpecific.asMap();
 	}
 

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/item/ItemApiLookupImpl.java
@@ -55,6 +55,7 @@ public class ItemApiLookupImpl<A, C> implements ItemApiLookup<A, C> {
 			return null;
 		});
 	}
+
 	private final Identifier identifier;
 	private final Class<A> apiClass;
 	private final Class<C> contextClass;

--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/FabricApiLookupTest.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/FabricApiLookupTest.java
@@ -69,8 +69,8 @@ public class FabricApiLookupTest implements ModInitializer {
 		InventoryExtractableProvider extractableProvider = new InventoryExtractableProvider();
 		InventoryInsertableProvider insertableProvider = new InventoryInsertableProvider();
 
-		ItemApis.INSERTABLE.registerForBlockEntities(insertableProvider, BlockEntityType.CHEST, BlockEntityType.DISPENSER, BlockEntityType.DROPPER, BlockEntityType.HOPPER);
-		ItemApis.EXTRACTABLE.registerForBlockEntities(extractableProvider, BlockEntityType.CHEST, BlockEntityType.DISPENSER, BlockEntityType.DROPPER, BlockEntityType.HOPPER);
+		BlockApiLookup.registerForBlockEntities(ItemApis.INSERTABLE,insertableProvider, BlockEntityType.CHEST, BlockEntityType.DISPENSER, BlockEntityType.DROPPER, BlockEntityType.HOPPER);
+		BlockApiLookup.registerForBlockEntities(ItemApis.EXTRACTABLE,extractableProvider, BlockEntityType.CHEST, BlockEntityType.DISPENSER, BlockEntityType.DROPPER, BlockEntityType.HOPPER);
 		ItemApis.EXTRACTABLE.registerSelf(COBBLE_GEN_BLOCK_ENTITY_TYPE);
 
 		testLookupRegistry();

--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/FabricApiLookupTest.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/FabricApiLookupTest.java
@@ -69,8 +69,8 @@ public class FabricApiLookupTest implements ModInitializer {
 		InventoryExtractableProvider extractableProvider = new InventoryExtractableProvider();
 		InventoryInsertableProvider insertableProvider = new InventoryInsertableProvider();
 
-		BlockApiLookup.registerForBlockEntities(ItemApis.INSERTABLE,insertableProvider, BlockEntityType.CHEST, BlockEntityType.DISPENSER, BlockEntityType.DROPPER, BlockEntityType.HOPPER);
-		BlockApiLookup.registerForBlockEntities(ItemApis.EXTRACTABLE,extractableProvider, BlockEntityType.CHEST, BlockEntityType.DISPENSER, BlockEntityType.DROPPER, BlockEntityType.HOPPER);
+		BlockApiLookup.registerForBlockEntities(ItemApis.INSERTABLE, insertableProvider, BlockEntityType.CHEST, BlockEntityType.DISPENSER, BlockEntityType.DROPPER, BlockEntityType.HOPPER);
+		BlockApiLookup.registerForBlockEntities(ItemApis.EXTRACTABLE, extractableProvider, BlockEntityType.CHEST, BlockEntityType.DISPENSER, BlockEntityType.DROPPER, BlockEntityType.HOPPER);
 		ItemApis.EXTRACTABLE.registerSelf(COBBLE_GEN_BLOCK_ENTITY_TYPE);
 
 		testLookupRegistry();

--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/compat/InventoryExtractableProvider.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/compat/InventoryExtractableProvider.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.test.lookup.compat;
 
+import java.util.function.BiFunction;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -23,12 +25,11 @@ import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.util.math.Direction;
 
-import net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup;
 import net.fabricmc.fabric.test.lookup.api.ItemExtractable;
 
-public class InventoryExtractableProvider implements BlockApiLookup.BlockEntityApiProvider<ItemExtractable, @NotNull Direction> {
+public class InventoryExtractableProvider implements BiFunction<BlockEntity, @NotNull Direction, ItemExtractable> {
 	@Override
-	public @Nullable ItemExtractable find(BlockEntity blockEntity, @NotNull Direction context) {
+	public @Nullable ItemExtractable apply(BlockEntity blockEntity, @NotNull Direction context) {
 		if (blockEntity instanceof Inventory) {
 			return new WrappedInventory((Inventory) blockEntity);
 		}

--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/compat/InventoryInsertableProvider.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/compat/InventoryInsertableProvider.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.test.lookup.compat;
 
+import java.util.function.BiFunction;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -23,12 +25,11 @@ import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.util.math.Direction;
 
-import net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup;
 import net.fabricmc.fabric.test.lookup.api.ItemInsertable;
 
-public class InventoryInsertableProvider implements BlockApiLookup.BlockEntityApiProvider<ItemInsertable, @NotNull Direction> {
+public class InventoryInsertableProvider implements BiFunction<BlockEntity, @NotNull Direction,ItemInsertable> {
 	@Override
-	public @Nullable ItemInsertable find(BlockEntity blockEntity, @NotNull Direction context) {
+	public @Nullable ItemInsertable apply(BlockEntity blockEntity, @NotNull Direction context) {
 		if (blockEntity instanceof Inventory) {
 			return new WrappedInventory((Inventory) blockEntity);
 		}

--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/compat/InventoryInsertableProvider.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/compat/InventoryInsertableProvider.java
@@ -27,7 +27,7 @@ import net.minecraft.util.math.Direction;
 
 import net.fabricmc.fabric.test.lookup.api.ItemInsertable;
 
-public class InventoryInsertableProvider implements BiFunction<BlockEntity, @NotNull Direction,ItemInsertable> {
+public class InventoryInsertableProvider implements BiFunction<BlockEntity, @NotNull Direction, ItemInsertable> {
 	@Override
 	public @Nullable ItemInsertable apply(BlockEntity blockEntity, @NotNull Direction context) {
 		if (blockEntity instanceof Inventory) {

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/CombinedProvidersImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/CombinedProvidersImpl.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.impl.transfer.fluid;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.item.Item;
@@ -67,7 +68,7 @@ public class CombinedProvidersImpl {
 
 		@Override
 		@Nullable
-		public Storage<FluidVariant> find(ItemStack itemStack, ContainerItemContext context) {
+		public Storage<FluidVariant> find(@NotNull ItemStack itemStack, ContainerItemContext context) {
 			if (!context.getItemVariant().matches(itemStack)) {
 				String errorMessage = String.format(
 						"Query stack %s and ContainerItemContext variant %s don't match.",

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/CombinedProvidersImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/CombinedProvidersImpl.java
@@ -17,7 +17,9 @@
 package net.fabricmc.fabric.impl.transfer.fluid;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -35,6 +37,8 @@ import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.CombinedStorage;
 
 public class CombinedProvidersImpl {
+	private static final Map<Item, Provider> ITEM_SPECIFIC = new HashMap<>();
+
 	public static Event<FluidStorage.CombinedItemApiProvider> createEvent(boolean invokeFallback) {
 		return EventFactory.createArrayBacked(FluidStorage.CombinedItemApiProvider.class, listeners -> context -> {
 			List<Storage<FluidVariant>> storages = new ArrayList<>();
@@ -83,23 +87,20 @@ public class CombinedProvidersImpl {
 	}
 
 	public static Event<FluidStorage.CombinedItemApiProvider> getOrCreateItemEvent(Item item) {
-		ItemApiLookup.ItemApiProvider<Storage<FluidVariant>, ContainerItemContext> existingProvider = FluidStorage.ITEM.getProvider(item);
+		Provider provider = ITEM_SPECIFIC.get(item);
 
-		if (existingProvider == null) {
-			FluidStorage.ITEM.registerForItems(new Provider(), item);
-			// The provider might not be new Provider() if a concurrent registration happened, re-query.
-			existingProvider = FluidStorage.ITEM.getProvider(item);
+		if (provider == null) {
+			synchronized (ITEM_SPECIFIC) {
+				provider = ITEM_SPECIFIC.get(item);
+
+				if (provider == null) {
+					provider = new Provider();
+					ITEM_SPECIFIC.putIfAbsent(item, provider);
+					FluidStorage.ITEM.getSpecificFor(item).register(provider);
+				}
+			}
 		}
 
-		if (existingProvider instanceof Provider registeredProvider) {
-			return registeredProvider.event;
-		} else {
-			String errorMessage = String.format(
-					"An incompatible provider was already registered for item %s. Provider: %s.",
-					item,
-					existingProvider
-			);
-			throw new IllegalStateException(errorMessage);
-		}
+		return provider.event;
 	}
 }


### PR DESCRIPTION
- Added preliminary providers, which are called before all other providers.
- You can register multiple providers for one item/block/entity type now.
- Fallback providers list is replaced by `Event`, where you can add phase ordering.
- All the changes are backward compatible. Some methods are marked with `@Deprecated`.