### PR TITLE
Don't enforce a RegistryByteBuf packet code for the extended screen handler type.

### DIFF
--- a/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/api/screenhandler/v1/ExtendedScreenHandlerType.java
+++ b/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/api/screenhandler/v1/ExtendedScreenHandlerType.java
@@ -74,14 +74,14 @@ import net.minecraft.screen.ScreenHandlerType;
  */
 public class ExtendedScreenHandlerType<T extends ScreenHandler, D> extends ScreenHandlerType<T> {
 	private final ExtendedFactory<T, D> factory;
-	private final PacketCodec<RegistryByteBuf, D> packetCodec;
+	private final PacketCodec<? super RegistryByteBuf, D> packetCodec;
 
 	/**
 	 * Constructs an extended screen handler type.
 	 *
 	 * @param factory the screen handler factory used for {@link #create(int, PlayerInventory, Object)}
 	 */
-	public ExtendedScreenHandlerType(ExtendedFactory<T, D> factory, PacketCodec<RegistryByteBuf, D> packetCodec) {
+	public ExtendedScreenHandlerType(ExtendedFactory<T, D> factory, PacketCodec<? super RegistryByteBuf, D> packetCodec) {
 		super(null, FeatureFlags.VANILLA_FEATURES);
 		this.factory = Objects.requireNonNull(factory, "screen handler factory cannot be null");
 		this.packetCodec = Objects.requireNonNull(packetCodec, "packet codec cannot be null");
@@ -112,7 +112,7 @@ public class ExtendedScreenHandlerType<T extends ScreenHandler, D> extends Scree
 	/**
 	 * @return the packet codec for serializing the data of this screen handler
 	 */
-	public PacketCodec<RegistryByteBuf, D> getPacketCodec() {
+	public PacketCodec<? super RegistryByteBuf, D> getPacketCodec() {
 		return packetCodec;
 	}
 

--- a/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/impl/screenhandler/Networking.java
+++ b/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/impl/screenhandler/Networking.java
@@ -51,7 +51,7 @@ public final class Networking implements ModInitializer {
 	// title: text
 	// customData: buf
 	public static final Identifier OPEN_ID = new Identifier("fabric-screen-handler-api-v1", "open_screen");
-	public static final Map<Identifier, PacketCodec<RegistryByteBuf, ?>> CODEC_BY_ID = new HashMap<>();
+	public static final Map<Identifier, PacketCodec<? super RegistryByteBuf, ?>> CODEC_BY_ID = new HashMap<>();
 
 	/**
 	 * Opens an extended screen handler by sending a custom packet to the client.


### PR DESCRIPTION
Im 99% sure this is backwards biniary compatible, let me know if you think otherwise 👍 

Fixes #3738