### PR TITLE
Fix: Common groups missing operator

### DIFF
--- a/fabric-item-group-api-v1/src/client/java/net/fabricmc/fabric/impl/client/itemgroup/FabricCreativeGuiComponents.java
+++ b/fabric-item-group-api-v1/src/client/java/net/fabricmc/fabric/impl/client/itemgroup/FabricCreativeGuiComponents.java
@@ -36,12 +36,12 @@ import net.fabricmc.fabric.impl.itemgroup.FabricItemGroupImpl;
 public class FabricCreativeGuiComponents {
 	private static final Identifier BUTTON_TEX = Identifier.of("fabric", "textures/gui/creative_buttons.png");
 	private static final double TABS_PER_PAGE = FabricItemGroupImpl.TABS_PER_PAGE;
-	public static final Set<ItemGroup> COMMON_GROUPS = Set.of(ItemGroups.SEARCH, ItemGroups.INVENTORY, ItemGroups.HOTBAR).stream()
+	public static final Set<ItemGroup> COMMON_GROUPS = Set.of(ItemGroups.SEARCH, ItemGroups.INVENTORY, ItemGroups.HOTBAR, ItemGroups.OPERATOR).stream()
 			.map(Registries.ITEM_GROUP::getOrThrow)
 			.collect(Collectors.toSet());
 
 	public static int getPageCount() {
-		return (int) Math.ceil((ItemGroups.getGroupsToDisplay().size() - COMMON_GROUPS.size()) / TABS_PER_PAGE);
+		return (int) Math.ceil((ItemGroups.getGroupsToDisplay().size() - COMMON_GROUPS.stream().filter(ItemGroup::shouldDisplay).count()) / TABS_PER_PAGE);
 	}
 
 	public static class ItemGroupButtonWidget extends ButtonWidget {


### PR DESCRIPTION
`FabricCreativeGuiComponents#COMMON_GROUPS` lacked the `OPERATOR` tab, as such this was causing problems with `getPageCount()` and `getPage(CreativeModeTab)`

This has been tested with Controlify, as this fixes https://github.com/isXander/Controlify/issues/405 (index out of bounds error when navigating to/from the last tab with Operator tab visible).

This is my first PR to the project and I've tried to keep to the guidelines as best as possible, but I'm happy to make any changes as necessary (and port to 1.21.2 and backport to 1.20 and 1.19 if required - I targeted 1.21.1 as it was the version I was able to test the problem on).