### PR TITLE
Allow retrieving model loading plugins

### DIFF
--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/ModelLoadingPlugin.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/ModelLoadingPlugin.java
@@ -17,8 +17,10 @@
 package net.fabricmc.fabric.api.client.model.loading.v1;
 
 import java.util.Collection;
+import java.util.List;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.UnmodifiableView;
 
 import net.minecraft.block.Block;
 import net.minecraft.resource.ResourceManager;
@@ -40,6 +42,14 @@ public interface ModelLoadingPlugin {
 	 */
 	static void register(ModelLoadingPlugin plugin) {
 		ModelLoadingPluginManager.registerPlugin(plugin);
+	}
+
+	/**
+	 * Gets a list of all registered model loading plugins.
+	 */
+	@UnmodifiableView
+	static List<ModelLoadingPlugin> getAll() {
+		return ModelLoadingPluginManager.PLUGINS_VIEW;
 	}
 
 	/**

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/PreparableModelLoadingPlugin.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/PreparableModelLoadingPlugin.java
@@ -16,9 +16,12 @@
 
 package net.fabricmc.fabric.api.client.model.loading.v1;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
+
+import org.jetbrains.annotations.UnmodifiableView;
 
 import net.minecraft.resource.ResourceManager;
 
@@ -42,6 +45,14 @@ public interface PreparableModelLoadingPlugin<T> {
 	}
 
 	/**
+	 * Gets a list of all registered preparable model loading plugins.
+	 */
+	@UnmodifiableView
+	static List<Holder<?>> getAll() {
+		return ModelLoadingPluginManager.PREPARABLE_PLUGINS_VIEW;
+	}
+
+	/**
 	 * Called towards the beginning of the model loading process, every time resource are (re)loaded.
 	 * Use the context object to extend model loading as desired.
 	 *
@@ -62,5 +73,12 @@ public interface PreparableModelLoadingPlugin<T> {
 		 * @param executor The executor that <b>must</b> be used to schedule any completable future.
 		 */
 		CompletableFuture<T> load(ResourceManager resourceManager, Executor executor);
+	}
+
+	/**
+	 * Bundles a {@link PreparableModelLoadingPlugin} with its corresponding {@link DataLoader}
+	 * for retrieval through {@link #getAll()}.
+	 */
+	record Holder<T>(DataLoader<T> loader, PreparableModelLoadingPlugin<T> plugin) {
 	}
 }

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/PreparableModelLoadingPlugin.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/PreparableModelLoadingPlugin.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.UnmodifiableView;
 
 import net.minecraft.resource.ResourceManager;
@@ -79,6 +80,10 @@ public interface PreparableModelLoadingPlugin<T> {
 	 * Bundles a {@link PreparableModelLoadingPlugin} with its corresponding {@link DataLoader}
 	 * for retrieval through {@link #getAll()}.
 	 */
-	record Holder<T>(DataLoader<T> loader, PreparableModelLoadingPlugin<T> plugin) {
+	@ApiStatus.NonExtendable
+	interface Holder<T> {
+		DataLoader<T> loader();
+
+		PreparableModelLoadingPlugin<T> plugin();
 	}
 }

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/ModelLoadingPluginManager.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/ModelLoadingPluginManager.java
@@ -33,7 +33,7 @@ import net.fabricmc.fabric.api.client.model.loading.v1.PreparableModelLoadingPlu
 
 public final class ModelLoadingPluginManager {
 	private static final List<ModelLoadingPlugin> PLUGINS = new ArrayList<>();
-	private static final List<PreparableModelLoadingPlugin.Holder<?>> PREPARABLE_PLUGINS = new ArrayList<>();
+	private static final List<HolderImpl<?>> PREPARABLE_PLUGINS = new ArrayList<>();
 
 	@UnmodifiableView
 	public static final List<ModelLoadingPlugin> PLUGINS_VIEW = Collections.unmodifiableList(PLUGINS);
@@ -50,7 +50,7 @@ public final class ModelLoadingPluginManager {
 		Objects.requireNonNull(loader, "data loader must not be null");
 		Objects.requireNonNull(plugin, "plugin must not be null");
 
-		PREPARABLE_PLUGINS.add(new PreparableModelLoadingPlugin.Holder<>(loader, plugin));
+		PREPARABLE_PLUGINS.add(new HolderImpl<>(loader, plugin));
 	}
 
 	public static CompletableFuture<List<ModelLoadingPlugin>> preparePlugins(ResourceManager resourceManager, Executor executor) {
@@ -60,17 +60,20 @@ public final class ModelLoadingPluginManager {
 			futures.add(CompletableFuture.completedFuture(plugin));
 		}
 
-		for (PreparableModelLoadingPlugin.Holder<?> holder : PREPARABLE_PLUGINS) {
+		for (HolderImpl<?> holder : PREPARABLE_PLUGINS) {
 			futures.add(preparePlugin(holder, resourceManager, executor));
 		}
 
 		return Util.combineSafe(futures);
 	}
 
-	private static <T> CompletableFuture<ModelLoadingPlugin> preparePlugin(PreparableModelLoadingPlugin.Holder<T> holder, ResourceManager resourceManager, Executor executor) {
-		CompletableFuture<T> dataFuture = holder.loader().load(resourceManager, executor);
-		return dataFuture.thenApply(data -> pluginContext -> holder.plugin().initialize(data, pluginContext));
+	private static <T> CompletableFuture<ModelLoadingPlugin> preparePlugin(HolderImpl<T> holder, ResourceManager resourceManager, Executor executor) {
+		CompletableFuture<T> dataFuture = holder.loader.load(resourceManager, executor);
+		return dataFuture.thenApply(data -> pluginContext -> holder.plugin.initialize(data, pluginContext));
 	}
 
 	private ModelLoadingPluginManager() { }
+
+	private record HolderImpl<T>(PreparableModelLoadingPlugin.DataLoader<T> loader, PreparableModelLoadingPlugin<T> plugin) implements PreparableModelLoadingPlugin.Holder<T> {
+	}
 }

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/ModelLoadingPluginManager.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/ModelLoadingPluginManager.java
@@ -17,10 +17,13 @@
 package net.fabricmc.fabric.impl.client.model.loading;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+
+import org.jetbrains.annotations.UnmodifiableView;
 
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Util;
@@ -30,9 +33,12 @@ import net.fabricmc.fabric.api.client.model.loading.v1.PreparableModelLoadingPlu
 
 public final class ModelLoadingPluginManager {
 	private static final List<ModelLoadingPlugin> PLUGINS = new ArrayList<>();
-	private static final List<PreparablePluginHolder<?>> PREPARABLE_PLUGINS = new ArrayList<>();
+	private static final List<PreparableModelLoadingPlugin.Holder<?>> PREPARABLE_PLUGINS = new ArrayList<>();
 
-	public static final ThreadLocal<List<ModelLoadingPlugin>> CURRENT_PLUGINS = new ThreadLocal<>();
+	@UnmodifiableView
+	public static final List<ModelLoadingPlugin> PLUGINS_VIEW = Collections.unmodifiableList(PLUGINS);
+	@UnmodifiableView
+	public static final List<PreparableModelLoadingPlugin.Holder<?>> PREPARABLE_PLUGINS_VIEW = Collections.unmodifiableList(PREPARABLE_PLUGINS);
 
 	public static void registerPlugin(ModelLoadingPlugin plugin) {
 		Objects.requireNonNull(plugin, "plugin must not be null");
@@ -44,7 +50,7 @@ public final class ModelLoadingPluginManager {
 		Objects.requireNonNull(loader, "data loader must not be null");
 		Objects.requireNonNull(plugin, "plugin must not be null");
 
-		PREPARABLE_PLUGINS.add(new PreparablePluginHolder<>(loader, plugin));
+		PREPARABLE_PLUGINS.add(new PreparableModelLoadingPlugin.Holder<>(loader, plugin));
 	}
 
 	public static CompletableFuture<List<ModelLoadingPlugin>> preparePlugins(ResourceManager resourceManager, Executor executor) {
@@ -54,19 +60,17 @@ public final class ModelLoadingPluginManager {
 			futures.add(CompletableFuture.completedFuture(plugin));
 		}
 
-		for (PreparablePluginHolder<?> holder : PREPARABLE_PLUGINS) {
+		for (PreparableModelLoadingPlugin.Holder<?> holder : PREPARABLE_PLUGINS) {
 			futures.add(preparePlugin(holder, resourceManager, executor));
 		}
 
 		return Util.combineSafe(futures);
 	}
 
-	private static <T> CompletableFuture<ModelLoadingPlugin> preparePlugin(PreparablePluginHolder<T> holder, ResourceManager resourceManager, Executor executor) {
-		CompletableFuture<T> dataFuture = holder.loader.load(resourceManager, executor);
-		return dataFuture.thenApply(data -> pluginContext -> holder.plugin.initialize(data, pluginContext));
+	private static <T> CompletableFuture<ModelLoadingPlugin> preparePlugin(PreparableModelLoadingPlugin.Holder<T> holder, ResourceManager resourceManager, Executor executor) {
+		CompletableFuture<T> dataFuture = holder.loader().load(resourceManager, executor);
+		return dataFuture.thenApply(data -> pluginContext -> holder.plugin().initialize(data, pluginContext));
 	}
 
 	private ModelLoadingPluginManager() { }
-
-	private record PreparablePluginHolder<T>(PreparableModelLoadingPlugin.DataLoader<T> loader, PreparableModelLoadingPlugin<T> plugin) { }
 }


### PR DESCRIPTION
This is accomplished though static `ModelLoadingPlugin#getAll` and `PreparableModelLoadingPlugin#getAll`. This functionality is necessary for alternative model loading implementations to support Model Loading API v1, such as the one Embeddedt's ModernFix uses to load models lazily.