### PR TITLE
Optimize screenshot delays in automated client test

### DIFF
--- a/fabric-api-base/src/testmodClient/java/net/fabricmc/fabric/test/base/client/FabricApiAutoTestClient.java
+++ b/fabric-api-base/src/testmodClient/java/net/fabricmc/fabric/test/base/client/FabricApiAutoTestClient.java
@@ -113,7 +113,7 @@ public class FabricApiAutoTestClient implements ClientModInitializer {
 		{
 			enableDebugHud();
 			waitForWorldTicks(200);
-			takeScreenshot("in_game_overworld");
+			takeScreenshot("in_game_overworld", Duration.ZERO);
 		}
 
 		MixinEnvironment.getCurrentEnvironment().audit();
@@ -147,7 +147,7 @@ public class FabricApiAutoTestClient implements ClientModInitializer {
 			server.runCommand("gamemode creative " + profile.getName());
 
 			waitForWorldTicks(20);
-			takeScreenshot("server_in_game");
+			takeScreenshot("server_in_game", Duration.ZERO);
 
 			{ // Test that we can enter and exit configuration
 				server.runCommand("debugconfig config " + profile.getName());

--- a/fabric-api-base/src/testmodClient/java/net/fabricmc/fabric/test/base/client/FabricClientTestHelper.java
+++ b/fabric-api-base/src/testmodClient/java/net/fabricmc/fabric/test/base/client/FabricClientTestHelper.java
@@ -200,7 +200,7 @@ public final class FabricClientTestHelper {
 				throw new RuntimeException("Timed out waiting for " + what);
 			}
 
-			waitFor(Duration.ofMillis(10));
+			waitFor(Duration.ofMillis(50));
 		}
 	}
 

--- a/fabric-api-base/src/testmodClient/java/net/fabricmc/fabric/test/base/client/FabricClientTestHelper.java
+++ b/fabric-api-base/src/testmodClient/java/net/fabricmc/fabric/test/base/client/FabricClientTestHelper.java
@@ -82,7 +82,7 @@ public final class FabricClientTestHelper {
 	}
 
 	public static void takeScreenshot(String name) {
-		takeScreenshot(name, Duration.ofSeconds(1));
+		takeScreenshot(name, Duration.ofMillis(50));
 	}
 
 	public static void takeScreenshot(String name, Duration delay) {
@@ -200,7 +200,7 @@ public final class FabricClientTestHelper {
 				throw new RuntimeException("Timed out waiting for " + what);
 			}
 
-			waitFor(Duration.ofSeconds(1));
+			waitFor(Duration.ofMillis(10));
 		}
 	}
 


### PR DESCRIPTION
I've done multiple test runs on GitHub Actions and this seems to be as low as the timings can go while still reliably generating all of the screenshots correctly.