### PR TITLE
Add ItemVariant#withComponentChanges and FluidVariant#withComponentChanges

### DIFF
--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariant.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariant.java
@@ -84,4 +84,11 @@ public interface FluidVariant extends TransferVariant<Fluid> {
 	default RegistryEntry<Fluid> getRegistryEntry() {
 		return getFluid().getRegistryEntry();
 	}
+
+	/**
+	 * Creates a copy of this FluidVariant with the provided component changes applied.
+	 * @param changes the changes to apply
+	 * @return the new variant with the changes applied
+	 */
+	FluidVariant withChanges(ComponentChanges changes);
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariant.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariant.java
@@ -90,5 +90,6 @@ public interface FluidVariant extends TransferVariant<Fluid> {
 	 * @param changes the changes to apply
 	 * @return the new variant with the changes applied
 	 */
+	@Override
 	FluidVariant withComponentChanges(ComponentChanges changes);
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariant.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariant.java
@@ -90,5 +90,5 @@ public interface FluidVariant extends TransferVariant<Fluid> {
 	 * @param changes the changes to apply
 	 * @return the new variant with the changes applied
 	 */
-	FluidVariant withChanges(ComponentChanges changes);
+	FluidVariant withComponentChanges(ComponentChanges changes);
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/ItemVariant.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/ItemVariant.java
@@ -106,4 +106,13 @@ public interface ItemVariant extends TransferVariant<Item> {
 		if (isBlank()) return ItemStack.EMPTY;
 		return new ItemStack(getRegistryEntry(), count, getComponents());
 	}
+
+	/**
+	 * Creates a copy of this ItemVariant with the provided component changes applied.
+	 * @param changes the changes to apply
+	 * @return the new variant with the changes applied
+	 *
+	 * @see ItemStack#applyUnvalidatedChanges(ComponentChanges)
+	 */
+	ItemVariant withChanges(ComponentChanges changes);
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/ItemVariant.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/ItemVariant.java
@@ -114,5 +114,6 @@ public interface ItemVariant extends TransferVariant<Item> {
 	 *
 	 * @see ItemStack#applyUnvalidatedChanges(ComponentChanges)
 	 */
+	@Override
 	ItemVariant withComponentChanges(ComponentChanges changes);
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/ItemVariant.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/ItemVariant.java
@@ -114,5 +114,5 @@ public interface ItemVariant extends TransferVariant<Item> {
 	 *
 	 * @see ItemStack#applyUnvalidatedChanges(ComponentChanges)
 	 */
-	ItemVariant withChanges(ComponentChanges changes);
+	ItemVariant withComponentChanges(ComponentChanges changes);
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/TransferVariant.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/TransferVariant.java
@@ -81,5 +81,7 @@ public interface TransferVariant<O> {
 	 * @param changes the changes to apply
 	 * @return the new variant with the changes applied
 	 */
-	TransferVariant<O> withComponentChanges(ComponentChanges changes);
+	default TransferVariant<O> withComponentChanges(ComponentChanges changes) {
+		throw new UnsupportedOperationException("withComponentChanges is not supported by this TransferVariant");
+	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/TransferVariant.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/TransferVariant.java
@@ -75,4 +75,11 @@ public interface TransferVariant<O> {
 	default boolean isOf(O object) {
 		return getObject() == object;
 	}
+
+	/**
+	 * Creates a copy of this TransferVariant with the provided component changes applied.
+	 * @param changes the changes to apply
+	 * @return the new variant with the changes applied
+	 */
+	TransferVariant<O> withComponentChanges(ComponentChanges changes);
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/TransferApiImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/TransferApiImpl.java
@@ -20,11 +20,16 @@ import java.util.AbstractList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import net.minecraft.component.ComponentChanges;
+import net.minecraft.component.ComponentType;
 
 import net.fabricmc.fabric.api.transfer.v1.storage.SlottedStorage;
 import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
@@ -106,5 +111,25 @@ public class TransferApiImpl {
 				return storage.getSlotCount();
 			}
 		};
+	}
+
+	public static ComponentChanges mergeChanges(ComponentChanges base, ComponentChanges applied) {
+		ComponentChanges.Builder builder = ComponentChanges.builder();
+
+		writeChangesTo(base, builder);
+		writeChangesTo(applied, builder);
+
+		return builder.build();
+	}
+
+	@SuppressWarnings("unchecked")
+	private static void writeChangesTo(ComponentChanges changes, ComponentChanges.Builder builder) {
+		for (Map.Entry<ComponentType<?>, Optional<?>> entry : changes.entrySet()) {
+			if (entry.getValue().isPresent()) {
+				builder.add((ComponentType<Object>) entry.getKey(), entry.getValue().get());
+			} else {
+				builder.remove(entry.getKey());
+			}
+		}
 	}
 }

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/FluidVariantImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/FluidVariantImpl.java
@@ -97,7 +97,7 @@ public class FluidVariantImpl implements FluidVariant {
 	}
 
 	@Override
-	public FluidVariant withChanges(ComponentChanges changes) {
+	public FluidVariant withComponentChanges(ComponentChanges changes) {
 		return of(fluid, TransferApiImpl.mergeChanges(getComponents(), changes));
 	}
 

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/FluidVariantImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/fluid/FluidVariantImpl.java
@@ -31,6 +31,7 @@ import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
+import net.fabricmc.fabric.impl.transfer.TransferApiImpl;
 
 public class FluidVariantImpl implements FluidVariant {
 	public static FluidVariant of(Fluid fluid, ComponentChanges components) {
@@ -93,6 +94,11 @@ public class FluidVariantImpl implements FluidVariant {
 	@Override
 	public ComponentMap getComponentMap() {
 		return componentMap;
+	}
+
+	@Override
+	public FluidVariant withChanges(ComponentChanges changes) {
+		return of(fluid, TransferApiImpl.mergeChanges(getComponents(), changes));
 	}
 
 	@Override

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/ItemVariantImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/ItemVariantImpl.java
@@ -78,7 +78,7 @@ public class ItemVariantImpl implements ItemVariant {
 	}
 
 	@Override
-	public ItemVariant withChanges(ComponentChanges changes) {
+	public ItemVariant withComponentChanges(ComponentChanges changes) {
 		return of(item, TransferApiImpl.mergeChanges(getComponents(), changes));
 	}
 

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/ItemVariantImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/ItemVariantImpl.java
@@ -28,6 +28,7 @@ import net.minecraft.item.Items;
 import net.minecraft.registry.entry.RegistryEntry;
 
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import net.fabricmc.fabric.impl.transfer.TransferApiImpl;
 
 public class ItemVariantImpl implements ItemVariant {
 	public static ItemVariant of(Item item, ComponentChanges components) {
@@ -74,6 +75,11 @@ public class ItemVariantImpl implements ItemVariant {
 	@Override
 	public ComponentMap getComponentMap() {
 		return getCachedStack().getComponents();
+	}
+
+	@Override
+	public ItemVariant withChanges(ComponentChanges changes) {
+		return of(item, TransferApiImpl.mergeChanges(getComponents(), changes));
 	}
 
 	@Override

--- a/fabric-transfer-api-v1/src/test/java/net/fabricmc/fabric/test/transfer/unittests/FluidVariantTests.java
+++ b/fabric-transfer-api-v1/src/test/java/net/fabricmc/fabric/test/transfer/unittests/FluidVariantTests.java
@@ -47,17 +47,17 @@ class FluidVariantTests extends AbstractTransferApiTest {
 	@Test
 	public void testWithComponentChanges() {
 		FluidVariant variant = FluidVariant.of(Fluids.WATER, ComponentChanges.builder()
-				.add(DataComponentTypes.FIRE_RESISTANT, Unit.INSTANCE)
+				.add(DataComponentTypes.HIDE_TOOLTIP, Unit.INSTANCE)
 				.build());
 
 		FluidVariant newVariant = variant.withComponentChanges(ComponentChanges.builder()
-				.remove(DataComponentTypes.FIRE_RESISTANT)
+				.remove(DataComponentTypes.HIDE_TOOLTIP)
 				.add(DataComponentTypes.GLIDER, Unit.INSTANCE)
 				.build());
 
 		Assertions.assertFalse(
-				newVariant.getComponentMap().contains(DataComponentTypes.FIRE_RESISTANT),
-				"New variant's FIRE_RESISTANT component was removed, but is still present"
+				newVariant.getComponentMap().contains(DataComponentTypes.HIDE_TOOLTIP),
+				"New variant's HIDE_TOOLTIP component was removed, but is still present"
 		);
 
 		Assertions.assertTrue(

--- a/fabric-transfer-api-v1/src/test/java/net/fabricmc/fabric/test/transfer/unittests/FluidVariantTests.java
+++ b/fabric-transfer-api-v1/src/test/java/net/fabricmc/fabric/test/transfer/unittests/FluidVariantTests.java
@@ -18,11 +18,15 @@ package net.fabricmc.fabric.test.transfer.unittests;
 
 import static net.fabricmc.fabric.test.transfer.TestUtil.assertEquals;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import net.minecraft.component.ComponentChanges;
+import net.minecraft.component.DataComponentTypes;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.fluid.Fluids;
+import net.minecraft.util.Unit;
 
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 
@@ -38,6 +42,28 @@ class FluidVariantTests extends AbstractTransferApiTest {
 		assertFluidEquals(Fluids.LAVA, FluidVariant.of(Fluids.LAVA), FluidVariant.of(Fluids.FLOWING_LAVA));
 		assertEquals(FluidVariant.of(Fluids.WATER), FluidVariant.of(Fluids.FLOWING_WATER));
 		assertEquals(FluidVariant.of(Fluids.LAVA), FluidVariant.of(Fluids.FLOWING_LAVA));
+	}
+
+	@Test
+	public void testWithChanges() {
+		FluidVariant variant = FluidVariant.of(Fluids.WATER, ComponentChanges.builder()
+				.add(DataComponentTypes.FIRE_RESISTANT, Unit.INSTANCE)
+				.build());
+
+		FluidVariant newVariant = variant.withChanges(ComponentChanges.builder()
+				.remove(DataComponentTypes.FIRE_RESISTANT)
+				.add(DataComponentTypes.GLIDER, Unit.INSTANCE)
+				.build());
+
+		Assertions.assertFalse(
+				newVariant.getComponentMap().contains(DataComponentTypes.FIRE_RESISTANT),
+				"New variant's FIRE_RESISTANT component was removed, but is still present"
+		);
+
+		Assertions.assertTrue(
+				newVariant.getComponentMap().contains(DataComponentTypes.GLIDER),
+				"New variant's GLIDER component was added, but is not present"
+		);
 	}
 
 	private static void assertFluidEquals(Fluid fluid, FluidVariant... variants) {

--- a/fabric-transfer-api-v1/src/test/java/net/fabricmc/fabric/test/transfer/unittests/FluidVariantTests.java
+++ b/fabric-transfer-api-v1/src/test/java/net/fabricmc/fabric/test/transfer/unittests/FluidVariantTests.java
@@ -45,12 +45,12 @@ class FluidVariantTests extends AbstractTransferApiTest {
 	}
 
 	@Test
-	public void testWithChanges() {
+	public void testWithComponentChanges() {
 		FluidVariant variant = FluidVariant.of(Fluids.WATER, ComponentChanges.builder()
 				.add(DataComponentTypes.FIRE_RESISTANT, Unit.INSTANCE)
 				.build());
 
-		FluidVariant newVariant = variant.withChanges(ComponentChanges.builder()
+		FluidVariant newVariant = variant.withComponentChanges(ComponentChanges.builder()
 				.remove(DataComponentTypes.FIRE_RESISTANT)
 				.add(DataComponentTypes.GLIDER, Unit.INSTANCE)
 				.build());


### PR DESCRIPTION
Right now making a new transfer variant with some changed components is a bit cumbersome.
This PR adds a method to both ItemVariant and FluidVariant for easily making a copy of a variant with your component changes applied.