### PR TITLE
Use `ConcurrentHashMap` inside `RegistryAttributeImpl`

### DIFF
--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistryAttributeImpl.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistryAttributeImpl.java
@@ -17,8 +17,8 @@
 package net.fabricmc.fabric.impl.registry.sync;
 
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import net.minecraft.registry.RegistryKey;
 
@@ -26,7 +26,7 @@ import net.fabricmc.fabric.api.event.registry.RegistryAttribute;
 import net.fabricmc.fabric.api.event.registry.RegistryAttributeHolder;
 
 public final class RegistryAttributeImpl implements RegistryAttributeHolder {
-	private static final Map<RegistryKey<?>, RegistryAttributeHolder> HOLDER_MAP = new HashMap<>();
+	private static final Map<RegistryKey<?>, RegistryAttributeHolder> HOLDER_MAP = new ConcurrentHashMap<>();
 
 	public static RegistryAttributeHolder getHolder(RegistryKey<?> registryKey) {
 		return HOLDER_MAP.computeIfAbsent(registryKey, key -> new RegistryAttributeImpl());


### PR DESCRIPTION
Resolves #3969 
Needs backport to whatever version is supported


A `static final` map, keyed by `RegistryKey` of a registry, was being modified in the worker thread, which sometimes caused CME. The registry itself does not suffer from this problem, as a registry cannot be modified by more than one thread due to freezing. However, two registries could be created in two threads; thus requiring this change.