### PR TITLE
fix!: ClientConfigurationConnectionEvents

### DIFF
--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientConfigurationConnectionEvents.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientConfigurationConnectionEvents.java
@@ -28,13 +28,23 @@ import net.fabricmc.fabric.api.event.EventFactory;
  */
 public final class ClientConfigurationConnectionEvents {
 	/**
-	 * Event indicating a connection entering the CONFIGURATION state, ready for registering channel handlers.
+	 * Event indicating a connection is about to entering the CONFIGURATION state, ready for registering channel handlers.
+	 * <p>No custom packets should be sent when this event is invoked.
 	 *
 	 * @see ClientConfigurationNetworking#registerReceiver(CustomPayload.Id, ClientConfigurationNetworking.ConfigurationPayloadHandler)
 	 */
 	public static final Event<ClientConfigurationConnectionEvents.Init> INIT = EventFactory.createArrayBacked(ClientConfigurationConnectionEvents.Init.class, callbacks -> (handler, client) -> {
 		for (ClientConfigurationConnectionEvents.Init callback : callbacks) {
 			callback.onConfigurationInit(handler, client);
+		}
+	});
+
+	/**
+	 * Event indicating a connection has entered the CONFIGURATION state, ready for sending packets.
+	 */
+	public static final Event<ClientConfigurationConnectionEvents.Start> START = EventFactory.createArrayBacked(ClientConfigurationConnectionEvents.Start.class, callbacks -> (handler, client) -> {
+		for (ClientConfigurationConnectionEvents.Start callback : callbacks) {
+			callback.onConfigurationStart(handler, client);
 		}
 	});
 
@@ -66,6 +76,11 @@ public final class ClientConfigurationConnectionEvents {
 	@FunctionalInterface
 	public interface Init {
 		void onConfigurationInit(ClientConfigurationNetworkHandler handler, MinecraftClient client);
+	}
+
+	@FunctionalInterface
+	public interface Start {
+		void onConfigurationStart(ClientConfigurationNetworkHandler handler, MinecraftClient client);
 	}
 
 	@FunctionalInterface

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientConfigurationConnectionEvents.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientConfigurationConnectionEvents.java
@@ -29,6 +29,7 @@ import net.fabricmc.fabric.api.event.EventFactory;
 public final class ClientConfigurationConnectionEvents {
 	/**
 	 * Event indicating a connection is about to entering the CONFIGURATION state, ready for registering channel handlers.
+	 *
 	 * <p>No custom packets should be sent when this event is invoked.
 	 *
 	 * @see ClientConfigurationNetworking#registerReceiver(CustomPayload.Id, ClientConfigurationNetworking.ConfigurationPayloadHandler)
@@ -42,8 +43,8 @@ public final class ClientConfigurationConnectionEvents {
 	/**
 	 * Event indicating a connection has entered the CONFIGURATION state, ready for sending packets.
 	 */
-	public static final Event<ClientConfigurationConnectionEvents.Start> START = EventFactory.createArrayBacked(ClientConfigurationConnectionEvents.Start.class, callbacks -> (handler, client) -> {
-		for (ClientConfigurationConnectionEvents.Start callback : callbacks) {
+	public static final Event<Configure> CONFIGURE = EventFactory.createArrayBacked(Configure.class, callbacks -> (handler, client) -> {
+		for (ClientConfigurationConnectionEvents.Configure callback : callbacks) {
 			callback.onConfigurationStart(handler, client);
 		}
 	});
@@ -53,9 +54,9 @@ public final class ClientConfigurationConnectionEvents {
 	 *
 	 * <p>No packets should be sent when this event is invoked.
 	 */
-	public static final Event<ClientConfigurationConnectionEvents.Ready> READY = EventFactory.createArrayBacked(ClientConfigurationConnectionEvents.Ready.class, callbacks -> (handler, client) -> {
-		for (ClientConfigurationConnectionEvents.Ready callback : callbacks) {
-			callback.onConfigurationReady(handler, client);
+	public static final Event<Complete> COMPLETE = EventFactory.createArrayBacked(Complete.class, callbacks -> (handler, client) -> {
+		for (ClientConfigurationConnectionEvents.Complete callback : callbacks) {
+			callback.onConfigurationComplete(handler, client);
 		}
 	});
 
@@ -79,13 +80,13 @@ public final class ClientConfigurationConnectionEvents {
 	}
 
 	@FunctionalInterface
-	public interface Start {
+	public interface Configure {
 		void onConfigurationStart(ClientConfigurationNetworkHandler handler, MinecraftClient client);
 	}
 
 	@FunctionalInterface
-	public interface Ready {
-		void onConfigurationReady(ClientConfigurationNetworkHandler handler, MinecraftClient client);
+	public interface Complete {
+		void onConfigurationComplete(ClientConfigurationNetworkHandler handler, MinecraftClient client);
 	}
 
 	@FunctionalInterface

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientConfigurationNetworkAddon.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientConfigurationNetworkAddon.java
@@ -60,8 +60,9 @@ public final class ClientConfigurationNetworkAddon extends ClientCommonNetworkAd
 		try {
 			ClientConfigurationConnectionEvents.CONFIGURE.invoker().onConfigurationStart(this.handler, this.client);
 		} catch (RuntimeException e) {
-			LOGGER.error("Exception thrown while invoking ClientConfigurationConnectionEvents.START", e);
+			LOGGER.error("Exception thrown while invoking ClientConfigurationConnectionEvents.CONFIGURE", e);
 		}
+
 		super.onServerReady();
 	}
 

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientConfigurationNetworkAddon.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientConfigurationNetworkAddon.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.impl.networking.client;
 
+import static net.fabricmc.fabric.impl.networking.NetworkingImpl.LOGGER;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -51,6 +53,16 @@ public final class ClientConfigurationNetworkAddon extends ClientCommonNetworkAd
 	@Override
 	protected void invokeInitEvent() {
 		ClientConfigurationConnectionEvents.INIT.invoker().onConfigurationInit(this.handler, this.client);
+	}
+
+	@Override
+	public void onServerReady() {
+		try {
+			ClientConfigurationConnectionEvents.START.invoker().onConfigurationStart(this.handler, this.client);
+		} catch (RuntimeException e) {
+			LOGGER.error("Exception thrown while invoking ClientConfigurationConnectionEvents.START", e);
+		}
+		super.onServerReady();
 	}
 
 	@Override

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientConfigurationNetworkAddon.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientConfigurationNetworkAddon.java
@@ -73,6 +73,8 @@ public final class ClientConfigurationNetworkAddon extends ClientCommonNetworkAd
 		if (register && !this.sentInitialRegisterPacket) {
 			this.sendInitialChannelRegistrationPacket();
 			this.sentInitialRegisterPacket = true;
+
+			this.onServerReady();
 		}
 	}
 

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientConfigurationNetworkAddon.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientConfigurationNetworkAddon.java
@@ -58,7 +58,7 @@ public final class ClientConfigurationNetworkAddon extends ClientCommonNetworkAd
 	@Override
 	public void onServerReady() {
 		try {
-			ClientConfigurationConnectionEvents.START.invoker().onConfigurationStart(this.handler, this.client);
+			ClientConfigurationConnectionEvents.CONFIGURE.invoker().onConfigurationStart(this.handler, this.client);
 		} catch (RuntimeException e) {
 			LOGGER.error("Exception thrown while invoking ClientConfigurationConnectionEvents.START", e);
 		}
@@ -97,7 +97,7 @@ public final class ClientConfigurationNetworkAddon extends ClientCommonNetworkAd
 	}
 
 	public void handleReady() {
-		ClientConfigurationConnectionEvents.READY.invoker().onConfigurationReady(this.handler, this.client);
+		ClientConfigurationConnectionEvents.COMPLETE.invoker().onConfigurationComplete(this.handler, this.client);
 		ClientNetworkingImpl.setClientConfigurationAddon(null);
 	}
 

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/ClientLoginNetworkHandlerMixin.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/ClientLoginNetworkHandlerMixin.java
@@ -30,7 +30,6 @@ import net.minecraft.network.ClientConnection;
 import net.minecraft.network.packet.s2c.login.LoginQueryRequestS2CPacket;
 
 import net.fabricmc.fabric.impl.networking.NetworkHandlerExtensions;
-import net.fabricmc.fabric.impl.networking.client.ClientConfigurationNetworkAddon;
 import net.fabricmc.fabric.impl.networking.client.ClientLoginNetworkAddon;
 import net.fabricmc.fabric.impl.networking.payload.PacketByteBufLoginQueryRequestPayload;
 
@@ -63,12 +62,6 @@ abstract class ClientLoginNetworkHandlerMixin implements NetworkHandlerExtension
 				payload.data().skipBytes(payload.data().readableBytes());
 			}
 		}
-	}
-
-	@Inject(method = "onSuccess", at = @At("TAIL"))
-	private void handleConfigurationReady(CallbackInfo ci) {
-		NetworkHandlerExtensions networkHandlerExtensions = (NetworkHandlerExtensions) connection.getPacketListener();
-		((ClientConfigurationNetworkAddon) networkHandlerExtensions.getAddon()).onServerReady();
 	}
 
 	@Override

--- a/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/configuration/NetworkingConfigurationTest.java
+++ b/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/configuration/NetworkingConfigurationTest.java
@@ -30,6 +30,7 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.api.networking.v1.ServerConfigurationConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerConfigurationNetworking;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.test.networking.NetworkingTestmods;
 
 /**
@@ -59,11 +60,13 @@ public class NetworkingConfigurationTest implements ModInitializer {
 
 		ServerConfigurationNetworking.registerGlobalReceiver(ConfigurationCompletePacket.ID, (packet, context) -> {
 			context.networkHandler().completeTask(TestConfigurationTask.KEY);
+		});
+
+		ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> {
 			if (!clientHelloReceived) {
 				throw new IllegalStateException("Client did not send hello packet before completing configuration");
 			}
 		});
-
 	}
 
 	public record TestConfigurationTask(String data) implements ServerPlayerConfigurationTask {

--- a/fabric-networking-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/networking/client/configuration/NetworkingConfigurationClientTest.java
+++ b/fabric-networking-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/networking/client/configuration/NetworkingConfigurationClientTest.java
@@ -17,12 +17,21 @@
 package net.fabricmc.fabric.test.networking.client.configuration;
 
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.networking.v1.ClientConfigurationConnectionEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientConfigurationNetworking;
 import net.fabricmc.fabric.test.networking.configuration.NetworkingConfigurationTest;
 
 public class NetworkingConfigurationClientTest implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
+		ClientConfigurationConnectionEvents.CONFIGURE.register((handler, client) -> {
+			if (ClientConfigurationNetworking.canSend(NetworkingConfigurationTest.ConfigurationClientHelloPacket.ID)) {
+				ClientConfigurationNetworking.send(NetworkingConfigurationTest.ConfigurationClientHelloPacket.INSTANCE);
+			} else {
+				throw new RuntimeException("Server does not support ConfigurationClientHelloPacket");
+			}
+		});
+
 		ClientConfigurationNetworking.registerGlobalReceiver(NetworkingConfigurationTest.ConfigurationPacket.ID, (packet, context) -> {
 			// Handle stuff here
 


### PR DESCRIPTION
fix #3830

# Breaking Changes
ClientConfigurationConnectionEvents.READY was renamed to COMPLETE