### PR TITLE
Fix vanilla storage game tests being sensitive to rotation

### DIFF
--- a/fabric-transfer-api-v1/src/testmod/java/net/fabricmc/fabric/test/transfer/gametests/VanillaStorageTests.java
+++ b/fabric-transfer-api-v1/src/testmod/java/net/fabricmc/fabric/test/transfer/gametests/VanillaStorageTests.java
@@ -113,10 +113,11 @@ public class VanillaStorageTests {
 		InventoryStorage storage = InventoryStorage.of(inventory, null);
 
 		BlockPos comparatorPos = new BlockPos(1, 2, 0);
+		Direction comparatorFacing = context.getRotation().rotate(Direction.WEST);
 		// support block under the comparator
 		context.setBlockState(comparatorPos.offset(Direction.DOWN), Blocks.GREEN_WOOL.getDefaultState());
 		// comparator
-		context.setBlockState(comparatorPos, Blocks.COMPARATOR.getDefaultState().with(ComparatorBlock.FACING, Direction.WEST));
+		context.setBlockState(comparatorPos, Blocks.COMPARATOR.getDefaultState().with(ComparatorBlock.FACING, comparatorFacing));
 
 		try (Transaction transaction = Transaction.openOuter()) {
 			if (world.getBlockTickScheduler().isQueued(context.getAbsolutePos(comparatorPos), Blocks.COMPARATOR)) {


### PR DESCRIPTION
This pull request fixes issues with running `/test verifyclass VanillaStorageTests` within game tests caused by a comparator being placed without regard for the test run's rotation.