### PR TITLE
Print the full stack trace from the dedicated server watchdog 

### DIFF
--- a/fabric-crash-report-info-v1/build.gradle
+++ b/fabric-crash-report-info-v1/build.gradle
@@ -1,1 +1,5 @@
 version = getSubprojectVersion(project)
+
+testDependencies(project, [
+	':fabric-command-api-v2'
+])

--- a/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/impl/ThreadPrinting.java
+++ b/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/impl/ThreadPrinting.java
@@ -1,0 +1,77 @@
+package net.fabricmc.fabric.impl;
+
+import java.lang.management.LockInfo;
+import java.lang.management.MonitorInfo;
+import java.lang.management.ThreadInfo;
+
+public class ThreadPrinting {
+
+	public static String fullThreadInfoToString(ThreadInfo threadInfo) {
+		StringBuilder sb = new StringBuilder("\"" + threadInfo.getThreadName() + "\"" +
+				(threadInfo.isDaemon() ? " daemon" : "") +
+				" prio=" + threadInfo.getPriority() +
+				" Id=" + threadInfo.getThreadId() + " " +
+				threadInfo.getThreadState());
+
+		if (threadInfo.getLockName() != null) {
+			sb.append(" on ").append(threadInfo.getLockName());
+		}
+
+		if (threadInfo.getLockOwnerName() != null) {
+			sb.append(" owned by \"").append(threadInfo.getLockOwnerName())
+					.append("\" Id=").append(threadInfo.getLockOwnerId());
+		}
+
+		if (threadInfo.isSuspended()) {
+			sb.append(" (suspended)");
+		}
+
+		if (threadInfo.isInNative()) {
+			sb.append(" (in native)");
+		}
+
+		sb.append('\n');
+
+		StackTraceElement[] stackTraceElements = threadInfo.getStackTrace();
+		for (int i = 0; i < stackTraceElements.length; i++) {
+			StackTraceElement ste = stackTraceElements[i];
+			sb.append("\tat ").append(ste.toString());
+			sb.append('\n');
+			if (i == 0 && threadInfo.getLockInfo() != null) {
+				Thread.State ts = threadInfo.getThreadState();
+				switch (ts) {
+					case BLOCKED -> {
+						sb.append("\t-  blocked on ").append(threadInfo.getLockInfo());
+						sb.append('\n');
+					}
+					case WAITING, TIMED_WAITING -> {
+						sb.append("\t-  waiting on ").append(threadInfo.getLockInfo());
+						sb.append('\n');
+					}
+					default -> {
+					}
+				}
+			}
+
+			for (MonitorInfo mi : threadInfo.getLockedMonitors()) {
+				if (mi.getLockedStackDepth() == i) {
+					sb.append("\t-  locked ").append(mi);
+					sb.append('\n');
+				}
+			}
+		}
+
+		LockInfo[] locks = threadInfo.getLockedSynchronizers();
+		if (locks.length > 0) {
+			sb.append("\n\tNumber of locked synchronizers = ").append(locks.length);
+			sb.append('\n');
+			for (LockInfo li : locks) {
+				sb.append("\t- ").append(li);
+				sb.append('\n');
+			}
+		}
+
+		sb.append('\n');
+		return sb.toString();
+	}
+}

--- a/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/impl/ThreadPrinting.java
+++ b/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/impl/ThreadPrinting.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.impl;
 
 import java.lang.management.LockInfo;

--- a/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/impl/ThreadPrinting.java
+++ b/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/impl/ThreadPrinting.java
@@ -23,11 +23,11 @@ import java.lang.management.ThreadInfo;
 public class ThreadPrinting {
 
 	public static String fullThreadInfoToString(ThreadInfo threadInfo) {
-		StringBuilder sb = new StringBuilder("\"" + threadInfo.getThreadName() + "\"" +
-				(threadInfo.isDaemon() ? " daemon" : "") +
-				" prio=" + threadInfo.getPriority() +
-				" Id=" + threadInfo.getThreadId() + " " +
-				threadInfo.getThreadState());
+		StringBuilder sb = new StringBuilder("\"" + threadInfo.getThreadName() + "\""
+				+ (threadInfo.isDaemon() ? " daemon" : "")
+				+ " prio=" + threadInfo.getPriority()
+				+ " Id=" + threadInfo.getThreadId() + " "
+				+ threadInfo.getThreadState());
 
 		if (threadInfo.getLockName() != null) {
 			sb.append(" on ").append(threadInfo.getLockName());
@@ -49,23 +49,25 @@ public class ThreadPrinting {
 		sb.append('\n');
 
 		StackTraceElement[] stackTraceElements = threadInfo.getStackTrace();
+
 		for (int i = 0; i < stackTraceElements.length; i++) {
 			StackTraceElement ste = stackTraceElements[i];
 			sb.append("\tat ").append(ste.toString());
 			sb.append('\n');
+
 			if (i == 0 && threadInfo.getLockInfo() != null) {
 				Thread.State ts = threadInfo.getThreadState();
 				switch (ts) {
-					case BLOCKED -> {
-						sb.append("\t-  blocked on ").append(threadInfo.getLockInfo());
-						sb.append('\n');
-					}
-					case WAITING, TIMED_WAITING -> {
-						sb.append("\t-  waiting on ").append(threadInfo.getLockInfo());
-						sb.append('\n');
-					}
-					default -> {
-					}
+				case BLOCKED -> {
+					sb.append("\t-  blocked on ").append(threadInfo.getLockInfo());
+					sb.append('\n');
+				}
+				case WAITING, TIMED_WAITING -> {
+					sb.append("\t-  waiting on ").append(threadInfo.getLockInfo());
+					sb.append('\n');
+				}
+				default -> {
+				}
 				}
 			}
 
@@ -78,9 +80,11 @@ public class ThreadPrinting {
 		}
 
 		LockInfo[] locks = threadInfo.getLockedSynchronizers();
+
 		if (locks.length > 0) {
 			sb.append("\n\tNumber of locked synchronizers = ").append(locks.length);
 			sb.append('\n');
+
 			for (LockInfo li : locks) {
 				sb.append("\t- ").append(li);
 				sb.append('\n');

--- a/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/impl/crash/report/info/ThreadPrinting.java
+++ b/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/impl/crash/report/info/ThreadPrinting.java
@@ -21,6 +21,9 @@ import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
 
 public class ThreadPrinting {
+	/**
+	 * A modified copy of {@link ThreadInfo#toString} without the MAX_FRAMES check.
+	 */
 	public static String fullThreadInfoToString(ThreadInfo threadInfo) {
 		StringBuilder sb = new StringBuilder("\"" + threadInfo.getThreadName() + "\""
 				+ (threadInfo.isDaemon() ? " daemon" : "")

--- a/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/impl/crash/report/info/ThreadPrinting.java
+++ b/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/impl/crash/report/info/ThreadPrinting.java
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.impl;
+package net.fabricmc.fabric.impl.crash.report.info;
 
 import java.lang.management.LockInfo;
 import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
 
 public class ThreadPrinting {
-
 	public static String fullThreadInfoToString(ThreadInfo threadInfo) {
 		StringBuilder sb = new StringBuilder("\"" + threadInfo.getThreadName() + "\""
 				+ (threadInfo.isDaemon() ? " daemon" : "")

--- a/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/mixin/crash/report/info/DedicatedServerWatchdogMixin.java
+++ b/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/mixin/crash/report/info/DedicatedServerWatchdogMixin.java
@@ -1,0 +1,29 @@
+package net.fabricmc.fabric.mixin.crash.report.info;
+
+import java.lang.management.ThreadInfo;
+
+import net.fabricmc.fabric.impl.ThreadPrinting;
+
+import net.minecraft.server.dedicated.DedicatedServerWatchdog;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(DedicatedServerWatchdog.class)
+public class DedicatedServerWatchdogMixin {
+
+    @ModifyArg(method = "createCrashReport(Ljava/lang/String;J)Lnet/minecraft/util/crash/CrashReport;",
+            at = @At(value = "INVOKE",
+                    target = "Ljava/lang/StringBuilder;append(Ljava/lang/Object;)Ljava/lang/StringBuilder;",
+                    ordinal = 0,
+                    remap = false)
+    )
+    private static Object printEntireThreadDump(Object object) {
+        if (object instanceof ThreadInfo threadInfo) {
+            return ThreadPrinting.fullThreadInfoToString(threadInfo);
+        }
+        return object;
+    }
+}
+

--- a/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/mixin/crash/report/info/DedicatedServerWatchdogMixin.java
+++ b/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/mixin/crash/report/info/DedicatedServerWatchdogMixin.java
@@ -28,7 +28,6 @@ import net.fabricmc.fabric.impl.ThreadPrinting;
 
 @Mixin(DedicatedServerWatchdog.class)
 public class DedicatedServerWatchdogMixin {
-
 	@ModifyArg(method = "createCrashReport(Ljava/lang/String;J)Lnet/minecraft/util/crash/CrashReport;",
 			at = @At(value = "INVOKE",
 					target = "Ljava/lang/StringBuilder;append(Ljava/lang/Object;)Ljava/lang/StringBuilder;",
@@ -39,6 +38,7 @@ public class DedicatedServerWatchdogMixin {
 		if (object instanceof ThreadInfo threadInfo) {
 			return ThreadPrinting.fullThreadInfoToString(threadInfo);
 		}
+
 		return object;
 	}
 }

--- a/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/mixin/crash/report/info/DedicatedServerWatchdogMixin.java
+++ b/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/mixin/crash/report/info/DedicatedServerWatchdogMixin.java
@@ -24,7 +24,7 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 import net.minecraft.server.dedicated.DedicatedServerWatchdog;
 
-import net.fabricmc.fabric.impl.ThreadPrinting;
+import net.fabricmc.fabric.impl.crash.report.info.ThreadPrinting;
 
 @Mixin(DedicatedServerWatchdog.class)
 public class DedicatedServerWatchdogMixin {

--- a/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/mixin/crash/report/info/DedicatedServerWatchdogMixin.java
+++ b/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/mixin/crash/report/info/DedicatedServerWatchdogMixin.java
@@ -1,29 +1,44 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.crash.report.info;
 
 import java.lang.management.ThreadInfo;
-
-import net.fabricmc.fabric.impl.ThreadPrinting;
-
-import net.minecraft.server.dedicated.DedicatedServerWatchdog;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 
+import net.minecraft.server.dedicated.DedicatedServerWatchdog;
+
+import net.fabricmc.fabric.impl.ThreadPrinting;
+
 @Mixin(DedicatedServerWatchdog.class)
 public class DedicatedServerWatchdogMixin {
 
-    @ModifyArg(method = "createCrashReport(Ljava/lang/String;J)Lnet/minecraft/util/crash/CrashReport;",
-            at = @At(value = "INVOKE",
-                    target = "Ljava/lang/StringBuilder;append(Ljava/lang/Object;)Ljava/lang/StringBuilder;",
-                    ordinal = 0,
-                    remap = false)
-    )
-    private static Object printEntireThreadDump(Object object) {
-        if (object instanceof ThreadInfo threadInfo) {
-            return ThreadPrinting.fullThreadInfoToString(threadInfo);
-        }
-        return object;
-    }
+	@ModifyArg(method = "createCrashReport(Ljava/lang/String;J)Lnet/minecraft/util/crash/CrashReport;",
+			at = @At(value = "INVOKE",
+					target = "Ljava/lang/StringBuilder;append(Ljava/lang/Object;)Ljava/lang/StringBuilder;",
+					ordinal = 0,
+					remap = false)
+	)
+	private static Object printEntireThreadDump(Object object) {
+		if (object instanceof ThreadInfo threadInfo) {
+			return ThreadPrinting.fullThreadInfoToString(threadInfo);
+		}
+		return object;
+	}
 }
-

--- a/fabric-crash-report-info-v1/src/main/resources/fabric-crash-report-info-v1.mixins.json
+++ b/fabric-crash-report-info-v1/src/main/resources/fabric-crash-report-info-v1.mixins.json
@@ -3,6 +3,7 @@
   "package": "net.fabricmc.fabric.mixin.crash.report.info",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
+    "DedicatedServerWatchdogMixin",
     "SystemDetailsMixin"
   ],
   "injectors": {

--- a/fabric-crash-report-info-v1/src/testmod/java/net/fabricmc/fabric/test/crash/report/info/ThreadDumpTests.java
+++ b/fabric-crash-report-info-v1/src/testmod/java/net/fabricmc/fabric/test/crash/report/info/ThreadDumpTests.java
@@ -31,7 +31,6 @@ import net.minecraft.util.crash.ReportType;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 
-
 public class ThreadDumpTests implements ModInitializer {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ThreadDumpTests.class);
 

--- a/fabric-crash-report-info-v1/src/testmod/java/net/fabricmc/fabric/test/crash/report/info/ThreadDumpTests.java
+++ b/fabric-crash-report-info-v1/src/testmod/java/net/fabricmc/fabric/test/crash/report/info/ThreadDumpTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.crash.report.info;
+
+import static net.minecraft.server.command.CommandManager.literal;
+
+import com.mojang.brigadier.context.CommandContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.dedicated.DedicatedServerWatchdog;
+import net.minecraft.text.Text;
+import net.minecraft.util.crash.CrashReport;
+import net.minecraft.util.crash.ReportType;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+
+
+public class ThreadDumpTests implements ModInitializer {
+	private static final Logger LOGGER = LoggerFactory.getLogger(ThreadDumpTests.class);
+
+	@Override
+	public void onInitialize() {
+		CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) ->
+				dispatcher.register(literal("print_thread_dump_test_command").executes(this::executeDumpCommand)));
+	}
+
+	private int executeDumpCommand(CommandContext<ServerCommandSource> context) {
+		final ServerCommandSource source = context.getSource();
+		CrashReport crashReport = DedicatedServerWatchdog.createCrashReport("Watching Server", context.getSource().getServer().getThread().threadId());
+		LOGGER.info(crashReport.asString(ReportType.MINECRAFT_CRASH_REPORT));
+		source.sendFeedback(() -> Text.literal("Thread Dump printed to console."), false);
+		return 1;
+	}
+}

--- a/fabric-crash-report-info-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-crash-report-info-v1/src/testmod/resources/fabric.mod.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "id": "fabric-crash-report-info-v1-testmod",
+  "name": "Fabric Crash Report Info (v1) Test Mod",
+  "version": "1.0.0",
+  "environment": "*",
+  "license": "Apache-2.0",
+  "entrypoints": {
+    "main": [
+      "net.fabricmc.fabric.test.crash.report.info.ThreadDumpTests"
+    ]
+  }
+}


### PR DESCRIPTION
Turns out 1.21.2 broke my FullStack Watchdog mod but instead of merging someone's PR to port my mod to that version, I figured maybe it'll be better to have it in Fabric API itself.

This code simply swaps the ThreadInfo being passed to StringBuilder with a full stacktrace string instead. The reason for this is ThreadInfo's toString method will truncate the stacktrace for itself. We need the full dump in order to see problems so doing our own copy of that toString method but without the truncating should do the trick