### PR TITLE
Use identifier path composition methods

### DIFF
--- a/fabric-object-builder-api-v1/src/client/java/net/fabricmc/fabric/mixin/object/builder/client/EntityModelLayersMixin.java
+++ b/fabric-object-builder-api-v1/src/client/java/net/fabricmc/fabric/mixin/object/builder/client/EntityModelLayersMixin.java
@@ -32,7 +32,7 @@ public class EntityModelLayersMixin {
 	private static void createSign(WoodType type, CallbackInfoReturnable<EntityModelLayer> cir) {
 		if (type.name().indexOf(Identifier.NAMESPACE_SEPARATOR) != -1) {
 			Identifier identifier = Identifier.of(type.name());
-			cir.setReturnValue(new EntityModelLayer(Identifier.of(identifier.getNamespace(), "sign/" + identifier.getPath()), "main"));
+			cir.setReturnValue(new EntityModelLayer(identifier.withPrefixedPath("sign/"), "main"));
 		}
 	}
 
@@ -40,7 +40,7 @@ public class EntityModelLayersMixin {
 	private static void createHangingSign(WoodType type, CallbackInfoReturnable<EntityModelLayer> cir) {
 		if (type.name().indexOf(Identifier.NAMESPACE_SEPARATOR) != -1) {
 			Identifier identifier = Identifier.of(type.name());
-			cir.setReturnValue(new EntityModelLayer(Identifier.of(identifier.getNamespace(), "hanging_sign/" + identifier.getPath()), "main"));
+			cir.setReturnValue(new EntityModelLayer(identifier.withPrefixedPath("hanging_sign/"), "main"));
 		}
 	}
 }

--- a/fabric-object-builder-api-v1/src/client/java/net/fabricmc/fabric/mixin/object/builder/client/HangingSignEditScreenMixin.java
+++ b/fabric-object-builder-api-v1/src/client/java/net/fabricmc/fabric/mixin/object/builder/client/HangingSignEditScreenMixin.java
@@ -36,7 +36,7 @@ public abstract class HangingSignEditScreenMixin extends AbstractSignEditScreen 
 	private Identifier init(String id, Operation<Identifier> original) {
 		if (signType.name().indexOf(Identifier.NAMESPACE_SEPARATOR) != -1) {
 			Identifier identifier = Identifier.of(signType.name());
-			return Identifier.of(identifier.getNamespace(), "textures/gui/hanging_signs/" + identifier.getPath() + ".png");
+			return identifier.withPath(path -> "textures/gui/hanging_signs/" + path + ".png");
 		}
 
 		return original.call(id);

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/FabricShaderProgram.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/FabricShaderProgram.java
@@ -40,6 +40,6 @@ public final class FabricShaderProgram extends ShaderProgram {
 	 */
 	public static Identifier rewriteAsId(String input, String containedId) {
 		Identifier contained = Identifier.of(containedId);
-		return Identifier.of(contained.getNamespace(), input.replace(containedId, contained.getPath()));
+		return contained.withPath(path -> input.replace(containedId, path));
 	}
 }


### PR DESCRIPTION
This pull request has no behavioral changes; it just replaces usages of `Identifier.of` where using more specific methods that operate on the path only would be more clear.