### PR TITLE
Fix includeData in pick events

### DIFF
--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModificationContext.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModificationContext.java
@@ -298,8 +298,8 @@ public interface BiomeModificationContext {
 		}
 
 		/**
-		 * @see BiomeEffects#method_65135()
-		 * @see BiomeEffects.Builder#method_65137(int)
+		 * @see BiomeEffects#getMusicVolume()
+		 * @see BiomeEffects.Builder#musicVolume(float)
 		 */
 		void setMusicVolume(float volume);
 	}

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentTarget.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentTarget.java
@@ -36,7 +36,7 @@ import net.minecraft.world.chunk.ChunkStatus;
  * <p>Fabric implements this on {@link Entity}, {@link BlockEntity}, {@link ServerWorld} and {@link Chunk} via mixin.</p>
  *
  * <p>Note about {@link BlockEntity} and {@link Chunk} targets: these objects need to be notified of changes to their
- * state (using {@link BlockEntity#markDirty()} and {@link Chunk#setNeedsSaving(boolean)} respectively), otherwise the modifications will not take effect properly.
+ * state (using {@link BlockEntity#markDirty()} and {@link Chunk#markNeedsSaving()} respectively), otherwise the modifications will not take effect properly.
  * The {@link #setAttached(AttachmentType, Object)} method handles this automatically, but this needs to be done manually
  * when attached data is mutable, for example:
  * <pre>{@code

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricRecipeProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricRecipeProvider.java
@@ -36,6 +36,8 @@ import net.minecraft.data.DataWriter;
 import net.minecraft.data.recipe.CraftingRecipeJsonBuilder;
 import net.minecraft.data.recipe.RecipeExporter;
 import net.minecraft.data.recipe.RecipeGenerator;
+import net.minecraft.data.recipe.ShapedRecipeJsonBuilder;
+import net.minecraft.data.recipe.ShapelessRecipeJsonBuilder;
 import net.minecraft.recipe.Recipe;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/block/BlockPickInteractionAware.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/block/BlockPickInteractionAware.java
@@ -28,7 +28,7 @@ import net.minecraft.world.WorldView;
 
 /**
  * Convenience interface for blocks that want more stack picking context than what
- * {@link Block#getPickStack(WorldView, BlockPos, BlockState)} provides.
+ * {@link Block#getPickStack(WorldView, BlockPos, BlockState, boolean)} provides.
  *
  * <p>The hit result is guaranteed to be a {@link BlockHitResult} that did not miss.
  */

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/ServerPlayNetworkHandlerMixin.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/ServerPlayNetworkHandlerMixin.java
@@ -48,11 +48,11 @@ public abstract class ServerPlayNetworkHandlerMixin {
 	}
 
 	@WrapOperation(method = "onPickItemFromBlock", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;getPickStack(Lnet/minecraft/world/WorldView;Lnet/minecraft/util/math/BlockPos;Z)Lnet/minecraft/item/ItemStack;"))
-	public ItemStack onPickItemFromBlock(BlockState state, WorldView world, BlockPos pos, boolean bl, Operation<ItemStack> operation, @Local PickItemFromBlockC2SPacket packet) {
-		ItemStack stack = PlayerPickItemEvents.BLOCK.invoker().onPickItemFromBlock(player, pos, state, packet.includeData());
+	public ItemStack onPickItemFromBlock(BlockState state, WorldView world, BlockPos pos, boolean includeData, Operation<ItemStack> operation, @Local PickItemFromBlockC2SPacket packet) {
+		ItemStack stack = PlayerPickItemEvents.BLOCK.invoker().onPickItemFromBlock(player, pos, state, includeData);
 
 		if (stack == null) {
-			return operation.call(state, world, pos, bl);
+			return operation.call(state, world, pos, includeData);
 		} else if (!stack.isEmpty()) {
 			this.onPickItem(stack);
 		}
@@ -63,7 +63,7 @@ public abstract class ServerPlayNetworkHandlerMixin {
 
 	@WrapOperation(method = "onPickItemFromEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;getPickBlockStack()Lnet/minecraft/item/ItemStack;"))
 	public ItemStack onPickItemFromEntity(Entity entity, Operation<ItemStack> operation, @Local PickItemFromEntityC2SPacket packet) {
-		ItemStack stack = PlayerPickItemEvents.ENTITY.invoker().onPickItemFromEntity(player, entity, packet.includeData());
+		ItemStack stack = PlayerPickItemEvents.ENTITY.invoker().onPickItemFromEntity(player, entity, packet.includeData() && player.isInCreativeMode());
 
 		if (stack == null) {
 			return operation.call(entity);


### PR DESCRIPTION
Fixes an issue where the game mode check for `includeData` was omitted. Vanilla only allows `includeData` if the player is in Creative mode. Only affects the snapshots.

Also fixes several javadoc issues.