### PR TITLE
Add c:indestructible tag

### DIFF
--- a/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalItemTags.java
+++ b/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalItemTags.java
@@ -290,6 +290,13 @@ public final class ConventionalItemTags {
 	 */
 	public static final TagKey<Item> HIDDEN_FROM_RECIPE_VIEWERS = register("hidden_from_recipe_viewers");
 
+	/**
+	 * For items that should not be destroyed under any circumstances.
+	 * This does not prevent vanilla ways of destruction. These need to be handled by the mod itself (Explosions, Burning as Fuel, Crafting, Durability Breaking)
+	 */
+	public static final TagKey<Item> INDESTRUCTIBLE = register("indestructible");
+
+
 	private static TagKey<Item> register(String tagId) {
 		return TagRegistration.ITEM_TAG.registerC(tagId);
 	}


### PR DESCRIPTION
This PR adds the c:indestructible tag to items. 

This tag is there to represent items which shall not be destroyed. 

I don't know if c:indestructible is the correct naming. But I don't have a better idea. 

I have not added a block tag. As I would be unsure if bedrock would go into it? For some mods bedrock may be considered as destructible. 

A different idea would be to use fabric:indestructible and change all the vanilla cases where items are destroyed or used in crafting. But this would likely be to out of scope for fabric-api. 

