### PR TITLE
Install git in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ jobs:
       image: mcr.microsoft.com/openjdk/jdk:${{ matrix.java }}
       options: --user root
     steps:
+      - run: apt update && apt install git -y && git --version
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
This is to make sure that grgit is working before I trigger the release.