### PR TITLE
Add tests for convention tag keys matching field names

### DIFF
--- a/fabric-convention-tags-v2/src/testmod/java/net/fabricmc/fabric/test/tag/convention/v2/TagUtilTest.java
+++ b/fabric-convention-tags-v2/src/testmod/java/net/fabricmc/fabric/test/tag/convention/v2/TagUtilTest.java
@@ -16,12 +16,20 @@
 
 package net.fabricmc.fabric.test.tag.convention.v2;
 
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import org.objectweb.asm.Opcodes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.minecraft.block.Blocks;
 import net.minecraft.enchantment.Enchantments;
 import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.tag.TagKey;
 import net.minecraft.world.biome.BiomeKeys;
 
 import net.fabricmc.api.ModInitializer;
@@ -29,13 +37,124 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.tag.convention.v2.ConventionalBiomeTags;
 import net.fabricmc.fabric.api.tag.convention.v2.ConventionalBlockTags;
 import net.fabricmc.fabric.api.tag.convention.v2.ConventionalEnchantmentTags;
+import net.fabricmc.fabric.api.tag.convention.v2.ConventionalEntityTypeTags;
+import net.fabricmc.fabric.api.tag.convention.v2.ConventionalFluidTags;
+import net.fabricmc.fabric.api.tag.convention.v2.ConventionalItemTags;
+import net.fabricmc.fabric.api.tag.convention.v2.ConventionalStructureTags;
 import net.fabricmc.fabric.api.tag.convention.v2.TagUtil;
 
 public class TagUtilTest implements ModInitializer {
 	private static final Logger LOGGER = LoggerFactory.getLogger(TagUtilTest.class);
 
+	private static final Class<?>[] TAG_CLASSES = {
+			ConventionalBiomeTags.class,
+			ConventionalBlockTags.class,
+			ConventionalEnchantmentTags.class,
+			ConventionalEntityTypeTags.class,
+			ConventionalFluidTags.class,
+			ConventionalItemTags.class,
+			ConventionalStructureTags.class,
+	};
+
+	// Think twice before choosing an inconsistent name
+	private static final Set<TagKey<?>> IGNORED_TAGS = Set.of(
+			ConventionalBiomeTags.IS_CONIFEROUS_TREE,
+			ConventionalBiomeTags.IS_DECIDUOUS_TREE,
+			ConventionalBiomeTags.IS_JUNGLE_TREE,
+			ConventionalBiomeTags.IS_SAVANNA_TREE,
+			ConventionalBiomeTags.IS_VEGETATION_DENSE,
+			ConventionalBiomeTags.IS_VEGETATION_DENSE_OVERWORLD,
+			ConventionalBiomeTags.IS_VEGETATION_SPARSE,
+			ConventionalBiomeTags.IS_VEGETATION_SPARSE_OVERWORLD,
+
+			ConventionalBlockTags.RED_SANDSTONE_BLOCKS,
+			ConventionalBlockTags.RED_SANDSTONE_SLABS,
+			ConventionalBlockTags.RED_SANDSTONE_STAIRS,
+			ConventionalBlockTags.UNCOLORED_SANDSTONE_BLOCKS,
+			ConventionalBlockTags.UNCOLORED_SANDSTONE_SLABS,
+			ConventionalBlockTags.UNCOLORED_SANDSTONE_STAIRS,
+
+			ConventionalItemTags.RED_SANDSTONE_BLOCKS,
+			ConventionalItemTags.RED_SANDSTONE_SLABS,
+			ConventionalItemTags.RED_SANDSTONE_STAIRS,
+			ConventionalItemTags.UNCOLORED_SANDSTONE_BLOCKS,
+			ConventionalItemTags.UNCOLORED_SANDSTONE_SLABS,
+			ConventionalItemTags.UNCOLORED_SANDSTONE_STAIRS
+	);
+
+	private static boolean isValidTagField(Field field) {
+		if ((field.getModifiers() & Opcodes.ACC_STATIC) == 0) {
+			// Ignore instance fields
+			return false;
+		}
+
+		if (field.getType() != TagKey.class) {
+			// Ignore fields that are not of type TagKey<?>
+			return false;
+		}
+
+		if (field.getAnnotation(Deprecated.class) != null) {
+			// Ignore deprecated fields
+			return false;
+		}
+
+		return true;
+	}
+
+	private static void validateTagKey(TagKey<?> key, Field field, Class<?> clazz) {
+		String path = key.id().getPath();
+		String uppercasePath = path.toUpperCase(Locale.ROOT);
+
+		String expected = field.getName();
+		String[] acceptables;
+
+		if (uppercasePath.contains("/")) {
+			String[] parts = uppercasePath.split("/");
+			List<String> reversedParts = List.of(parts).reversed();
+
+			acceptables = new String[] {
+				String.join("_", parts),
+				String.join("_", reversedParts),
+			};
+		} else {
+			acceptables = new String[] {
+				uppercasePath,
+			};
+		}
+
+		boolean found = false;
+
+		for (String acceptable : acceptables) {
+			if (expected.equals(acceptable)) {
+				found = true;
+				break;
+			}
+		}
+
+		if (!found) {
+			String fullName = clazz.getSimpleName() + "." + expected;
+			throw new AssertionError("Expected field " + fullName + " to match one of " + Arrays.toString(acceptables) + " for tag " + key);
+		}
+	}
+
 	@Override
 	public void onInitialize() {
+		for (Class<?> clazz : TAG_CLASSES) {
+			for (Field field : clazz.getFields()) {
+				if (isValidTagField(field)) {
+					try {
+						TagKey<?> key = (TagKey<?>) field.get(null);
+
+						if (!IGNORED_TAGS.contains(key)) {
+							validateTagKey(key, field, clazz);
+						}
+					} catch (IllegalAccessException | IllegalArgumentException e) {
+						throw new AssertionError("Failed to access field " + field, e);
+					}
+				}
+			}
+		}
+
 		ServerLifecycleEvents.SERVER_STARTED.register(server -> {
 			if (!TagUtil.isIn(server.getRegistryManager(), ConventionalEnchantmentTags.INCREASE_BLOCK_DROPS, server.getRegistryManager().get(RegistryKeys.ENCHANTMENT).get(Enchantments.FORTUNE))) {
 				throw new AssertionError("Failed to find fortune in c:increase_block_drops!");

--- a/fabric-convention-tags-v2/src/testmod/java/net/fabricmc/fabric/test/tag/convention/v2/TagUtilTest.java
+++ b/fabric-convention-tags-v2/src/testmod/java/net/fabricmc/fabric/test/tag/convention/v2/TagUtilTest.java
@@ -17,12 +17,12 @@
 package net.fabricmc.fabric.test.tag.convention.v2;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-import org.objectweb.asm.Opcodes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,7 +83,7 @@ public class TagUtilTest implements ModInitializer {
 	);
 
 	private static boolean isValidTagField(Field field) {
-		if ((field.getModifiers() & Opcodes.ACC_STATIC) == 0) {
+		if (!Modifier.isStatic(field.getModifiers())) {
 			// Ignore instance fields
 			return false;
 		}


### PR DESCRIPTION
Issues such as #3921 can be prevented through automated tests, so this pull request introduces said tests.