### PR TITLE
Fix incorrect tag warnings, and add fail option.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -432,6 +432,8 @@ loom {
 			inherit testmodClient
 			name "Auto Test Client"
 			vmArg "-Dfabric.autoTest"
+			vmArg "-Dfabric-tag-conventions-v2.missingTagTranslationWarning=fail"
+			vmArg "-Dfabric-tag-conventions-v1.legacyTagWarning=fail"
 		}
 
 		// Create duplicate tasks for this, as jacoco slows things down a bit
@@ -525,6 +527,8 @@ tasks.register('runProductionAutoTestClient', JavaExec) {
 		jvmArgs(
 				"-Dfabric.addMods=${remapJar.archiveFile.get().asFile.absolutePath}${File.pathSeparator}${remapTestmodJar.archiveFile.get().asFile.absolutePath}",
 				"-Dfabric.autoTest",
+				"-Dfabric-tag-conventions-v2.missingTagTranslationWarning=fail",
+				"-Dfabric-tag-conventions-v1.legacyTagWarning=fail"
 				)
 		jvmArgs(debugArgs)
 	}

--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/EnglishTagLangGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/EnglishTagLangGenerator.java
@@ -265,6 +265,7 @@ public class EnglishTagLangGenerator extends FabricLanguageProvider {
 		translationBuilder.add(ConventionalItemTags.PLAYER_WORKSTATIONS_CRAFTING_TABLES, "Crafting Tables");
 		translationBuilder.add(ConventionalItemTags.PLAYER_WORKSTATIONS_FURNACES, "Furnaces");
 		translationBuilder.add(ConventionalItemTags.STRINGS, "Strings");
+		translationBuilder.add(ConventionalItemTags.LEATHERS, "Leathers");
 		translationBuilder.add(ConventionalItemTags.MUSIC_DISCS, "Music Discs");
 		translationBuilder.add(ConventionalItemTags.RODS, "Rods");
 		translationBuilder.add(ConventionalItemTags.WOODEN_RODS, "Wooden Rods");

--- a/fabric-convention-tags-v2/src/generated/resources/assets/fabric-convention-tags-v2/lang/en_us.json
+++ b/fabric-convention-tags-v2/src/generated/resources/assets/fabric-convention-tags-v2/lang/en_us.json
@@ -176,6 +176,7 @@
   "tag.item.c.ingots.gold": "Gold Ingots",
   "tag.item.c.ingots.iron": "Iron Ingots",
   "tag.item.c.ingots.netherite": "Netherite Ingots",
+  "tag.item.c.leathers": "Leathers",
   "tag.item.c.music_discs": "Music Discs",
   "tag.item.c.nuggets": "Nuggets",
   "tag.item.c.ores": "Ores",

--- a/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/impl/tag/convention/v2/TranslationConventionLogWarnings.java
+++ b/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/impl/tag/convention/v2/TranslationConventionLogWarnings.java
@@ -59,7 +59,12 @@ public class TranslationConventionLogWarnings implements ModInitializer {
 	private enum LogWarningMode {
 		SILENCED,
 		SHORT,
-		VERBOSE
+		VERBOSE,
+		FAIL;
+
+		boolean verbose() {
+			return this == VERBOSE || this == FAIL;
+		}
 	}
 
 	public void onInitialize() {
@@ -99,9 +104,7 @@ public class TranslationConventionLogWarnings implements ModInitializer {
 					""");
 
 			// Print out all untranslated tags when desired.
-			boolean isConfigSetToVerbose = LOG_UNTRANSLATED_WARNING_MODE == LogWarningMode.VERBOSE;
-
-			if (isConfigSetToVerbose) {
+			if (LOG_UNTRANSLATED_WARNING_MODE.verbose()) {
 				stringBuilder.append("\nUntranslated item tags:");
 
 				for (TagKey<Item> tagKey : untranslatedItemTags) {
@@ -110,6 +113,10 @@ public class TranslationConventionLogWarnings implements ModInitializer {
 			}
 
 			LOGGER.warn(stringBuilder.toString());
+
+			if (LOG_UNTRANSLATED_WARNING_MODE == LogWarningMode.FAIL) {
+				throw new RuntimeException("Tag translation validation failed");
+			}
 		});
 	}
 }

--- a/fabric-resource-conditions-api-v1/src/testmod/resources/assets/fabric-resource-conditions-api-v1-testmod/lang/en_us.json
+++ b/fabric-resource-conditions-api-v1/src/testmod/resources/assets/fabric-resource-conditions-api-v1-testmod/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+  "tag.item.fabric-resource-conditions-api-v1-testmod.test_condition": "Test Condition"
+}


### PR DESCRIPTION
Fix incorrect tag warnings when only running with Fabric API
Add option to crash the game if either the legacy or translation checks fail
Set the above option for the auto test client, and the testmod IDE run config.