### PR TITLE
24w34a porting fixes

### DIFF
--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/VillagerInteractionRegistries.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/VillagerInteractionRegistries.java
@@ -46,7 +46,7 @@ public final class VillagerInteractionRegistries {
 	 * by any profession villagers.
 	 *
 	 * @param item the item to register
-	 * @deprecated Add items to the {@linkplain net.minecraft.tag.ItemTags#VILLAGER_PICKS_UP {@code <#789950127774105602>:villager_picks_up} item tag} instead
+	 * @deprecated Add items to the {@linkplain net.minecraft.registry.tag.ItemTags#VILLAGER_PICKS_UP {@code minecraft:villager_picks_up} item tag} instead.
 	 */
 	@Deprecated
 	public static void registerCollectable(ItemConvertible item) {

--- a/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalItemTags.java
+++ b/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalItemTags.java
@@ -209,7 +209,7 @@ public final class ConventionalItemTags {
 	public static final TagKey<Item> GLAZED_TERRACOTTAS = register("glazed_terracottas");
 	public static final TagKey<Item> CONCRETES = register("concretes");
 	/**
-	 * Block tag equivalent is {@link BlockTags#CONCRETE_POWDERS}.
+	 * Block tag equivalent is {@link BlockTags#CONCRETE_POWDER}.
 	 */
 	public static final TagKey<Item> CONCRETE_POWDERS = register("concrete_powders");
 

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/elytra/ElytraFlightControllerMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/elytra/ElytraFlightControllerMixin.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.entity.event.elytra;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.mob.ElytraFlightController;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+import net.fabricmc.fabric.api.entity.event.v1.EntityElytraEvents;
+
+@Mixin(ElytraFlightController.class)
+public class ElytraFlightControllerMixin {
+	@Shadow
+	@Final
+	private LivingEntity entity;
+
+	@WrapOperation(method = "update", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isOf(Lnet/minecraft/item/Item;)Z"))
+	private boolean checkAllowEvent(ItemStack instance, Item item, Operation<Boolean> original) {
+		// ALLOW event is checked by LivingEntityMixin.
+		return original.call(instance, item) || EntityElytraEvents.CUSTOM.invoker().useCustomElytra(this.entity, false);
+	}
+}

--- a/fabric-entity-events-v1/src/main/resources/fabric-entity-events-v1.mixins.json
+++ b/fabric-entity-events-v1/src/main/resources/fabric-entity-events-v1.mixins.json
@@ -13,6 +13,7 @@
     "ServerPlayerEntityMixin",
     "TadpoleEntityMixin",
     "VillagerEntityMixin",
+    "elytra.ElytraFlightControllerMixin",
     "elytra.LivingEntityMixin",
     "elytra.PlayerEntityMixin"
   ],

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/DiamondElytraItem.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/DiamondElytraItem.java
@@ -23,6 +23,6 @@ import net.fabricmc.fabric.api.entity.event.v1.FabricElytraItem;
 
 public class DiamondElytraItem extends ArmorItem implements FabricElytraItem {
 	public DiamondElytraItem() {
-		super(ArmorMaterials.DIAMOND, Type.CHESTPLATE, new Settings().maxCount(1));
+		super(ArmorMaterials.DIAMOND, Type.CHESTPLATE, new Settings().maxCount(1).maxDamage(100));
 	}
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/CustomDamageHandler.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/CustomDamageHandler.java
@@ -32,7 +32,8 @@ public interface CustomDamageHandler {
 	/**
 	 * Called to apply damage to the given stack.
 	 * This can be used to e.g. drain from a battery before actually damaging the item.
-	 * Note that this does not get called if non-entities, such as dispensers, are damaging the item.
+	 * Note that this does not get called if non-entities, such as dispensers, are damaging the item,
+	 * or for thrown tridents.
 	 * Calling {@code breakCallback} breaks the item, bypassing the vanilla logic. The return value is
 	 * ignored in this case.
 	 * @param amount the amount of damage originally requested

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerTickEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerTickEvents.java
@@ -22,12 +22,22 @@ import net.minecraft.server.world.ServerWorld;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
+/**
+ * Contains events that are triggered on the server every tick.
+ *
+ * <p>A dedicated server may "pause" if no player is present for a
+ * certain length of time (by default, 1 minute). See {@code pause-when-empty-seconds}
+ * property in {@code server.properties}.
+ * When the server is "paused", none of the events here will be invoked.
+ */
 public final class ServerTickEvents {
 	private ServerTickEvents() {
 	}
 
 	/**
 	 * Called at the start of the server tick.
+	 *
+	 * <p>When the dedicated server is "paused", this event is not invoked.
 	 */
 	public static final Event<StartTick> START_SERVER_TICK = EventFactory.createArrayBacked(StartTick.class, callbacks -> server -> {
 		for (StartTick event : callbacks) {
@@ -37,6 +47,8 @@ public final class ServerTickEvents {
 
 	/**
 	 * Called at the end of the server tick.
+	 *
+	 * <p>When the dedicated server is "paused", this event is not invoked.
 	 */
 	public static final Event<EndTick> END_SERVER_TICK = EventFactory.createArrayBacked(EndTick.class, callbacks -> server -> {
 		for (EndTick event : callbacks) {
@@ -46,6 +58,8 @@ public final class ServerTickEvents {
 
 	/**
 	 * Called at the start of a ServerWorld's tick.
+	 *
+	 * <p>When the dedicated server is "paused", this event is not invoked.
 	 */
 	public static final Event<StartWorldTick> START_WORLD_TICK = EventFactory.createArrayBacked(StartWorldTick.class, callbacks -> world -> {
 		for (StartWorldTick callback : callbacks) {
@@ -57,6 +71,8 @@ public final class ServerTickEvents {
 	 * Called at the end of a ServerWorld's tick.
 	 *
 	 * <p>End of world tick may be used to start async computations for the next tick.
+	 *
+	 * <p>When the dedicated server is "paused", this event is not invoked.
 	 */
 	public static final Event<EndWorldTick> END_WORLD_TICK = EventFactory.createArrayBacked(EndWorldTick.class, callbacks -> world -> {
 		for (EndWorldTick callback : callbacks) {

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/ModelModifier.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/ModelModifier.java
@@ -159,8 +159,8 @@ public final class ModelModifier {
 
 			/**
 			 * The baker being used to bake this model.
-			 * It can be used to {@linkplain Baker#getOrLoadModel load unbaked models} and
-			 * {@linkplain Baker#bake load baked models}.
+			 * It can be used to {@linkplain Baker#getModel get unbaked models} and
+			 * {@linkplain Baker#bake bake models}.
 			 */
 			Baker baker();
 		}
@@ -227,8 +227,8 @@ public final class ModelModifier {
 
 			/**
 			 * The baker being used to bake this model.
-			 * It can be used to {@linkplain Baker#getOrLoadModel load unbaked models} and
-			 * {@linkplain Baker#bake load baked models}.
+			 * It can be used to {@linkplain Baker#getModel get unbaked models} and
+			 * {@linkplain Baker#bake bake models}.
 			 */
 			Baker baker();
 		}

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/EntityTrackingEvents.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/EntityTrackingEvents.java
@@ -29,7 +29,7 @@ public final class EntityTrackingEvents {
 	/**
 	 * An event that is called before player starts tracking an entity.
 	 * Typically, this occurs when an entity enters a client's view distance.
-	 * This event is called before the player's client is sent the entity's {@link Entity#createSpawnPacket() spawn packet}.
+	 * This event is called before the player's client is sent the entity's {@linkplain Entity#createSpawnPacket spawn packet}.
 	 */
 	public static final Event<StartTracking> START_TRACKING = EventFactory.createArrayBacked(StartTracking.class, callbacks -> (trackedEntity, player) -> {
 		for (StartTracking callback : callbacks) {

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/api/recipe/v1/ingredient/CustomIngredient.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/api/recipe/v1/ingredient/CustomIngredient.java
@@ -65,7 +65,6 @@ public interface CustomIngredient {
 	 *     <li>These stacks are generally used for display purposes, and need not be exhaustive or perfectly accurate.</li>
 	 *     <li>An exception is ingredients that {@linkplain #requiresTesting() don't require testing},
 	 *     for which it is important that the returned stacks correspond exactly to all the accepted {@link Item}s.</li>
-	 *     <li>At least one stack must be returned for the ingredient not to be considered {@linkplain Ingredient#isEmpty() empty}.</li>
 	 *     <li>The ingredient should try to return at least one stack with each accepted {@link Item}.
 	 *     This allows mods that inspect the ingredient to figure out which stacks it might accept.</li>
 	 * </ul>

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/api/recipe/v1/ingredient/CustomIngredientSerializer.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/api/recipe/v1/ingredient/CustomIngredientSerializer.java
@@ -61,7 +61,7 @@ public interface CustomIngredientSerializer<T extends CustomIngredient> {
 	 *
 	 * <p>Codecs are used to read the ingredient from the recipe JSON files.
 	 *
-	 * @see Ingredient#ALLOW_EMPTY_CODEC
+	 * @see Ingredient#CODEC
 	 */
 	MapCodec<T> getCodec();
 

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/api/recipe/v1/ingredient/FabricIngredient.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/api/recipe/v1/ingredient/FabricIngredient.java
@@ -41,7 +41,7 @@ public interface FabricIngredient {
 	 *
 	 * <p>If {@code false}, {@linkplain Ingredient#test testing this ingredient} with an item stack must be equivalent to checking whether
 	 * the item stack's item is included in the ingredient's {@linkplain Ingredient#getMatchingStacks() list of matching stacks}.
-	 * In that case, optimized matching logic can be used, for example using {@link Ingredient#getMatchingItemIds()}.
+	 * In that case, optimized matching logic can be used.
 	 *
 	 * <p>If {@code true}, the ingredient must always be tested using {@link Ingredient#test(ItemStack)}.
 	 * Note that Fabric patches some vanilla systems such as shapeless recipes to account for this.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidConstants.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidConstants.java
@@ -69,7 +69,7 @@ public final class FluidConstants {
 	public static final int LAVA_VISCOSITY = 6000;
 	public static final int LAVA_VISCOSITY_NETHER = 2000;
 	/**
-	 * For flowable fluids, the viscosity should match {@code VISCOSITY_RATIO} * {@link FlowableFluid#getFlowSpeed}.
+	 * For flowable fluids, the viscosity should match {@code VISCOSITY_RATIO} * {@link FlowableFluid#getMaxFlowDistance}.
 	 */
 	public static final int VISCOSITY_RATIO = 200;
 

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariantAttributeHandler.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariantAttributeHandler.java
@@ -87,7 +87,7 @@ public interface FluidVariantAttributeHandler {
 	 * Return a positive integer, representing the viscosity of this fluid.
 	 * Fluids with lower viscosity generally flow faster than fluids with higher viscosity.
 	 *
-	 * <p>More precisely, viscosity should be {@value FluidConstants#VISCOSITY_RATIO} * {@link FlowableFluid#getFlowSpeed} for flowable fluids.
+	 * <p>More precisely, viscosity should be {@value FluidConstants#VISCOSITY_RATIO} * {@link FlowableFluid#getMaxFlowDistance} for flowable fluids.
 	 * The reference values are {@value FluidConstants#WATER_VISCOSITY} for water,
 	 * {@value FluidConstants#LAVA_VISCOSITY_NETHER} for lava in ultrawarm dimensions (such as the nether),
 	 * and {@value FluidConstants#LAVA_VISCOSITY} for lava in other dimensions.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariantAttributes.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariantAttributes.java
@@ -135,7 +135,7 @@ public final class FluidVariantAttributes {
 	 * Return a positive integer, representing the viscosity of this fluid variant.
 	 * Fluids with lower viscosity generally flow faster than fluids with higher viscosity.
 	 *
-	 * <p>More precisely, viscosity should be {@value FluidConstants#VISCOSITY_RATIO} * {@link FlowableFluid#getFlowSpeed} for flowable fluids.
+	 * <p>More precisely, viscosity should be {@value FluidConstants#VISCOSITY_RATIO} * {@link FlowableFluid#getMaxFlowDistance} for flowable fluids.
 	 * The reference values are {@value FluidConstants#WATER_VISCOSITY} for water,
 	 * {@value FluidConstants#LAVA_VISCOSITY_NETHER} for lava in ultrawarm dimensions (such as the nether),
 	 * and {@value FluidConstants#LAVA_VISCOSITY} for lava in other dimensions.


### PR DESCRIPTION
- Fixes custom elytra not working
- Various javadoc fixes

Related: there is a bug that is causing durability-less custom elytra to not function (as seen in testmod). I believe this affects 1.20.5 and above; if this is to be fixed it will be in a separate PR.