### PR TITLE
Fix crash when generating flat world

### DIFF
--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/modification/BiomeModificationImpl.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/modification/BiomeModificationImpl.java
@@ -160,7 +160,7 @@ public class BiomeModificationImpl {
 						dimensionOptions.chunkGenerator().indexedFeaturesListSupplier = Suppliers.memoize(
 							() -> PlacedFeatureIndexer.collectIndexedFeatures(
 									List.copyOf(dimensionOptions.chunkGenerator().getBiomeSource().getBiomes()),
-									(biomeEntry) -> (biomeEntry.value().generationSettings).getFeatures(),
+									biomeEntry -> dimensionOptions.chunkGenerator().getGenerationSettings(biomeEntry).getFeatures(),
 									true
 							)
 						);


### PR DESCRIPTION
Resolves #3736 

Affects 1.20.5 and 1.20.6.

This time tested with:

- Regular world
- Superflat, Classic
- Superflat, Desert
- Superflat, Void
- With the provided testmod, Void