### PR TITLE
Make data generation .cache reproducible

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DataCacheCachedDataMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DataCacheCachedDataMixin.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.datagen;
+
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.hash.HashCode;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(targets = "net.minecraft.data.DataCache$CachedData")
+public abstract class DataCacheCachedDataMixin {
+	@WrapOperation(method = "write", at = @At(value = "INVOKE", target = "Lcom/google/common/collect/ImmutableMap;entrySet()Lcom/google/common/collect/ImmutableSet;"))
+	private ImmutableSet<Map.Entry<Path, HashCode>> sortPaths(ImmutableMap<Path, HashCode> instance, Operation<ImmutableSet<Map.Entry<Path, HashCode>>> original) {
+		return original.call(instance).stream()
+				.sorted(Map.Entry.comparingByKey(Comparator.comparing(k -> normalizePath(k.toString()))))
+				.collect(ImmutableSet.toImmutableSet());
+	}
+
+	@WrapOperation(method = "write", at = @At(value = "INVOKE", target = "Ljava/nio/file/Path;toString()Ljava/lang/String;"))
+	private String pathToString(Path instance, Operation<String> original) {
+		return normalizePath(original.call(instance));
+	}
+
+	@Unique
+	private static String normalizePath(String path) {
+		return path.replace('\\', '/');
+	}
+}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DataCacheCachedDataMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DataCacheCachedDataMixin.java
@@ -20,27 +20,25 @@ import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.hash.HashCode;
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(targets = "net.minecraft.data.DataCache$CachedData")
 public abstract class DataCacheCachedDataMixin {
-	@WrapOperation(method = "write", at = @At(value = "INVOKE", target = "Lcom/google/common/collect/ImmutableMap;entrySet()Lcom/google/common/collect/ImmutableSet;"))
-	private ImmutableSet<Map.Entry<Path, HashCode>> sortPaths(ImmutableMap<Path, HashCode> instance, Operation<ImmutableSet<Map.Entry<Path, HashCode>>> original) {
-		return original.call(instance).stream()
+	@ModifyExpressionValue(method = "write", at = @At(value = "INVOKE", target = "Lcom/google/common/collect/ImmutableMap;entrySet()Lcom/google/common/collect/ImmutableSet;"))
+	private ImmutableSet<Map.Entry<Path, HashCode>> sortPaths(ImmutableSet<Map.Entry<Path, HashCode>> original) {
+		return original.stream()
 				.sorted(Map.Entry.comparingByKey(Comparator.comparing(k -> normalizePath(k.toString()))))
 				.collect(ImmutableSet.toImmutableSet());
 	}
 
-	@WrapOperation(method = "write", at = @At(value = "INVOKE", target = "Ljava/nio/file/Path;toString()Ljava/lang/String;"))
-	private String pathToString(Path instance, Operation<String> original) {
-		return normalizePath(original.call(instance));
+	@ModifyExpressionValue(method = "write", at = @At(value = "INVOKE", target = "Ljava/nio/file/Path;toString()Ljava/lang/String;"))
+	private String pathToString(String original) {
+		return normalizePath(original);
 	}
 
 	@Unique

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DataCacheMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DataCacheMixin.java
@@ -25,7 +25,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import net.minecraft.data.DataCache;
 
 @Mixin(DataCache.class)
-public class DataCacheMixin {
+public abstract class DataCacheMixin {
 	// Lambda in write()V
 	@Redirect(method = "method_46571", at = @At(value = "INVOKE", target = "Ljava/time/LocalDateTime;now()Ljava/time/LocalDateTime;"))
 	private LocalDateTime constantTime() {

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DataCacheMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DataCacheMixin.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.datagen;
+
+import java.time.LocalDateTime;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.data.DataCache;
+
+@Mixin(DataCache.class)
+public class DataCacheMixin {
+	// Lambda in write()V
+	@Redirect(method = "method_46571", at = @At(value = "INVOKE", target = "Ljava/time/LocalDateTime;now()Ljava/time/LocalDateTime;"))
+	private LocalDateTime constantTime() {
+		// Write a constant time to the .cache file to ensure datagen output is reproducible
+		return LocalDateTime.MIN;
+	}
+}

--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
@@ -3,6 +3,7 @@
   "package": "net.fabricmc.fabric.mixin.datagen",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
+    "DataCacheMixin",
     "DataProviderMixin",
     "TagBuilderMixin",
     "TagProviderMixin",

--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
@@ -3,6 +3,7 @@
   "package": "net.fabricmc.fabric.mixin.datagen",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
+    "DataCacheCachedDataMixin",
     "DataCacheMixin",
     "DataProviderMixin",
     "TagBuilderMixin",


### PR DESCRIPTION
As far as I can tell this timestamp is never used, by setting it to a constant value Gradle will be able to consider skipping datageneration tasks if the input never changes. As datagen is an input to its self it does take 2 runs to be skipped.

Also see: https://github.com/FabricMC/fabric-loom/pull/1226