### PR TITLE
Remove deprecated FRAPI fallback consumers

### DIFF
--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/material/MaterialFinder.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/material/MaterialFinder.java
@@ -115,12 +115,8 @@ public interface MaterialFinder extends MaterialView {
 	 * <p>This property is respected only in block contexts. It will not have an effect in other contexts.
 	 *
 	 * @see ShadeMode
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default MaterialFinder shadeMode(ShadeMode mode) {
-		return this;
-	}
+	MaterialFinder shadeMode(ShadeMode mode);
 
 	/**
 	 * Copies all properties from the given {@link MaterialView} to this material finder.

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/material/MaterialView.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/material/MaterialView.java
@@ -57,10 +57,6 @@ public interface MaterialView {
 
 	/**
 	 * @see MaterialFinder#shadeMode(ShadeMode)
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default ShadeMode shadeMode() {
-		return ShadeMode.ENHANCED;
-	}
+	ShadeMode shadeMode();
 }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/Mesh.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/Mesh.java
@@ -40,13 +40,6 @@ public interface Mesh {
 
 	/**
 	 * Outputs all quads in this mesh to the given quad emitter.
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default void outputTo(QuadEmitter emitter) {
-		forEach(quad -> {
-			emitter.copyFrom(quad);
-			emitter.emit();
-		});
-	};
+	void outputTo(QuadEmitter emitter);
 }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/RenderContext.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/RenderContext.java
@@ -17,17 +17,11 @@
 package net.fabricmc.fabric.api.renderer.v1.render;
 
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 import org.jetbrains.annotations.Nullable;
 
-import net.minecraft.block.BlockState;
-import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.client.render.model.json.ModelTransformationMode;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
-import net.minecraft.world.BlockRenderView;
 
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
 import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
@@ -59,12 +53,8 @@ public interface RenderContext {
 
 	/**
 	 * Returns whether this context currently has at least one transform.
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default boolean hasTransform() {
-		return true;
-	}
+	boolean hasTransform();
 
 	/**
 	 * Causes all models/quads/meshes sent to this consumer to be transformed by the provided
@@ -101,24 +91,16 @@ public interface RenderContext {
 	 *
 	 * <p>This function can only be used on a block render context (i.e. in {@link FabricBakedModel#emitBlockQuads}).
 	 * Calling it on another context (e.g. in {@link FabricBakedModel#emitItemQuads}) will throw an exception.
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default boolean isFaceCulled(@Nullable Direction face) {
-		return false;
-	}
+	boolean isFaceCulled(@Nullable Direction face);
 
 	/**
 	 * Returns the current transformation mode.
 	 *
 	 * <p>This function can only be used on an item render context (i.e. in {@link FabricBakedModel#emitItemQuads}).
 	 * Calling it on another context (e.g. in {@link FabricBakedModel#emitBlockQuads}) will throw an exception.
-	 *
-	 * @apiNote The default implementation will be removed in the next breaking release.
 	 */
-	default ModelTransformationMode itemTransformationMode() {
-		return ModelTransformationMode.NONE;
-	}
+	ModelTransformationMode itemTransformationMode();
 
 	@FunctionalInterface
 	interface QuadTransform {
@@ -135,48 +117,5 @@ public interface RenderContext {
 	@Deprecated
 	default Consumer<Mesh> meshConsumer() {
 		return mesh -> mesh.outputTo(getEmitter());
-	}
-
-	/**
-	 * @deprecated Use {@link FabricBakedModel#emitBlockQuads(BlockRenderView, BlockState, BlockPos, Supplier, RenderContext) emitBlockQuads}
-	 * or {@link FabricBakedModel#emitItemQuads(ItemStack, Supplier, RenderContext) emitItemQuads} on the baked model
-	 * that you want to consume instead.
-	 */
-	@Deprecated(forRemoval = true)
-	BakedModelConsumer bakedModelConsumer();
-
-	/**
-	 * @deprecated Use {@link FabricBakedModel#emitBlockQuads(BlockRenderView, BlockState, BlockPos, Supplier, RenderContext) emitBlockQuads}
-	 * or {@link FabricBakedModel#emitItemQuads(ItemStack, Supplier, RenderContext) emitItemQuads} on the baked model
-	 * that you want to consume instead.
-	 */
-	@Deprecated(forRemoval = true)
-	default Consumer<BakedModel> fallbackConsumer() {
-		return bakedModelConsumer();
-	}
-
-	@Deprecated(forRemoval = true)
-	interface BakedModelConsumer extends Consumer<BakedModel> {
-		/**
-		 * Render a baked model by processing its {@linkplain BakedModel#getQuads} using the rendered block state.
-		 *
-		 * <p>For block contexts, this will pass the block state being rendered to {@link BakedModel#getQuads}.
-		 * For item contexts, this will pass a {@code null} block state to {@link BakedModel#getQuads}.
-		 * {@link #accept(BakedModel, BlockState)} can be used instead to pass the block state explicitly.
-		 */
-		@Override
-		void accept(BakedModel model);
-
-		/**
-		 * Render a baked model by processing its {@linkplain BakedModel#getQuads} with an explicit block state.
-		 *
-		 * <p>This overload allows passing the block state (or {@code null} to query the item quads).
-		 * This is useful when a model is being wrapped, and expects a different
-		 * block state than the one of the block being rendered.
-		 *
-		 * <p>For item render contexts, you can use this function if you want to render the model with a specific block state.
-		 * Otherwise, use {@linkplain #accept(BakedModel)} the other overload} to render the usual item quads.
-		 */
-		void accept(BakedModel model, @Nullable BlockState state);
 	}
 }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/impl/renderer/VanillaModelEncoder.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/impl/renderer/VanillaModelEncoder.java
@@ -38,7 +38,6 @@ import net.fabricmc.fabric.api.util.TriState;
 
 /**
  * Routines for adaptation of vanilla {@link BakedModel}s to FRAPI pipelines.
- * Even though Indigo calls them directly, they are not for use by third party renderers, and might change at any time.
  */
 public class VanillaModelEncoder {
 	private static final Renderer RENDERER = RendererAccess.INSTANCE.getRenderer();

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AbstractRenderContext.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AbstractRenderContext.java
@@ -28,11 +28,25 @@ import net.minecraft.client.render.VertexConsumer;
 
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
 import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
+import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
+import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.EncodingFormat;
 import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.MutableQuadViewImpl;
 
 abstract class AbstractRenderContext implements RenderContext {
 	private static final QuadTransform NO_TRANSFORM = q -> true;
+
+	private final MutableQuadViewImpl editorQuad = new MutableQuadViewImpl() {
+		{
+			data = new int[EncodingFormat.TOTAL_STRIDE];
+			clear();
+		}
+
+		@Override
+		public void emitDirectly() {
+			renderQuad(this);
+		}
+	};
 
 	private QuadTransform activeTransform = NO_TRANSFORM;
 	private final ObjectArrayList<QuadTransform> transformStack = new ObjectArrayList<>();
@@ -56,6 +70,14 @@ abstract class AbstractRenderContext implements RenderContext {
 	protected int overlay;
 	private final Vector4f posVec = new Vector4f();
 	private final Vector3f normalVec = new Vector3f();
+
+	@Override
+	public QuadEmitter getEmitter() {
+		editorQuad.clear();
+		return editorQuad;
+	}
+
+	protected abstract void renderQuad(MutableQuadViewImpl quadView);
 
 	protected final boolean transform(MutableQuadView q) {
 		return activeTransform.transform(q);


### PR DESCRIPTION
FRAPI fallback consumers have been deprecated for a long time and now is a good time to remove them. This PR also removes default implementations (mostly no-op implementations) from FRAPI methods that have an appropriate API note. Some code in Indigo was refactored slightly.