### PR TITLE
Add more TAWs for custom RenderLayers

### DIFF
--- a/fabric-transitive-access-wideners-v1/build.gradle
+++ b/fabric-transitive-access-wideners-v1/build.gradle
@@ -44,6 +44,8 @@ task generateAccessWidener {
 
 		FileSystems.newFileSystem(URI.create("jar:${clientJar.toUri()}"), [create: false]).withCloseable { fs ->
 			generateRenderPhaseFields(lines, fs)
+			lines.add("")
+			generateRenderPhaseInnerClasses(lines, fs)
 		}
 
 		file('src/main/resources/fabric-transitive-access-wideners-v1.accesswidener').text = String.join('\n', lines) + '\n'
@@ -111,6 +113,17 @@ def generateRenderPhaseFields(List<String> lines, FileSystem fs) {
 		// All protected static fields of RenderPhase
 		if ((field.access & Opcodes.ACC_PROTECTED) != 0 && (field.access & Opcodes.ACC_STATIC) != 0) {
 			lines.add("transitive-accessible field net/minecraft/client/render/RenderPhase ${field.name} ${field.desc}")
+		}
+	}
+}
+
+def generateRenderPhaseInnerClasses(List<String> lines, FileSystem fs) {
+	lines.add("# Protected static inner classes of RenderPhase")
+
+	for (def innerClass : loadClass(fs.getPath("net/minecraft/client/render/RenderPhase.class")).innerClasses) {
+		// All protected static inner classes of RenderPhase
+		if ((innerClass.access & Opcodes.ACC_PROTECTED) != 0 && (innerClass.access & Opcodes.ACC_STATIC) != 0) {
+			lines.add("transitive-accessible class net/minecraft/client/render/RenderPhase\$${innerClass.innerName}")
 		}
 	}
 }

--- a/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.accesswidener
+++ b/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.accesswidener
@@ -58,6 +58,9 @@ transitive-accessible class net/minecraft/client/model/ModelPart$Quad
 transitive-accessible method net/minecraft/client/render/RenderLayer of (Lnet/minecraft/client/render/RenderPhase$ShaderProgram;)Lnet/minecraft/client/render/RenderLayer$MultiPhaseParameters;
 transitive-accessible method net/minecraft/client/render/RenderLayer of (Ljava/lang/String;Lnet/minecraft/client/render/VertexFormat;Lnet/minecraft/client/render/VertexFormat$DrawMode;IZZLnet/minecraft/client/render/RenderLayer$MultiPhaseParameters;)Lnet/minecraft/client/render/RenderLayer$MultiPhase;
 transitive-accessible method net/minecraft/client/render/RenderLayer of (Ljava/lang/String;Lnet/minecraft/client/render/VertexFormat;Lnet/minecraft/client/render/VertexFormat$DrawMode;ILnet/minecraft/client/render/RenderLayer$MultiPhaseParameters;)Lnet/minecraft/client/render/RenderLayer$MultiPhase;
+transitive-accessible class net/minecraft/client/render/RenderLayer$MultiPhase
+transitive-accessible class net/minecraft/client/render/RenderLayer$MultiPhaseParameters
+transitive-accessible class net/minecraft/client/render/RenderLayer$OutlineMode
 
 # Registering custom block entity renderers
 transitive-accessible method net/minecraft/client/render/block/entity/BlockEntityRendererFactories register (Lnet/minecraft/block/entity/BlockEntityType;Lnet/minecraft/client/render/block/entity/BlockEntityRendererFactory;)V
@@ -333,3 +336,21 @@ transitive-accessible field net/minecraft/client/render/RenderPhase ITEM_ENTITY_
 transitive-accessible field net/minecraft/client/render/RenderPhase FULL_LINE_WIDTH Lnet/minecraft/client/render/RenderPhase$LineWidth;
 transitive-accessible field net/minecraft/client/render/RenderPhase NO_COLOR_LOGIC Lnet/minecraft/client/render/RenderPhase$ColorLogic;
 transitive-accessible field net/minecraft/client/render/RenderPhase OR_REVERSE Lnet/minecraft/client/render/RenderPhase$ColorLogic;
+
+# Protected static inner classes of RenderPhase
+transitive-accessible class net/minecraft/client/render/RenderPhase$Transparency
+transitive-accessible class net/minecraft/client/render/RenderPhase$ShaderProgram
+transitive-accessible class net/minecraft/client/render/RenderPhase$Texture
+transitive-accessible class net/minecraft/client/render/RenderPhase$TextureBase
+transitive-accessible class net/minecraft/client/render/RenderPhase$Texturing
+transitive-accessible class net/minecraft/client/render/RenderPhase$Lightmap
+transitive-accessible class net/minecraft/client/render/RenderPhase$Overlay
+transitive-accessible class net/minecraft/client/render/RenderPhase$Cull
+transitive-accessible class net/minecraft/client/render/RenderPhase$DepthTest
+transitive-accessible class net/minecraft/client/render/RenderPhase$WriteMaskState
+transitive-accessible class net/minecraft/client/render/RenderPhase$Layering
+transitive-accessible class net/minecraft/client/render/RenderPhase$Target
+transitive-accessible class net/minecraft/client/render/RenderPhase$LineWidth
+transitive-accessible class net/minecraft/client/render/RenderPhase$ColorLogic
+transitive-accessible class net/minecraft/client/render/RenderPhase$OffsetTexturing
+transitive-accessible class net/minecraft/client/render/RenderPhase$Textures

--- a/fabric-transitive-access-wideners-v1/template.accesswidener
+++ b/fabric-transitive-access-wideners-v1/template.accesswidener
@@ -53,6 +53,9 @@ transitive-accessible class net/minecraft/client/model/ModelPart$Quad
 transitive-accessible method net/minecraft/client/render/RenderLayer of (Lnet/minecraft/client/render/RenderPhase$ShaderProgram;)Lnet/minecraft/client/render/RenderLayer$MultiPhaseParameters;
 transitive-accessible method net/minecraft/client/render/RenderLayer of (Ljava/lang/String;Lnet/minecraft/client/render/VertexFormat;Lnet/minecraft/client/render/VertexFormat$DrawMode;IZZLnet/minecraft/client/render/RenderLayer$MultiPhaseParameters;)Lnet/minecraft/client/render/RenderLayer$MultiPhase;
 transitive-accessible method net/minecraft/client/render/RenderLayer of (Ljava/lang/String;Lnet/minecraft/client/render/VertexFormat;Lnet/minecraft/client/render/VertexFormat$DrawMode;ILnet/minecraft/client/render/RenderLayer$MultiPhaseParameters;)Lnet/minecraft/client/render/RenderLayer$MultiPhase;
+transitive-accessible class net/minecraft/client/render/RenderLayer$MultiPhase
+transitive-accessible class net/minecraft/client/render/RenderLayer$MultiPhaseParameters
+transitive-accessible class net/minecraft/client/render/RenderLayer$OutlineMode
 
 # Registering custom block entity renderers
 transitive-accessible method net/minecraft/client/render/block/entity/BlockEntityRendererFactories register (Lnet/minecraft/block/entity/BlockEntityType;Lnet/minecraft/client/render/block/entity/BlockEntityRendererFactory;)V


### PR DESCRIPTION
Adds new TAWs for creating custom `RenderLayer`s. The old AWs fell short of their job since the `MultiPhase`, and `MultiPhaseParameters` classes were protected/private which are used by the `RenderLayer#of` method so if you did want to make a custom RenderLayer you would need to AW these yourself (which defeated the point of the original TAWs). 

I've added TAWs for those two classes and the `OutlineMode` enum used in building a `MultiPhaseParameters` instance, this also adds TAWs for the `RenderPhase` subclasses so that mods can create their own custom phases suited to their needs.

Pretty much any mod I've seen that made use of custom `RenderLayer`s was AWing all of these things themselves so this should be very helpful for this purpose.