### PR TITLE
Remove unnecessary local capture

### DIFF
--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/WorldChunkMixin.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/WorldChunkMixin.java
@@ -45,7 +45,7 @@ abstract class WorldChunkMixin {
 	public abstract World getWorld();
 
 	@Inject(method = "setBlockEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/entity/BlockEntity;markRemoved()V"))
-	private void onLoadBlockEntity(BlockEntity blockEntity, CallbackInfo ci, @Local(ordinal = 1) BlockEntity removedBlockEntity) {
+	private void onLoadBlockEntity(BlockEntity blockEntity, CallbackInfo ci) {
 		if (this.getWorld() instanceof ServerWorld) {
 			ServerBlockEntityEvents.BLOCK_ENTITY_LOAD.invoker().onLoad(blockEntity, (ServerWorld) this.getWorld());
 		} else if (this.getWorld() instanceof ClientWorld) {


### PR DESCRIPTION
This was used in the past, however its no longer being used. So the local capture is being checked for no reason.