### PR TITLE
Add mixin audit unit test

### DIFF
--- a/fabric-api-base/src/test/java/net/fabricmc/fabric/test/base/MixinAuditTest.java
+++ b/fabric-api-base/src/test/java/net/fabricmc/fabric/test/base/MixinAuditTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.base;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.spongepowered.asm.mixin.MixinEnvironment;
+
+import net.minecraft.Bootstrap;
+import net.minecraft.SharedConstants;
+
+/**
+ * A simple unit test that forces Mixin to load and apply all mixins.
+ *
+ * <p>This test is useful when porting to a new version as you don't need to wait for the game to load to check for mixin errors.
+ */
+public class MixinAuditTest {
+	@BeforeAll
+	static void beforeAll() {
+		SharedConstants.createGameVersion();
+		Bootstrap.initialize();
+	}
+
+	@Test
+	void auditMixins() {
+		MixinEnvironment.getCurrentEnvironment().audit();
+	}
+}


### PR DESCRIPTION
This is useful when porting to a new version as you don't need to wait for the game to load to check for mixin errors.