### PR TITLE
Revert registry sync changes. Allowing duplicate entries and vanilla clients on servers with modded registries.

### DIFF
--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/server/ServerConfigurationNetworkAddon.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/server/ServerConfigurationNetworkAddon.java
@@ -20,11 +20,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import org.jetbrains.annotations.Nullable;
-
 import net.minecraft.network.NetworkPhase;
 import net.minecraft.network.PacketCallbacks;
-import net.minecraft.network.packet.BrandCustomPayload;
 import net.minecraft.network.packet.CustomPayload;
 import net.minecraft.network.packet.Packet;
 import net.minecraft.network.packet.s2c.common.CommonPingS2CPacket;
@@ -47,8 +44,6 @@ public final class ServerConfigurationNetworkAddon extends AbstractChanneledNetw
 	private final MinecraftServer server;
 	private final ServerConfigurationNetworking.Context context;
 	private RegisterState registerState = RegisterState.NOT_SENT;
-	@Nullable
-	private String clientBrand = null;
 
 	public ServerConfigurationNetworkAddon(ServerConfigurationNetworkHandler handler, MinecraftServer server) {
 		super(ServerNetworkingImpl.CONFIGURATION, ((ServerCommonNetworkHandlerAccessor) handler).getConnection(), "ServerConfigurationNetworkAddon for " + handler.getDebugProfile().getName());
@@ -58,16 +53,6 @@ public final class ServerConfigurationNetworkAddon extends AbstractChanneledNetw
 
 		// Must register pending channels via lateinit
 		this.registerPendingChannels((ChannelInfoHolder) this.connection, NetworkPhase.CONFIGURATION);
-	}
-
-	@Override
-	public boolean handle(CustomPayload payload) {
-		if (payload instanceof BrandCustomPayload brandCustomPayload) {
-			clientBrand = brandCustomPayload.brand();
-			return false;
-		}
-
-		return super.handle(payload);
 	}
 
 	@Override
@@ -182,10 +167,6 @@ public final class ServerConfigurationNetworkAddon extends AbstractChanneledNetw
 	@Override
 	public void sendPacket(Packet<?> packet, PacketCallbacks callback) {
 		handler.send(packet, callback);
-	}
-
-	public @Nullable String getClientBrand() {
-		return clientBrand;
 	}
 
 	private enum RegisterState {

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
@@ -41,7 +41,6 @@ import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.packet.Packet;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
@@ -148,9 +147,9 @@ public final class RegistrySyncManager {
 	}
 
 	/**
-	 * Creates a {@link NbtCompound} used to sync the registry ids.
+	 * Creates a {@link Map} used to sync the registry ids.
 	 *
-	 * @return a {@link NbtCompound} to sync, null when empty
+	 * @return a {@link Map} to sync, null when empty
 	 */
 	@Nullable
 	public static Map<Identifier, Object2IntMap<Identifier>> createAndPopulateRegistryMap() {

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
@@ -41,6 +41,7 @@ import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.packet.Packet;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
@@ -58,7 +59,6 @@ import net.minecraft.util.thread.ThreadExecutor;
 import net.fabricmc.fabric.api.event.registry.RegistryAttribute;
 import net.fabricmc.fabric.api.event.registry.RegistryAttributeHolder;
 import net.fabricmc.fabric.api.networking.v1.ServerConfigurationNetworking;
-import net.fabricmc.fabric.impl.networking.server.ServerNetworkingImpl;
 import net.fabricmc.fabric.impl.registry.sync.packet.DirectRegistryPacketHandler;
 import net.fabricmc.fabric.impl.registry.sync.packet.RegistryPacketHandler;
 
@@ -66,14 +66,9 @@ public final class RegistrySyncManager {
 	public static final boolean DEBUG = Boolean.getBoolean("fabric.registry.debug");
 
 	public static final DirectRegistryPacketHandler DIRECT_PACKET_HANDLER = new DirectRegistryPacketHandler();
+
 	private static final Logger LOGGER = LoggerFactory.getLogger("FabricRegistrySync");
 	private static final boolean DEBUG_WRITE_REGISTRY_DATA = Boolean.getBoolean("fabric.registry.debug.writeContentsAsCsv");
-	private static final Text INCOMPATIBLE_FABRIC_CLIENT_TEXT = Text.literal("This server requires ").append(Text.literal("Fabric API").formatted(Formatting.GREEN))
-			.append(" installed on your client!").formatted(Formatting.YELLOW)
-			.append(Text.literal("\nContact server's administrator for more information!").formatted(Formatting.GOLD));
-	private static final Text INCOMPATIBLE_VANILLA_CLIENT_TEXT = Text.literal("This server requires ").append(Text.literal("Fabric Loader and Fabric API").formatted(Formatting.GREEN))
-			.append(" installed on your client!").formatted(Formatting.YELLOW)
-			.append(Text.literal("\nContact server's administrator for more information!").formatted(Formatting.GOLD));
 
 	//Set to true after vanilla's bootstrap has completed
 	public static boolean postBootstrap = false;
@@ -86,21 +81,15 @@ public final class RegistrySyncManager {
 			return;
 		}
 
+		if (!ServerConfigurationNetworking.canSend(handler, DIRECT_PACKET_HANDLER.getPacketId())) {
+			// Don't send if the client cannot receive
+			return;
+		}
+
 		final Map<Identifier, Object2IntMap<Identifier>> map = RegistrySyncManager.createAndPopulateRegistryMap();
 
 		if (map == null) {
 			// Don't send when there is nothing to map
-			return;
-		}
-
-		if (!ServerConfigurationNetworking.canSend(handler, DIRECT_PACKET_HANDLER.getPacketId())) {
-			// Disconnect incompatible clients
-			Text message = switch (ServerNetworkingImpl.getAddon(handler).getClientBrand()) {
-			case "fabric" -> INCOMPATIBLE_FABRIC_CLIENT_TEXT;
-			case null, default -> INCOMPATIBLE_VANILLA_CLIENT_TEXT;
-			};
-
-			handler.disconnect(message);
 			return;
 		}
 
@@ -159,9 +148,9 @@ public final class RegistrySyncManager {
 	}
 
 	/**
-	 * Creates a {@link Map} used to sync the registry ids.
+	 * Creates a {@link NbtCompound} used to sync the registry ids.
 	 *
-	 * @return a {@link Map} to sync, null when empty
+	 * @return a {@link NbtCompound} to sync, null when empty
 	 */
 	@Nullable
 	public static Map<Identifier, Object2IntMap<Identifier>> createAndPopulateRegistryMap() {

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/SimpleRegistryMixin.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/mixin/registry/sync/SimpleRegistryMixin.java
@@ -25,7 +25,6 @@ import java.util.Set;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.mojang.serialization.Lifecycle;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
@@ -48,7 +47,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.registry.MutableRegistry;
-import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.SimpleRegistry;
@@ -56,7 +54,6 @@ import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.registry.entry.RegistryEntryInfo;
 import net.minecraft.util.Identifier;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.fabricmc.fabric.api.event.registry.RegistryAttribute;
@@ -68,7 +65,6 @@ import net.fabricmc.fabric.impl.registry.sync.RegistrySyncManager;
 import net.fabricmc.fabric.impl.registry.sync.RemapException;
 import net.fabricmc.fabric.impl.registry.sync.RemapStateImpl;
 import net.fabricmc.fabric.impl.registry.sync.RemappableRegistry;
-import net.fabricmc.loader.api.FabricLoader;
 
 @Mixin(SimpleRegistry.class)
 public abstract class SimpleRegistryMixin<T> implements MutableRegistry<T>, RemappableRegistry, ListenableRegistry<T> {
@@ -385,19 +381,5 @@ public abstract class SimpleRegistryMixin<T> implements MutableRegistry<T>, Rema
 			fabric_prevIndexedEntries = null;
 			fabric_prevEntries = null;
 		}
-	}
-
-	@ModifyExpressionValue(method = "add", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Util;throwOrPause(Ljava/lang/Throwable;)Ljava/lang/Throwable;"))
-	private <E extends Throwable> E throwOnDuplicate(E t) throws E {
-		// I hate this as much as you do, blame Hypixel for sending duplicate entries to the client via dynamic registries.
-		if (!FabricLoader.getInstance().isDevelopmentEnvironment()
-				&& FabricLoader.getInstance().getEnvironmentType() == EnvType.CLIENT
-				&& ((SimpleRegistryAccessor) Registries.REGISTRIES).isFrozen()) {
-			LOGGER.error("Exception caught when adding entry to registry. This is likely a server or mod issue.", t);
-			return t;
-		}
-
-		// Actually throw the exception when a duplicate is found, before the registries are frozen
-		throw t;
 	}
 }


### PR DESCRIPTION
Revert the 2 registry sync changes as they are causing more trouble than they are solving, we can re-introduce these in 1.21.1.