### PR TITLE
Add ServerChunkEvents.Generate

### DIFF
--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkEvents.java
@@ -38,6 +38,17 @@ public final class ServerChunkEvents {
 	});
 
 	/**
+	 * Called when a newly generated chunk is loaded into a ServerWorld.
+	 *
+	 * <p>When this event is called, the chunk is already in the world.
+	 */
+	public static final Event<ServerChunkEvents.Generate> CHUNK_GENERATE = EventFactory.createArrayBacked(ServerChunkEvents.Generate.class, callbacks -> (serverWorld, chunk) -> {
+		for (Generate callback : callbacks) {
+			callback.onChunkGenerate(serverWorld, chunk);
+		}
+	});
+
+	/**
 	 * Called when a chunk is unloaded from a ServerWorld.
 	 *
 	 * <p>When this event is called, the chunk is still present in the world.
@@ -51,6 +62,11 @@ public final class ServerChunkEvents {
 	@FunctionalInterface
 	public interface Load {
 		void onChunkLoad(ServerWorld world, WorldChunk chunk);
+	}
+
+	@FunctionalInterface
+	public interface Generate {
+		void onChunkGenerate(ServerWorld world, WorldChunk chunk);
 	}
 
 	@FunctionalInterface

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkGeneratingMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkGeneratingMixin.java
@@ -26,6 +26,7 @@ import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkGenerating;
 import net.minecraft.world.chunk.ChunkGenerationContext;
 import net.minecraft.world.chunk.WorldChunk;
+import net.minecraft.world.chunk.WrapperProtoChunk;
 
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
 
@@ -35,5 +36,8 @@ abstract class ChunkGeneratingMixin {
 	private static void onChunkLoad(Chunk chunk, ChunkGenerationContext chunkGenerationContext, AbstractChunkHolder chunkHolder, CallbackInfoReturnable<Chunk> callbackInfoReturnable) {
 		// We fire the event at TAIL since the chunk is guaranteed to be a WorldChunk then.
 		ServerChunkEvents.CHUNK_LOAD.invoker().onChunkLoad(chunkGenerationContext.world(), (WorldChunk) callbackInfoReturnable.getReturnValue());
+		if (!(chunk instanceof WrapperProtoChunk)) {
+			ServerChunkEvents.CHUNK_GENERATE.invoker().onChunkGenerate(chunkGenerationContext.world(), (WorldChunk) callbackInfoReturnable.getReturnValue());
+		}
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkGeneratingMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkGeneratingMixin.java
@@ -36,6 +36,7 @@ abstract class ChunkGeneratingMixin {
 	private static void onChunkLoad(Chunk chunk, ChunkGenerationContext chunkGenerationContext, AbstractChunkHolder chunkHolder, CallbackInfoReturnable<Chunk> callbackInfoReturnable) {
 		// We fire the event at TAIL since the chunk is guaranteed to be a WorldChunk then.
 		ServerChunkEvents.CHUNK_LOAD.invoker().onChunkLoad(chunkGenerationContext.world(), (WorldChunk) callbackInfoReturnable.getReturnValue());
+
 		if (!(chunk instanceof WrapperProtoChunk)) {
 			ServerChunkEvents.CHUNK_GENERATE.invoker().onChunkGenerate(chunkGenerationContext.world(), (WorldChunk) callbackInfoReturnable.getReturnValue());
 		}

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.event.lifecycle;
+
+import com.mojang.logging.LogUtils;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import org.slf4j.Logger;
+
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+
+public final class ServerChunkLifecycleTests implements ModInitializer {
+	private static final Logger LOGGER = LogUtils.getLogger();
+
+	@Override
+	public void onInitialize() {
+		setupChunkGenerateTest();
+	}
+
+	/**
+	 * After creating an SP world and waiting for all nearby chunks to generate (logging to stop),
+	 * closing the SP world and opening it again should not log any fresh generation.
+	 * Moving to an unexplored area will start logging again.
+	 */
+	private static void setupChunkGenerateTest() {
+		final Object2IntMap<Identifier> generated = new Object2IntOpenHashMap<>();
+
+		ServerTickEvents.END_WORLD_TICK.register(world -> {
+			final int count = generated.removeInt(world.getRegistryKey().getValue());
+
+			if (count > 0) {
+				LOGGER.info("Loaded {} freshly generated chunks in {} during tick #{}", count, world.getRegistryKey().getValue(), world.getServer().getTicks());
+			}
+		});
+
+		ServerChunkEvents.CHUNK_GENERATE.register((world, chunk) -> {
+			generated.mergeInt(world.getRegistryKey().getValue(), 1, Integer::sum);
+		});
+	}
+}

--- a/fabric-lifecycle-events-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-lifecycle-events-v1/src/testmod/resources/fabric.mod.json
@@ -12,6 +12,7 @@
     "main": [
       "net.fabricmc.fabric.test.event.lifecycle.CommonLifecycleTests",
       "net.fabricmc.fabric.test.event.lifecycle.ServerBlockEntityLifecycleTests",
+      "net.fabricmc.fabric.test.event.lifecycle.ServerChunkLifecycleTests",
       "net.fabricmc.fabric.test.event.lifecycle.ServerEntityLifecycleTests",
       "net.fabricmc.fabric.test.event.lifecycle.ServerLifecycleTests",
       "net.fabricmc.fabric.test.event.lifecycle.ServerTickTests",


### PR DESCRIPTION
Add a new chunk generate event, fired alongside the chunk load event when a chunk is first upgraded to full status.

My use case for this is a world map mod, I need to know when new chunks are generated to map them. I don't need to map a chunk that is just loading, only generated, I have other hooks to re-map chunks when blocks change.

Until now I've used a mixin to accomplish this, however, this makes compatibility more difficult with mods like Moonrise that rewrite the chunk system.

Some additional context (Mojang mappings):
- https://github.com/jpenilla/squaremap/commit/cbee307394cb417b4fcc9ac67fb1b0dd5b842070
- https://github.com/Tuinity/Moonrise/blob/a70073ae3e64ddf77829ada3c05a4c7e3c81554d/fabric/src/main/java/ca/spottedleaf/moonrise/fabric/FabricHooks.java#L88
- https://github.com/Tuinity/Moonrise/blob/a70073ae3e64ddf77829ada3c05a4c7e3c81554d/neoforge/src/main/java/ca/spottedleaf/moonrise/neoforge/NeoForgeHooks.java#L82