### PR TITLE
No longer allow unused registry ids when syncing.

### DIFF
--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
@@ -36,7 +36,6 @@ import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.objects.Object2IntLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
@@ -277,14 +276,10 @@ public final class RegistrySyncManager {
 				continue;
 			}
 
-			if (registry instanceof RemappableRegistry) {
-				Object2IntMap<Identifier> idMap = new Object2IntOpenHashMap<>();
-
-				for (Identifier key : registryMap.keySet()) {
-					idMap.put(key, registryMap.getInt(key));
-				}
-
-				((RemappableRegistry) registry).remap(registryId.toString(), idMap, mode);
+			if (registry instanceof RemappableRegistry remappableRegistry) {
+				remappableRegistry.remap(registryId.toString(), registryMap, mode);
+			} else {
+				throw new RemapException("Registry " + registryId + " is not remappable");
 			}
 		}
 

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MainMixin.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/MainMixin.java
@@ -17,31 +17,32 @@
 package net.fabricmc.fabric.mixin.registry.sync;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.item.ItemGroups;
 import net.minecraft.registry.Registries;
-import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.Main;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.fabric.impl.registry.sync.trackers.vanilla.BlockInitTracker;
 import net.fabricmc.loader.api.FabricLoader;
 
-@Mixin(MinecraftServer.class)
-public class MinecraftServerMixin {
-	@Unique
-	private static final Logger FABRIC_LOGGER = LoggerFactory.getLogger(MinecraftServerMixin.class);
+@Mixin(Main.class)
+public class MainMixin {
+	@Shadow
+	@Final
+	private static Logger LOGGER;
 
-	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;setupServer()Z"), method = "runServer")
-	private void beforeSetupServer(CallbackInfo info) {
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Util;startTimerHack()V"), method = "main")
+	private static void afterModInit(CallbackInfo info) {
 		if (FabricLoader.getInstance().getEnvironmentType() == EnvType.SERVER) {
 			// Freeze the registries on the server
-			FABRIC_LOGGER.debug("Freezing registries");
+			LOGGER.debug("Freezing registries");
 
 			Registries.bootstrap();
 			BlockInitTracker.postFreeze();

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/SimpleRegistryMixin.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/SimpleRegistryMixin.java
@@ -299,8 +299,10 @@ public abstract class SimpleRegistryMixin<T> implements MutableRegistry<T>, Rema
 		for (int i = 0; i < rawIdToEntry.size(); i++) {
 			RegistryEntry.Reference<T> reference = rawIdToEntry.get(i);
 
-			// Unused id, skip
-			if (reference == null) continue;
+			// Unused id, can happen if there are holes in the registry.
+			if (reference == null) {
+				throw new RemapException("Unused id " + i + " in registry " + getKey().getValue());
+			}
 
 			Identifier id = reference.registryKey().getValue();
 

--- a/fabric-registry-sync-v0/src/main/resources/fabric-registry-sync-v0.mixins.json
+++ b/fabric-registry-sync-v0/src/main/resources/fabric-registry-sync-v0.mixins.json
@@ -8,7 +8,7 @@
     "DebugChunkGeneratorAccessor",
     "ExperimentalRegistriesValidatorMixin",
     "IdListMixin",
-    "MinecraftServerMixin",
+    "MainMixin",
     "RegistriesAccessor",
     "RegistriesMixin",
     "RegistryLoaderMixin",


### PR DESCRIPTION
No longer allow unused registry ids when syncing, this was previously used when ids were saved to disk. Vanilla no longer supports this, and will cause weird and wonderful errors later on.

Also minor code cleanup.