### PR TITLE
[1.20.4] Alter StartTracking with Before and After Variants

### DIFF
--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/EntityTrackingEvents.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/EntityTrackingEvents.java
@@ -26,14 +26,25 @@ import net.fabricmc.fabric.api.event.EventFactory;
  * Events related to a tracking entities within a player's view distance.
  */
 public final class EntityTrackingEvents {
+
 	/**
 	 * An event that is called before player starts tracking an entity.
 	 * Typically, this occurs when an entity enters a client's view distance.
-	 * This event is called before the player's client is sent the entity's {@link Entity#createSpawnPacket() spawn packet}.
+	 * This event is called <strong>before</strong> the player's client is sent the entity's {@link Entity#createSpawnPacket() spawn packet}.
 	 */
-	public static final Event<StartTracking> START_TRACKING = EventFactory.createArrayBacked(StartTracking.class, callbacks -> (trackedEntity, player) -> {
-		for (StartTracking callback : callbacks) {
-			callback.onStartTracking(trackedEntity, player);
+	public static final Event<BeforeStartTracking> BEFORE_START_TRACKING = EventFactory.createArrayBacked(BeforeStartTracking.class, callbacks -> (trackedEntity, player) -> {
+		for (BeforeStartTracking callback : callbacks) {
+			callback.beforeStartTracking(trackedEntity, player);
+		}
+	});
+
+	/**
+	 * An event that is called after player starts tracking an entity.
+	 * This event is called <strong>after</strong> the player's client is sent the entity's {@link Entity#createSpawnPacket() spawn packet}.
+	 */
+	public static final Event<AfterStartTracking> AFTER_START_TRACKING = EventFactory.createArrayBacked(AfterStartTracking.class, callbacks -> (trackedEntity, player) -> {
+		for (AfterStartTracking callback : callbacks) {
+			callback.afterStartTracking(trackedEntity, player);
 		}
 	});
 
@@ -49,14 +60,24 @@ public final class EntityTrackingEvents {
 	});
 
 	@FunctionalInterface
-	public interface StartTracking {
+	public interface BeforeStartTracking {
 		/**
 		 * Called before an entity starts getting tracked by a player.
 		 *
 		 * @param trackedEntity the entity that will be tracked
 		 * @param player the player that will track the entity
 		 */
-		void onStartTracking(Entity trackedEntity, ServerPlayerEntity player);
+		void beforeStartTracking(Entity trackedEntity, ServerPlayerEntity player);
+	}
+
+	public interface AfterStartTracking {
+		/**
+		 * Called after an entity starts getting tracked by a player.
+		 *
+		 * @param trackedEntity the entity that will be tracked
+		 * @param player the player that will track the entity
+		 */
+		void afterStartTracking(Entity trackedEntity, ServerPlayerEntity player);
 	}
 
 	@FunctionalInterface
@@ -71,5 +92,24 @@ public final class EntityTrackingEvents {
 	}
 
 	private EntityTrackingEvents() {
+	}
+
+	//--
+
+	/**
+	 * @deprecated Use {#BEFORE_START_TRACKING} or {@link #AFTER_START_TRACKING} instead
+	 */
+	@Deprecated(forRemoval = true)
+	public static final Event<BeforeStartTracking> START_TRACKING = BEFORE_START_TRACKING;
+
+	@Deprecated(forRemoval = true)
+	@FunctionalInterface
+	public interface StartTracking extends BeforeStartTracking {
+		void onStartTracking(Entity trackedEntity, ServerPlayerEntity player);
+
+		@Override
+		default void beforeStartTracking(Entity trackedEntity, ServerPlayerEntity player) {
+			onStartTracking(trackedEntity, player);
+		}
 	}
 }

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/EntityTrackingEvents.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/EntityTrackingEvents.java
@@ -99,17 +99,16 @@ public final class EntityTrackingEvents {
 	/**
 	 * @deprecated Use {#BEFORE_START_TRACKING} or {@link #AFTER_START_TRACKING} instead
 	 */
-	@Deprecated(forRemoval = true)
-	public static final Event<BeforeStartTracking> START_TRACKING = BEFORE_START_TRACKING;
-
-	@Deprecated(forRemoval = true)
-	@FunctionalInterface
-	public interface StartTracking extends BeforeStartTracking {
-		void onStartTracking(Entity trackedEntity, ServerPlayerEntity player);
-
-		@Override
-		default void beforeStartTracking(Entity trackedEntity, ServerPlayerEntity player) {
-			onStartTracking(trackedEntity, player);
+	@Deprecated()
+	public static final Event<StartTracking> START_TRACKING = EventFactory.createArrayBacked(StartTracking.class, callbacks -> (trackedEntity, player) -> {
+		for (StartTracking callback : callbacks) {
+			callback.onStartTracking(trackedEntity, player);
 		}
+	});
+
+	@Deprecated()
+	@FunctionalInterface
+	public interface StartTracking {
+		void onStartTracking(Entity trackedEntity, ServerPlayerEntity player);
 	}
 }

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/EntityTrackerEntryMixin.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/EntityTrackerEntryMixin.java
@@ -36,8 +36,13 @@ abstract class EntityTrackerEntryMixin {
 	private Entity entity;
 
 	@Inject(method = "startTracking", at = @At("HEAD"))
-	private void onStartTracking(ServerPlayerEntity player, CallbackInfo ci) {
-		EntityTrackingEvents.START_TRACKING.invoker().onStartTracking(this.entity, player);
+	private void onStartTrackingBefore(ServerPlayerEntity player, CallbackInfo ci) {
+		EntityTrackingEvents.BEFORE_START_TRACKING.invoker().beforeStartTracking(this.entity, player);
+	}
+
+	@Inject(method = "startTracking", at = @At("TAIL"))
+	private void onStartTrackingAfter(ServerPlayerEntity player, CallbackInfo ci) {
+		EntityTrackingEvents.AFTER_START_TRACKING.invoker().afterStartTracking(this.entity, player);
 	}
 
 	@Inject(method = "stopTracking", at = @At("TAIL"))

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/EntityTrackerEntryMixin.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/EntityTrackerEntryMixin.java
@@ -37,6 +37,7 @@ abstract class EntityTrackerEntryMixin {
 
 	@Inject(method = "startTracking", at = @At("HEAD"))
 	private void onStartTrackingBefore(ServerPlayerEntity player, CallbackInfo ci) {
+		EntityTrackingEvents.START_TRACKING.invoker().onStartTracking(this.entity, player);
 		EntityTrackingEvents.BEFORE_START_TRACKING.invoker().beforeStartTracking(this.entity, player);
 	}
 


### PR DESCRIPTION
The Point of this PR is to have an After Variant for StartTracking as the current implementation calls the `StartTracking` event before any packets for the Entity's creation making such an event pointless if you need to sync things like data attachment to the Client as such will require some delayed method of handling any packet sent until the entity exists. Evidence of such an event being useful can be found within [Cardinal Components](https://github.com/Ladysnake/Cardinal-Components-API/blob/1a9bf0a0f67d0fd5f7a9195a0c927c2e5eae3443/cardinal-components-entity/src/main/java/dev/onyxstudios/cca/mixin/entity/common/MixinEntityTrackerEntry.java#L43) and [NeoForge](https://github.com/neoforged/NeoForge/blob/9f0d3d489e3746bfe5664ca989f309c261b90c89/patches/net/minecraft/server/level/ServerEntity.java.patch#L29). 


Additionally, this PR attempts to keep binary compatibility with previous API versions with such old variants extending the renaming of the old event. 