### PR TITLE
Add access to ClientConfigurationNetworkHandler in context

### DIFF
--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientConfigurationNetworking.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientConfigurationNetworking.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientConfigurationNetworkHandler;
 import net.minecraft.network.packet.CustomPayload;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.thread.ThreadExecutor;
@@ -279,6 +280,11 @@ public final class ClientConfigurationNetworking {
 		 * @return The MinecraftClient instance
 		 */
 		MinecraftClient client();
+
+		/**
+		 * @return The ClientConfigurationNetworkHandler instance
+		 */
+		ClientConfigurationNetworkHandler networkHandler();
 
 		/**
 		 * @return The packet sender

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientConfigurationNetworkAddon.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientConfigurationNetworkAddon.java
@@ -44,7 +44,7 @@ public final class ClientConfigurationNetworkAddon extends ClientCommonNetworkAd
 
 	public ClientConfigurationNetworkAddon(ClientConfigurationNetworkHandler handler, MinecraftClient client) {
 		super(ClientNetworkingImpl.CONFIGURATION, ((ClientCommonNetworkHandlerAccessor) handler).getConnection(), "ClientPlayNetworkAddon for " + ((ClientConfigurationNetworkHandlerAccessor) handler).getProfile().getName(), handler, client);
-		this.context = new ContextImpl(client, this);
+		this.context = new ContextImpl(client, handler, this);
 
 		// Must register pending channels via lateinit
 		this.registerPendingChannels((ChannelInfoHolder) this.connection, NetworkPhase.CONFIGURATION);
@@ -128,9 +128,10 @@ public final class ClientConfigurationNetworkAddon extends ClientCommonNetworkAd
 		return (ChannelInfoHolder) ((ClientCommonNetworkHandlerAccessor) handler).getConnection();
 	}
 
-	private record ContextImpl(MinecraftClient client, PacketSender responseSender) implements ClientConfigurationNetworking.Context {
+	private record ContextImpl(MinecraftClient client, ClientConfigurationNetworkHandler networkHandler, PacketSender responseSender) implements ClientConfigurationNetworking.Context {
 		private ContextImpl {
 			Objects.requireNonNull(client, "client");
+			Objects.requireNonNull(networkHandler, "networkHandler");
 			Objects.requireNonNull(responseSender, "responseSender");
 		}
 	}

--- a/fabric-networking-api-v1/src/test/java/net/fabricmc/fabric/test/networking/unit/CommonPacketTests.java
+++ b/fabric-networking-api-v1/src/test/java/net/fabricmc/fabric/test/networking/unit/CommonPacketTests.java
@@ -139,6 +139,11 @@ public class CommonPacketTests {
 			}
 
 			@Override
+			public ClientConfigurationNetworkHandler networkHandler() {
+				return clientNetworkHandler;
+			}
+
+			@Override
 			public PacketSender responseSender() {
 				return packetSender;
 			}


### PR DESCRIPTION
Add a way to access the `ClientConfigurationNetworkHandler` from a `ClientConfigurationNetworking.Context`, so that you can access the network handler from a client configuration event.

My usecase is that I want to store extra data in the network handler, but it doesn't seem like the network handler is easy to access from an event handler. The server configuration context has a way to access the network handler so why not.