### PR TITLE
add AllowWorldChange, AllowTeleport and AfterTeleport

### DIFF
--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerEntityWorldChangeEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerEntityWorldChangeEvents.java
@@ -45,6 +45,19 @@ public final class ServerEntityWorldChangeEvents {
 		}
 	});
 
+    /**
+	 * Called before a player is being moved to a different world.
+	 */
+	public static final Event<AllowPlayerChange> ALLOW_PLAYER_CHANGE_WORLD = EventFactory.createArrayBacked(AllowPlayerChange.class, callbacks -> (player, origin, destination) -> {
+		for (AllowPlayerChange callback : callbacks) {
+			if(!callback.allowChangeWorld(player, origin, destination)){
+                return false;
+            }
+		}
+
+        return true;
+	});
+
 	/**
 	 * An event which is called after a player has been moved to a different world.
 	 *
@@ -73,6 +86,18 @@ public final class ServerEntityWorldChangeEvents {
 		 * @param destination the destination world the new entity is in
 		 */
 		void afterChangeWorld(Entity originalEntity, Entity newEntity, ServerWorld origin, ServerWorld destination);
+	}
+
+	@FunctionalInterface
+	public interface AllowPlayerChange {
+		/**
+		 * Called before a player is being moved to a different world.
+		 *
+		 * @param player the player
+		 * @param origin the original world the player was in
+		 * @param destination the new world the player was moved to
+		 */
+		boolean allowChangeWorld(ServerPlayerEntity player, ServerWorld origin, ServerWorld destination);
 	}
 
 	@FunctionalInterface

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerEntityWorldChangeEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerEntityWorldChangeEvents.java
@@ -50,7 +50,7 @@ public final class ServerEntityWorldChangeEvents {
 	 */
 	public static final Event<AllowPlayerChange> ALLOW_PLAYER_CHANGE_WORLD = EventFactory.createArrayBacked(AllowPlayerChange.class, callbacks -> (player, origin, destination) -> {
 		for (AllowPlayerChange callback : callbacks) {
-			if(!callback.allowChangeWorld(player, origin, destination)){
+			if (!callback.allowChangeWorld(player, origin, destination)){
 				return false;
 			}
 		}

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerEntityWorldChangeEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerEntityWorldChangeEvents.java
@@ -94,8 +94,9 @@ public final class ServerEntityWorldChangeEvents {
 		 * Called before a player is being moved to a different world.
 		 *
 		 * @param player the player
-		 * @param origin the original world the player was in
-		 * @param destination the new world the player was moved to
+		 * @param origin the original world the player is in
+		 * @param destination the new world the player is moving to
+		 * @return true if the player is allowed to change worlds, false otherwise
 		 */
 		boolean allowChangeWorld(ServerPlayerEntity player, ServerWorld origin, ServerWorld destination);
 	}

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerEntityWorldChangeEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerEntityWorldChangeEvents.java
@@ -45,17 +45,17 @@ public final class ServerEntityWorldChangeEvents {
 		}
 	});
 
-    /**
+	/**
 	 * Called before a player is being moved to a different world.
 	 */
 	public static final Event<AllowPlayerChange> ALLOW_PLAYER_CHANGE_WORLD = EventFactory.createArrayBacked(AllowPlayerChange.class, callbacks -> (player, origin, destination) -> {
 		for (AllowPlayerChange callback : callbacks) {
 			if(!callback.allowChangeWorld(player, origin, destination)){
-                return false;
-            }
+				return false;
+			}
 		}
 
-        return true;
+		return true;
 	});
 
 	/**

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -18,7 +18,7 @@ package net.fabricmc.fabric.api.entity.event.v1;
 
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.server.network.ServerPlayerEntity;
-
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.Vec3d;
 
 import net.fabricmc.fabric.api.event.Event;
@@ -67,9 +67,9 @@ public final class ServerPlayerEvents {
     /**
      * Called when a player is about to be teleported.
      */
-    public static final Event<AllowTeleport> ALLOW_TELEPORT = EventFactory.createArrayBacked(AllowTeleport.class, callbacks -> (player, pos) -> {
+    public static final Event<AllowTeleport> ALLOW_TELEPORT = EventFactory.createArrayBacked(AllowTeleport.class, callbacks -> (player, world, pos) -> {
 		for (AllowTeleport callback : callbacks) {
-			if (!callback.allowTeleport(player, pos)) {
+			if (!callback.allowTeleport(player, world, pos)) {
 				return false;
 			}
 		}
@@ -116,10 +116,11 @@ public final class ServerPlayerEvents {
 		 * Called when a player is about to be teleported.
          * 
          * @param player the teleporting player
+         * @param world the world to teleport to
          * @param pos the new position to teleport to
          * @return true if the teleport should go ahead, false otherwise.
 		 */
-		boolean allowTeleport(ServerPlayerEntity player, Vec3d pos);
+		boolean allowTeleport(ServerPlayerEntity player, ServerWorld world, Vec3d pos);
 	}
 
     @FunctionalInterface

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -19,6 +19,8 @@ package net.fabricmc.fabric.api.entity.event.v1;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 
+import net.minecraft.util.math.Vec3d;
+
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
@@ -61,6 +63,28 @@ public final class ServerPlayerEvents {
 
 		return true;
 	});
+    
+    /**
+     * Called when a player is about to be teleported.
+     */
+    public static final Event<AllowTeleport> ALLOW_TELEPORT = EventFactory.createArrayBacked(AllowTeleport.class, callbacks -> (player, pos) -> {
+		for (AllowTeleport callback : callbacks) {
+			if (!callback.allowTeleport(player, pos)) {
+				return false;
+			}
+		}
+
+		return true;
+	});
+
+    /**
+     * Called when a player has been teleported.
+     */
+    public static final Event<AfterTeleport> AFTER_TELEPORT = EventFactory.createArrayBacked(AfterTeleport.class, callbacks -> (player) -> {
+		for (AfterTeleport callback : callbacks) {
+			callback.afterTeleport(player);
+		}
+	});
 
 	@FunctionalInterface
 	public interface CopyFrom {
@@ -84,6 +108,28 @@ public final class ServerPlayerEvents {
 		 * @param alive whether the old player is still alive
 		 */
 		void afterRespawn(ServerPlayerEntity oldPlayer, ServerPlayerEntity newPlayer, boolean alive);
+	}
+
+    @FunctionalInterface
+	public interface AllowTeleport {
+		/**
+		 * Called when a player is about to be teleported.
+         * 
+         * @param player the teleporting player
+         * @param pos the new position to teleport to
+         * @return true if the teleport should go ahead, false otherwise.
+		 */
+		boolean allowTeleport(ServerPlayerEntity player, Vec3d pos);
+	}
+
+    @FunctionalInterface
+	public interface AfterTeleport {
+		/**
+		 * Called when a player has been teleported.
+         * 
+         * @param player the teleported player
+		 */
+		void afterTeleport(ServerPlayerEntity player);
 	}
 
 	/**

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -114,7 +114,8 @@ public final class ServerPlayerEvents {
 	public interface AllowTeleport {
 		/**
 		 * Called when a player is about to be teleported.
-		* 
+		 * <p>this event will not call if the player is using a portal.
+		 * 
 		 * @param player the teleporting player
 		 * @param world the world to teleport to
 		 * @param pos the new position to teleport to
@@ -127,6 +128,7 @@ public final class ServerPlayerEvents {
 	public interface AfterTeleport {
 		/**
 		 * Called when a player has been teleported.
+		 * <p>this event will not call if the player used a portal.
 		 * 
 		 * @param player the teleported player
 		 */

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -63,11 +63,11 @@ public final class ServerPlayerEvents {
 
 		return true;
 	});
-    
-    /**
-     * Called when a player is about to be teleported.
-     */
-    public static final Event<AllowTeleport> ALLOW_TELEPORT = EventFactory.createArrayBacked(AllowTeleport.class, callbacks -> (player, world, pos) -> {
+
+	/**
+	 * Called when a player is about to be teleported.
+	 */
+	public static final Event<AllowTeleport> ALLOW_TELEPORT = EventFactory.createArrayBacked(AllowTeleport.class, callbacks -> (player, world, pos) -> {
 		for (AllowTeleport callback : callbacks) {
 			if (!callback.allowTeleport(player, world, pos)) {
 				return false;
@@ -77,10 +77,10 @@ public final class ServerPlayerEvents {
 		return true;
 	});
 
-    /**
-     * Called when a player has been teleported.
-     */
-    public static final Event<AfterTeleport> AFTER_TELEPORT = EventFactory.createArrayBacked(AfterTeleport.class, callbacks -> (player) -> {
+	/**
+	 * Called when a player has been teleported.
+	 */
+	public static final Event<AfterTeleport> AFTER_TELEPORT = EventFactory.createArrayBacked(AfterTeleport.class, callbacks -> (player) -> {
 		for (AfterTeleport callback : callbacks) {
 			callback.afterTeleport(player);
 		}
@@ -110,25 +110,25 @@ public final class ServerPlayerEvents {
 		void afterRespawn(ServerPlayerEntity oldPlayer, ServerPlayerEntity newPlayer, boolean alive);
 	}
 
-    @FunctionalInterface
+	@FunctionalInterface
 	public interface AllowTeleport {
 		/**
 		 * Called when a player is about to be teleported.
-         * 
-         * @param player the teleporting player
-         * @param world the world to teleport to
-         * @param pos the new position to teleport to
-         * @return true if the teleport should go ahead, false otherwise.
+		* 
+		 * @param player the teleporting player
+		 * @param world the world to teleport to
+		 * @param pos the new position to teleport to
+		 * @return true if the teleport should go ahead, false otherwise.
 		 */
 		boolean allowTeleport(ServerPlayerEntity player, ServerWorld world, Vec3d pos);
 	}
 
-    @FunctionalInterface
+	@FunctionalInterface
 	public interface AfterTeleport {
 		/**
 		 * Called when a player has been teleported.
-         * 
-         * @param player the teleported player
+		 * 
+		 * @param player the teleported player
 		 */
 		void afterTeleport(ServerPlayerEntity player);
 	}

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -114,8 +114,9 @@ public final class ServerPlayerEvents {
 	public interface AllowTeleport {
 		/**
 		 * Called when a player is about to be teleported.
+		 *
 		 * <p>this event will not call if the player is using a portal.
-		 * 
+		 *
 		 * @param player the teleporting player
 		 * @param world the world to teleport to
 		 * @param pos the new position to teleport to
@@ -128,8 +129,9 @@ public final class ServerPlayerEvents {
 	public interface AfterTeleport {
 		/**
 		 * Called when a player has been teleported.
+		 *
 		 * <p>this event will not call if the player used a portal.
-		 * 
+		 *
 		 * @param player the teleported player
 		 */
 		void afterTeleport(ServerPlayerEntity player);

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/ServerPlayerEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/ServerPlayerEntityMixin.java
@@ -87,12 +87,12 @@ abstract class ServerPlayerEntityMixin extends LivingEntityMixin {
 	@Inject(method = "teleportTo", at = @At(value = "FIELD", target = "Lnet/minecraft/server/network/ServerPlayerEntity;inTeleportationState:Z", opcode = Opcodes.PUTFIELD, shift = At.Shift.BEFORE), cancellable = true)
 	private void beforeWorldChanged(TeleportTarget teleportTarget, CallbackInfoReturnable<Entity> cir) {
 		ServerPlayerEntity player = (ServerPlayerEntity) (Object) this;
-        boolean allowed = ServerEntityWorldChangeEvents.ALLOW_PLAYER_CHANGE_WORLD.invoker().allowChangeWorld(player, player.getServerWorld(), teleportTarget.world());
-        if (!allowed) {
-            cir.setReturnValue(null);
-            cir.cancel();    
-        }
-    }
+		boolean allowed = ServerEntityWorldChangeEvents.ALLOW_PLAYER_CHANGE_WORLD.invoker().allowChangeWorld(player, player.getServerWorld(), teleportTarget.world());
+		if (!allowed) {
+			cir.setReturnValue(null);
+			cir.cancel();
+		}
+	}
 
 	/**
 	 * This is called by {@code teleportTo}.
@@ -107,20 +107,20 @@ abstract class ServerPlayerEntityMixin extends LivingEntityMixin {
 		ServerPlayerEvents.COPY_FROM.invoker().copyFromPlayer(oldPlayer, (ServerPlayerEntity) (Object) this, alive);
 	}
 
-    @Inject(method = "teleport(Lnet/minecraft/server/world/ServerWorld;DDDLjava/util/Set;FF)Z", at = @At("HEAD"), cancellable = true)
-    private void beforeTeleport(ServerWorld world, double destX, double destY, double destZ, Set<PositionFlag> flags, float yaw, float pitch, CallbackInfoReturnable<Boolean> cir) throws CommandSyntaxException {
-        ServerPlayerEntity player = (ServerPlayerEntity) (Object) this;
-        boolean allowed = ServerPlayerEvents.ALLOW_TELEPORT.invoker().allowTeleport(player, world, new Vec3d(destX, destY, destZ));
-        if (!allowed) {
-            throw new CommandSyntaxException(null, new LiteralMessage(""));
-        }
-    }
+	@Inject(method = "teleport(Lnet/minecraft/server/world/ServerWorld;DDDLjava/util/Set;FF)Z", at = @At("HEAD"), cancellable = true)
+	private void beforeTeleport(ServerWorld world, double destX, double destY, double destZ, Set<PositionFlag> flags, float yaw, float pitch, CallbackInfoReturnable<Boolean> cir) throws CommandSyntaxException {
+		ServerPlayerEntity player = (ServerPlayerEntity) (Object) this;
+		boolean allowed = ServerPlayerEvents.ALLOW_TELEPORT.invoker().allowTeleport(player, world, new Vec3d(destX, destY, destZ));
+		if (!allowed) {
+			throw new CommandSyntaxException(null, new LiteralMessage(""));
+		}
+	}
 
-    @Inject(method = "teleport(Lnet/minecraft/server/world/ServerWorld;DDDLjava/util/Set;FF)Z", at = @At("TAIL"), cancellable = true)
-    private void afterTeleported(ServerWorld world, double destX, double destY, double destZ, Set<PositionFlag> flags, float yaw, float pitch, CallbackInfoReturnable<Boolean> cir) {
-        ServerPlayerEntity player = (ServerPlayerEntity) (Object) this;
-        ServerPlayerEvents.AFTER_TELEPORT.invoker().afterTeleport(player);
-    }
+	@Inject(method = "teleport(Lnet/minecraft/server/world/ServerWorld;DDDLjava/util/Set;FF)Z", at = @At("TAIL"), cancellable = true)
+	private void afterTeleported(ServerWorld world, double destX, double destY, double destZ, Set<PositionFlag> flags, float yaw, float pitch, CallbackInfoReturnable<Boolean> cir) {
+		ServerPlayerEntity player = (ServerPlayerEntity) (Object) this;
+		ServerPlayerEvents.AFTER_TELEPORT.invoker().afterTeleport(player);
+	}
 
 	@Redirect(method = "trySleep", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;get(Lnet/minecraft/state/property/Property;)Ljava/lang/Comparable;"))
 	private Comparable<?> redirectSleepDirection(BlockState state, Property<?> property, BlockPos pos) {

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/ServerPlayerEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/ServerPlayerEntityMixin.java
@@ -84,13 +84,13 @@ abstract class ServerPlayerEntityMixin extends LivingEntityMixin {
 		ServerLivingEntityEvents.AFTER_DEATH.invoker().afterDeath((ServerPlayerEntity) (Object) this, source);
 	}
 
-	@Inject(method = "teleportTo", at = @At(value = "FIELD", target = "Lnet/minecraft/server/network/ServerPlayerEntity;inTeleportationState:Z", opcode = Opcodes.PUTFIELD, shift = At.Shift.BEFORE), cancellable = true)
+	@Inject(method = "teleportTo", at = @At(value = "FIELD", target = "Lnet/minecraft/server/network/ServerPlayerEntity;inTeleportationState:Z", opcode = Opcodes.PUTFIELD), cancellable = true)
 	private void beforeWorldChanged(TeleportTarget teleportTarget, CallbackInfoReturnable<Entity> cir) {
 		ServerPlayerEntity player = (ServerPlayerEntity) (Object) this;
 		boolean allowed = ServerEntityWorldChangeEvents.ALLOW_PLAYER_CHANGE_WORLD.invoker().allowChangeWorld(player, player.getServerWorld(), teleportTarget.world());
+
 		if (!allowed) {
 			cir.setReturnValue(null);
-			cir.cancel();
 		}
 	}
 
@@ -107,16 +107,17 @@ abstract class ServerPlayerEntityMixin extends LivingEntityMixin {
 		ServerPlayerEvents.COPY_FROM.invoker().copyFromPlayer(oldPlayer, (ServerPlayerEntity) (Object) this, alive);
 	}
 
-	@Inject(method = "teleport(Lnet/minecraft/server/world/ServerWorld;DDDLjava/util/Set;FF)Z", at = @At("HEAD"), cancellable = true)
+	@Inject(method = "teleport(Lnet/minecraft/server/world/ServerWorld;DDDLjava/util/Set;FF)Z", at = @At("HEAD"))
 	private void beforeTeleport(ServerWorld world, double destX, double destY, double destZ, Set<PositionFlag> flags, float yaw, float pitch, CallbackInfoReturnable<Boolean> cir) throws CommandSyntaxException {
 		ServerPlayerEntity player = (ServerPlayerEntity) (Object) this;
 		boolean allowed = ServerPlayerEvents.ALLOW_TELEPORT.invoker().allowTeleport(player, world, new Vec3d(destX, destY, destZ));
+
 		if (!allowed) {
 			throw new CommandSyntaxException(null, new LiteralMessage(""));
 		}
 	}
 
-	@Inject(method = "teleport(Lnet/minecraft/server/world/ServerWorld;DDDLjava/util/Set;FF)Z", at = @At("TAIL"), cancellable = true)
+	@Inject(method = "teleport(Lnet/minecraft/server/world/ServerWorld;DDDLjava/util/Set;FF)Z", at = @At("TAIL"))
 	private void afterTeleported(ServerWorld world, double destX, double destY, double destZ, Set<PositionFlag> flags, float yaw, float pitch, CallbackInfoReturnable<Boolean> cir) {
 		ServerPlayerEntity player = (ServerPlayerEntity) (Object) this;
 		ServerPlayerEvents.AFTER_TELEPORT.invoker().afterTeleport(player);

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/ServerPlayerEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/ServerPlayerEntityMixin.java
@@ -100,7 +100,7 @@ abstract class ServerPlayerEntityMixin extends LivingEntityMixin {
         ServerPlayerEntity player = (ServerPlayerEntity) (Object) this;
         boolean allowed = ServerPlayerEvents.ALLOW_TELEPORT.invoker().allowTeleport(player, new Vec3d(destX, destY, destZ));
         if (!allowed) {
-            throw new CommandSyntaxException(null, new LiteralMessage("You are not allowed to teleport from this location."));
+            throw new CommandSyntaxException(null, new LiteralMessage(""));
         }
     }
 

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -67,7 +67,7 @@ public final class EntityEventTests implements ModInitializer {
 		ServerEntityWorldChangeEvents.ALLOW_PLAYER_CHANGE_WORLD.register((player, origin, destination) -> {
 			if (player.getStackInHand(Hand.MAIN_HAND).getItem() == Items.END_ROD) {
 				LOGGER.info("Player {} failed to change world because of handing an end rod", player.getGameProfile().getName());
-			return false;
+				return false;
 			}
 			LOGGER.info("Allow Moving player {}: [{} -> {}]", player, origin.getRegistryKey().getValue(), destination.getRegistryKey().getValue());
 			return true;

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -80,6 +80,20 @@ public final class EntityEventTests implements ModInitializer {
 			LOGGER.info("Respawned {}, [{}, {}]", oldPlayer.getGameProfile().getName(), oldPlayer.getWorld().getRegistryKey().getValue(), newPlayer.getWorld().getRegistryKey().getValue());
 		});
 
+        ServerPlayerEvents.ALLOW_TELEPORT.register((player, pos) -> {
+            if(pos.getY() < -256)
+            {
+                LOGGER.info("Player {} is trying to teleport to a negative Y position", player.getGameProfile().getName());
+                return false;
+            }
+            LOGGER.info("Player {} is teleporting to {}", player.getGameProfile().getName(), pos);
+            return true;
+        });
+
+        ServerPlayerEvents.AFTER_TELEPORT.register((player) -> {
+            LOGGER.info("Player {} is teleported", player.getGameProfile().getName());
+        });
+    
 		// No fall damage if holding a feather in the main hand
 		ServerLivingEntityEvents.ALLOW_DAMAGE.register((entity, source, amount) -> {
 			if (source.getTypeRegistryEntry().matchesKey(DamageTypes.FALL) && entity.getStackInHand(Hand.MAIN_HAND).isOf(Items.FEATHER)) {

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -64,6 +64,15 @@ public final class EntityEventTests implements ModInitializer {
 			LOGGER.info("Entity {} Killed: {}", entity, killed);
 		});
 
+		ServerEntityWorldChangeEvents.ALLOW_PLAYER_CHANGE_WORLD.register((player, origin, destination) -> {
+			if (player.getStackInHand(Hand.MAIN_HAND).getItem() == Items.END_ROD) {
+                LOGGER.info("Player {} failed to change world because of handing an end rod", player.getGameProfile().getName());
+                return false;
+            }
+            LOGGER.info("Allow Moving player {}: [{} -> {}]", player, origin.getRegistryKey().getValue(), destination.getRegistryKey().getValue());
+            return true;
+        });
+
 		ServerEntityWorldChangeEvents.AFTER_PLAYER_CHANGE_WORLD.register((player, origin, destination) -> {
 			LOGGER.info("Moved player {}: [{} -> {}]", player, origin.getRegistryKey().getValue(), destination.getRegistryKey().getValue());
 		});
@@ -80,13 +89,13 @@ public final class EntityEventTests implements ModInitializer {
 			LOGGER.info("Respawned {}, [{}, {}]", oldPlayer.getGameProfile().getName(), oldPlayer.getWorld().getRegistryKey().getValue(), newPlayer.getWorld().getRegistryKey().getValue());
 		});
 
-        ServerPlayerEvents.ALLOW_TELEPORT.register((player, pos) -> {
-            if(pos.getY() < -256)
+        ServerPlayerEvents.ALLOW_TELEPORT.register((player, world, pos) -> {
+            if (pos.y < -256)
             {
-                LOGGER.info("Player {} is trying to teleport to a negative Y position", player.getGameProfile().getName());
+                LOGGER.info("Player {} is trying to teleport below the world height", player.getGameProfile().getName());
                 return false;
             }
-            LOGGER.info("Player {} is teleporting to {}", player.getGameProfile().getName(), pos);
+            LOGGER.info("Player {} is teleporting to {} {}", player.getGameProfile().getName(), world, pos);
             return true;
         });
 

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -66,12 +66,12 @@ public final class EntityEventTests implements ModInitializer {
 
 		ServerEntityWorldChangeEvents.ALLOW_PLAYER_CHANGE_WORLD.register((player, origin, destination) -> {
 			if (player.getStackInHand(Hand.MAIN_HAND).getItem() == Items.END_ROD) {
-                LOGGER.info("Player {} failed to change world because of handing an end rod", player.getGameProfile().getName());
-                return false;
-            }
-            LOGGER.info("Allow Moving player {}: [{} -> {}]", player, origin.getRegistryKey().getValue(), destination.getRegistryKey().getValue());
-            return true;
-        });
+				LOGGER.info("Player {} failed to change world because of handing an end rod", player.getGameProfile().getName());
+			return false;
+			}
+			LOGGER.info("Allow Moving player {}: [{} -> {}]", player, origin.getRegistryKey().getValue(), destination.getRegistryKey().getValue());
+			return true;
+		});
 
 		ServerEntityWorldChangeEvents.AFTER_PLAYER_CHANGE_WORLD.register((player, origin, destination) -> {
 			LOGGER.info("Moved player {}: [{} -> {}]", player, origin.getRegistryKey().getValue(), destination.getRegistryKey().getValue());
@@ -89,20 +89,20 @@ public final class EntityEventTests implements ModInitializer {
 			LOGGER.info("Respawned {}, [{}, {}]", oldPlayer.getGameProfile().getName(), oldPlayer.getWorld().getRegistryKey().getValue(), newPlayer.getWorld().getRegistryKey().getValue());
 		});
 
-        ServerPlayerEvents.ALLOW_TELEPORT.register((player, world, pos) -> {
-            if (pos.y < -256)
-            {
-                LOGGER.info("Player {} is trying to teleport below the world height", player.getGameProfile().getName());
-                return false;
-            }
-            LOGGER.info("Player {} is teleporting to {} {}", player.getGameProfile().getName(), world, pos);
-            return true;
-        });
+		ServerPlayerEvents.ALLOW_TELEPORT.register((player, world, pos) -> {
+			if (pos.y < -256)
+			{
+				LOGGER.info("Player {} is trying to teleport below the world height", player.getGameProfile().getName());
+				return false;
+			}
+			LOGGER.info("Player {} is teleporting to {} {}", player.getGameProfile().getName(), world, pos);
+			return true;
+		});
 
-        ServerPlayerEvents.AFTER_TELEPORT.register((player) -> {
-            LOGGER.info("Player {} is teleported", player.getGameProfile().getName());
-        });
-    
+		ServerPlayerEvents.AFTER_TELEPORT.register((player) -> {
+			LOGGER.info("Player {} is teleported", player.getGameProfile().getName());
+		});
+
 		// No fall damage if holding a feather in the main hand
 		ServerLivingEntityEvents.ALLOW_DAMAGE.register((entity, source, amount) -> {
 			if (source.getTypeRegistryEntry().matchesKey(DamageTypes.FALL) && entity.getStackInHand(Hand.MAIN_HAND).isOf(Items.FEATHER)) {


### PR DESCRIPTION
~~I implemented an API that allows for custom actions to be executed before and after a player teleports to inject custom code at the beginning and end of the teleport method. This approach provides more control and flexibility over teleport behavior, such as restricting teleportation for some case or triggering specific effects after teleportation.~~
Added three APIs:
AllowWorldChange: Called when the player's dimension changes to check if the player is allowed to cross dimensions.
AllowTeleport: Called before the player teleports to check if the player is allowed to teleport.
AfterTeleport: Called after the player teleports to execute custom logic.
The first API can be used for portals, while the other two can be applied to various teleport commands and mods that use teleport commands.