### PR TITLE
Add a FabricBlockModelSupplier, FabricTextureMap and SimpleBlockStateSupplier for easier data generation with Block Models & States.

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricBlockModelSupplier.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricBlockModelSupplier.java
@@ -6,30 +6,34 @@ import net.minecraft.util.Identifier;
 import java.util.HashMap;
 import java.util.function.Supplier;
 
-/* Acceptor for the BlockStateModelGenerator's blockStateCollector (datagen) */
+/**
+ * Acceptable class for BlockStateModelGenerator's blockStateCollector
+ * @see BlockStateModelGenerator
+ */
 
 public class BlockModelSupplier implements Supplier<JsonElement> {
     protected final JsonObject jsonObject;
 
-    public BlockModelSupplier()
+    public BlockModelSupplier(String type)
     {
         this.jsonObject = new JsonObject();
-    }
-  
-    // You're expected to manually add a parent type
-    // TODO possibly change to be a construction parameter?
-    public BlockModelSupplier addParentType(String type)
-    {
-        this.jsonObject.addProperty("parent", "minecraft:block/" + type);
-        return this;
+		this.jsonObject.addProperty("parent", "minecraft:block/" + type);
     }
 
-    public BlockModelSupplier addParentType(String modID, String type)
+	/**
+ 	 * Have an acceptable <modID> parameter in case of custom model parents.
+	 */
+	public BlockModelSupplier(String modID, String type)
     {
-        this.jsonObject.addProperty("parent", modID + ":block/" + type);
-        return this;
+        this.jsonObject = new JsonObject();
+		this.jsonObject.addProperty("parent", modID + ":block/" + type);
     }
 
+	/**
+	 * Add textures.
+	 *
+	 * @param textureMap The {@link FabricDataGenerator} instance
+	 */
     public BlockModelSupplier addTextureData(HashMap<String, Identifier> textureMap)
     {
         JsonObject textureData = new JsonObject();
@@ -53,11 +57,6 @@ public class BlockModelSupplier implements Supplier<JsonElement> {
 
     @Override
     public JsonElement get() {
-        if (this.jsonObject.get("parent") == null)
-        {
-            // Default to cube_all if no parent is added!
-            this.jsonObject.addProperty("parent", "minecraft:block/cube_all");
-        }
         return this.jsonObject;
     }
 }

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricBlockModelSupplier.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricBlockModelSupplier.java
@@ -7,33 +7,41 @@ import java.util.HashMap;
 import java.util.function.Supplier;
 
 /**
- * Acceptable class for {@link BlockStateModelGenerator}'s blockStateCollector.
+ * Acceptable class for {@link net.minecraft.data.client.BlockStateModelGenerator}'s blockStateCollector.
  * makes generating more specific block models easier for modders.
  */
 
 public class FabricBlockModelSupplier implements Supplier<JsonElement> {
     protected final JsonObject jsonObject;
 
+    /**
+     * Constructor for vanilla parent types.
+     *
+     * @param type The parent type for the model.
+     */
     public FabricBlockModelSupplier(String type)
     {
         this.jsonObject = new JsonObject();
-		this.jsonObject.addProperty("parent", "minecraft:block/" + type);
+        this.jsonObject.addProperty("parent", "minecraft:block/" + type);
     }
 
-	/**
- 	 * Have an acceptable <modID> parameter in case of custom model parents.
-	 */
-	public FabricBlockModelSupplier(String modID, String type)
+    /**
+     * Have an acceptable <modID> parameter in case of custom model parents.
+     *
+     * @param modID The modID as the prefix to the parent type in the Identifier.
+     * @param type The parent type for the model.
+     */
+    public FabricBlockModelSupplier(String modID, String type)
     {
         this.jsonObject = new JsonObject();
-		this.jsonObject.addProperty("parent", modID + ":block/" + type);
+        this.jsonObject.addProperty("parent", modID + ":block/" + type);
     }
 
-	/**
-	 * Add HashMap textures to the model's JsonObject.
-	 *
-	 * @param textureMap HashMap containing the data for the textures.
-	 */
+    /**
+     * Add HashMap textures to the model's JsonObject.
+     *
+     * @param textureMap {@link HashMap} containing the data for the textures.
+     */
     public FabricBlockModelSupplier addTextureData(HashMap<String, Identifier> textureMap)
     {
         JsonObject textureData = new JsonObject();
@@ -46,11 +54,11 @@ public class FabricBlockModelSupplier implements Supplier<JsonElement> {
         return this;
     }
 
-	/**
-	 * Add a sample texture as 'all' of the textures. Can only be used on the cube_all parent.
-	 *
-	 * @param texture {@link Identifier} for the location of the texture.
-	 */
+    /**
+     * Add a sample texture as 'all' of the textures. Can only be used on the cube_all parent.
+     *
+     * @param texture {@link Identifier} for the location of the texture.
+     */
     public FabricBlockModelSupplier simpleCubeAllTextures(Identifier texture)
     {
         JsonObject textureData = new JsonObject();
@@ -60,11 +68,11 @@ public class FabricBlockModelSupplier implements Supplier<JsonElement> {
         return this;
     }
 
-	/**
-	 * Returns the {@link JsonObject} for the Model.
+    /**
+     * Returns the {@link JsonObject} for the Model.
      *
-  	 * @return the supplier's JsonObject
-	 */
+     * @return the supplier's {@link JsonObject}
+     */
     @Override
     public JsonElement get() {
         return this.jsonObject;

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricBlockModelSupplier.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricBlockModelSupplier.java
@@ -8,7 +8,7 @@ import java.util.function.Supplier;
 import java.util.Map;
 
 /**
- * Acceptable class for {@link net.minecraft.data.client.BlockStateModelGenerator}'s blockStateCollector.
+ * Acceptable class for {@link net.minecraft.data.client.BlockStateModelGenerator}'s modelCollector.
  * makes generating more specific block models easier for modders.
  */
 
@@ -41,10 +41,11 @@ public class FabricBlockModelSupplier implements Supplier<JsonElement> {
     /**
      * Add HashMap textures to the model's JsonObject.
      *
-     * @param textureMap {@link HashMap} containing the data for the textures.
+     * @param fabricTextureMap {@link FabricTextureMap} containing the data for the textures.
      */
-    public FabricBlockModelSupplier addTextureData(HashMap<String, Identifier> textureMap)
+    public FabricBlockModelSupplier addTextureData(FabricTextureMap fabricTextureMap)
     {
+		HashMap<String, Identifier> textureMap = fabricTextureMap.get();
         JsonObject textureData = new JsonObject();
         for (Map.Entry<String, Identifier> entry : textureMap.entrySet()) {
 			String key = entry.getKey();

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricBlockModelSupplier.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricBlockModelSupplier.java
@@ -1,0 +1,63 @@
+package net.fabricmc.fabric.api.datagen.v1;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import net.minecraft.util.Identifier;
+import java.util.HashMap;
+import java.util.function.Supplier;
+
+/* Acceptor for the BlockStateModelGenerator's blockStateCollector (datagen) */
+
+public class BlockModelSupplier implements Supplier<JsonElement> {
+    protected final JsonObject jsonObject;
+
+    public BlockModelSupplier()
+    {
+        this.jsonObject = new JsonObject();
+    }
+  
+    // You're expected to manually add a parent type
+    // TODO possibly change to be a construction parameter?
+    public BlockModelSupplier addParentType(String type)
+    {
+        this.jsonObject.addProperty("parent", "minecraft:block/" + type);
+        return this;
+    }
+
+    public BlockModelSupplier addParentType(String modID, String type)
+    {
+        this.jsonObject.addProperty("parent", modID + ":block/" + type);
+        return this;
+    }
+
+    public BlockModelSupplier addTextureData(HashMap<String, Identifier> textureMap)
+    {
+        JsonObject textureData = new JsonObject();
+        for (String key : textureMap.keySet()) {
+            Identifier identifier = textureMap.get(key);
+            textureData.addProperty(key, identifier.getNamespace() + ":" + identifier.getPath());
+        }
+
+        this.jsonObject.add("textures", textureData);
+        return this;
+    }
+
+    public BlockModelSupplier simpleTextureData(Identifier texture)
+    {
+        JsonObject textureData = new JsonObject();
+        textureData.addProperty("all", texture.getNamespace() + ":" + texture.getPath());
+
+        this.jsonObject.add("textures", textureData);
+        return this;
+    }
+
+    @Override
+    public JsonElement get() {
+        if (this.jsonObject.get("parent") == null)
+        {
+            // Default to cube_all if no parent is added!
+            this.jsonObject.addProperty("parent", "minecraft:block/cube_all");
+        }
+        return this.jsonObject;
+    }
+}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricBlockModelSupplier.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricBlockModelSupplier.java
@@ -46,7 +46,7 @@ public class FabricBlockModelSupplier implements Supplier<JsonElement> {
     public FabricBlockModelSupplier addTextureData(HashMap<String, Identifier> textureMap)
     {
         JsonObject textureData = new JsonObject();
-        for (Map.Entry<String, Number> entry : textureMap.entrySet()) {
+        for (Map.Entry<String, Identifier> entry : textureMap.entrySet()) {
 			String key = entry.getKey();
             Identifier identifier = entry.getValue();
             textureData.addProperty(key, identifier.getNamespace() + ":" + identifier.getPath());

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricBlockModelSupplier.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricBlockModelSupplier.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import net.minecraft.util.Identifier;
 import java.util.HashMap;
 import java.util.function.Supplier;
+import java.util.Map;
 
 /**
  * Acceptable class for {@link net.minecraft.data.client.BlockStateModelGenerator}'s blockStateCollector.
@@ -45,8 +46,9 @@ public class FabricBlockModelSupplier implements Supplier<JsonElement> {
     public FabricBlockModelSupplier addTextureData(HashMap<String, Identifier> textureMap)
     {
         JsonObject textureData = new JsonObject();
-        for (String key : textureMap.keySet()) {
-            Identifier identifier = textureMap.get(key);
+        for (Map.Entry<String, Number> entry : textureMap.entrySet()) {
+			String key = entry.getKey();
+            Identifier identifier = entry.getValue();
             textureData.addProperty(key, identifier.getNamespace() + ":" + identifier.getPath());
         }
 

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricBlockModelSupplier.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricBlockModelSupplier.java
@@ -11,10 +11,10 @@ import java.util.function.Supplier;
  * makes generating more specific block models easier for modders.
  */
 
-public class BlockModelSupplier implements Supplier<JsonElement> {
+public class FabricBlockModelSupplier implements Supplier<JsonElement> {
     protected final JsonObject jsonObject;
 
-    public BlockModelSupplier(String type)
+    public FabricBlockModelSupplier(String type)
     {
         this.jsonObject = new JsonObject();
 		this.jsonObject.addProperty("parent", "minecraft:block/" + type);
@@ -23,7 +23,7 @@ public class BlockModelSupplier implements Supplier<JsonElement> {
 	/**
  	 * Have an acceptable <modID> parameter in case of custom model parents.
 	 */
-	public BlockModelSupplier(String modID, String type)
+	public FabricBlockModelSupplier(String modID, String type)
     {
         this.jsonObject = new JsonObject();
 		this.jsonObject.addProperty("parent", modID + ":block/" + type);
@@ -34,7 +34,7 @@ public class BlockModelSupplier implements Supplier<JsonElement> {
 	 *
 	 * @param textureMap HashMap containing the data for the textures.
 	 */
-    public BlockModelSupplier addTextureData(HashMap<String, Identifier> textureMap)
+    public FabricBlockModelSupplier addTextureData(HashMap<String, Identifier> textureMap)
     {
         JsonObject textureData = new JsonObject();
         for (String key : textureMap.keySet()) {
@@ -51,7 +51,7 @@ public class BlockModelSupplier implements Supplier<JsonElement> {
 	 *
 	 * @param texture {@link Identifier} for the location of the texture.
 	 */
-    public BlockModelSupplier simpleCubeAllTextures(Identifier texture)
+    public FabricBlockModelSupplier simpleCubeAllTextures(Identifier texture)
     {
         JsonObject textureData = new JsonObject();
         textureData.addProperty("all", texture.getNamespace() + ":" + texture.getPath());

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricBlockModelSupplier.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricBlockModelSupplier.java
@@ -7,8 +7,8 @@ import java.util.HashMap;
 import java.util.function.Supplier;
 
 /**
- * Acceptable class for BlockStateModelGenerator's blockStateCollector
- * @see BlockStateModelGenerator
+ * Acceptable class for {@link BlockStateModelGenerator}'s blockStateCollector.
+ * makes generating more specific block models easier for modders.
  */
 
 public class BlockModelSupplier implements Supplier<JsonElement> {
@@ -30,9 +30,9 @@ public class BlockModelSupplier implements Supplier<JsonElement> {
     }
 
 	/**
-	 * Add textures.
+	 * Add HashMap textures to the model's JsonObject.
 	 *
-	 * @param textureMap The {@link FabricDataGenerator} instance
+	 * @param textureMap HashMap containing the data for the textures.
 	 */
     public BlockModelSupplier addTextureData(HashMap<String, Identifier> textureMap)
     {
@@ -46,7 +46,12 @@ public class BlockModelSupplier implements Supplier<JsonElement> {
         return this;
     }
 
-    public BlockModelSupplier simpleTextureData(Identifier texture)
+	/**
+	 * Add a sample texture as 'all' of the textures. Can only be used on the cube_all parent.
+	 *
+	 * @param texture {@link Identifier} for the location of the texture.
+	 */
+    public BlockModelSupplier simpleCubeAllTextures(Identifier texture)
     {
         JsonObject textureData = new JsonObject();
         textureData.addProperty("all", texture.getNamespace() + ":" + texture.getPath());
@@ -55,6 +60,11 @@ public class BlockModelSupplier implements Supplier<JsonElement> {
         return this;
     }
 
+	/**
+	 * Returns the {@link JsonObject} for the Model.
+     *
+  	 * @return the supplier's JsonObject
+	 */
     @Override
     public JsonElement get() {
         return this.jsonObject;

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricTextureMap.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricTextureMap.java
@@ -37,8 +37,9 @@ public class FabricTextureMap {
 			throw new IllegalStateException(String.format("You need to provide %s more texture names to allocate to texture locations!", difference));
 		}
 		if (difference < 0) {
-			throw new IllegalStateException(String.format("You need to provide %s more texture locations to link to texture names!", difference));
+			throw new IllegalStateException(String.format("You need to provide %s more texture locations to link to texture names!", -difference));
 		}
+
 		for (int i = 0; i < bufferNames.size(); i++) {
 			map.put(bufferNames.get(i), textureList.get(i));
 		}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricTextureMap.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricTextureMap.java
@@ -1,0 +1,53 @@
+package net.fabricmc.fabric.api.datagen.v1;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import net.minecraft.util.Identifier;
+
+/**
+ * Constructor class for making Maps for BlockModel textures.
+ * {@see FabricBlockModelSupplier}
+ */
+
+public class FabricTextureMap {
+	private final HashMap<String, Identifier> map;
+	private final List<String> bufferNames;
+
+	/**
+	 * Constructor for the FabricTextureMap. Sets the private variables for later accession.
+	 *
+	 * @param textureNames Different texture names.
+	 */
+	public FabricTextureMap(String... textureNames) {
+		this.map = new HashMap<>();
+		this.bufferNames = Arrays.stream(textureNames).toList();
+	}
+
+	/**
+	 * Link the texture names to the locations of their textures.
+	 *
+	 * @param textureLocations Identifiers for the location of each texture.
+	 */
+	public FabricTextureMap set(Identifier... textureLocations) {
+		List<Identifier> textureList = Arrays.stream(textureLocations).toList();
+		if (textureList.size() != this.bufferNames.size()) {
+			throw new IllegalStateException("Provided texture locations should be same length as texture names!");
+		}
+		for (int i = 0; i < bufferNames.size(); i++) {
+			map.put(bufferNames.get(i), textureList.get(i));
+		}
+
+		return this;
+	}
+
+	/**
+	 * Return the resulting {@link HashMap}.
+	 *
+	 * @return this HashMap.
+	 */
+	public HashMap<String, Identifier> get() {
+		return this.map;
+	}
+}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricTextureMap.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricTextureMap.java
@@ -32,8 +32,12 @@ public class FabricTextureMap {
 	 */
 	public FabricTextureMap set(Identifier... textureLocations) {
 		List<Identifier> textureList = Arrays.stream(textureLocations).toList();
-		if (textureList.size() != this.bufferNames.size()) {
-			throw new IllegalStateException("Provided texture locations should be same length as texture names!");
+		int difference = textureList.size() - this.bufferNames.size();
+		if (difference > 0) {
+			throw new IllegalStateException(String.format("You need to provide %s more texture names to allocate to texture locations!", difference));
+		}
+		if (difference < 0) {
+			throw new IllegalStateException(String.format("You need to provide %s more texture locations to link to texture names!", difference));
 		}
 		for (int i = 0; i < bufferNames.size(); i++) {
 			map.put(bufferNames.get(i), textureList.get(i));

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/SimpleBlockStateSupplier.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/SimpleBlockStateSupplier.java
@@ -1,0 +1,57 @@
+package net.fabricmc.fabric.api.datagen.v1;
+
+import com.google.gson.JsonElement;
+
+import com.google.gson.JsonObject;
+
+import net.minecraft.block.Block;
+import net.minecraft.data.client.BlockStateSupplier;
+import net.minecraft.util.Identifier;
+
+/**
+ * Basic constructor class for generating non-variant aligned blockstates,
+ * since there is no built-in class for non-variant blockstates.
+ */
+public class SimpleBlockStateSupplier implements BlockStateSupplier {
+	private final Block block;
+	private final JsonObject jsonObject;
+
+	/**
+	 * Constructor for the SimpleBlockStateSupplier. Generates the entire jsonObject.
+	 *
+	 * @param block Block to be applied to.
+	 * @param modelLocation Location of the block's default model.
+	 */
+	public SimpleBlockStateSupplier(Block block, Identifier modelLocation)
+	{
+		this.block=block;
+		this.jsonObject=new JsonObject();
+
+		JsonObject variants = new JsonObject();
+		JsonObject defaultVariant = new JsonObject();
+		defaultVariant.addProperty("model", modelLocation.getNamespace() + ":" + modelLocation.getPath());
+		variants.add("", defaultVariant);
+
+		this.jsonObject.add("variants", variants);
+	}
+
+	/**
+	 * Returns the block this is being applied to.
+	 *
+	 * @return this block
+	 */
+	@Override
+	public Block getBlock() {
+		return this.block;
+	}
+
+	/**
+	 * Returns the resulting {@link JsonElement} from the class.
+	 *
+	 * @return this jsonObject
+	 */
+	@Override
+	public JsonElement get() {
+		return this.jsonObject;
+	}
+}

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
@@ -42,6 +42,8 @@ import net.fabricmc.fabric.api.datagen.v1.FabricBlockModelSupplier;
 
 import net.fabricmc.fabric.api.datagen.v1.FabricTextureMap;
 
+import net.fabricmc.fabric.api.datagen.v1.SimpleBlockStateSupplier;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -307,6 +309,7 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 			blockStateModelGenerator.registerSimpleCubeAll(BLOCK_THAT_DROPS_NOTHING);
 
 			// registerSimpleCubeAll() -> FabricBlockModelSupplier::new
+			blockStateModelGenerator.blockStateCollector.accept(new SimpleBlockStateSupplier(SIMPLE_BLOCK, new Identifier(MOD_ID, "simple_block")));
 			blockStateModelGenerator.modelCollector.accept(new Identifier(MOD_ID, "simple_block"),
 					() -> new FabricBlockModelSupplier("cube_all")
 							.addTextureData(new FabricTextureMap("all")

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
@@ -29,6 +29,7 @@ import static net.fabricmc.fabric.test.datagen.DataGeneratorTestContent.TEST_DYN
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
@@ -36,6 +37,11 @@ import java.util.function.Consumer;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import net.fabricmc.fabric.api.datagen.v1.FabricBlockModelSupplier;
+
+import net.fabricmc.fabric.api.datagen.v1.FabricTextureMap;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -294,11 +300,28 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 
 		@Override
 		public void generateBlockStateModels(BlockStateModelGenerator blockStateModelGenerator) {
-			blockStateModelGenerator.registerSimpleCubeAll(SIMPLE_BLOCK);
+			// blockStateModelGenerator.registerSimpleCubeAll(SIMPLE_BLOCK);
 			blockStateModelGenerator.registerSimpleCubeAll(BLOCK_WITHOUT_ITEM);
 			blockStateModelGenerator.registerSimpleCubeAll(BLOCK_WITHOUT_LOOT_TABLE);
 			blockStateModelGenerator.registerSimpleCubeAll(BLOCK_WITH_VANILLA_LOOT_TABLE);
 			blockStateModelGenerator.registerSimpleCubeAll(BLOCK_THAT_DROPS_NOTHING);
+
+			// registerSimpleCubeAll() -> FabricBlockModelSupplier::new
+			blockStateModelGenerator.modelCollector.accept(new Identifier(MOD_ID, "simple_block"),
+					() -> new FabricBlockModelSupplier("cube_all")
+							.addTextureData(new FabricTextureMap("all")
+									.set(new Identifier(MOD_ID, "block/simple_block")))
+							.get());
+
+			/* In reality, for cube_all textures you'd want to try and do a .registerSimpleCubeAll() from
+			   the blockStateModelGenerator. You could also do something like this if you needed to access
+			   it using the FabricBlockModelSupplier:
+
+				blockStateModelGenerator.modelCollector.accept(new Identifier(MOD_ID, "simple_block"),
+					() -> new FabricBlockModelSupplier("cube_all")
+							.simpleCubeAllTextures(new Identifier(MOD_ID, "block/simple_block"))
+							.get());
+			*/
 		}
 
 		@Override


### PR DESCRIPTION
Currently, data generation is very new and restricted. In this case, block model generation is very limited - being incredibly inaccessible and anything even slightly more complex than a `cube_all` model requires custom classes to be built for generating them. A FabricBlockModelSupplier would fix this issue, where you could easily simply provide the parent type and a (see below) new class - FabricTextureMap with the texture name and location, which can then be turned into a resulting JSON. As an example, creating a `cube_column` model can be easily made, like so - the SimpleBlockStateSupplier allows for no-variant based blockstates to be generated easily, because this isn't a built-in feature for fabric at the moment:

```java
public static class ModelGenerator extends FabricModelProvider
{
    private static final Block CHEESE_LOG = // ... 
    public ModelGenerator(FabricDataOutput output) { super(output); }

    @Override
    public void generateBlockStateModels(BlockStateModelGenerator blockStateModelGenerator)
    {
        // We can create the block's model & simple state like so:
        blockStateModelGenerator.blockStateCollector.accept(new SimpleBlockStateSupplier(CHEESE_LOG, new Identifier("modid", "cheese_log")));
        blockStateModelGenerator.modelCollector.accept(new Identifier("modid", "cheese_log"),
            () -> new FabricBlockModelSupplier("cube_column") // The parent type is the parameter.
                .addTextureData(new FabricTextureMap("end", "side")
                    .set(new Identifier("modid", "block/cheese_log_end"), new Identifier("modid", "block/cheese_log_side")))
                .get());
    }

    @Override
    public void generateItemModels(ItemModelGenerator itemModelGenerator)
    {
        // ...
    }
}
```
Which would then be outputted as this, and if done correctly should also generate a basic block parent item model, as well - however some methods won't produce Item Models. Unsure as to the reason of this, looking into it.
```json
{
  "parent": "minecraft:block/cube_column",
  "textures": {
    "end": "modid:block/cheese_log_end",
    "side": "modid:block/cheese_log_side"
  }
}
```
```json
{
  "parent": "modid:block/cheese_log"
}
```
The creation of a FabricTextureMap not only could potentially help in the long run with other future classes requiring something similar but also, as a whole, it's much easier to use than a raw HashMap - it allows for the code to be more readable than initially (especially without double bracket indentation) and also reduces the line count and should also help reduce external variables being used when people wouldn't use double bracket indentation for the HashMap.

As a whole, I think these additions could greatly help the data generation part of fabric, although more specifically attributed towards Block Models - although the FabricBlockModelSupplier could work perfectly fine with Item Models, as well - for example, this is a snippet of how I had recently used it as a custom class for one of my mods more recently:
```java
// Model Generator code...
protected void simpleItem(ItemModelGenerator generator, String ID)
{
	generator.writer.accept(new Identifier("modid", "item/" + ID),
			() -> new FabricBlockModelSupplier("modid", ID)
					.get());
}

@Override
public void generateItemModels(ItemModelGenerator itemModelGenerator) {
	simpleItem(itemModelGenerator, "myblockitem")
}
```
This generates a simple Item Model JSON like so:
```json
{
  "parent": "modid:block/myblockitem"
}
```
This is because of the FabricBlockModelSupplier's support for custom model types and it's immediate initialization of the "parent" JSON.