### PR TITLE
Add transitive access wideners for ID_MAPPER of ItemModelTypes and related types

### DIFF
--- a/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.accesswidener
+++ b/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.accesswidener
@@ -60,6 +60,14 @@ transitive-accessible class net/minecraft/client/render/RenderLayer$OutlineMode
 # Registering custom block entity renderers
 transitive-accessible method net/minecraft/client/render/block/entity/BlockEntityRendererFactories register (Lnet/minecraft/block/entity/BlockEntityType;Lnet/minecraft/client/render/block/entity/BlockEntityRendererFactory;)V
 
+# Adding custom item model types
+transitive-accessible field net/minecraft/client/render/item/model/ItemModelTypes ID_MAPPER Lnet/minecraft/util/dynamic/Codecs$IdMapper;
+transitive-accessible field net/minecraft/client/render/item/tint/TintSourceTypes ID_MAPPER Lnet/minecraft/util/dynamic/Codecs$IdMapper;
+transitive-accessible field net/minecraft/client/render/item/property/bool/BooleanProperties ID_MAPPER Lnet/minecraft/util/dynamic/Codecs$IdMapper;
+transitive-accessible field net/minecraft/client/render/item/property/numeric/NumericProperties ID_MAPPER Lnet/minecraft/util/dynamic/Codecs$IdMapper;
+transitive-accessible field net/minecraft/client/render/item/property/select/SelectProperties ID_MAPPER Lnet/minecraft/util/dynamic/Codecs$IdMapper;
+transitive-accessible field net/minecraft/client/render/item/model/special/SpecialModelTypes ID_MAPPER Lnet/minecraft/util/dynamic/Codecs$IdMapper;
+
 # Creating custom sensor types
 transitive-accessible method net/minecraft/entity/ai/brain/sensor/SensorType <init> (Ljava/util/function/Supplier;)V
 

--- a/fabric-transitive-access-wideners-v1/template.accesswidener
+++ b/fabric-transitive-access-wideners-v1/template.accesswidener
@@ -55,6 +55,14 @@ transitive-accessible class net/minecraft/client/render/RenderLayer$OutlineMode
 # Registering custom block entity renderers
 transitive-accessible method net/minecraft/client/render/block/entity/BlockEntityRendererFactories register (Lnet/minecraft/block/entity/BlockEntityType;Lnet/minecraft/client/render/block/entity/BlockEntityRendererFactory;)V
 
+# Adding custom item model types
+transitive-accessible field net/minecraft/client/render/item/model/ItemModelTypes ID_MAPPER Lnet/minecraft/util/dynamic/Codecs$IdMapper;
+transitive-accessible field net/minecraft/client/render/item/tint/TintSourceTypes ID_MAPPER Lnet/minecraft/util/dynamic/Codecs$IdMapper;
+transitive-accessible field net/minecraft/client/render/item/property/bool/BooleanProperties ID_MAPPER Lnet/minecraft/util/dynamic/Codecs$IdMapper;
+transitive-accessible field net/minecraft/client/render/item/property/numeric/NumericProperties ID_MAPPER Lnet/minecraft/util/dynamic/Codecs$IdMapper;
+transitive-accessible field net/minecraft/client/render/item/property/select/SelectProperties ID_MAPPER Lnet/minecraft/util/dynamic/Codecs$IdMapper;
+transitive-accessible field net/minecraft/client/render/item/model/special/SpecialModelTypes ID_MAPPER Lnet/minecraft/util/dynamic/Codecs$IdMapper;
+
 # Creating custom sensor types
 transitive-accessible method net/minecraft/entity/ai/brain/sensor/SensorType <init> (Ljava/util/function/Supplier;)V
 


### PR DESCRIPTION
Adds TAWs for the following fields:
- `ItemModelTypes.ID_MAPPER`
- `TintSourceTypes.ID_MAPPER`
- `BooleanProperties.ID_MAPPER`
- `NumericProperties.ID_MAPPER`
- `SelectProperties.ID_MAPPER`
- `SpecialModelTypes.ID_MAPPER`

Those were added in 24w45a for the new item models. They act as pseudo-registries for those client resource-types. Adding to them is an easy way to create custom behavior for item models.

Note that adding to the `SpecialModelTypes.BLOCK_TO_MODEL_TYPE` map would also be desirable to handle block display entities and enderman holding of custom blocks with special renderers. But since that map isn't easily extendable, I'll leave a proper solution of that for someone else to figure out.