### PR TITLE
After Damage Event

### DIFF
--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
@@ -125,7 +125,7 @@ public final class ServerLivingEntityEvents {
 
 		/**
 		 * Called after a living entity took damage, unless they were killed. The damage taken is given as damage taken
-		 * before armor or enchantments are applied.
+		 * before armor or enchantments are applied, but after other effects like shields are applied.
 		 *
 		 * @param entity the entity that was damaged
 		 * @param source the source of the damage

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
@@ -42,6 +42,12 @@ public final class ServerLivingEntityEvents {
 		return true;
 	});
 
+	public static final Event<AfterDamage> AFTER_DAMAGE = EventFactory.createArrayBacked(AfterDamage.class, callbacks -> (entity, source, damageDealt, damageTaken, blocked) -> {
+		for (AfterDamage callback : callbacks) {
+			callback.afterDamage(entity, source, damageDealt, damageTaken, blocked);
+		}
+	});
+
 	/**
 	 * An event that is called when an entity takes fatal damage.
 	 *
@@ -102,6 +108,12 @@ public final class ServerLivingEntityEvents {
 		 * @return true if the damage should go ahead, false to cancel the damage.
 		 */
 		boolean allowDamage(LivingEntity entity, DamageSource source, float amount);
+	}
+
+	@FunctionalInterface
+	public interface AfterDamage {
+
+		void afterDamage(LivingEntity entity, DamageSource source, float damageDealt, float damageTaken, boolean blocked);
 	}
 
 	@FunctionalInterface

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
@@ -46,15 +46,15 @@ public final class ServerLivingEntityEvents {
 	 * An event that is called after an entity is damaged. This is fired from {@link LivingEntity#damage} after damage
 	 * is applied, or after that damage was blocked by a shield.
 	 *
-	 * <p>Damage dealt is the damage initially applied to the entity. Damage taken is the amount of damage the entity
-	 * actually took, after effects such as shields and extra freezing damage are applied. Damage taken does NOT include
-	 * damage reduction from armor and enchantments.
+	 * <p>The base damage taken is the damage initially applied to the entity. Damage taken is the amount of damage the
+	 * entity actually took, after effects such as shields and extra freezing damage are applied. Damage taken does NOT
+	 * include damage reduction from armor and enchantments.
 	 *
 	 * <p>This event is not fired if the entity was killed by the damage.
 	 */
-	public static final Event<AfterDamage> AFTER_DAMAGE = EventFactory.createArrayBacked(AfterDamage.class, callbacks -> (entity, source, damageDealt, damageTaken, blocked) -> {
+	public static final Event<AfterDamage> AFTER_DAMAGE = EventFactory.createArrayBacked(AfterDamage.class, callbacks -> (entity, source, baseDamageTaken, damageTaken, blocked) -> {
 		for (AfterDamage callback : callbacks) {
-			callback.afterDamage(entity, source, damageDealt, damageTaken, blocked);
+			callback.afterDamage(entity, source, baseDamageTaken, damageTaken, blocked);
 		}
 	});
 
@@ -123,16 +123,16 @@ public final class ServerLivingEntityEvents {
 	@FunctionalInterface
 	public interface AfterDamage {
 		/**
-		 * Called after a living entity took damage, unless they were killed. The damage taken is given as damage taken
-		 * before armor or enchantments are applied, but after other effects like shields are applied.
+		 * Called after a living entity took damage, unless they were killed. The base damage taken is given as damage
+		 * taken before armor or enchantments are applied, but after other effects like shields are applied.
 		 *
 		 * @param entity the entity that was damaged
 		 * @param source the source of the damage
-		 * @param damageDealt the amount of damage initially dealt
+		 * @param baseDamageTaken the amount of damage initially dealt
 		 * @param damageTaken the amount of damage actually taken by the entity, before armor and enchantment effects
 		 * @param blocked whether the damage was blocked by a shield
 		 */
-		void afterDamage(LivingEntity entity, DamageSource source, float damageDealt, float damageTaken, boolean blocked);
+		void afterDamage(LivingEntity entity, DamageSource source, float baseDamageTaken, float damageTaken, boolean blocked);
 	}
 
 	@FunctionalInterface

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
@@ -45,12 +45,12 @@ public final class ServerLivingEntityEvents {
 	/**
 	 * An event that is called after an entity is damaged. This is fired from {@link LivingEntity#damage} after damage
 	 * is applied, or after that damage was blocked by a shield.
-	 * <p>
-	 * Damage dealt is the damage initially applied to the entity. Damage taken is the amount of damage the entity
+	 *
+	 * <p>Damage dealt is the damage initially applied to the entity. Damage taken is the amount of damage the entity
 	 * actually took, after effects such as shields and extra freezing damage are applied. Damage taken does NOT include
 	 * damage reduction from armor and enchantments.
-	 * <p>
-	 * This event is not fired if the entity was killed by the damage.
+	 *
+	 * <p>This event is not fired if the entity was killed by the damage.
 	 */
 	public static final Event<AfterDamage> AFTER_DAMAGE = EventFactory.createArrayBacked(AfterDamage.class, callbacks -> (entity, source, damageDealt, damageTaken, blocked) -> {
 		for (AfterDamage callback : callbacks) {
@@ -122,7 +122,6 @@ public final class ServerLivingEntityEvents {
 
 	@FunctionalInterface
 	public interface AfterDamage {
-
 		/**
 		 * Called after a living entity took damage, unless they were killed. The damage taken is given as damage taken
 		 * before armor or enchantments are applied, but after other effects like shields are applied.

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerLivingEntityEvents.java
@@ -42,6 +42,16 @@ public final class ServerLivingEntityEvents {
 		return true;
 	});
 
+	/**
+	 * An event that is called after an entity is damaged. This is fired from {@link LivingEntity#damage} after damage
+	 * is applied, or after that damage was blocked by a shield.
+	 * <p>
+	 * Damage dealt is the damage initially applied to the entity. Damage taken is the amount of damage the entity
+	 * actually took, after effects such as shields and extra freezing damage are applied. Damage taken does NOT include
+	 * damage reduction from armor and enchantments.
+	 * <p>
+	 * This event is not fired if the entity was killed by the damage.
+	 */
 	public static final Event<AfterDamage> AFTER_DAMAGE = EventFactory.createArrayBacked(AfterDamage.class, callbacks -> (entity, source, damageDealt, damageTaken, blocked) -> {
 		for (AfterDamage callback : callbacks) {
 			callback.afterDamage(entity, source, damageDealt, damageTaken, blocked);
@@ -113,6 +123,16 @@ public final class ServerLivingEntityEvents {
 	@FunctionalInterface
 	public interface AfterDamage {
 
+		/**
+		 * Called after a living entity took damage, unless they were killed. The damage taken is given as damage taken
+		 * before armor or enchantments are applied.
+		 *
+		 * @param entity the entity that was damaged
+		 * @param source the source of the damage
+		 * @param damageDealt the amount of damage initially dealt
+		 * @param damageTaken the amount of damage actually taken by the entity, before armor and enchantment effects
+		 * @param blocked whether the damage was blocked by a shield
+		 */
 		void afterDamage(LivingEntity entity, DamageSource source, float damageDealt, float damageTaken, boolean blocked);
 	}
 

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -30,6 +30,7 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import net.minecraft.block.BedBlock;
 import net.minecraft.block.BlockState;
@@ -50,8 +51,6 @@ import net.minecraft.world.World;
 import net.fabricmc.fabric.api.entity.event.v1.EntitySleepEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerEntityCombatEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
-
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(LivingEntity.class)
 abstract class LivingEntityMixin {

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -87,7 +87,9 @@ abstract class LivingEntityMixin {
 
 	@Inject(method = "damage", at = @At("TAIL"), locals = LocalCapture.CAPTURE_FAILHARD)
 	private void afterDamage(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir, float dealt, boolean blocked) {
-		ServerLivingEntityEvents.AFTER_DAMAGE.invoker().afterDamage((LivingEntity) (Object) this, source, dealt, amount, blocked);
+		if (!isDead()) {
+			ServerLivingEntityEvents.AFTER_DAMAGE.invoker().afterDamage((LivingEntity) (Object) this, source, dealt, amount, blocked);
+		}
 	}
 
 	@Inject(method = "sleep", at = @At("RETURN"))

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -51,6 +51,8 @@ import net.fabricmc.fabric.api.entity.event.v1.EntitySleepEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerEntityCombatEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
 
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
 @Mixin(LivingEntity.class)
 abstract class LivingEntityMixin {
 	@Shadow
@@ -80,6 +82,13 @@ abstract class LivingEntityMixin {
 	private void beforeDamage(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
 		if (!ServerLivingEntityEvents.ALLOW_DAMAGE.invoker().allowDamage((LivingEntity) (Object) this, source, amount)) {
 			cir.setReturnValue(false);
+		}
+	}
+
+	@Inject(method = "damage", at = @At("TAIL"), locals = LocalCapture.CAPTURE_FAILHARD)
+	private void afterDamage(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir, float dealt, boolean blocked) {
+		if (amount > 0f) {
+			ServerLivingEntityEvents.AFTER_DAMAGE.invoker().afterDamage((LivingEntity) (Object) this, source, dealt, amount, blocked);
 		}
 	}
 

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -87,9 +87,7 @@ abstract class LivingEntityMixin {
 
 	@Inject(method = "damage", at = @At("TAIL"), locals = LocalCapture.CAPTURE_FAILHARD)
 	private void afterDamage(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir, float dealt, boolean blocked) {
-		if (amount > 0f) {
-			ServerLivingEntityEvents.AFTER_DAMAGE.invoker().afterDamage((LivingEntity) (Object) this, source, dealt, amount, blocked);
-		}
+		ServerLivingEntityEvents.AFTER_DAMAGE.invoker().afterDamage((LivingEntity) (Object) this, source, dealt, amount, blocked);
 	}
 
 	@Inject(method = "sleep", at = @At("RETURN"))

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -90,8 +90,8 @@ public final class EntityEventTests implements ModInitializer {
 			return true;
 		});
 
-		ServerLivingEntityEvents.AFTER_DAMAGE.register((entity, source, damageDealt, damageTaken, blocked) -> {
-			LOGGER.info("Entity {} received {} damage from {} (dealt {}, blocked {})", entity.getName().getString(), damageTaken, source.getName(), damageDealt, blocked);
+		ServerLivingEntityEvents.AFTER_DAMAGE.register((entity, source, baseDamageTaken, damageTaken, blocked) -> {
+			LOGGER.info("Entity {} received {} damage from {} (initially dealt {}, blocked {})", entity.getName().getString(), damageTaken, source.getName(), baseDamageTaken, blocked);
 		});
 
 		ServerLivingEntityEvents.ALLOW_DEATH.register((entity, source, amount) -> {

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -90,6 +90,10 @@ public final class EntityEventTests implements ModInitializer {
 			return true;
 		});
 
+		ServerLivingEntityEvents.AFTER_DAMAGE.register((entity, source, damageDealt, damageTaken, blocked) -> {
+			LOGGER.info("Entity {} received {} damage from {} (dealt {}, blocked {})", entity.getName().getString(), damageTaken, source.getName(), damageDealt, blocked);
+		});
+
 		ServerLivingEntityEvents.ALLOW_DEATH.register((entity, source, amount) -> {
 			LOGGER.info("{} is going to die to {} damage from {} damage source", entity.getName().getString(), amount, source.getName());
 


### PR DESCRIPTION
Adds a server-side only entity event after an entity is damaged. The event is fired after damage is applied, and includes both damage dealt and damage taken. However, damage taken is a bit weird. Its not the final amount of health reduction, but the damage the entity receives *just* armour / enchantments are applied and *after* shield, `freeze_hurts_extra_types`, and helmet damage reduction. The event is not fired if the damage killed the entity. 

I'm not sure if the difference between damage dealt and damage taken is clear enough that they should be separate here. Maybe it would be best to only supply the damage taken? These two numbers are both supplied to the `player_hurt_entity` and `entity_hurt_player` advancement criteria, so I thought their inclusion here made sense. However, as this is a fairly easy change to make I thought I would just open this now to see what people think.