### PR TITLE
Remove LevelProperties check

### DIFF
--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/modification/MinecraftServerMixin.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/mixin/biome/modification/MinecraftServerMixin.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.fabric.mixin.biome.modification;
 
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -25,26 +24,16 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.registry.DynamicRegistryManager;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.world.SaveProperties;
-import net.minecraft.world.level.LevelProperties;
 
 import net.fabricmc.fabric.impl.biome.modification.BiomeModificationImpl;
 
 @Mixin(MinecraftServer.class)
 public abstract class MinecraftServerMixin {
-	@Final
-	@Shadow
-	protected SaveProperties saveProperties;
-
 	@Shadow
 	public abstract DynamicRegistryManager.Immutable getRegistryManager();
 
 	@Inject(method = "<init>", at = @At(value = "RETURN"))
 	private void finalizeWorldGen(CallbackInfo ci) {
-		if (!(saveProperties instanceof LevelProperties levelProperties)) {
-			throw new RuntimeException("Incompatible SaveProperties passed to MinecraftServer: " + saveProperties);
-		}
-
 		BiomeModificationImpl.INSTANCE.finalizeWorldGen(getRegistryManager());
 	}
 }


### PR DESCRIPTION
Removes the check that makes sure `saveProperties` on `MinecraftServer` is an instance of `LevelProperties`, as since the `LevelProperties` class is unused in the entire fabric API. This allows mods to use their own implementation of `SaveProperties`.