### PR TITLE
Add mixins for FabricItem.getAttributeModifiers (1.21)

### DIFF
--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemStackMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemStackMixin.java
@@ -25,7 +25,10 @@ import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
+import net.minecraft.component.ComponentType;
+import net.minecraft.component.type.AttributeModifiersComponent;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.Item;
@@ -63,5 +66,28 @@ public abstract class ItemStackMixin implements FabricItemStack {
 		}
 
 		original.call(instance, amount, serverWorld, serverPlayerEntity, consumer);
+	}
+
+	@Redirect(
+			method = "appendAttributeModifiersTooltip",
+			at = @At(
+					value = "INVOKE",
+					target = "Lnet/minecraft/item/ItemStack;getOrDefault(Lnet/minecraft/component/ComponentType;Ljava/lang/Object;)Ljava/lang/Object;"
+			)
+	)
+	public Object appendAttributeModifiersTooltip(ItemStack stack, ComponentType<AttributeModifiersComponent> type, Object fallback) {
+		return getItem().getAttributeModifiers(stack);
+	}
+
+	@Redirect(
+			method = {"applyAttributeModifier", "applyAttributeModifiers"},
+			at = @At(
+					value = "INVOKE",
+					target = "Lnet/minecraft/item/Item;getAttributeModifiers()Lnet/minecraft/component/type/AttributeModifiersComponent;"
+			)
+	)
+	public AttributeModifiersComponent applyAttributeModifiers(Item item) {
+		ItemStack stack = (ItemStack) (Object) this;
+		return item.getAttributeModifiers(stack);
 	}
 }


### PR DESCRIPTION
Added an ItemStack mixin to call `FabricItem.getAttributeModifiers(ItemStack)`.
Similar to #3797, but for 1.21.
Resolves #3787

I tested it on a dev client&server and a prod client&server, and I didn't encounter any issue.
