### PR TITLE
Fix AFTER_SETUP event not being able to render

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderEvents.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderEvents.java
@@ -69,6 +69,8 @@ public final class WorldRenderEvents {
 	 * identified and rebuilt but before chunks are uploaded to GPU.
 	 *
 	 * <p>Use for setup of state that depends on view frustum.
+	 *
+	 * <b>Can NOT be used to render anything after MC 1.21.2 due to a glClear call, use {@link WorldRenderEvents#BEFORE_TERRAIN} instead.
 	 */
 	public static final Event<AfterSetup> AFTER_SETUP = EventFactory.createArrayBacked(AfterSetup.class, context -> { }, callbacks -> context -> {
 		for (final AfterSetup callback : callbacks) {

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderEvents.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderEvents.java
@@ -70,7 +70,7 @@ public final class WorldRenderEvents {
 	 *
 	 * <p>Use for setup of state that depends on view frustum.
 	 *
-	 * <b>Can NOT be used to render anything after MC 1.21.2 due to a glClear call, use {@link WorldRenderEvents#BEFORE_TERRAIN} instead.
+	 * <b>Can NOT be used to render anything after MC 1.21.2 due to a glClear call, use {@link WorldRenderEvents#BEFORE_TERRAIN} instead.</b>
 	 */
 	public static final Event<AfterSetup> AFTER_SETUP = EventFactory.createArrayBacked(AfterSetup.class, context -> { }, callbacks -> context -> {
 		for (final AfterSetup callback : callbacks) {

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderEvents.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderEvents.java
@@ -264,11 +264,6 @@ public final class WorldRenderEvents {
 	}
 
 	@FunctionalInterface
-	public interface BeforeTerrain {
-		void beforeTerrain(WorldRenderContext context);
-	}
-
-	@FunctionalInterface
 	public interface BeforeEntities {
 		void beforeEntities(WorldRenderContext context);
 	}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderEvents.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderEvents.java
@@ -35,7 +35,6 @@ import net.fabricmc.fabric.api.event.EventFactory;
  * <p>The order of events each frame is as follows:
  * <ul><li>START
  * <li>AFTER_SETUP
- * <li>BEFORE_TERRAIN
  * <li>BEFORE_ENTITIES
  * <li>AFTER_ENTITIES
  * <li>BEFORE_BLOCK_OUTLINE
@@ -69,23 +68,10 @@ public final class WorldRenderEvents {
 	 * identified and rebuilt but before chunks are uploaded to GPU.
 	 *
 	 * <p>Use for setup of state that depends on view frustum.
-	 *
-	 * <b>Can NOT be used to render anything after MC 1.21.2 due to a glClear call, use {@link WorldRenderEvents#BEFORE_TERRAIN} instead.</b>
 	 */
 	public static final Event<AfterSetup> AFTER_SETUP = EventFactory.createArrayBacked(AfterSetup.class, context -> { }, callbacks -> context -> {
 		for (final AfterSetup callback : callbacks) {
 			callback.afterSetup(context);
-		}
-	});
-
-	/**
-	 * Called before the terrain layers are output to the framebuffer, but after the terrain shader fog has been set up.
-	 *
-	 * <p>Use to render before the terrain is drawn.
-	 */
-	public static final Event<BeforeTerrain> BEFORE_TERRAIN = EventFactory.createArrayBacked(BeforeTerrain.class, context -> { }, callbacks -> context -> {
-		for (final BeforeTerrain callback : callbacks) {
-			callback.beforeTerrain(context);
 		}
 	});
 

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderEvents.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderEvents.java
@@ -35,6 +35,7 @@ import net.fabricmc.fabric.api.event.EventFactory;
  * <p>The order of events each frame is as follows:
  * <ul><li>START
  * <li>AFTER_SETUP
+ * <li>BEFORE_TERRAIN
  * <li>BEFORE_ENTITIES
  * <li>AFTER_ENTITIES
  * <li>BEFORE_BLOCK_OUTLINE
@@ -72,6 +73,17 @@ public final class WorldRenderEvents {
 	public static final Event<AfterSetup> AFTER_SETUP = EventFactory.createArrayBacked(AfterSetup.class, context -> { }, callbacks -> context -> {
 		for (final AfterSetup callback : callbacks) {
 			callback.afterSetup(context);
+		}
+	});
+
+	/**
+	 * Called before the terrain layers are output to the framebuffer, but after the terrain shader fog has been set up.
+	 *
+	 * <p>Use to render before the terrain is drawn.
+	 */
+	public static final Event<BeforeTerrain> BEFORE_TERRAIN = EventFactory.createArrayBacked(BeforeTerrain.class, context -> { }, callbacks -> context -> {
+		for (final BeforeTerrain callback : callbacks) {
+			callback.beforeTerrain(context);
 		}
 	});
 
@@ -261,6 +273,11 @@ public final class WorldRenderEvents {
 	@FunctionalInterface
 	public interface AfterSetup {
 		void afterSetup(WorldRenderContext context);
+	}
+
+	@FunctionalInterface
+	public interface BeforeTerrain {
+		void beforeTerrain(WorldRenderContext context);
 	}
 
 	@FunctionalInterface

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
@@ -80,7 +80,6 @@ public abstract class WorldRendererMixin {
 	@Inject(method = "setupTerrain", at = @At("RETURN"))
 	private void afterTerrainSetup(Camera camera, Frustum frustum, boolean hasForcedFrustum, boolean spectator, CallbackInfo ci) {
 		context.setFrustum(frustum);
-		WorldRenderEvents.AFTER_SETUP.invoker().afterSetup(context);
 	}
 
 	@Inject(
@@ -93,7 +92,7 @@ public abstract class WorldRendererMixin {
 			) // Points to after profiler.push("terrain");
 	)
 	private void beforeTerrainSolid(CallbackInfo ci) {
-		WorldRenderEvents.BEFORE_TERRAIN.invoker().beforeTerrain(context);
+		WorldRenderEvents.AFTER_SETUP.invoker().afterSetup(context);
 	}
 
 	@Inject(

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
@@ -90,7 +90,7 @@ public abstract class WorldRendererMixin {
 				target = "Lnet/minecraft/util/profiler/Profiler;push(Ljava/lang/String;)V",
 				ordinal = 0,
 				shift = Shift.AFTER
-			)
+			) // Points to after profiler.push("terrain");
 	)
 	private void beforeTerrainSolid(CallbackInfo ci) {
 		WorldRenderEvents.BEFORE_TERRAIN.invoker().beforeTerrain(context);

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
@@ -87,6 +87,19 @@ public abstract class WorldRendererMixin {
 			method = "method_62214",
 			at = @At(
 				value = "INVOKE",
+				target = "Lnet/minecraft/util/profiler/Profiler;push(Ljava/lang/String;)V",
+				ordinal = 0,
+				shift = Shift.AFTER
+			)
+	)
+	private void beforeTerrainSolid(CallbackInfo ci) {
+		WorldRenderEvents.BEFORE_TERRAIN.invoker().beforeTerrain(context);
+	}
+
+	@Inject(
+			method = "method_62214",
+			at = @At(
+				value = "INVOKE",
 				target = "Lnet/minecraft/client/render/WorldRenderer;renderLayer(Lnet/minecraft/client/render/RenderLayer;DDDLorg/joml/Matrix4f;Lorg/joml/Matrix4f;)V",
 				ordinal = 2,
 				shift = Shift.AFTER

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
@@ -85,9 +85,9 @@ public abstract class WorldRendererMixin {
 	@Inject(
 			method = "method_62214",
 			at = @At(
-				value = "INVOKE",
+				value = "INVOKE_STRING",
 				target = "Lnet/minecraft/util/profiler/Profiler;push(Ljava/lang/String;)V",
-				ordinal = 0,
+				args = "ldc=terrain",
 				shift = Shift.AFTER
 			) // Points to after profiler.push("terrain");
 	)


### PR DESCRIPTION
Due to 1.21.2 changing the way how level rendering works, adding a `RenderSystem.clear` after the `AFTER_SETUP` event, rendering is not possible with this event, so I moved the event to a later point after the clear call but before the terrain rendering