### PR TITLE
Add a level screen provider registry

### DIFF
--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/LevelScreenProviderRegistry.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/LevelScreenProviderRegistry.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.client.screen.v1;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.minecraft.client.gui.screen.world.LevelScreenProvider;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.world.gen.WorldPreset;
+
+import net.fabricmc.fabric.mixin.screen.LevelScreenProviderAccessor;
+
+/**
+ * Adds registration hooks for {@link LevelScreenProvider}s.
+ */
+public final class LevelScreenProviderRegistry {
+	private static final Logger LOGGER = LoggerFactory.getLogger(LevelScreenProviderRegistry.class);
+
+	private LevelScreenProviderRegistry() {
+	}
+
+	/**
+	 * Registers a provider for a screen that allows users to adjust the generation options for a given world preset.
+	 *
+	 * @param worldPreset the world preset to register the provider for
+	 * @param provider    the provider for the screen
+	 */
+	public static void register(RegistryKey<WorldPreset> worldPreset, LevelScreenProvider provider) {
+		Objects.requireNonNull(worldPreset, "world preset cannot be null");
+		Objects.requireNonNull(provider, "level screen provider cannot be null");
+
+		Optional<RegistryKey<WorldPreset>> key = Optional.of(worldPreset);
+		LevelScreenProvider old = LevelScreenProviderAccessor.fabric_getWorldPresetToScreenProvider().put(key, provider);
+
+		if (old != null) {
+			LOGGER.debug("Replaced old level screen provider mapping from {} to {} with {}", worldPreset, old, provider);
+		}
+	}
+}

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/LevelScreenProviderAccessor.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/LevelScreenProviderAccessor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.screen;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.client.gui.screen.world.LevelScreenProvider;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.world.gen.WorldPreset;
+
+@Mixin(LevelScreenProvider.class)
+public interface LevelScreenProviderAccessor {
+	@Accessor("WORLD_PRESET_TO_SCREEN_PROVIDER")
+	static Map<Optional<RegistryKey<WorldPreset>>, LevelScreenProvider> fabric_getWorldPresetToScreenProvider() {
+		throw new AssertionError("Untransformed @Accessor");
+	}
+}

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/LevelScreenProviderMixin.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/LevelScreenProviderMixin.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.screen;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.client.gui.screen.world.LevelScreenProvider;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.world.gen.WorldPreset;
+
+@Mixin(LevelScreenProvider.class)
+public interface LevelScreenProviderMixin {
+	@WrapOperation(method = "<clinit>", at = @At(value = "INVOKE", target = "Ljava/util/Map;of(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/util/Map;"))
+	private static Map<Optional<RegistryKey<WorldPreset>>, LevelScreenProvider> makeMutable(Object k1, Object v1, Object k2, Object v2, Operation<Map<Optional<RegistryKey<WorldPreset>>, LevelScreenProvider>> operation) {
+		return new HashMap<>(operation.call(k1, v1, k2, v2));
+	}
+}

--- a/fabric-screen-api-v1/src/client/resources/fabric-screen-api-v1.mixins.json
+++ b/fabric-screen-api-v1/src/client/resources/fabric-screen-api-v1.mixins.json
@@ -5,6 +5,8 @@
   "client": [
     "GameRendererMixin",
     "HandledScreenMixin",
+    "LevelScreenProviderAccessor",
+    "LevelScreenProviderMixin",
     "MinecraftClientMixin",
     "ScreenMixin"
   ],

--- a/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/FabriclandScreen.java
+++ b/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/FabriclandScreen.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.screen;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.world.CreateWorldScreen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.world.GeneratorOptionsHolder;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.screen.ScreenTexts;
+import net.minecraft.text.Text;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.gen.chunk.ChunkGenerator;
+
+import net.fabricmc.fabric.test.screen.chunk.FabriclandChunkGenerator;
+import net.fabricmc.fabric.test.screen.chunk.FabriclandChunkGeneratorConfig;
+
+public class FabriclandScreen extends Screen {
+	private static final Text TITLE = Text.literal("Fabricland");
+
+	private static final int BUTTON_WIDTH = 150;
+	private static final int LARGE_BUTTON_WIDTH = 210;
+	private static final int BUTTON_HEIGHT = 20;
+
+	private final CreateWorldScreen parent;
+	private final Random random = Random.create();
+
+	private FabriclandChunkGeneratorConfig config;
+
+	public FabriclandScreen(CreateWorldScreen parent, GeneratorOptionsHolder generatorOptionsHolder) {
+		super(TITLE);
+		this.parent = parent;
+
+		ChunkGenerator chunkGenerator = generatorOptionsHolder.selectedDimensions().getChunkGenerator();
+		this.config = FabriclandChunkGeneratorConfig.from(chunkGenerator);
+	}
+
+	@Override
+	protected void init() {
+		int x = (this.width - LARGE_BUTTON_WIDTH) / 2;
+
+		this.addDrawableChild(createChangeBlockButton("outline", FabriclandChunkGeneratorConfig::outline, (config, outline) -> config.withOutline(outline)).dimensions(x, 80, LARGE_BUTTON_WIDTH, BUTTON_HEIGHT).build());
+		this.addDrawableChild(createChangeBlockButton("background", FabriclandChunkGeneratorConfig::background, (config, background) -> config.withBackground(background)).dimensions(x, 105, LARGE_BUTTON_WIDTH, BUTTON_HEIGHT).build());
+
+		this.addDrawableChild(ButtonWidget.builder(ScreenTexts.DONE, button -> {
+			this.parent.getWorldCreator().applyModifier((dynamicRegistryManager, dimensionsRegistryHolder) -> {
+				Registry<Biome> biomeRegistry = dynamicRegistryManager.getOrThrow(RegistryKeys.BIOME);
+				ChunkGenerator chunkGenerator = new FabriclandChunkGenerator(biomeRegistry, config);
+
+				return dimensionsRegistryHolder.with(dynamicRegistryManager, chunkGenerator);
+			});
+
+			this.client.setScreen(this.parent);
+		}).dimensions((this.width - BUTTON_WIDTH) / 2, this.height - 28, BUTTON_WIDTH, BUTTON_HEIGHT).build());
+	}
+
+	@Override
+	public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+		super.render(context, mouseX, mouseY, delta);
+		context.drawCenteredTextWithShadow(this.textRenderer, this.title, this.width / 2, 8, 0xFFFFFF);
+	}
+
+	@Override
+	public void close() {
+		this.client.setScreen(this.parent);
+	}
+
+	private ButtonWidget.Builder createChangeBlockButton(String suffix, Function<FabriclandChunkGeneratorConfig, BlockState> getter, BiFunction<FabriclandChunkGeneratorConfig, BlockState, FabriclandChunkGeneratorConfig> setter) {
+		Text title = getChangeBlockButtonMessage(suffix, getter.apply(this.config));
+
+		return ButtonWidget.builder(title, button -> {
+			Registries.BLOCK.getRandom(this.random).ifPresent(entry -> {
+				BlockState next = entry.value().getDefaultState();
+
+				this.config = setter.apply(this.config, next);
+				button.setMessage(getChangeBlockButtonMessage(suffix, next));
+			});
+		});
+	}
+
+	private static Text getChangeBlockButtonMessage(String suffix, BlockState state) {
+		return Text.translatable("generator.fabric-screen-api-v1-testmod.fabricland." + suffix, state.getBlock().getName());
+	}
+}

--- a/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/ScreenTests.java
+++ b/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/ScreenTests.java
@@ -28,17 +28,29 @@ import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.ClickableWidget;
 import net.minecraft.client.render.RenderLayer;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
+import net.minecraft.world.gen.WorldPreset;
 
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.screen.v1.LevelScreenProviderRegistry;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenKeyboardEvents;
 import net.fabricmc.fabric.api.client.screen.v1.Screens;
+import net.fabricmc.fabric.test.screen.chunk.FabriclandChunkGenerator;
 
 public final class ScreenTests implements ClientModInitializer {
+	public static final String MOD_ID = "fabric-screen-api-v1-testmod";
+
 	public static final Identifier ARMOR_FULL_TEXTURE = Identifier.ofVanilla("hud/armor_full");
 	private static final Logger LOGGER = LoggerFactory.getLogger("FabricScreenApiTests");
+
+	public static final Identifier FABRICLAND_ID = id("fabricland");
+	public static final RegistryKey<WorldPreset> FABRICLAND_WORLD_PRESET = RegistryKey.of(RegistryKeys.WORLD_PRESET, FABRICLAND_ID);
 
 	@Override
 	public void onInitializeClient() {
@@ -48,6 +60,12 @@ public final class ScreenTests implements ClientModInitializer {
 		});
 
 		ScreenEvents.AFTER_INIT.register(this::afterInitScreen);
+
+		Registry.register(Registries.CHUNK_GENERATOR, FABRICLAND_ID, FabriclandChunkGenerator.CODEC);
+		LevelScreenProviderRegistry.register(FABRICLAND_WORLD_PRESET, (parent, generatorOptionsHolder) -> {
+			LOGGER.info("Provided level screen provider for Fabricland");
+			return new FabriclandScreen(parent, generatorOptionsHolder);
+		});
 	}
 
 	private void afterInitScreen(MinecraftClient client, Screen screen, int windowWidth, int windowHeight) {
@@ -94,6 +112,10 @@ public final class ScreenTests implements ClientModInitializer {
 		} else if (screen instanceof CreativeInventoryScreen) {
 			Screens.getButtons(screen).add(new TestButtonWidget());
 		}
+	}
+
+	public static Identifier id(String name) {
+		return Identifier.of(MOD_ID, name);
 	}
 
 	// Test that mouseReleased is called

--- a/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/chunk/FabriclandChunkGenerator.java
+++ b/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/chunk/FabriclandChunkGenerator.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.screen.chunk;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.registry.RegistryEntryLookup;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.RegistryOps;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.ChunkRegion;
+import net.minecraft.world.HeightLimitView;
+import net.minecraft.world.Heightmap.Type;
+import net.minecraft.world.StructureWorldAccess;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.BiomeKeys;
+import net.minecraft.world.biome.source.BiomeAccess;
+import net.minecraft.world.biome.source.FixedBiomeSource;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.gen.StructureAccessor;
+import net.minecraft.world.gen.chunk.Blender;
+import net.minecraft.world.gen.chunk.ChunkGenerator;
+import net.minecraft.world.gen.chunk.VerticalBlockSample;
+import net.minecraft.world.gen.noise.NoiseConfig;
+
+public class FabriclandChunkGenerator extends ChunkGenerator {
+	public static final MapCodec<FabriclandChunkGenerator> CODEC = RecordCodecBuilder.mapCodec(instance ->
+			instance.group(
+					RegistryOps.getEntryLookupCodec(RegistryKeys.BIOME),
+					FabriclandChunkGeneratorConfig.CODEC.optionalFieldOf("settings", FabriclandChunkGeneratorConfig.DEFAULT).forGetter(generator -> generator.config)
+			).apply(instance, instance.stable(FabriclandChunkGenerator::new))
+	);
+
+	private final FabriclandChunkGeneratorConfig config;
+
+	public FabriclandChunkGenerator(RegistryEntryLookup<Biome> biomeRegistry, FabriclandChunkGeneratorConfig config) {
+		super(new FixedBiomeSource(biomeRegistry.getOrThrow(BiomeKeys.CHERRY_GROVE)));
+
+		this.config = config;
+	}
+
+	public FabriclandChunkGeneratorConfig getConfig() {
+		return this.config;
+	}
+
+	@Override
+	public void buildSurface(ChunkRegion region, StructureAccessor structures, NoiseConfig noiseConfig, Chunk chunk) {
+	}
+
+	@Override
+	public void carve(ChunkRegion chunkRegion, long seed, NoiseConfig noiseConfig, BiomeAccess biomeAccess, StructureAccessor structureAccessor, Chunk chunk) {
+	}
+
+	@Override
+	public void generateFeatures(StructureWorldAccess world, Chunk chunk, StructureAccessor structureAccessor) {
+		BlockPos.Mutable pos = new BlockPos.Mutable();
+
+		for (int x = 0; x < 16; x++) {
+			for (int z = 0; z < 16; z++) {
+				pos.set(x, 64, z);
+				chunk.setBlockState(pos, this.config.getState(pos), false);
+			}
+		}
+	}
+
+	@Override
+	protected MapCodec<? extends FabriclandChunkGenerator> getCodec() {
+		return CODEC;
+	}
+
+	@Override
+	public VerticalBlockSample getColumnSample(int x, int z, HeightLimitView world, NoiseConfig noiseConfig) {
+		return new VerticalBlockSample(0, new BlockState[0]);
+	}
+
+	@Override
+	public void getDebugHudText(List<String> text, NoiseConfig noiseConfig, BlockPos pos) {
+	}
+
+	@Override
+	public int getHeight(int x, int z, Type heightmap, HeightLimitView world, NoiseConfig noiseConfig) {
+		return 0;
+	}
+
+	@Override
+	public int getMinimumY() {
+		return 0;
+	}
+
+	@Override
+	public int getSeaLevel() {
+		return 0;
+	}
+
+	@Override
+	public int getWorldHeight() {
+		return 0;
+	}
+
+	@Override
+	public void populateEntities(ChunkRegion region) {
+	}
+
+	@Override
+	public CompletableFuture<Chunk> populateNoise(Blender blender, NoiseConfig noiseConfig, StructureAccessor structureAccessor, Chunk chunk) {
+		return CompletableFuture.completedFuture(chunk);
+	}
+}

--- a/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/chunk/FabriclandChunkGeneratorConfig.java
+++ b/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/chunk/FabriclandChunkGeneratorConfig.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.screen.chunk;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import it.unimi.dsi.fastutil.longs.LongSet;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.gen.chunk.ChunkGenerator;
+
+public record FabriclandChunkGeneratorConfig(BlockState outline, BlockState background) {
+	private static final LongSet OUTLINE_POSITIONS = LongSet.of(
+			pos(6, 14),
+
+			pos(7, 13),
+			pos(5, 13),
+
+			pos(7, 12),
+			pos(4, 12),
+
+			pos(8, 11),
+			pos(6, 11),
+			pos(3, 11),
+
+			pos(9, 10),
+			pos(5, 10),
+			pos(2, 10),
+
+			pos(10, 9),
+			pos(4, 9),
+			pos(2, 9),
+			pos(1, 9),
+
+			pos(11, 8),
+			pos(3, 8),
+			pos(1, 8),
+
+			pos(12, 7),
+			pos(3, 7),
+			pos(2, 7),
+
+			pos(13, 6),
+			pos(4, 6),
+
+			pos(13, 5),
+			pos(5, 5),
+
+			pos(12, 4),
+			pos(6, 4),
+
+			pos(11, 3),
+			pos(7, 3),
+
+			pos(10, 2),
+			pos(8, 2),
+			pos(7, 2),
+
+			pos(9, 1),
+			pos(8, 1)
+	);
+
+	public static final FabriclandChunkGeneratorConfig DEFAULT = new FabriclandChunkGeneratorConfig(Blocks.ORANGE_WOOL.getDefaultState(), Blocks.WHITE_WOOL.getDefaultState());
+
+	public static final Codec<FabriclandChunkGeneratorConfig> CODEC = RecordCodecBuilder.create(instance ->
+			instance.group(
+					BlockState.CODEC.fieldOf("outline").forGetter(FabriclandChunkGeneratorConfig::outline),
+					BlockState.CODEC.fieldOf("background").forGetter(FabriclandChunkGeneratorConfig::background)
+			).apply(instance, instance.stable(FabriclandChunkGeneratorConfig::new))
+	);
+
+	public BlockState getState(BlockPos blockPos) {
+		long pos = pos(blockPos.getX(), blockPos.getZ());
+		boolean outline = OUTLINE_POSITIONS.contains(pos);
+
+		return outline ? this.outline : this.background;
+	}
+
+	public FabriclandChunkGeneratorConfig withOutline(BlockState outline) {
+		return new FabriclandChunkGeneratorConfig(outline, this.background);
+	}
+
+	public FabriclandChunkGeneratorConfig withBackground(BlockState background) {
+		return new FabriclandChunkGeneratorConfig(this.outline, background);
+	}
+
+	private static long pos(int x, int z) {
+		return BlockPos.asLong(x, 0, z);
+	}
+
+	public static FabriclandChunkGeneratorConfig from(ChunkGenerator chunkGenerator) {
+		if (chunkGenerator instanceof FabriclandChunkGenerator fabricland) {
+			return fabricland.getConfig();
+		}
+
+		return DEFAULT;
+	}
+}

--- a/fabric-screen-api-v1/src/testmodClient/resources/assets/fabric-screen-api-v1-testmod/lang/en_us.json
+++ b/fabric-screen-api-v1/src/testmodClient/resources/assets/fabric-screen-api-v1-testmod/lang/en_us.json
@@ -1,0 +1,5 @@
+{
+  "generator.fabric-screen-api-v1-testmod.fabricland": "Fabricland",
+  "generator.fabric-screen-api-v1-testmod.fabricland.background": "Background: %s",
+  "generator.fabric-screen-api-v1-testmod.fabricland.outline": "Outline: %s"
+}

--- a/fabric-screen-api-v1/src/testmodClient/resources/data/fabric-screen-api-v1-testmod/worldgen/world_preset/fabricland.json
+++ b/fabric-screen-api-v1/src/testmodClient/resources/data/fabric-screen-api-v1-testmod/worldgen/world_preset/fabricland.json
@@ -1,0 +1,10 @@
+{
+  "dimensions": {
+    "minecraft:overworld": {
+      "type": "minecraft:overworld",
+      "generator": {
+        "type": "fabric-screen-api-v1-testmod:fabricland"
+      }
+    }
+  }
+}

--- a/fabric-screen-api-v1/src/testmodClient/resources/data/minecraft/tags/worldgen/world_preset/extended.json
+++ b/fabric-screen-api-v1/src/testmodClient/resources/data/minecraft/tags/worldgen/world_preset/extended.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "fabric-screen-api-v1-testmod:fabricland"
+  ]
+}

--- a/fabric-screen-api-v1/src/testmodClient/resources/data/minecraft/tags/worldgen/world_preset/normal.json
+++ b/fabric-screen-api-v1/src/testmodClient/resources/data/minecraft/tags/worldgen/world_preset/normal.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "fabric-screen-api-v1-testmod:fabricland"
+  ]
+}


### PR DESCRIPTION
This pull request adds a registry for level screen providers in the `fabric-screen-api-v1` module, which control the screens available from clicking 'Customize' on the create world screen. It can be used in the following way:

```java
Identifier id = Identifier.of("example", "fabricland");
RegistryKey<WorldPreset> key = RegistryKey.of(RegistryKeys.WORLD_PRESET, key);

LevelScreenProviderRegistry.register(FABRICLAND_WORLD_PRESET, (parent, generatorOptionsHolder) -> {
	ChunkGenerator chunkGenerator = generatorOptionsHolder.selectedDimensions().getChunkGenerator();
	// Return a screen here that calls `parent.getWorldCreator().applyModifier(...)` to apply changes
});
```

To test this registry, a Fabricland chunk generator and world preset has been added to the `fabric-screen-api-v1` test mod. The create world screen allows opening a customization screen which allows the background and outline blocks that are generated to be changed:

!['World Type: Fabricland' button next to 'Customize' button](https://github.com/user-attachments/assets/525b4081-3781-42df-b1fb-bae536b512f4)
![Fabricland made of granite and red glazed terracotta](https://github.com/user-attachments/assets/a6e03520-403d-422c-bedf-206c00843632)

The corresponding names in Yarn mappings may be improved, so the `LevelScreenProviderRegistry` class name in this API should not be considered final.

Note that the `LevelScreenProviderMixin` class modifies `Map.of` rather than replacing the field value as other registry API mixins do; the `Map.of` method is more brittle, but seemingly is required as `LevelScreenProvider` is an interface. See [this Discord message](https://discord.com/channels/507304429255393322/566276937035546624/1288241478187094127) for more information.

Fixes #3926