### PR TITLE
Fix the outdated EntitySelectorOptionRegistry usage documentation

### DIFF
--- a/fabric-command-api-v2/src/main/java/net/fabricmc/fabric/api/command/v2/EntitySelectorOptionRegistry.java
+++ b/fabric-command-api-v2/src/main/java/net/fabricmc/fabric/api/command/v2/EntitySelectorOptionRegistry.java
@@ -46,7 +46,7 @@ public final class EntitySelectorOptionRegistry {
 	 * 	    final float minHealth = reader.getReader().readFloat();
 	 *
 	 * 	    if (minHealth > 0) {
-	 * 	        reader.setPredicate((entity) -> entity instanceof LivingEntity livingEntity && livingEntity.getHealth() >= minHealth);
+	 * 	        reader.addPredicate((entity) -> entity instanceof LivingEntity livingEntity && livingEntity.getHealth() >= minHealth);
 	 * 	    }
 	 * 	},
 	 * 	(reader) -> true


### PR DESCRIPTION
Fix the EntitySelectorOptionRegistry usage documentation by changing outdated `setPredicate` to `addPredicate`.
Fixes #3856 