### PR TITLE
Add a event for modify player's movement during using item

### DIFF
--- a/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/client/entity/event/ClientPlayerEvents.java
+++ b/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/client/entity/event/ClientPlayerEvents.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.client.entity.event;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+import net.minecraft.client.network.ClientPlayerEntity;
+
+public final class ClientPlayerEvents {
+	/*
+	 * An event that is called when a player is moving during using an item.
+	 */
+	public static final Event<ModifyPlayerMovementDuringUsingitem> MODIFY_PLAYER_MOVEMENT_DURING_USINGITEM = EventFactory.createArrayBacked(ModifyPlayerMovementDuringUsingitem.class, callbacks -> player -> {
+		for (ModifyPlayerMovementDuringUsingitem callback : callbacks) {
+			callback.modifyPlayerMovementDuringUsingitem(player);
+		}
+	});
+
+	@FunctionalInterface
+	public interface ModifyPlayerMovementDuringUsingitem {
+		/**
+		 * @param player the player is moving during using an item.
+		 */
+		void modifyPlayerMovementDuringUsingitem(ClientPlayerEntity player);
+	}
+}

--- a/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/client/entity/event/ClientPlayerEvents.java
+++ b/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/client/entity/event/ClientPlayerEvents.java
@@ -22,7 +22,7 @@ import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.client.network.ClientPlayerEntity;
 
 public final class ClientPlayerEvents {
-	/*
+	/**
 	 * An event that is called when a player is moving during using an item.
 	 */
 	public static final Event<ModifyPlayerMovementDuringUsingitem> MODIFY_PLAYER_MOVEMENT_DURING_USINGITEM = EventFactory.createArrayBacked(ModifyPlayerMovementDuringUsingitem.class, callbacks -> player -> {
@@ -34,6 +34,8 @@ public final class ClientPlayerEvents {
 	@FunctionalInterface
 	public interface ModifyPlayerMovementDuringUsingitem {
 		/**
+		 * Called when a player is moving during using an item.
+		 * 
 		 * @param player the player is moving during using an item.
 		 */
 		void modifyPlayerMovementDuringUsingitem(ClientPlayerEntity player);

--- a/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/entity/event/client/ClientPlayerEvents.java
+++ b/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/entity/event/client/ClientPlayerEvents.java
@@ -16,37 +16,29 @@
 
 package net.fabricmc.fabric.api.entity.event.client;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.minecraft.client.network.ClientPlayerEntity;
 
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
 public final class ClientPlayerEvents {
-	/*
-	 * Flag for using default slowdown during using an item.
-	 */
-	public static final float USE_DEFAULT_SLOWDOWN_SPEED = -1.0F;
-
-	/*
-	 * Default percentage of speed slowdown when using an item in Minecraft.
-	 */
-	private static final float DEFAULT_SLOWDOWN_SPEED = 0.2F;
-
 	/**
 	 * An event that is called when a player is moving during using an item.
 	 */
 	public static final Event<AdjustUsingItemSpeed> ADJUST_USING_ITEM_SPEED = EventFactory.createArrayBacked(AdjustUsingItemSpeed.class, callbacks -> player -> {
-		float maxSpeed = USE_DEFAULT_SLOWDOWN_SPEED;
+		Float maxSpeedPercentage = null;
 
 		for (AdjustUsingItemSpeed callback : callbacks) {
-			float currentSpeed = callback.adjustUsingItemSpeed(player);
+			Float speedPercentage = callback.adjustUsingItemSpeed(player);
 
-			if (currentSpeed >= 0.0F && currentSpeed <= 1.0F) {
-				maxSpeed = currentSpeed > maxSpeed ? currentSpeed : maxSpeed;
+			if (speedPercentage != null && speedPercentage >= 0.0F && speedPercentage <= 1.0F) {
+				maxSpeedPercentage = maxSpeedPercentage == null ? speedPercentage : Math.max(speedPercentage, maxSpeedPercentage);
 			}
 		}
 
-		return maxSpeed == USE_DEFAULT_SLOWDOWN_SPEED ? DEFAULT_SLOWDOWN_SPEED : maxSpeed;
+		return maxSpeedPercentage;
 	});
 
 	@FunctionalInterface
@@ -55,9 +47,10 @@ public final class ClientPlayerEvents {
 		 * Called when a player is moving during using an item.
 		 *
 		 * @param player the player is moving during using an item.
-		 * @return the percentage of the player's speed from 0.0F to 1.0F.
-		 * Return {@link #USE_DEFAULT_SLOWDOWN_SPEED} indicates that no adjustment should be applied.
+		 * @return the percentage of player's speed from 0.0F to 1.0F,
+		 * or {@code null} indicates that no adjustment should be applied.
 		 */
-		float adjustUsingItemSpeed(ClientPlayerEntity player);
+		@Nullable
+		Float adjustUsingItemSpeed(ClientPlayerEntity player);
 	}
 }

--- a/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/entity/event/client/ClientPlayerEvents.java
+++ b/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/entity/event/client/ClientPlayerEvents.java
@@ -33,7 +33,7 @@ public final class ClientPlayerEvents {
 		for (AdjustUsingItemSpeed callback : callbacks) {
 			Float speedPercentage = callback.adjustUsingItemSpeed(player);
 
-			if (speedPercentage != null && speedPercentage >= 0.0F && speedPercentage <= 1.0F) {
+			if (speedPercentage != null) {
 				maxSpeedPercentage = maxSpeedPercentage == null ? speedPercentage : Math.max(speedPercentage, maxSpeedPercentage);
 			}
 		}
@@ -47,7 +47,7 @@ public final class ClientPlayerEvents {
 		 * Called when a player is moving during using an item.
 		 *
 		 * @param player the player is moving during using an item.
-		 * @return the percentage of player's speed from 0.0F to 1.0F,
+		 * @return a Float representing the speed adjustment as a percentage (e.g., 0.8 for 80% speed),
 		 * or {@code null} indicates that no adjustment should be applied.
 		 */
 		@Nullable

--- a/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/entity/event/client/ClientPlayerEvents.java
+++ b/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/entity/event/client/ClientPlayerEvents.java
@@ -25,19 +25,24 @@ public final class ClientPlayerEvents {
 	/**
 	 * An event that is called when a player is moving during using an item.
 	 */
-	public static final Event<ModifyPlayerMovementDuringUsingitem> MODIFY_PLAYER_MOVEMENT_DURING_USINGITEM = EventFactory.createArrayBacked(ModifyPlayerMovementDuringUsingitem.class, callbacks -> player -> {
-		for (ModifyPlayerMovementDuringUsingitem callback : callbacks) {
-			callback.modifyPlayerMovementDuringUsingitem(player);
+	public static final Event<DisableUsingitemSlowdown> DISABLE_USINGITEM_SLOWDOWN = EventFactory.createArrayBacked(DisableUsingitemSlowdown.class, callbacks -> player -> {
+		for (DisableUsingitemSlowdown callback : callbacks) {
+			if (callback.disableUsingitemSlowdown(player)) {
+				return true;
+			}
 		}
+
+		return false;
 	});
 
 	@FunctionalInterface
-	public interface ModifyPlayerMovementDuringUsingitem {
+	public interface DisableUsingitemSlowdown {
 		/**
 		 * Called when a player is moving during using an item.
 		 *
 		 * @param player the player is moving during using an item.
+		 * @return true if the player can move without slowdown during using an item, false otherwise.
 		 */
-		void modifyPlayerMovementDuringUsingitem(ClientPlayerEntity player);
+		boolean disableUsingitemSlowdown(ClientPlayerEntity player);
 	}
 }

--- a/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/entity/event/client/ClientPlayerEvents.java
+++ b/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/entity/event/client/ClientPlayerEvents.java
@@ -25,7 +25,7 @@ public final class ClientPlayerEvents {
 	/*
 	 * Flag for using default slowdown during using an item.
 	 */
-	public static final float USING_DEFAULT_SLOWDOWN_SPEED = -1.0F;
+	public static final float USE_DEFAULT_SLOWDOWN_SPEED = -1.0F;
 
 	/*
 	 * Default percentage of speed slowdown when using an item in Minecraft.
@@ -36,7 +36,7 @@ public final class ClientPlayerEvents {
 	 * An event that is called when a player is moving during using an item.
 	 */
 	public static final Event<AdjustUsingItemSpeed> ADJUST_USING_ITEM_SPEED = EventFactory.createArrayBacked(AdjustUsingItemSpeed.class, callbacks -> player -> {
-		float maxSpeed = -0.1F;
+		float maxSpeed = USE_DEFAULT_SLOWDOWN_SPEED;
 
 		for (AdjustUsingItemSpeed callback : callbacks) {
 			float currentSpeed = callback.adjustUsingItemSpeed(player);
@@ -46,7 +46,7 @@ public final class ClientPlayerEvents {
 			}
 		}
 
-		return maxSpeed == -0.1F ? DEFAULT_SLOWDOWN_SPEED : maxSpeed;
+		return maxSpeed == USE_DEFAULT_SLOWDOWN_SPEED ? DEFAULT_SLOWDOWN_SPEED : maxSpeed;
 	});
 
 	@FunctionalInterface
@@ -56,7 +56,7 @@ public final class ClientPlayerEvents {
 		 *
 		 * @param player the player is moving during using an item.
 		 * @return the percentage of the player's speed from 0.0F to 1.0F.
-		 * {@link #DEFAULT_SLOWDOWN_SPEED} indicates that no adjustment should be applied.
+		 * Return {@link #USE_DEFAULT_SLOWDOWN_SPEED} indicates that no adjustment should be applied.
 		 */
 		float adjustUsingItemSpeed(ClientPlayerEntity player);
 	}

--- a/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/entity/event/client/ClientPlayerEvents.java
+++ b/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/entity/event/client/ClientPlayerEvents.java
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.api.client.entity.event;
+package net.fabricmc.fabric.api.entity.event.client;
+
+import net.minecraft.client.network.ClientPlayerEntity;
 
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
-
-import net.minecraft.client.network.ClientPlayerEntity;
 
 public final class ClientPlayerEvents {
 	/**
@@ -35,7 +35,7 @@ public final class ClientPlayerEvents {
 	public interface ModifyPlayerMovementDuringUsingitem {
 		/**
 		 * Called when a player is moving during using an item.
-		 * 
+		 *
 		 * @param player the player is moving during using an item.
 		 */
 		void modifyPlayerMovementDuringUsingitem(ClientPlayerEntity player);

--- a/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/entity/event/client/ClientPlayerEvents.java
+++ b/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/entity/event/client/ClientPlayerEvents.java
@@ -28,9 +28,9 @@ public final class ClientPlayerEvents {
 	public static final float USING_DEFAULT_SLOWDOWN_SPEED = -1.0F;
 
 	/*
-	 * Default slowdown speed when using an item in Minecraft.
+	 * Default percentage of speed slowdown when using an item in Minecraft.
 	 */
-	public static final float DEFAULT_SLOWDOWN_SPEED = 0.2F;
+	private static final float DEFAULT_SLOWDOWN_SPEED = 0.2F;
 
 	/**
 	 * An event that is called when a player is moving during using an item.

--- a/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/entity/event/client/ClientPlayerEvents.java
+++ b/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/entity/event/client/ClientPlayerEvents.java
@@ -22,27 +22,42 @@ import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
 public final class ClientPlayerEvents {
+	/*
+	 * Flag for using default slowdown during using an item.
+	 */
+	public static final float USING_DEFAULT_SLOWDOWN_SPEED = -1.0F;
+
+	/*
+	 * Default slowdown speed when using an item in Minecraft.
+	 */
+	public static final float DEFAULT_SLOWDOWN_SPEED = 0.2F;
+
 	/**
 	 * An event that is called when a player is moving during using an item.
 	 */
-	public static final Event<DisableUsingitemSlowdown> DISABLE_USINGITEM_SLOWDOWN = EventFactory.createArrayBacked(DisableUsingitemSlowdown.class, callbacks -> player -> {
-		for (DisableUsingitemSlowdown callback : callbacks) {
-			if (callback.disableUsingitemSlowdown(player)) {
-				return true;
+	public static final Event<AdjustUsingItemSpeed> ADJUST_USING_ITEM_SPEED = EventFactory.createArrayBacked(AdjustUsingItemSpeed.class, callbacks -> player -> {
+		float maxSpeed = -0.1F;
+
+		for (AdjustUsingItemSpeed callback : callbacks) {
+			float currentSpeed = callback.adjustUsingItemSpeed(player);
+
+			if (currentSpeed >= 0.0F && currentSpeed <= 1.0F) {
+				maxSpeed = currentSpeed > maxSpeed ? currentSpeed : maxSpeed;
 			}
 		}
 
-		return false;
+		return maxSpeed == -0.1F ? DEFAULT_SLOWDOWN_SPEED : maxSpeed;
 	});
 
 	@FunctionalInterface
-	public interface DisableUsingitemSlowdown {
+	public interface AdjustUsingItemSpeed {
 		/**
 		 * Called when a player is moving during using an item.
 		 *
 		 * @param player the player is moving during using an item.
-		 * @return true if the player can move without slowdown during using an item, false otherwise.
+		 * @return the percentage of the player's speed from 0.0F to 1.0F.
+		 * {@link #DEFAULT_SLOWDOWN_SPEED} indicates that no adjustment should be applied.
 		 */
-		boolean disableUsingitemSlowdown(ClientPlayerEntity player);
+		float adjustUsingItemSpeed(ClientPlayerEntity player);
 	}
 }

--- a/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/entity/event/client/ClientPlayerEvents.java
+++ b/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/entity/event/client/ClientPlayerEvents.java
@@ -25,13 +25,13 @@ import net.fabricmc.fabric.api.event.EventFactory;
 
 public final class ClientPlayerEvents {
 	/**
-	 * An event that is called when a player is moving during using an item.
+	 * An event that is called when a player is moving while using an item.
 	 */
-	public static final Event<ModifyItemUseSpeed> MODIFY_ITEM_USE_SPEED = EventFactory.createArrayBacked(ModifyItemUseSpeed.class, callbacks -> player -> {
+	public static final Event<ModifyItemUseMovementSpeed> MODIFY_ITEM_USE_MOVEMENT_SPEED = EventFactory.createArrayBacked(ModifyItemUseMovementSpeed.class, callbacks -> player -> {
 		Float maxSpeedPercentage = null;
 
-		for (ModifyItemUseSpeed callback : callbacks) {
-			Float speedPercentage = callback.modifyItemUseSpeed(player);
+		for (ModifyItemUseMovementSpeed callback : callbacks) {
+			Float speedPercentage = callback.modifyItemUseMovementSpeed(player);
 
 			if (speedPercentage != null) {
 				maxSpeedPercentage = maxSpeedPercentage == null ? speedPercentage : Math.max(speedPercentage, maxSpeedPercentage);
@@ -42,7 +42,7 @@ public final class ClientPlayerEvents {
 	});
 
 	@FunctionalInterface
-	public interface ModifyItemUseSpeed {
+	public interface ModifyItemUseMovementSpeed {
 		/**
 		 * Called when a player is moving while using an item.
 		 *
@@ -51,6 +51,6 @@ public final class ClientPlayerEvents {
 		 * or {@code null} indicates that no modification should be applied.
 		 */
 		@Nullable
-		Float modifyItemUseSpeed(ClientPlayerEntity player);
+		Float modifyItemUseMovementSpeed(ClientPlayerEntity player);
 	}
 }

--- a/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/entity/event/client/ClientPlayerEvents.java
+++ b/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/entity/event/client/ClientPlayerEvents.java
@@ -44,11 +44,11 @@ public final class ClientPlayerEvents {
 	@FunctionalInterface
 	public interface ModifyItemUseSpeed {
 		/**
-		 * Called when a player is moving during using an item.
+		 * Called when a player is moving while using an item.
 		 *
-		 * @param player the player is moving during using an item.
-		 * @return a Float representing the speed modifyment as a percentage (e.g., 0.8 for 80% speed),
-		 * or {@code null} indicates that no modifyment should be applied.
+		 * @param player the player that is moving while using an item.
+		 * @return a Float representing the speed modification as a percentage (e.g., 0.8 for 80% speed),
+		 * or {@code null} indicates that no modification should be applied.
 		 */
 		@Nullable
 		Float modifyItemUseSpeed(ClientPlayerEntity player);

--- a/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/entity/event/client/ClientPlayerEvents.java
+++ b/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/api/entity/event/client/ClientPlayerEvents.java
@@ -27,11 +27,11 @@ public final class ClientPlayerEvents {
 	/**
 	 * An event that is called when a player is moving during using an item.
 	 */
-	public static final Event<AdjustUsingItemSpeed> ADJUST_USING_ITEM_SPEED = EventFactory.createArrayBacked(AdjustUsingItemSpeed.class, callbacks -> player -> {
+	public static final Event<ModifyItemUseSpeed> MODIFY_ITEM_USE_SPEED = EventFactory.createArrayBacked(ModifyItemUseSpeed.class, callbacks -> player -> {
 		Float maxSpeedPercentage = null;
 
-		for (AdjustUsingItemSpeed callback : callbacks) {
-			Float speedPercentage = callback.adjustUsingItemSpeed(player);
+		for (ModifyItemUseSpeed callback : callbacks) {
+			Float speedPercentage = callback.modifyItemUseSpeed(player);
 
 			if (speedPercentage != null) {
 				maxSpeedPercentage = maxSpeedPercentage == null ? speedPercentage : Math.max(speedPercentage, maxSpeedPercentage);
@@ -42,15 +42,15 @@ public final class ClientPlayerEvents {
 	});
 
 	@FunctionalInterface
-	public interface AdjustUsingItemSpeed {
+	public interface ModifyItemUseSpeed {
 		/**
 		 * Called when a player is moving during using an item.
 		 *
 		 * @param player the player is moving during using an item.
-		 * @return a Float representing the speed adjustment as a percentage (e.g., 0.8 for 80% speed),
-		 * or {@code null} indicates that no adjustment should be applied.
+		 * @return a Float representing the speed modifyment as a percentage (e.g., 0.8 for 80% speed),
+		 * or {@code null} indicates that no modifyment should be applied.
 		 */
 		@Nullable
-		Float adjustUsingItemSpeed(ClientPlayerEntity player);
+		Float modifyItemUseSpeed(ClientPlayerEntity player);
 	}
 }

--- a/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/mixin/client/entity/event/ClientPlayerMixin.java
+++ b/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/mixin/client/entity/event/ClientPlayerMixin.java
@@ -28,13 +28,16 @@ import net.fabricmc.fabric.api.entity.event.client.ClientPlayerEvents;
 @Mixin(ClientPlayerEntity.class)
 abstract class ClientPlayerMixin {
 	@Inject(method = "tickMovement", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;isUsingItem()Z"))
-	private void beforeTickMovement(CallbackInfo ci) {
+	private void invokeAdjustUsingItemSpeedEvent(CallbackInfo ci) {
 		ClientPlayerEntity player = (ClientPlayerEntity) (Object) this;
 
 		if (player.isUsingItem() && !player.hasVehicle() && (player.input.movementForward != 0.0F || player.input.movementSideways != 0.0F)) {
-			float slowdown = ClientPlayerEvents.ADJUST_USING_ITEM_SPEED.invoker().adjustUsingItemSpeed(player) * 5.0F;
-			player.input.movementSideways *= slowdown;
-			player.input.movementForward *= slowdown;
+			Float speedPercentage = ClientPlayerEvents.ADJUST_USING_ITEM_SPEED.invoker().adjustUsingItemSpeed(player);
+
+			if (speedPercentage != null) {
+				player.input.movementSideways *= speedPercentage * 5.0F;
+				player.input.movementForward *= speedPercentage * 5.0F;
+			}
 		}
 	}
 }

--- a/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/mixin/client/entity/event/ClientPlayerMixin.java
+++ b/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/mixin/client/entity/event/ClientPlayerMixin.java
@@ -21,9 +21,9 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import net.fabricmc.fabric.api.client.entity.event.ClientPlayerEvents;
-
 import net.minecraft.client.network.ClientPlayerEntity;
+
+import net.fabricmc.fabric.api.entity.event.client.ClientPlayerEvents;
 
 @Mixin(ClientPlayerEntity.class)
 abstract class ClientPlayerMixin {

--- a/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/mixin/client/entity/event/ClientPlayerMixin.java
+++ b/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/mixin/client/entity/event/ClientPlayerMixin.java
@@ -32,10 +32,9 @@ abstract class ClientPlayerMixin {
 		ClientPlayerEntity player = (ClientPlayerEntity) (Object) this;
 
 		if (player.isUsingItem() && !player.hasVehicle() && (player.input.movementForward != 0.0F || player.input.movementSideways != 0.0F)) {
-			if (ClientPlayerEvents.DISABLE_USINGITEM_SLOWDOWN.invoker().disableUsingitemSlowdown(player)) {
-				player.input.movementSideways *= 5.0F;
-				player.input.movementForward *= 5.0F;
-			}
+			float slowdown = ClientPlayerEvents.ADJUST_USING_ITEM_SPEED.invoker().adjustUsingItemSpeed(player) * 5.0F;
+			player.input.movementSideways *= slowdown;
+			player.input.movementForward *= slowdown;
 		}
 	}
 }

--- a/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/mixin/client/entity/event/ClientPlayerMixin.java
+++ b/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/mixin/client/entity/event/ClientPlayerMixin.java
@@ -32,7 +32,10 @@ abstract class ClientPlayerMixin {
 		ClientPlayerEntity player = (ClientPlayerEntity) (Object) this;
 
 		if (player.isUsingItem() && !player.hasVehicle() && (player.input.movementForward != 0.0F || player.input.movementSideways != 0.0F)) {
-			ClientPlayerEvents.MODIFY_PLAYER_MOVEMENT_DURING_USINGITEM.invoker().modifyPlayerMovementDuringUsingitem(player);
+			if (ClientPlayerEvents.DISABLE_USINGITEM_SLOWDOWN.invoker().disableUsingitemSlowdown(player)) {
+				player.input.movementSideways *= 5.0F;
+				player.input.movementForward *= 5.0F;
+			}
 		}
 	}
 }

--- a/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/mixin/client/entity/event/ClientPlayerMixin.java
+++ b/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/mixin/client/entity/event/ClientPlayerMixin.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.entity.event;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.fabricmc.fabric.api.client.entity.event.ClientPlayerEvents;
+
+import net.minecraft.client.network.ClientPlayerEntity;
+
+@Mixin(ClientPlayerEntity.class)
+abstract class ClientPlayerMixin {
+	@Inject(method = "tickMovement", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;isUsingItem()Z"))
+	private void beforeTickMovement(CallbackInfo ci) {
+		ClientPlayerEntity player = (ClientPlayerEntity) (Object) this;
+
+		if (player.isUsingItem() && !player.hasVehicle() && (player.input.movementForward != 0.0F || player.input.movementSideways != 0.0F)) {
+			ClientPlayerEvents.MODIFY_PLAYER_MOVEMENT_DURING_USINGITEM.invoker().modifyPlayerMovementDuringUsingitem(player);
+		}
+	}
+}

--- a/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/mixin/client/entity/event/ClientPlayerMixin.java
+++ b/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/mixin/client/entity/event/ClientPlayerMixin.java
@@ -28,11 +28,11 @@ import net.fabricmc.fabric.api.entity.event.client.ClientPlayerEvents;
 @Mixin(ClientPlayerEntity.class)
 abstract class ClientPlayerMixin {
 	@Inject(method = "tickMovement", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;isUsingItem()Z"))
-	private void invokeModifyItemUseSpeedEvent(CallbackInfo ci) {
+	private void invokeModifyItemUseMovementSpeedEvent(CallbackInfo ci) {
 		ClientPlayerEntity player = (ClientPlayerEntity) (Object) this;
 
 		if (player.isUsingItem() && !player.hasVehicle() && (player.input.movementForward != 0.0F || player.input.movementSideways != 0.0F)) {
-			Float speedPercentage = ClientPlayerEvents.MODIFY_ITEM_USE_SPEED.invoker().modifyItemUseSpeed(player);
+			Float speedPercentage = ClientPlayerEvents.MODIFY_ITEM_USE_MOVEMENT_SPEED.invoker().modifyItemUseMovementSpeed(player);
 
 			if (speedPercentage != null) {
 				player.input.movementSideways *= speedPercentage * 5.0F;

--- a/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/mixin/client/entity/event/ClientPlayerMixin.java
+++ b/fabric-entity-events-v1/src/client/java/net/fabricmc/fabric/mixin/client/entity/event/ClientPlayerMixin.java
@@ -28,11 +28,11 @@ import net.fabricmc.fabric.api.entity.event.client.ClientPlayerEvents;
 @Mixin(ClientPlayerEntity.class)
 abstract class ClientPlayerMixin {
 	@Inject(method = "tickMovement", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;isUsingItem()Z"))
-	private void invokeAdjustUsingItemSpeedEvent(CallbackInfo ci) {
+	private void invokeModifyItemUseSpeedEvent(CallbackInfo ci) {
 		ClientPlayerEntity player = (ClientPlayerEntity) (Object) this;
 
 		if (player.isUsingItem() && !player.hasVehicle() && (player.input.movementForward != 0.0F || player.input.movementSideways != 0.0F)) {
-			Float speedPercentage = ClientPlayerEvents.ADJUST_USING_ITEM_SPEED.invoker().adjustUsingItemSpeed(player);
+			Float speedPercentage = ClientPlayerEvents.MODIFY_ITEM_USE_SPEED.invoker().modifyItemUseSpeed(player);
 
 			if (speedPercentage != null) {
 				player.input.movementSideways *= speedPercentage * 5.0F;

--- a/fabric-entity-events-v1/src/client/resources/fabric-entity-events-v1.client.mixins.json
+++ b/fabric-entity-events-v1/src/client/resources/fabric-entity-events-v1.client.mixins.json
@@ -3,7 +3,8 @@
   "package": "net.fabricmc.fabric.mixin.client.entity.event",
   "compatibilityLevel": "JAVA_17",
   "client": [
-    "elytra.ClientPlayerEntityMixin"
+    "elytra.ClientPlayerEntityMixin",
+    "ClientPlayerMixin"
   ],
   "injectors": {
     "defaultRequire": 1,

--- a/fabric-entity-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/entity/event/client/EntityEventTestsClient.java
+++ b/fabric-entity-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/entity/event/client/EntityEventTestsClient.java
@@ -47,7 +47,7 @@ public class EntityEventTestsClient implements ClientModInitializer {
 				return 0.0F;
 			}
 
-			return ClientPlayerEvents.USE_DEFAULT_SLOWDOWN_SPEED;
+			return null;
 		});
 
 		ClientPlayerEvents.ADJUST_USING_ITEM_SPEED.register(player -> {
@@ -56,7 +56,7 @@ public class EntityEventTestsClient implements ClientModInitializer {
 				return 0.5F;
 			}
 
-			return ClientPlayerEvents.USE_DEFAULT_SLOWDOWN_SPEED;
+			return null;
 		});
 	}
 }

--- a/fabric-entity-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/entity/event/client/EntityEventTestsClient.java
+++ b/fabric-entity-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/entity/event/client/EntityEventTestsClient.java
@@ -17,16 +17,33 @@
 package net.fabricmc.fabric.test.entity.event.client;
 
 import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.item.Items;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.entity.event.ClientPlayerEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.LivingEntityFeatureRenderEvents;
 import net.fabricmc.fabric.test.entity.event.EntityEventTests;
 
 public class EntityEventTestsClient implements ClientModInitializer {
+	private static final Logger LOGGER = LoggerFactory.getLogger(EntityEventTestsClient.class);
+
 	@Override
 	public void onInitializeClient() {
 		LivingEntityFeatureRenderEvents.ALLOW_CAPE_RENDER.register(player -> {
 			return !player.getEquippedStack(EquipmentSlot.CHEST).isOf(EntityEventTests.DIAMOND_ELYTRA);
+		});
+
+		ClientPlayerEvents.MODIFY_PLAYER_MOVEMENT_DURING_USINGITEM.register(player -> {
+			LOGGER.info("Player {} is moving during using item.", player);
+
+			if(player.getMainHandStack().isOf(Items.BOW) && player.getEquippedStack(EquipmentSlot.FEET).isOf(Items.DIAMOND_BOOTS)) {
+				LOGGER.info("Player {} can move without slowdown becase of diamond boots on feet.", player);
+				player.input.movementForward *= 5F;
+				player.input.movementSideways *= 5F;
+			}
 		});
 	}
 }

--- a/fabric-entity-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/entity/event/client/EntityEventTestsClient.java
+++ b/fabric-entity-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/entity/event/client/EntityEventTestsClient.java
@@ -39,7 +39,7 @@ public class EntityEventTestsClient implements ClientModInitializer {
 		ClientPlayerEvents.MODIFY_PLAYER_MOVEMENT_DURING_USINGITEM.register(player -> {
 			LOGGER.info("Player {} is moving during using item.", player);
 
-			if(player.getMainHandStack().isOf(Items.BOW) && player.getEquippedStack(EquipmentSlot.FEET).isOf(Items.DIAMOND_BOOTS)) {
+			if (player.getMainHandStack().isOf(Items.BOW) && player.getEquippedStack(EquipmentSlot.FEET).isOf(Items.DIAMOND_BOOTS)) {
 				LOGGER.info("Player {} can move without slowdown becase of diamond boots on feet.", player);
 				player.input.movementForward *= 5F;
 				player.input.movementSideways *= 5F;

--- a/fabric-entity-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/entity/event/client/EntityEventTestsClient.java
+++ b/fabric-entity-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/entity/event/client/EntityEventTestsClient.java
@@ -47,7 +47,7 @@ public class EntityEventTestsClient implements ClientModInitializer {
 				return 0.0F;
 			}
 
-			return ClientPlayerEvents.USING_DEFAULT_SLOWDOWN_SPEED;
+			return ClientPlayerEvents.USE_DEFAULT_SLOWDOWN_SPEED;
 		});
 
 		ClientPlayerEvents.ADJUST_USING_ITEM_SPEED.register(player -> {
@@ -56,7 +56,7 @@ public class EntityEventTestsClient implements ClientModInitializer {
 				return 0.5F;
 			}
 
-			return ClientPlayerEvents.USING_DEFAULT_SLOWDOWN_SPEED;
+			return ClientPlayerEvents.USE_DEFAULT_SLOWDOWN_SPEED;
 		});
 	}
 }

--- a/fabric-entity-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/entity/event/client/EntityEventTestsClient.java
+++ b/fabric-entity-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/entity/event/client/EntityEventTestsClient.java
@@ -36,14 +36,13 @@ public class EntityEventTestsClient implements ClientModInitializer {
 			return !player.getEquippedStack(EquipmentSlot.CHEST).isOf(EntityEventTests.DIAMOND_ELYTRA);
 		});
 
-		ClientPlayerEvents.MODIFY_PLAYER_MOVEMENT_DURING_USINGITEM.register(player -> {
-			LOGGER.info("Player {} is moving during using item.", player);
-
+		ClientPlayerEvents.DISABLE_USINGITEM_SLOWDOWN.register(player -> {
 			if (player.getMainHandStack().isOf(Items.BOW) && player.getEquippedStack(EquipmentSlot.FEET).isOf(Items.DIAMOND_BOOTS)) {
 				LOGGER.info("Player {} can move without slowdown becase of diamond boots on feet.", player);
-				player.input.movementForward *= 5F;
-				player.input.movementSideways *= 5F;
+				return true;
 			}
+
+			return false;
 		});
 	}
 }

--- a/fabric-entity-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/entity/event/client/EntityEventTestsClient.java
+++ b/fabric-entity-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/entity/event/client/EntityEventTestsClient.java
@@ -36,13 +36,27 @@ public class EntityEventTestsClient implements ClientModInitializer {
 			return !player.getEquippedStack(EquipmentSlot.CHEST).isOf(EntityEventTests.DIAMOND_ELYTRA);
 		});
 
-		ClientPlayerEvents.DISABLE_USINGITEM_SLOWDOWN.register(player -> {
-			if (player.getMainHandStack().isOf(Items.BOW) && player.getEquippedStack(EquipmentSlot.FEET).isOf(Items.DIAMOND_BOOTS)) {
-				LOGGER.info("Player {} can move without slowdown becase of diamond boots on feet.", player);
-				return true;
+		ClientPlayerEvents.ADJUST_USING_ITEM_SPEED.register(player -> {
+			if (player.getMainHandStack().isOf(Items.BOW) && player.getEquippedStack(EquipmentSlot.FEET).isOf(Items.LEATHER_BOOTS)) {
+				LOGGER.info("Player {} can move with normal speed becase of leather boots on feet.", player);
+				return 1.0F;
 			}
 
-			return false;
+			if (player.getMainHandStack().isOf(Items.BOW) && player.getEquippedStack(EquipmentSlot.FEET).isOf(Items.IRON_BOOTS)) {
+				LOGGER.info("Player {} can't move during using bow becase of iron boots on feet.", player);
+				return 0.0F;
+			}
+
+			return ClientPlayerEvents.USING_DEFAULT_SLOWDOWN_SPEED;
+		});
+
+		ClientPlayerEvents.ADJUST_USING_ITEM_SPEED.register(player -> {
+			if (player.getMainHandStack().isOf(Items.BOW) && player.getOffHandStack().isOf(Items.FEATHER)) {
+				LOGGER.info("Player {} can move with half speed becase of feather in offhand.", player);
+				return 0.5F;
+			}
+
+			return ClientPlayerEvents.USING_DEFAULT_SLOWDOWN_SPEED;
 		});
 	}
 }

--- a/fabric-entity-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/entity/event/client/EntityEventTestsClient.java
+++ b/fabric-entity-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/entity/event/client/EntityEventTestsClient.java
@@ -16,15 +16,15 @@
 
 package net.fabricmc.fabric.test.entity.event.client;
 
-import net.minecraft.entity.EquipmentSlot;
-import net.minecraft.item.Items;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.item.Items;
+
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.client.entity.event.ClientPlayerEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.LivingEntityFeatureRenderEvents;
+import net.fabricmc.fabric.api.entity.event.client.ClientPlayerEvents;
 import net.fabricmc.fabric.test.entity.event.EntityEventTests;
 
 public class EntityEventTestsClient implements ClientModInitializer {

--- a/fabric-entity-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/entity/event/client/EntityEventTestsClient.java
+++ b/fabric-entity-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/entity/event/client/EntityEventTestsClient.java
@@ -37,7 +37,7 @@ public class EntityEventTestsClient implements ClientModInitializer {
 		});
 
 		// the most common usage is to modify using item speed based on main hand item, most for custom items.
-		ClientPlayerEvents.ADJUST_USING_ITEM_SPEED.register(player -> {
+		ClientPlayerEvents.MODIFY_ITEM_USE_SPEED.register(player -> {
 			if (player.getMainHandStack().isOf(Items.GOLDEN_APPLE)) {
 				LOGGER.info("Player {} can move with half speed when eating golden apple.", player);
 				return 0.5F;
@@ -52,7 +52,7 @@ public class EntityEventTestsClient implements ClientModInitializer {
 		});
 
 		// another possible usages is to modify using item speed when certain conditions (e.g. equipped items) are met.
-		ClientPlayerEvents.ADJUST_USING_ITEM_SPEED.register(player -> {
+		ClientPlayerEvents.MODIFY_ITEM_USE_SPEED.register(player -> {
 			if (player.getMainHandStack().isOf(Items.BOW) && player.getEquippedStack(EquipmentSlot.FEET).isOf(Items.LEATHER_BOOTS)) {
 				LOGGER.info("Player {} can move with 80% speed becase of leather boots on feet.", player);
 				return 0.8F;
@@ -67,7 +67,7 @@ public class EntityEventTestsClient implements ClientModInitializer {
 		});
 
 		// this is used to test when multiple mods modify the using item speed together.
-		ClientPlayerEvents.ADJUST_USING_ITEM_SPEED.register(player -> {
+		ClientPlayerEvents.MODIFY_ITEM_USE_SPEED.register(player -> {
 			if (player.getMainHandStack().isOf(Items.BOW) && player.getOffHandStack().isOf(Items.FEATHER)) {
 				LOGGER.info("Player {} can move with half speed becase of feather in offhand.", player);
 				return 0.5F;

--- a/fabric-entity-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/entity/event/client/EntityEventTestsClient.java
+++ b/fabric-entity-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/entity/event/client/EntityEventTestsClient.java
@@ -37,7 +37,7 @@ public class EntityEventTestsClient implements ClientModInitializer {
 		});
 
 		// the most common usage is to modify using item speed based on main hand item, most for custom items.
-		ClientPlayerEvents.MODIFY_ITEM_USE_SPEED.register(player -> {
+		ClientPlayerEvents.MODIFY_ITEM_USE_MOVEMENT_SPEED.register(player -> {
 			if (player.getMainHandStack().isOf(Items.GOLDEN_APPLE)) {
 				LOGGER.info("Player {} can move with half speed when eating golden apple.", player);
 				return 0.5F;
@@ -52,7 +52,7 @@ public class EntityEventTestsClient implements ClientModInitializer {
 		});
 
 		// another possible usages is to modify using item speed when certain conditions (e.g. equipped items) are met.
-		ClientPlayerEvents.MODIFY_ITEM_USE_SPEED.register(player -> {
+		ClientPlayerEvents.MODIFY_ITEM_USE_MOVEMENT_SPEED.register(player -> {
 			if (player.getMainHandStack().isOf(Items.BOW) && player.getEquippedStack(EquipmentSlot.FEET).isOf(Items.LEATHER_BOOTS)) {
 				LOGGER.info("Player {} can move with 80% speed becase of leather boots on feet.", player);
 				return 0.8F;
@@ -67,7 +67,7 @@ public class EntityEventTestsClient implements ClientModInitializer {
 		});
 
 		// this is used to test when multiple mods modify the using item speed together.
-		ClientPlayerEvents.MODIFY_ITEM_USE_SPEED.register(player -> {
+		ClientPlayerEvents.MODIFY_ITEM_USE_MOVEMENT_SPEED.register(player -> {
 			if (player.getMainHandStack().isOf(Items.BOW) && player.getOffHandStack().isOf(Items.FEATHER)) {
 				LOGGER.info("Player {} can move with half speed becase of feather in offhand.", player);
 				return 0.5F;

--- a/fabric-entity-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/entity/event/client/EntityEventTestsClient.java
+++ b/fabric-entity-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/entity/event/client/EntityEventTestsClient.java
@@ -36,10 +36,26 @@ public class EntityEventTestsClient implements ClientModInitializer {
 			return !player.getEquippedStack(EquipmentSlot.CHEST).isOf(EntityEventTests.DIAMOND_ELYTRA);
 		});
 
+		// the most common usage is to modify using item speed based on main hand item, most for custom items.
+		ClientPlayerEvents.ADJUST_USING_ITEM_SPEED.register(player -> {
+			if (player.getMainHandStack().isOf(Items.GOLDEN_APPLE)) {
+				LOGGER.info("Player {} can move with half speed when eating golden apple.", player);
+				return 0.5F;
+			}
+
+			if (player.getMainHandStack().isOf(Items.ENCHANTED_GOLDEN_APPLE)) {
+				LOGGER.info("Player {} can move with normal speed when eating enchanted golden apple.", player);
+				return 1.0F;
+			}
+
+			return null;
+		});
+
+		// another possible usages is to modify using item speed when certain conditions (e.g. equipped items) are met.
 		ClientPlayerEvents.ADJUST_USING_ITEM_SPEED.register(player -> {
 			if (player.getMainHandStack().isOf(Items.BOW) && player.getEquippedStack(EquipmentSlot.FEET).isOf(Items.LEATHER_BOOTS)) {
-				LOGGER.info("Player {} can move with normal speed becase of leather boots on feet.", player);
-				return 1.0F;
+				LOGGER.info("Player {} can move with 80% speed becase of leather boots on feet.", player);
+				return 0.8F;
 			}
 
 			if (player.getMainHandStack().isOf(Items.BOW) && player.getEquippedStack(EquipmentSlot.FEET).isOf(Items.IRON_BOOTS)) {
@@ -50,6 +66,7 @@ public class EntityEventTestsClient implements ClientModInitializer {
 			return null;
 		});
 
+		// this is used to test when multiple mods modify the using item speed together.
 		ClientPlayerEvents.ADJUST_USING_ITEM_SPEED.register(player -> {
 			if (player.getMainHandStack().isOf(Items.BOW) && player.getOffHandStack().isOf(Items.FEATHER)) {
 				LOGGER.info("Player {} can move with half speed becase of feather in offhand.", player);


### PR DESCRIPTION
Fixes #4103 
### Add a event for modify player's movement during using item.

The event ADJUST_USING_ITEM_SPEED is used to adjust a player's movement speed while using an item. It allows mods to modify the player's movement speed based on specific conditions when they are using a item.

When a player is moving while using an item, the movement speed can be modified based on various conditions. The return value is a float representing the speed adjustment percentage (e.g., 0.8 for 80% of the original speed). If it returns null, it means there is no speed adjustment. Among multiple speeds, the maximum value is taken.

The most common usecase is to modify using item speed based on main hand item, most for custom items. Another possible usecase is to modify using item speed when certain conditions (e.g. equipped items) are met.