### PR TITLE
Fix typo in ClientLifecycleEvents.java

### DIFF
--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientLifecycleEvents.java
@@ -26,7 +26,7 @@ public final class ClientLifecycleEvents {
 	}
 
 	/**
-	 * Called when Minecraft has started and it's client about to tick for the first time.
+	 * Called when Minecraft has started and its client about to tick for the first time.
 	 *
 	 * <p>This occurs while the splash screen is displayed.
 	 */


### PR DESCRIPTION
Per [Cambridge Dictionary](https://dictionary.cambridge.org/grammar/british-grammar/it-s-or-its), `it's` is reserved for `it is` or `it has`, but in this context it is being used as neither of those.

This pull request fixes this error in the `CLIENT_STARTED` event's description comment.