### PR TITLE
Add mixins for FabricItem.getAttributeModifiers

### DIFF
--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemStackMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemStackMixin.java
@@ -23,7 +23,10 @@ import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
+import net.minecraft.component.DataComponentType;
+import net.minecraft.component.type.AttributeModifiersComponent;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.Item;
@@ -56,5 +59,28 @@ public abstract class ItemStackMixin implements FabricItemStack {
 		}
 
 		original.call(instance, amount, random, serverPlayerEntity, runnable);
+	}
+
+	@Redirect(
+			method = "appendAttributeModifiersTooltip",
+			at = @At(
+					value = "INVOKE",
+					target = "Lnet/minecraft/item/ItemStack;getOrDefault(Lnet/minecraft/component/DataComponentType;Ljava/lang/Object;)Ljava/lang/Object;"
+			)
+	)
+	public Object appendAttributeModifiersTooltip(ItemStack stack, DataComponentType<AttributeModifiersComponent> type, Object fallback) {
+		return getItem().getAttributeModifiers(stack);
+	}
+
+	@Redirect(
+			method = "applyAttributeModifiers",
+			at = @At(
+					value = "INVOKE",
+					target = "Lnet/minecraft/item/Item;getAttributeModifiers()Lnet/minecraft/component/type/AttributeModifiersComponent;"
+			)
+	)
+	public AttributeModifiersComponent applyAttributeModifiers(Item item) {
+		ItemStack stack = (ItemStack) (Object) this;
+		return item.getAttributeModifiers(stack);
 	}
 }


### PR DESCRIPTION
Added an ItemStack mixin to call `FabricItem.getAttributeModifiers(ItemStack)`.
Also added a mixin when Minecraft creates the item tooltip, because unlike 1.20.4, which get attribute modifiers using `getAttributeModifiers`, 1.20.6 loads them from data components.

I tested it on a production client with a mod of mine (source not yet upstream), and it worked. I'll test it on a server later.

Resolves #3787