### PR TITLE
Cleanup usages of `Text`

### DIFF
--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientCommandSourceMixin.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientCommandSourceMixin.java
@@ -43,7 +43,7 @@ abstract class ClientCommandSourceMixin implements FabricClientCommandSource {
 
 	@Override
 	public void sendError(Text message) {
-		sendFeedback(Text.literal("").append(message).formatted(Formatting.RED));
+		sendFeedback(Text.empty().append(message).formatted(Formatting.RED));
 	}
 
 	@Override

--- a/fabric-game-rule-api-v1/src/client/java/net/fabricmc/fabric/impl/gamerule/widget/DoubleRuleWidget.java
+++ b/fabric-game-rule-api-v1/src/client/java/net/fabricmc/fabric/impl/gamerule/widget/DoubleRuleWidget.java
@@ -22,6 +22,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.world.EditGameRulesScreen;
 import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.screen.ScreenTexts;
 import net.minecraft.text.OrderedText;
 import net.minecraft.text.Text;
 
@@ -37,9 +38,9 @@ public final class DoubleRuleWidget extends EditGameRulesScreen.NamedRuleWidget 
 
 		this.textFieldWidget = new TextFieldWidget(MinecraftClient.getInstance().textRenderer, 10, 5, 42, 20,
 				name.copy()
-				.append("\n")
+				.append(ScreenTexts.LINE_BREAK)
 				.append(ruleName)
-				.append("\n")
+				.append(ScreenTexts.LINE_BREAK)
 		);
 
 		this.textFieldWidget.setText(Double.toString(rule.get()));

--- a/fabric-game-rule-api-v1/src/client/java/net/fabricmc/fabric/impl/gamerule/widget/EnumRuleWidget.java
+++ b/fabric-game-rule-api-v1/src/client/java/net/fabricmc/fabric/impl/gamerule/widget/EnumRuleWidget.java
@@ -23,7 +23,6 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.world.EditGameRulesScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.resource.language.I18n;
 import net.minecraft.text.OrderedText;
 import net.minecraft.text.Text;
 
@@ -51,12 +50,7 @@ public final class EnumRuleWidget<E extends Enum<E>> extends EditGameRulesScreen
 
 	public Text getValueText(E value) {
 		final String key = this.rootTranslationKey + "." + value.name().toLowerCase(Locale.ROOT);
-
-		if (I18n.hasTranslation(key)) {
-			return Text.translatable(key);
-		}
-
-		return Text.literal(value.toString());
+		return Text.translatableWithFallback(key, value.toString());
 	}
 
 	@Override

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
@@ -36,6 +36,9 @@ import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.objects.Object2IntLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
+
+import net.minecraft.screen.ScreenTexts;
+
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
@@ -349,7 +352,7 @@ public final class RegistrySyncManager {
 
 		for (int i = 0; i < Math.min(namespaces.size(), toDisplay); i++) {
 			text = text.append(Text.literal(namespaces.get(i)).formatted(Formatting.YELLOW));
-			text = text.append("\n");
+			text = text.append(ScreenTexts.LINE_BREAK);
 		}
 
 		if (namespaces.size() > toDisplay) {

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
@@ -36,9 +36,6 @@ import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.objects.Object2IntLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
-
-import net.minecraft.screen.ScreenTexts;
-
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
@@ -49,6 +46,7 @@ import net.minecraft.network.packet.Packet;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
+import net.minecraft.screen.ScreenTexts;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerConfigurationNetworkHandler;
 import net.minecraft.server.network.ServerPlayerConfigurationTask;

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
@@ -325,7 +325,7 @@ public final class RegistrySyncManager {
 		}
 
 		// Create a nice user friendly error message.
-		MutableText text = Text.literal("");
+		MutableText text = Text.empty();
 
 		final int count = missingEntries.values().stream().mapToInt(List::size).sum();
 


### PR DESCRIPTION
- Replace usages of `Text.literal("")` with `Text.empty()` to remove a redundant empty `LiteralTextContent` object allocation
- Replace usages of newline literals with `ScreenTexts.LINE_BREAK`
- Replace manual translation with fallback in `EnumRuleWidget` with `Text.translatableWithFallback`