### PR TITLE
Add missing `minecraft:enchantable/vanishing` to `c:enchantables`

### DIFF
--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/ItemTagGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/ItemTagGenerator.java
@@ -597,7 +597,8 @@ public final class ItemTagGenerator extends FabricTagProvider.ItemTagProvider {
 				.addOptionalTag(ItemTags.CROSSBOW_ENCHANTABLE)
 				.addOptionalTag(ItemTags.MACE_ENCHANTABLE)
 				.addOptionalTag(ItemTags.FIRE_ASPECT_ENCHANTABLE)
-				.addOptionalTag(ItemTags.DURABILITY_ENCHANTABLE);
+				.addOptionalTag(ItemTags.DURABILITY_ENCHANTABLE)
+				.addOptionalTag(ItemTags.VANISHING_ENCHANTABLE);
 
 		// Deprecated tags below
 

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/enchantables.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/enchantables.json
@@ -51,6 +51,10 @@
     {
       "id": "#minecraft:enchantable/durability",
       "required": false
+    },
+    {
+      "id": "#minecraft:enchantable/vanishing",
+      "required": false
     }
   ]
 }


### PR DESCRIPTION
Makes sure the tag is fully complete. 

Neo PR: https://github.com/neoforged/NeoForge/pull/1494