### PR TITLE
Fix some registry-related bugs

### DIFF
--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/modification/BiomeModificationImpl.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/modification/BiomeModificationImpl.java
@@ -21,6 +21,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -35,6 +36,8 @@ import net.minecraft.registry.DynamicRegistryManager;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.SimpleRegistry;
+import net.minecraft.registry.entry.RegistryEntryInfo;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.gen.feature.util.PlacedFeatureIndexer;
@@ -165,6 +168,12 @@ public class BiomeModificationImpl {
 							)
 						);
 					});
+				}
+
+				if (biomes instanceof SimpleRegistry<Biome> registry) {
+					RegistryEntryInfo info = registry.keyToEntryInfo.get(key);
+					RegistryEntryInfo newInfo = new RegistryEntryInfo(Optional.empty(), info.lifecycle());
+					registry.keyToEntryInfo.put(key, newInfo);
 				}
 			}
 		}

--- a/fabric-biome-api-v1/src/main/resources/fabric-biome-api-v1.accesswidener
+++ b/fabric-biome-api-v1/src/main/resources/fabric-biome-api-v1.accesswidener
@@ -59,3 +59,6 @@ mutable field net/minecraft/world/biome/GenerationSettings allowedFeatures Ljava
 # ChunkGenerator
 accessible field net/minecraft/world/gen/chunk/ChunkGenerator indexedFeaturesListSupplier Ljava/util/function/Supplier;
 mutable field net/minecraft/world/gen/chunk/ChunkGenerator indexedFeaturesListSupplier Ljava/util/function/Supplier;
+
+# Registry mutation sync
+accessible field net/minecraft/registry/SimpleRegistry keyToEntryInfo Ljava/util/Map;

--- a/fabric-registry-sync-v0/src/main/resources/fabric-registry-sync-v0.mixins.json
+++ b/fabric-registry-sync-v0/src/main/resources/fabric-registry-sync-v0.mixins.json
@@ -11,11 +11,11 @@
     "MainMixin",
     "RegistriesAccessor",
     "RegistriesMixin",
+    "RegistryKeysMixin",
     "RegistryLoaderMixin",
     "SaveLoadingMixin",
     "SerializableRegistriesMixin",
-    "SimpleRegistryMixin",
-    "TagManagerLoaderMixin"
+    "SimpleRegistryMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Resolves #3894
Resolves #3897

The KPI-stripping code might be useful for other mods, however I don't think it is something we should offer as API yet. Nor would it make sense for us to keep them as RegSync internals that only Biome API uses.