### PR TITLE
Fix some datagen taws

### DIFF
--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.accesswidener
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.accesswidener
@@ -7,7 +7,7 @@ accessible field net/minecraft/data/DataGenerator output Lnet/minecraft/data/Dat
 mutable field net/minecraft/data/DataGenerator output Lnet/minecraft/data/DataOutput;
 
 accessible class net/minecraft/data/recipe/RecipeGenerator$RecipeProvider
-extendable method net/minecraft/data/recipe/RecipeGenerator$RecipeProvider run (Lnet/minecraft/data/DataWriter;)Ljava/util/concurrent/CompletableFuture;
+transitive-extendable method net/minecraft/data/recipe/RecipeGenerator$RecipeProvider run (Lnet/minecraft/data/DataWriter;)Ljava/util/concurrent/CompletableFuture;
 
 accessible field net/minecraft/data/tag/TagProvider$ProvidedTagBuilder builder Lnet/minecraft/registry/tag/TagBuilder;
 transitive-extendable method net/minecraft/data/tag/TagProvider$ProvidedTagBuilder add (Lnet/minecraft/registry/RegistryKey;)Lnet/minecraft/data/tag/TagProvider$ProvidedTagBuilder;
@@ -41,8 +41,8 @@ transitive-accessible field net/minecraft/client/data/BlockStateModelGenerator b
 transitive-accessible field net/minecraft/client/data/BlockStateModelGenerator modelCollector Ljava/util/function/BiConsumer;
 transitive-accessible field net/minecraft/client/data/BlockStateModelGenerator itemModelOutput Lnet/minecraft/client/data/ItemModelOutput;
 
-accessible field net/minecraft/client/data/ItemModelGenerator output Lnet/minecraft/client/data/ItemModelOutput;
-accessible field net/minecraft/client/data/ItemModelGenerator modelCollector Ljava/util/function/BiConsumer;
+transitive-accessible field net/minecraft/client/data/ItemModelGenerator output Lnet/minecraft/client/data/ItemModelOutput;
+transitive-accessible field net/minecraft/client/data/ItemModelGenerator modelCollector Ljava/util/function/BiConsumer;
 
 transitive-accessible method net/minecraft/client/data/TextureKey of (Ljava/lang/String;)Lnet/minecraft/client/data/TextureKey;
 transitive-accessible method net/minecraft/client/data/TextureKey of (Ljava/lang/String;Lnet/minecraft/client/data/TextureKey;)Lnet/minecraft/client/data/TextureKey;

--- a/fabric-data-generation-api-v1/template.accesswidener
+++ b/fabric-data-generation-api-v1/template.accesswidener
@@ -2,7 +2,7 @@ accessible field net/minecraft/data/DataGenerator output Lnet/minecraft/data/Dat
 mutable field net/minecraft/data/DataGenerator output Lnet/minecraft/data/DataOutput;
 
 accessible class net/minecraft/data/recipe/RecipeGenerator$RecipeProvider
-extendable method net/minecraft/data/recipe/RecipeGenerator$RecipeProvider run (Lnet/minecraft/data/DataWriter;)Ljava/util/concurrent/CompletableFuture;
+transitive-extendable method net/minecraft/data/recipe/RecipeGenerator$RecipeProvider run (Lnet/minecraft/data/DataWriter;)Ljava/util/concurrent/CompletableFuture;
 
 accessible field net/minecraft/data/tag/TagProvider$ProvidedTagBuilder builder Lnet/minecraft/registry/tag/TagBuilder;
 transitive-extendable method net/minecraft/data/tag/TagProvider$ProvidedTagBuilder add (Lnet/minecraft/registry/RegistryKey;)Lnet/minecraft/data/tag/TagProvider$ProvidedTagBuilder;
@@ -36,8 +36,8 @@ transitive-accessible field net/minecraft/client/data/BlockStateModelGenerator b
 transitive-accessible field net/minecraft/client/data/BlockStateModelGenerator modelCollector Ljava/util/function/BiConsumer;
 transitive-accessible field net/minecraft/client/data/BlockStateModelGenerator itemModelOutput Lnet/minecraft/client/data/ItemModelOutput;
 
-accessible field net/minecraft/client/data/ItemModelGenerator output Lnet/minecraft/client/data/ItemModelOutput;
-accessible field net/minecraft/client/data/ItemModelGenerator modelCollector Ljava/util/function/BiConsumer;
+transitive-accessible field net/minecraft/client/data/ItemModelGenerator output Lnet/minecraft/client/data/ItemModelOutput;
+transitive-accessible field net/minecraft/client/data/ItemModelGenerator modelCollector Ljava/util/function/BiConsumer;
 
 transitive-accessible method net/minecraft/client/data/TextureKey of (Ljava/lang/String;)Lnet/minecraft/client/data/TextureKey;
 transitive-accessible method net/minecraft/client/data/TextureKey of (Ljava/lang/String;Lnet/minecraft/client/data/TextureKey;)Lnet/minecraft/client/data/TextureKey;


### PR DESCRIPTION
`output` / `modelCollector` should have been transtive since the start.

`run` needs to be transitive as it causes issues with groovy classes using FabricRecipeProvider