### PR TITLE
Support loading a single resource condition instead of array

### DIFF
--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/ResourceCondition.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/ResourceCondition.java
@@ -38,6 +38,11 @@ public interface ResourceCondition {
 	 * A codec for a list of conditions.
 	 */
 	Codec<List<ResourceCondition>> LIST_CODEC = CODEC.listOf();
+	/**
+	 * A codec for parsing load conditions. Can either be an array of conditions or a single condition.
+	 */
+	Codec<ResourceCondition> CONDITION_CODEC = Codec.withAlternative(CODEC, CODEC.listOf(), conditions -> ResourceConditions.and(conditions.toArray(new ResourceCondition[0])));
+
 
 	/**
 	 * @return the type of the condition

--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/ResourceCondition.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/ResourceCondition.java
@@ -41,7 +41,7 @@ public interface ResourceCondition {
 	/**
 	 * A codec for parsing load conditions. Can either be an array of conditions or a single condition.
 	 */
-	Codec<ResourceCondition> CONDITION_CODEC = Codec.withAlternative(CODEC, CODEC.listOf(), conditions -> ResourceConditions.and(conditions.toArray(new ResourceCondition[0])));
+	Codec<ResourceCondition> CONDITION_CODEC = Codec.withAlternative(CODEC, LIST_CODEC, conditions -> ResourceConditions.and(conditions.toArray(new ResourceCondition[0])));
 
 	/**
 	 * @return the type of the condition

--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/ResourceCondition.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/ResourceCondition.java
@@ -43,7 +43,6 @@ public interface ResourceCondition {
 	 */
 	Codec<ResourceCondition> CONDITION_CODEC = Codec.withAlternative(CODEC, CODEC.listOf(), conditions -> ResourceConditions.and(conditions.toArray(new ResourceCondition[0])));
 
-
 	/**
 	 * @return the type of the condition
 	 */

--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/impl/resource/conditions/ResourceConditionsImpl.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/impl/resource/conditions/ResourceConditionsImpl.java
@@ -65,10 +65,10 @@ public final class ResourceConditionsImpl implements ModInitializer {
 		boolean debugLogEnabled = ResourceConditionsImpl.LOGGER.isDebugEnabled();
 
 		if (obj.has(ResourceConditions.CONDITIONS_KEY)) {
-			DataResult<List<ResourceCondition>> conditions = ResourceCondition.LIST_CODEC.parse(JsonOps.INSTANCE, obj.get(ResourceConditions.CONDITIONS_KEY));
+			DataResult<ResourceCondition> conditions = ResourceCondition.CONDITION_CODEC.parse(JsonOps.INSTANCE, obj.get(ResourceConditions.CONDITIONS_KEY));
 
 			if (conditions.isSuccess()) {
-				boolean matched = ResourceConditionsImpl.conditionsMet(conditions.getOrThrow(), registryLookup, true);
+				boolean matched = conditions.getOrThrow().test(registryLookup);
 
 				if (debugLogEnabled) {
 					String verdict = matched ? "Allowed" : "Rejected";

--- a/fabric-resource-conditions-api-v1/src/testmod/resources/data/fabric-resource-conditions-api-v1-testmod/predicates/loaded.json
+++ b/fabric-resource-conditions-api-v1/src/testmod/resources/data/fabric-resource-conditions-api-v1-testmod/predicates/loaded.json
@@ -4,12 +4,7 @@
   "predicate": {
     "type": "minecraft:pig"
   },
-  "fabric:load_conditions": [
-    {
-      "condition": "fabric:all_mods_loaded",
-      "values": [
-        "fabric-resource-conditions-api-v1"
-      ]
-    }
-  ]
+  "fabric:load_conditions": {
+    "condition": "fabric:true"
+  }
 }


### PR DESCRIPTION
This PR adds the ability for resource conditions to be parsed from a single condition rather than an array of conditions. This can be convenient if you only have a single condition to check against.
```json
{
  ...
  "fabric:load_conditions": {
    "condition": "fabric:all_mods_loaded",
    "values": [
      "modid"
    ]
  }
}
```

Technical details:
There's a new codec added to `ResourceCondition`: `CONDITIONS_CODEC`. It accepts either a resource condition or a list of resource conditions, and if it is a list it will wrap up the list in a `fabric:and` resource condition.