### PR TITLE
Don't track fake player network addons

### DIFF
--- a/fabric-events-interaction-v0/build.gradle
+++ b/fabric-events-interaction-v0/build.gradle
@@ -1,3 +1,3 @@
 version = getSubprojectVersion(project)
 
-moduleDependencies(project, ['fabric-api-base'])
+moduleDependencies(project, ['fabric-api-base', 'fabric-networking-api-v1'])

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/impl/event/interaction/FakePlayerNetworkHandler.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/impl/event/interaction/FakePlayerNetworkHandler.java
@@ -26,7 +26,9 @@ import net.minecraft.server.network.ConnectedClientData;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 
-public class FakePlayerNetworkHandler extends ServerPlayNetworkHandler {
+import net.fabricmc.fabric.impl.networking.UntrackedNetworkHandler;
+
+public final class FakePlayerNetworkHandler extends ServerPlayNetworkHandler implements UntrackedNetworkHandler {
 	private static final ClientConnection FAKE_CONNECTION = new FakeClientConnection();
 
 	public FakePlayerNetworkHandler(ServerPlayerEntity player) {

--- a/fabric-events-interaction-v0/src/main/resources/fabric.mod.json
+++ b/fabric-events-interaction-v0/src/main/resources/fabric.mod.json
@@ -18,6 +18,7 @@
   "depends": {
     "fabricloader": ">=0.15.11",
     "fabric-api-base": "*",
+    "fabric-networking-api-v1": "*",
     "minecraft": ">=1.15-alpha.19.37.a"
   },
   "entrypoints": {

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/UntrackedNetworkHandler.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/UntrackedNetworkHandler.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.networking;
+
+// An internal marker interface used by the fake player API to prevent the network addon from being tracked.
+public interface UntrackedNetworkHandler {
+}

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/ServerPlayNetworkHandlerMixin.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/ServerPlayNetworkHandlerMixin.java
@@ -30,6 +30,7 @@ import net.minecraft.server.network.ServerCommonNetworkHandler;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 
 import net.fabricmc.fabric.impl.networking.NetworkHandlerExtensions;
+import net.fabricmc.fabric.impl.networking.UntrackedNetworkHandler;
 import net.fabricmc.fabric.impl.networking.server.ServerPlayNetworkAddon;
 
 // We want to apply a bit earlier than other mods which may not use us in order to prevent refCount issues
@@ -45,8 +46,11 @@ abstract class ServerPlayNetworkHandlerMixin extends ServerCommonNetworkHandler 
 	@Inject(method = "<init>", at = @At("RETURN"))
 	private void initAddon(CallbackInfo ci) {
 		this.addon = new ServerPlayNetworkAddon((ServerPlayNetworkHandler) (Object) this, connection, server);
-		// A bit of a hack but it allows the field above to be set in case someone registers handlers during INIT event which refers to said field
-		this.addon.lateInit();
+
+		if (!(this instanceof UntrackedNetworkHandler)) {
+			// A bit of a hack but it allows the field above to be set in case someone registers handlers during INIT event which refers to said field
+			this.addon.lateInit();
+		}
 	}
 
 	@Inject(method = "onCustomPayload", at = @At("HEAD"), cancellable = true)


### PR DESCRIPTION
Fixes #3974

Its possible we dont actually need the addon at all, but this is a much safer change if mods were expecting an addon.