### PR TITLE
add ALLOW_PLAYER_CHANGE_WORLD

### DIFF
--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerEntityWorldChangeEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerEntityWorldChangeEvents.java
@@ -46,6 +46,19 @@ public final class ServerEntityWorldChangeEvents {
 	});
 
 	/**
+	 * Called before a player is being moved to a different world.
+	 */
+	public static final Event<AllowPlayerChange> ALLOW_PLAYER_CHANGE_WORLD = EventFactory.createArrayBacked(AllowPlayerChange.class, callbacks -> (player, origin, destination) -> {
+		for (AllowPlayerChange callback : callbacks) {
+			if (!callback.allowChangeWorld(player, origin, destination)){
+				return false;
+			}
+		}
+
+		return true;
+	});
+
+	/**
 	 * An event which is called after a player has been moved to a different world.
 	 *
 	 * <p>This is similar to {@link ServerEntityWorldChangeEvents#AFTER_ENTITY_CHANGE_WORLD} but is only called for players.
@@ -73,6 +86,19 @@ public final class ServerEntityWorldChangeEvents {
 		 * @param destination the destination world the new entity is in
 		 */
 		void afterChangeWorld(Entity originalEntity, Entity newEntity, ServerWorld origin, ServerWorld destination);
+	}
+
+	@FunctionalInterface
+	public interface AllowPlayerChange {
+		/**
+		 * Called before a player is being moved to a different world.
+		 *
+		 * @param player the player
+		 * @param origin the original world the player is in
+		 * @param destination the new world the player is moving to
+		 * @return true if the player is allowed to change worlds, false otherwise
+		 */
+		boolean allowChangeWorld(ServerPlayerEntity player, ServerWorld origin, ServerWorld destination);
 	}
 
 	@FunctionalInterface

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerEntityWorldChangeEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerEntityWorldChangeEvents.java
@@ -50,7 +50,7 @@ public final class ServerEntityWorldChangeEvents {
 	 */
 	public static final Event<AllowPlayerChange> ALLOW_PLAYER_CHANGE_WORLD = EventFactory.createArrayBacked(AllowPlayerChange.class, callbacks -> (player, origin, destination) -> {
 		for (AllowPlayerChange callback : callbacks) {
-			if (!callback.allowChangeWorld(player, origin, destination)){
+			if (!callback.allowChangeWorld(player, origin, destination)) {
 				return false;
 			}
 		}

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -65,7 +65,7 @@ public final class EntityEventTests implements ModInitializer {
 		});
 
 		ServerEntityWorldChangeEvents.ALLOW_PLAYER_CHANGE_WORLD.register((player, origin, destination) -> {
-			if (player.getStackInHand(Hand.MAIN_HAND).getItem() == Items.END_ROD) {
+			if (player.getMainHandStack().isOf(Items.END_ROD)) {
 				LOGGER.info("Player {} failed to change world because of handing an end rod", player.getGameProfile().getName());
 				return false;
 			}

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -64,6 +64,16 @@ public final class EntityEventTests implements ModInitializer {
 			LOGGER.info("Entity {} Killed: {}", entity, killed);
 		});
 
+		ServerEntityWorldChangeEvents.ALLOW_PLAYER_CHANGE_WORLD.register((player, origin, destination) -> {
+			if (player.getStackInHand(Hand.MAIN_HAND).getItem() == Items.END_ROD) {
+				LOGGER.info("Player {} failed to change world because of handing an end rod", player.getGameProfile().getName());
+				return false;
+			}
+
+			LOGGER.info("Allow Moving player {}: [{} -> {}]", player, origin.getRegistryKey().getValue(), destination.getRegistryKey().getValue());
+			return true;
+		});
+
 		ServerEntityWorldChangeEvents.AFTER_PLAYER_CHANGE_WORLD.register((player, origin, destination) -> {
 			LOGGER.info("Moved player {}: [{} -> {}]", player, origin.getRegistryKey().getValue(), destination.getRegistryKey().getValue());
 		});


### PR DESCRIPTION
ALLOW_PLAYER_CHANGE_WORLD: Called when the player's dimension changes to check if the player is allowed to cross dimensions.

solve issue:
https://github.com/FabricMC/fabric/issues/3294#issue-1877370481