### PR TITLE
Support extending dynamic registries in datagen

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricDataGenerator.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricDataGenerator.java
@@ -25,6 +25,9 @@ import org.jetbrains.annotations.ApiStatus;
 import net.minecraft.SharedConstants;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.data.DataProvider;
+import net.minecraft.registry.BuiltinRegistries;
+import net.minecraft.registry.ExperimentalRegistriesValidator;
+import net.minecraft.registry.RegistryBuilder;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.util.Identifier;
 
@@ -93,6 +96,20 @@ public final class FabricDataGenerator extends DataGenerator {
 	 */
 	public boolean isStrictValidationEnabled() {
 		return strictValidation;
+	}
+
+	/**
+	 * Get a future returning the default registries produced by {@link BuiltinRegistries} and
+	 * {@link DataGeneratorEntrypoint#buildRegistry(RegistryBuilder)}.
+	 *
+	 * <p>Generally one does not need direct access to the registries, and instead can pass them directly to a
+	 * {@link DataProvider} by using {@link Pack#addProvider(Pack.RegistryDependentFactory)}. However, this method may
+	 * be useful when extending the vanilla registries (such as with {@link ExperimentalRegistriesValidator}).
+	 *
+	 * @return A future containing the builtin registries.
+	 */
+	public CompletableFuture<RegistryWrapper.WrapperLookup> getRegistries() {
+		return registriesFuture;
 	}
 
 	/**

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGenHelper.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGenHelper.java
@@ -45,11 +45,13 @@ import net.minecraft.registry.Registerable;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.RegistryBuilder;
 import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryLoader;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.util.Util;
 
 import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
+import net.fabricmc.fabric.api.event.registry.DynamicRegistries;
 import net.fabricmc.fabric.api.resource.conditions.v1.ResourceCondition;
 import net.fabricmc.fabric.api.resource.conditions.v1.ResourceConditions;
 import net.fabricmc.loader.api.FabricLoader;
@@ -176,7 +178,7 @@ public final class FabricDataGenHelper {
 			BuilderData(RegistryKey key) {
 				this.key = key;
 				this.bootstrapFunctions = new ArrayList<>();
-				this.lifecycle = null;
+				this.lifecycle = Lifecycle.stable();
 			}
 
 			void with(RegistryBuilder.RegistryInfo<?> registryInfo) {
@@ -196,6 +198,11 @@ public final class FabricDataGenHelper {
 		}
 
 		Map<RegistryKey<?>, BuilderData> builderDataMap = new HashMap<>();
+
+		// Ensure all dynamic registries are present.
+		for (RegistryLoader.Entry<?> key : DynamicRegistries.getDynamicRegistries()) {
+			builderDataMap.computeIfAbsent(key.key(), BuilderData::new);
+		}
 
 		for (RegistryBuilder builder : builders) {
 			for (RegistryBuilder.RegistryInfo<?> info : builder.registries) {

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestContent.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestContent.java
@@ -56,6 +56,10 @@ public class DataGeneratorTestContent implements ModInitializer {
 			TEST_DATAGEN_DYNAMIC_REGISTRY_KEY,
 			new Identifier(MOD_ID, "tiny_potato")
 	);
+	public static final RegistryKey<TestDatagenObject> TEST_DYNAMIC_REGISTRY_EXTRA_ITEM_KEY = RegistryKey.of(
+			TEST_DATAGEN_DYNAMIC_REGISTRY_KEY,
+			new Identifier(MOD_ID, "tinier_potato")
+	);
 	// Empty registry
 	public static final RegistryKey<Registry<TestDatagenObject>> TEST_DATAGEN_DYNAMIC_EMPTY_REGISTRY_KEY =
 			RegistryKey.ofRegistry(new Identifier("fabric", "test_datagen_dynamic_empty"));

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/ExperimentalRegistriesValidatorMixin.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/ExperimentalRegistriesValidatorMixin.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.registry.sync;
+
+import java.util.List;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.registry.ExperimentalRegistriesValidator;
+import net.minecraft.registry.RegistryLoader;
+
+import net.fabricmc.fabric.api.event.registry.DynamicRegistries;
+
+@Mixin(ExperimentalRegistriesValidator.class)
+class ExperimentalRegistriesValidatorMixin {
+	@Redirect(at = @At(value = "FIELD", target = "Lnet/minecraft/registry/RegistryLoader;DYNAMIC_REGISTRIES:Ljava/util/List;"), method = "method_54839")
+	private static List<RegistryLoader.Entry<?>> getDynamicRegistries() {
+		// Register cloners for all dynamic registries.
+		return DynamicRegistries.getDynamicRegistries();
+	}
+}

--- a/fabric-registry-sync-v0/src/main/resources/fabric-registry-sync-v0.mixins.json
+++ b/fabric-registry-sync-v0/src/main/resources/fabric-registry-sync-v0.mixins.json
@@ -6,6 +6,7 @@
     "BootstrapMixin",
     "ChunkSerializerMixin",
     "DebugChunkGeneratorAccessor",
+    "ExperimentalRegistriesValidatorMixin",
     "IdListMixin",
     "MinecraftServerMixin",
     "RegistriesAccessor",


### PR DESCRIPTION
Data generators are passed a `CompletableFuture<RegistryWrapper.WrapperLookup>` which contains the default contents of vanilla's dynamic registries (and mods', if they implement `buildRegistry`). However, there are times when it is useful to extend this registry, for instance when generating multiple datapacks.

In vanilla, this is done by constructing a new `RegistryBuilder`, and passing that and the existing registries to `ExperimentalRegistriesValidator.validate`[^1]. However, there's a couple of issues in Fabric which prevent this from working — this PR attempts to resolve those.

 - `RegistryBuilder.createWrapperLookup` expects all registries to be present in the base registries (as it calls `getWrapperOrThrow` rather than `getWrapper`[^2]). This is true for vanilla's dynamic registries, but *not* custom Fabric ones. To resolve that, we ensure all dynamic registries are present (though possibly empty) in the initial datagen registries.

 - Dynamic registries are not added to `CloneableRegistries` in `ExperimentalRegistriesValidator.validate`. We simply replace the usage of vanilla's `DYNAMIC_REGISTRIES` with Fabric's own collection.

 - In order to extend the registries, we need access to the original `CompletableFuture<RegistryWrapper.WrapperLookup>`. However, this is only exposed when adding a pack, and is not generally available. This PR adds a getter for the registry future.

   I do have some mixed feelings about this change — it does feel a bit error prone to have both `RegistryDependentFactory` and this, but the alternatives I can think of feel more clunky.


[^1]: I think the Yarn name is a little misleading here, but I've spent too much time in the Mojmap version of this code, that I'm not sure I'd feel comfortable suggesting alternatives.
[^2]: The "correct" fix would be to use `getWrapper` here, [which is what NeoForge does](https://github.com/neoforged/NeoForge/blob/92b21d1e38d7bf23d19b1b96aaf69b8b65398437/patches/net/minecraft/core/RegistrySetBuilder.java.patch#L18-L35). However, doing that in Mixins is quite tricky!