### PR TITLE
Add eggs common tag

### DIFF
--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/EnglishTagLangGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/EnglishTagLangGenerator.java
@@ -274,6 +274,7 @@ public class EnglishTagLangGenerator extends FabricLanguageProvider {
 		translationBuilder.add(ConventionalItemTags.ROPES, "Ropes");
 		translationBuilder.add(ConventionalItemTags.CHAINS, "Chains");
 		translationBuilder.add(ConventionalItemTags.HIDDEN_FROM_RECIPE_VIEWERS, "Hidden From Recipe Viewers");
+		translationBuilder.add(ConventionalItemTags.EGGS, "Eggs");
 
 		// Enchantments
 		translationBuilder.add(ConventionalEnchantmentTags.INCREASE_BLOCK_DROPS, "Increases Block Drops");

--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/ItemTagGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/ItemTagGenerator.java
@@ -578,6 +578,9 @@ public final class ItemTagGenerator extends FabricTagProvider.ItemTagProvider {
 				.add(Items.CHAIN);
 
 		getOrCreateTagBuilder(ConventionalItemTags.HIDDEN_FROM_RECIPE_VIEWERS); // Generate tag so others can see it exists through JSON.
+
+		getOrCreateTagBuilder(ConventionalItemTags.EGGS)
+				.add(Items.EGG);
 	}
 
 	private void generateDyedTags() {

--- a/fabric-convention-tags-v2/src/generated/resources/assets/fabric-convention-tags-v2/lang/en_us.json
+++ b/fabric-convention-tags-v2/src/generated/resources/assets/fabric-convention-tags-v2/lang/en_us.json
@@ -145,6 +145,7 @@
   "tag.item.c.dyes.red": "Red Dyes",
   "tag.item.c.dyes.white": "White Dyes",
   "tag.item.c.dyes.yellow": "Yellow Dyes",
+  "tag.item.c.eggs": "Eggs",
   "tag.item.c.enchantables": "Enchantables",
   "tag.item.c.foods": "Foods",
   "tag.item.c.foods.berries": "Berries",

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/eggs.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/eggs.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:egg"
+  ]
+}

--- a/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalItemTags.java
+++ b/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalItemTags.java
@@ -302,6 +302,11 @@ public final class ConventionalItemTags {
 	public static final TagKey<Item> HIDDEN_FROM_RECIPE_VIEWERS = register("hidden_from_recipe_viewers");
 
 	/**
+	 * For eggs that are like chicken eggs, used for recipes.
+	 */
+	public static final TagKey<Item> EGGS = register("eggs");
+
+	/**
 	 * This tag is redundant. Please use {@link ConventionalItemTags#STORAGE_BLOCKS} tag instead.
 	 */
 	@Deprecated


### PR DESCRIPTION
This adds the eggs tag which is present on neoforge but is not on fabric, this is a very useful tags as it allows use of common eggs between platforms especially for recipes, several mods add their own egg to this tag but vanillas chicken egg is not in there by default unless a mod adds it which causes issues or is just slightly annoying that if you want to use it you either have to have an or for the tag and the vanilla item or you have to add the vanilla item yourself to the tag.