### PR TITLE
Add specific error when encoding packet with no encoder

### DIFF
--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/CustomPayloadPacketCodecMixin.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/CustomPayloadPacketCodecMixin.java
@@ -46,31 +46,15 @@ public abstract class CustomPayloadPacketCodecMixin<B extends PacketByteBuf> imp
 	}
 
 	@WrapOperation(method = {
+			"encode(Lnet/minecraft/network/PacketByteBuf;Lnet/minecraft/network/packet/CustomPayload$Id;Lnet/minecraft/network/packet/CustomPayload;)V",
 			"decode(Lnet/minecraft/network/PacketByteBuf;)Lnet/minecraft/network/packet/CustomPayload;"
 	}, at = @At(value = "INVOKE", target = "Lnet/minecraft/network/packet/CustomPayload$1;getCodec(Lnet/minecraft/util/Identifier;)Lnet/minecraft/network/codec/PacketCodec;"))
-	private PacketCodec<B, ? extends CustomPayload> wrapGetCodecDecode(@Coerce PacketCodec<B, CustomPayload> instance, Identifier identifier, Operation<PacketCodec<B, CustomPayload>> original, B packetByteBuf) {
+	private PacketCodec<B, ? extends CustomPayload> wrapGetCodec(@Coerce PacketCodec<B, CustomPayload> instance, Identifier identifier, Operation<PacketCodec<B, CustomPayload>> original, B packetByteBuf) {
 		if (customPayloadTypeProvider != null) {
 			CustomPayload.Type<B, ? extends CustomPayload> payloadType = customPayloadTypeProvider.get(packetByteBuf, identifier);
 
 			if (payloadType != null) {
 				return payloadType.codec();
-			}
-		}
-
-		return original.call(instance, identifier);
-	}
-
-	@WrapOperation(method = {
-			"encode(Lnet/minecraft/network/PacketByteBuf;Lnet/minecraft/network/packet/CustomPayload$Id;Lnet/minecraft/network/packet/CustomPayload;)V",
-	}, at = @At(value = "INVOKE", target = "Lnet/minecraft/network/packet/CustomPayload$1;getCodec(Lnet/minecraft/util/Identifier;)Lnet/minecraft/network/codec/PacketCodec;"))
-	private PacketCodec<B, ? extends CustomPayload> wrapGetCodecEncode(@Coerce PacketCodec<B, CustomPayload> instance, Identifier identifier, Operation<PacketCodec<B, CustomPayload>> original, B packetByteBuf) {
-		if (customPayloadTypeProvider != null) {
-			CustomPayload.Type<B, ? extends CustomPayload> payloadType = customPayloadTypeProvider.get(packetByteBuf, identifier);
-
-			if (payloadType != null) {
-				return payloadType.codec();
-			} else if (!identifier.getNamespace().equals("minecraft")) {
-				throw new RuntimeException("Failed to find encoder for custom payload channel \"" + identifier + "\". Are you sure you registered one using PayloadTypeRegistry for both the client and server?");
 			}
 		}
 

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/UnknownCustomPayloadMixin.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/UnknownCustomPayloadMixin.java
@@ -38,7 +38,7 @@ public class UnknownCustomPayloadMixin {
 
 			@Override
 			public void encode(T buf, CustomPayload value) {
-				throw new RuntimeException("Failed to find encoder for custom payload '" + value.getId().id() + "'");
+				throw new RuntimeException("Custom payload '" + value.getId().id() + "' has no registered codec");
 			}
 		};
 	}

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/UnknownCustomPayloadMixin.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/UnknownCustomPayloadMixin.java
@@ -38,7 +38,7 @@ public class UnknownCustomPayloadMixin {
 
 			@Override
 			public void encode(T buf, CustomPayload value) {
-				throw new RuntimeException("Failed to find encoder for custom payload. Are you sure you registered one using PayloadTypeRegistry for both the client and server?");
+				throw new RuntimeException("Failed to find encoder for custom payload '" + value.getId().id() + "'. Are you sure you registered one using PayloadTypeRegistry for both the client and server?");
 			}
 		};
 	}

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/UnknownCustomPayloadMixin.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/UnknownCustomPayloadMixin.java
@@ -1,0 +1,32 @@
+package net.fabricmc.fabric.mixin.networking;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
+import net.minecraft.network.packet.UnknownCustomPayload;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Coerce;
+
+@Mixin(UnknownCustomPayload.class)
+public class UnknownCustomPayloadMixin {
+
+	@ModifyReturnValue(method = "createCodec", at = @At("RETURN"))
+	private static <T extends PacketByteBuf> PacketCodec<T, CustomPayload> createCodec(@Coerce PacketCodec<T, CustomPayload> codec) {
+		return new PacketCodec<>() {
+			@Override
+			public CustomPayload decode(T buf) {
+				return codec.decode(buf);
+			}
+
+			@Override
+			public void encode(T buf, CustomPayload value) {
+				throw new RuntimeException("Failed to find encoder for custom payload. Are you sure you registered one using PayloadTypeRegistry for both the client and server?");
+			}
+		};
+	}
+
+}

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/UnknownCustomPayloadMixin.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/UnknownCustomPayloadMixin.java
@@ -38,7 +38,7 @@ public class UnknownCustomPayloadMixin {
 
 			@Override
 			public void encode(T buf, CustomPayload value) {
-				throw new RuntimeException("Failed to find encoder for custom payload '" + value.getId().id() + "'. Are you sure you registered one using PayloadTypeRegistry for both the client and server?");
+				throw new RuntimeException("Failed to find encoder for custom payload '" + value.getId().id() + "'");
 			}
 		};
 	}

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/UnknownCustomPayloadMixin.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/UnknownCustomPayloadMixin.java
@@ -1,19 +1,33 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.networking;
 
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Coerce;
 
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.codec.PacketCodec;
 import net.minecraft.network.packet.CustomPayload;
 import net.minecraft.network.packet.UnknownCustomPayload;
 
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Coerce;
-
 @Mixin(UnknownCustomPayload.class)
 public class UnknownCustomPayloadMixin {
-
 	@ModifyReturnValue(method = "createCodec", at = @At("RETURN"))
 	private static <T extends PacketByteBuf> PacketCodec<T, CustomPayload> createCodec(@Coerce PacketCodec<T, CustomPayload> codec) {
 		return new PacketCodec<>() {
@@ -28,5 +42,4 @@ public class UnknownCustomPayloadMixin {
 			}
 		};
 	}
-
 }

--- a/fabric-networking-api-v1/src/main/resources/fabric-networking-api-v1.mixins.json
+++ b/fabric-networking-api-v1/src/main/resources/fabric-networking-api-v1.mixins.json
@@ -12,6 +12,7 @@
     "EntityTrackerEntryMixin",
     "LoginQueryRequestS2CPacketMixin",
     "LoginQueryResponseC2SPacketMixin",
+    "UnknownCustomPayloadMixin",
     "PlayerManagerMixin",
     "ServerCommonNetworkHandlerMixin",
     "ServerConfigurationNetworkHandlerMixin",

--- a/fabric-networking-api-v1/src/test/java/net/fabricmc/fabric/test/networking/unit/PayloadTypeRegistryTests.java
+++ b/fabric-networking-api-v1/src/test/java/net/fabricmc/fabric/test/networking/unit/PayloadTypeRegistryTests.java
@@ -30,6 +30,7 @@ import net.minecraft.network.RegistryByteBuf;
 import net.minecraft.network.codec.PacketCodec;
 import net.minecraft.network.codec.PacketCodecs;
 import net.minecraft.network.packet.CustomPayload;
+import net.minecraft.network.packet.UnknownCustomPayload;
 import net.minecraft.network.packet.c2s.common.CustomPayloadC2SPacket;
 import net.minecraft.network.packet.s2c.common.CustomPayloadS2CPacket;
 
@@ -114,7 +115,7 @@ public class PayloadTypeRegistryTests {
 	}
 
 	@Test
-	void handleUnregisteredCustomPayloadError() {
+	void handleUnregisteredCustomPayloadEncodeError() {
 		// Create packet with no registered codec
 		var packetToSend = new CustomPayloadS2CPacket(() -> CustomPayload.id("no_codec"));
 
@@ -122,6 +123,15 @@ public class PayloadTypeRegistryTests {
 		assertThrowsExactly(RuntimeException.class, () -> {
 			CustomPayloadS2CPacket.CONFIGURATION_CODEC.encode(PacketByteBufs.create(), packetToSend);
 		});
+	}
+
+	@Test
+	void handleUnregisteredCustomPayloadDecodeAsUnknownCustomPayload() {
+		PacketByteBuf buf = PacketByteBufs.create();
+
+		buf.writeString("minecraft:no_codec");
+
+		assertEquals(UnknownCustomPayload.class, CustomPayloadS2CPacket.CONFIGURATION_CODEC.decode(buf).payload().getClass());
 	}
 
 	private record C2SPlayPayload(String value) implements CustomPayload {

--- a/fabric-networking-api-v1/src/test/java/net/fabricmc/fabric/test/networking/unit/PayloadTypeRegistryTests.java
+++ b/fabric-networking-api-v1/src/test/java/net/fabricmc/fabric/test/networking/unit/PayloadTypeRegistryTests.java
@@ -16,9 +16,6 @@
 
 package net.fabricmc.fabric.test.networking.unit;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +31,8 @@ import net.minecraft.network.packet.s2c.common.CustomPayloadS2CPacket;
 
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PayloadTypeRegistryTests {
 	@BeforeAll
@@ -110,6 +109,17 @@ public class PayloadTypeRegistryTests {
 		} else {
 			fail();
 		}
+	}
+
+	@Test
+	void handleUnregisteredCustomPayloadError() {
+		// Create packet with no registered codec
+		var packetToSend = new CustomPayloadS2CPacket(() -> CustomPayload.id("no_codec"));
+
+		// Should be *exactly* RuntimeException (with our custom message), NOT ClassCastException
+		assertThrowsExactly(RuntimeException.class, () -> {
+			CustomPayloadS2CPacket.CONFIGURATION_CODEC.encode(PacketByteBufs.create(), packetToSend);
+		});
 	}
 
 	private record C2SPlayPayload(String value) implements CustomPayload {

--- a/fabric-networking-api-v1/src/test/java/net/fabricmc/fabric/test/networking/unit/PayloadTypeRegistryTests.java
+++ b/fabric-networking-api-v1/src/test/java/net/fabricmc/fabric/test/networking/unit/PayloadTypeRegistryTests.java
@@ -16,6 +16,10 @@
 
 package net.fabricmc.fabric.test.networking.unit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -31,8 +35,6 @@ import net.minecraft.network.packet.s2c.common.CustomPayloadS2CPacket;
 
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class PayloadTypeRegistryTests {
 	@BeforeAll

--- a/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/play/NetworkingPlayPacketTest.java
+++ b/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/play/NetworkingPlayPacketTest.java
@@ -79,6 +79,10 @@ public final class NetworkingPlayPacketTest implements ModInitializer {
 					ctx.getSource().sendMessage(Text.literal("Spamming unknown packets state:" + spamUnknownPackets));
 					return Command.SINGLE_SUCCESS;
 				}))
+				.then(literal("sendMissingCodec").executes(ctx -> {
+					ServerPlayNetworking.getSender(ctx.getSource().getPlayer()).sendPacket(new CustomPayloadWithoutCodec());
+					return Command.SINGLE_SUCCESS;
+				}))
 				.then(literal("simple").executes(ctx -> {
 					ServerPlayNetworking.send(ctx.getSource().getPlayer(), new OverlayPacket(Text.literal("simple")));
 					return Command.SINGLE_SUCCESS;
@@ -121,6 +125,15 @@ public final class NetworkingPlayPacketTest implements ModInitializer {
 				}
 			}
 		});
+	}
+
+	public record CustomPayloadWithoutCodec() implements CustomPayload {
+		public static final CustomPayload.Id<CustomPayloadWithoutCodec> ID = new Id<>(NetworkingTestmods.id("no_codec"));
+
+		@Override
+		public Id<? extends CustomPayload> getId() {
+			return ID;
+		}
 	}
 
 	public record OverlayPacket(Text message) implements CustomPayload {


### PR DESCRIPTION
Adds a specific error when encoding a packet that doesn't have a registered encoder

To explain a bit more about the issue:
CustomPayload#getCodec returns a dummy decoder using unknownCodecFactory. This is fine when decoding, but not when encoding. When encoding, you'll end up with a confusing exception about casting to DiscardedPayload (or UnknownCustomPayload).

An ideal solution would not use #getCodec for encode, and would instead throw the more helpful exception directly when a codec is missing. Unfortunately I couldn't figure out a good way to do this since map is part of the anonymous class (perhaps someone with more knowledge of mixins could point me in the right direction).

Overwriting the entire #getCodec method is also an option, but I think is generally unfavoured.

For this PR, I just throw the error if the namespace isn't "minecraft", which might be problematic if mods add directly to the map instead of using Fabric's system. 