### PR TITLE
Fix handled screen not calling super.mouseReleased or super.mouseDragged

### DIFF
--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/HandledScreenMixin.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/HandledScreenMixin.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.screen;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.text.Text;
+
+@Mixin(HandledScreen.class)
+public abstract class HandledScreenMixin extends Screen {
+	private HandledScreenMixin(Text title) {
+		super(title);
+	}
+
+	@Inject(method = "mouseReleased", at = @At("HEAD"), cancellable = true)
+	private void callSuperMouseReleased(double mouseX, double mouseY, int button, CallbackInfoReturnable<Boolean> cir) {
+		if (super.mouseReleased(mouseX, mouseY, button)) {
+			cir.setReturnValue(true);
+		}
+	}
+
+	@Inject(method = "mouseDragged", at = @At("HEAD"), cancellable = true)
+	private void callSuperMouseReleased(double mouseX, double mouseY, int button, double deltaX, double deltaY, CallbackInfoReturnable<Boolean> cir) {
+		if (super.mouseDragged(mouseX, mouseY, button, deltaX, deltaY)) {
+			cir.setReturnValue(true);
+		}
+	}
+}

--- a/fabric-screen-api-v1/src/client/resources/fabric-screen-api-v1.mixins.json
+++ b/fabric-screen-api-v1/src/client/resources/fabric-screen-api-v1.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_17",
   "client": [
     "GameRendererMixin",
+    "HandledScreenMixin",
     "MinecraftClientMixin",
     "ScreenMixin"
   ],

--- a/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/ScreenTests.java
+++ b/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/ScreenTests.java
@@ -24,7 +24,10 @@ import org.slf4j.LoggerFactory;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.TitleScreen;
+import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
+import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.ClickableWidget;
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.api.ClientModInitializer;
@@ -87,6 +90,23 @@ public final class ScreenTests implements ClientModInitializer {
 			ScreenKeyboardEvents.afterKeyPress(screen).register((_screen, key, scancode, modifiers) -> {
 				LOGGER.warn("Pressed, Code: {}, Scancode: {}, Modifiers: {}", key, scancode, modifiers);
 			});
+		} else if (screen instanceof CreativeInventoryScreen) {
+			Screens.getButtons(screen).add(new TestButtonWidget());
+		}
+	}
+
+	// Test that mouseReleased is called
+	private static final class TestButtonWidget extends ButtonWidget {
+		private TestButtonWidget() {
+			super(10, 10, 10, 10, Text.literal("X"), button -> {
+				LOGGER.info("Pressed");
+			}, DEFAULT_NARRATION_SUPPLIER);
+		}
+
+		@Override
+		public boolean mouseReleased(double mouseX, double mouseY, int button) {
+			LOGGER.info("Released");
+			return true;
 		}
 	}
 }


### PR DESCRIPTION
Im not super keen on this fix as it feels like a recipe for something sutble to break. Id be intrested to know how others feel about this.

This fixes an issue where mouseReleased or mouseDragged would not be called for buttons added to HandledScreens.