### PR TITLE
Remove deprecated `BlockRenderLayerMap#putItem*`

### DIFF
--- a/fabric-blockrenderlayer-v1/src/client/java/net/fabricmc/fabric/api/blockrenderlayer/v1/BlockRenderLayerMap.java
+++ b/fabric-blockrenderlayer-v1/src/client/java/net/fabricmc/fabric/api/blockrenderlayer/v1/BlockRenderLayerMap.java
@@ -20,7 +20,6 @@ import net.minecraft.block.Block;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.RenderLayers;
 import net.minecraft.fluid.Fluid;
-import net.minecraft.item.Item;
 
 import net.fabricmc.fabric.impl.blockrenderlayer.BlockRenderLayerMapImpl;
 
@@ -55,20 +54,6 @@ public interface BlockRenderLayerMap {
 	 * @param blocks Identifies blocks to be mapped.
 	 */
 	void putBlocks(RenderLayer renderLayer, Block... blocks);
-
-	/**
-	 * @deprecated For blocks, calling {@link #putBlock(Block, RenderLayer)} is enough.
-	 * Other items always use a translucent render layer.
-	 */
-	@Deprecated(forRemoval = true)
-	void putItem(Item item, RenderLayer renderLayer);
-
-	/**
-	 * @deprecated For blocks, calling {@link #putBlocks(RenderLayer, Block...)} is enough.
-	 * Other items always use a translucent render layer.
-	 */
-	@Deprecated(forRemoval = true)
-	void putItems(RenderLayer renderLayer, Item... items);
 
 	/**
 	 * Map (or re-map) a fluid state with a render layer.  Re-mapping is not recommended but if done, last one in wins.


### PR DESCRIPTION
These methods turn the item into a block using `Block.getBlockFromItem(Item)` and use that block for actual registration. Thus, the `putIem*` methods are unnecessary and in my opinion are a confusing API. The comment that says "in previous snapshots Items had their own map for render layers" also makes me think that these methods were added and should have been removed in the same snapshot cycle, but were not.