### PR TITLE
Remove false legacy tag warning

### DIFF
--- a/deprecated/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/impl/tag/convention/ConventionLogWarnings.java
+++ b/deprecated/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/impl/tag/convention/ConventionLogWarnings.java
@@ -37,7 +37,6 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.tag.convention.v1.ConventionalBiomeTags;
 import net.fabricmc.fabric.api.tag.convention.v1.ConventionalBlockTags;
 import net.fabricmc.fabric.api.tag.convention.v1.ConventionalEnchantmentTags;
-import net.fabricmc.fabric.api.tag.convention.v1.ConventionalFluidTags;
 import net.fabricmc.fabric.api.tag.convention.v1.ConventionalItemTags;
 import net.fabricmc.fabric.api.tag.convention.v2.TagUtil;
 import net.fabricmc.loader.api.FabricLoader;

--- a/deprecated/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/impl/tag/convention/ConventionLogWarnings.java
+++ b/deprecated/fabric-convention-tags-v1/src/main/java/net/fabricmc/fabric/impl/tag/convention/ConventionLogWarnings.java
@@ -108,11 +108,6 @@ public class ConventionLogWarnings implements ModInitializer {
 			createMapEntry(ConventionalItemTags.BOWS, net.fabricmc.fabric.api.tag.convention.v2.ConventionalItemTags.BOWS_TOOLS),
 			createMapEntry(ConventionalItemTags.SHIELDS, net.fabricmc.fabric.api.tag.convention.v2.ConventionalItemTags.SHIELDS_TOOLS),
 
-			createMapEntry(ConventionalFluidTags.WATER, net.fabricmc.fabric.api.tag.convention.v2.ConventionalFluidTags.WATER),
-			createMapEntry(ConventionalFluidTags.LAVA, net.fabricmc.fabric.api.tag.convention.v2.ConventionalFluidTags.LAVA),
-			createMapEntry(ConventionalFluidTags.MILK, net.fabricmc.fabric.api.tag.convention.v2.ConventionalFluidTags.MILK),
-			createMapEntry(ConventionalFluidTags.HONEY, net.fabricmc.fabric.api.tag.convention.v2.ConventionalFluidTags.HONEY),
-
 			createMapEntry(ConventionalEnchantmentTags.INCREASES_BLOCK_DROPS, net.fabricmc.fabric.api.tag.convention.v2.ConventionalEnchantmentTags.INCREASE_BLOCK_DROPS),
 			createMapEntry(ConventionalEnchantmentTags.INCREASES_ENTITY_DROPS, net.fabricmc.fabric.api.tag.convention.v2.ConventionalEnchantmentTags.INCREASE_ENTITY_DROPS),
 			createMapEntry(ConventionalEnchantmentTags.ENTITY_MOVEMENT_ENHANCEMENT, net.fabricmc.fabric.api.tag.convention.v2.ConventionalEnchantmentTags.ENTITY_SPEED_ENHANCEMENTS),


### PR DESCRIPTION
It seems I accidentally had the fluid c tags point to themselves as legacy when they are not. 
![image](https://github.com/FabricMC/fabric/assets/40846040/c989b9a2-baed-4f41-87fa-ede6c01dfeb4)

This is a bug from: https://github.com/FabricMC/fabric/pull/3310

This fix PR will make warning stop showing erroneously.