### PR TITLE
Fix overriding vanilla translations

### DIFF
--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/server/LanguageMixin.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/mixin/resource/loader/server/LanguageMixin.java
@@ -35,6 +35,8 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import net.minecraft.util.Language;
 
 import net.fabricmc.fabric.impl.resource.loader.ServerLanguageUtil;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
 
 @Mixin(Language.class)
 class LanguageMixin {
@@ -49,6 +51,18 @@ class LanguageMixin {
 		}
 
 		return ImmutableMap.copyOf(map);
+	}
+
+	@Redirect(method = "load(Ljava/util/function/BiConsumer;Ljava/lang/String;)V", at = @At(value = "INVOKE", target = "Ljava/lang/Class;getResourceAsStream(Ljava/lang/String;)Ljava/io/InputStream;"))
+	private static InputStream readCorrectVanillaResource(Class instance, String path) throws IOException {
+		ModContainer mod = FabricLoader.getInstance().getModContainer("minecraft").orElseThrow();
+		Path langPath = mod.findPath(path).orElse(null);
+
+		if (langPath == null) {
+			throw new IOException("Could not read %s from minecraft ModContainer".formatted(path));
+		} else {
+			return Files.newInputStream(langPath);
+		}
 	}
 
 	private static void loadFromPath(Path path, BiConsumer<String, String> entryConsumer) {

--- a/fabric-resource-loader-v0/src/testmod/java/net/fabricmc/fabric/test/resource/loader/LanguageTestMod.java
+++ b/fabric-resource-loader-v0/src/testmod/java/net/fabricmc/fabric/test/resource/loader/LanguageTestMod.java
@@ -27,6 +27,8 @@ public class LanguageTestMod implements DedicatedServerModInitializer {
 	}
 
 	private static void testTranslationLoaded() {
+		testTranslationLoaded("item.minecraft.potato", "Potato"); // Test that vanilla translation loads
+		testTranslationLoaded("text.fabric-resource-loader-v0-testmod.server.lang.override", "Vanilla override test");
 		testTranslationLoaded("pack.source.fabricmod", "Fabric mod");
 		testTranslationLoaded("text.fabric-resource-loader-v0-testmod.server.lang.test0", "Test from fabric-resource-loader-v0-testmod");
 		testTranslationLoaded("text.fabric-resource-loader-v0-testmod.server.lang.test1", "Test from fabric-resource-loader-v0-testmod-test1");

--- a/fabric-resource-loader-v0/src/testmod/resources/assets/minecraft/lang/en_us.json
+++ b/fabric-resource-loader-v0/src/testmod/resources/assets/minecraft/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+  "text.fabric-resource-loader-v0-testmod.server.lang.override": "Vanilla override test"
+}


### PR DESCRIPTION
Fixes a longstanding bug where overriding vanilla translation can cause non-overridden ones to fail to load. Also adds a test.

Request porting to all maintained versions, if possible to 1.20.1.