### PR TITLE
Fix crash when using custom render layers in BLOCK_OUTLINE event

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
@@ -25,6 +25,7 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.At.Shift;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.block.BlockState;
@@ -123,11 +124,15 @@ public abstract class WorldRendererMixin {
 			if (!WorldRenderEvents.BLOCK_OUTLINE.invoker().onBlockOutline(context, context)) {
 				ci.cancel();
 			}
-
-			// The immediate mode VertexConsumers use a shared buffer, so we have to make sure that the immediate mode VCP
-			// can accept block outline lines rendered to the existing vertexConsumer by the vanilla block overlay.
-			context.consumers().getBuffer(RenderLayer.getLines());
 		}
+	}
+
+	@SuppressWarnings("ConstantConditions")
+	@ModifyVariable(method = "drawBlockOutline", at = @At("HEAD"))
+	private VertexConsumer resetBlockOutlineBuffer(VertexConsumer vertexConsumer) {
+		// The original VertexConsumer may have been ended during the block outlines event, so we
+		// have to re-request it to prevent a crash when the vanilla block overlay is submitted.
+		return context.consumers().getBuffer(RenderLayer.getLines());
 	}
 
 	@Inject(


### PR DESCRIPTION
This PR fixes a crash when a mod requests a custom render layer during the `WorldRenderEvents#BLOCK_OUTLINE` event as described in #3939.

Originally, the `WorldRendererMixin#onDrawBlockOutline` mixin simply requested a buffer for `RenderLayer#LINES` after firing the `WorldRenderEvents#BLOCK_OUTLINE` event and ignored the returned value. This meant the `VertexConsumer` argument in `WorldRenderer#drawBlockOutline` still held the original value and thus the vanilla block outline may try to submit vertices to it while it has already been ended.
This PR uses a `ModifyVariable` mixin to modify the `VertexConsumer` argument in `WorldRenderer#drawBlockOutline` with a newly requested buffer for `RenderLayer#LINES`, thus making sure the vanilla block outline does not cause a crash.