### PR TITLE
chore: fix links in transfer-api README.md

### DIFF
--- a/fabric-transfer-api-v1/README.md
+++ b/fabric-transfer-api-v1/README.md
@@ -18,8 +18,8 @@ The [`storage/base`](src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/b
 implementation of `Storage<T>`.
 
 Implementors of inventories with a fixed number of "slots" or "tanks" can use
-[`SingleVariantStorage`](src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/SingleStorage.java),
-and combine them with `CombinedStorage`.
+[`SingleVariantStorage`](src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/SingleVariantStorage.java),
+and combine them with [`CombinedStorage`](src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/CombinedStorage.java).
 
 ## Fluid transfer
 A `Storage<FluidVariant>` is any object that can store fluids. It is just a `Storage<T>`, where `T` is
@@ -30,10 +30,10 @@ The unit for fluid transfer is 1/81000ths of a bucket, also known as _droplets_.
 [`FluidConstants`](src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidConstants.java) contains a few helpful constants
 to work with droplets.
 
-Client-side [Fluid variant rendering](src/main/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRendering.java) will use regular fluid rendering by default,
+Client-side [Fluid variant rendering](src/client/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRendering.java) will use regular fluid rendering by default,
 ignoring the additional NBT data.
 `Fluid`s that wish to render differently depending on the stored NBT data can register a
-[`FluidVariantRenderHandler`](src/main/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRenderHandler.java).
+[`FluidVariantRenderHandler`](src/client/java/net/fabricmc/fabric/api/transfer/v1/client/fluid/FluidVariantRenderHandler.java).
 
 ## Item transfer
 A `Storage<ItemVariant>` is any object that can store items.


### PR DESCRIPTION
updates a few outdated paths so they link to the correct file again