### PR TITLE
[1.21.1] Add HudPreRenderCallback Event and HudPostRenderCallback.EVENT

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/HudPostRenderCallback.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/HudPostRenderCallback.java
@@ -1,0 +1,23 @@
+package net.fabricmc.fabric.api.client.rendering.v1;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.render.RenderTickCounter;
+
+public interface HudPostRenderCallback {
+	Event<HudPostRenderCallback> EVENT = EventFactory.createArrayBacked(HudPostRenderCallback.class, (listeners) -> (matrixStack, delta) -> {
+		for (HudPostRenderCallback event : listeners) {
+			event.onHudPostRender(matrixStack, delta);
+		}
+	});
+
+	/**
+	 * Called after rendering the whole hud, which is displayed in game, in a world.
+	 *
+	 * @param drawContext the {@link DrawContext} instance
+	 * @param tickCounter the {@link RenderTickCounter} instance
+	 */
+	void onHudPostRender(DrawContext drawContext, RenderTickCounter tickCounter);
+}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/HudPostRenderCallback.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/HudPostRenderCallback.java
@@ -1,10 +1,10 @@
 package net.fabricmc.fabric.api.client.rendering.v1;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
-
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.render.RenderTickCounter;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
 
 public interface HudPostRenderCallback {
 	Event<HudPostRenderCallback> EVENT = EventFactory.createArrayBacked(HudPostRenderCallback.class, (listeners) -> (matrixStack, delta) -> {

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/HudPreRenderCallback.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/HudPreRenderCallback.java
@@ -1,10 +1,10 @@
 package net.fabricmc.fabric.api.client.rendering.v1;
 
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
-
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.render.RenderTickCounter;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
 
 public interface HudPreRenderCallback {
 	Event<HudPreRenderCallback> EVENT = EventFactory.createArrayBacked(HudPreRenderCallback.class, (listeners) -> (matrixStack, delta) -> {

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/HudPreRenderCallback.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/HudPreRenderCallback.java
@@ -1,0 +1,23 @@
+package net.fabricmc.fabric.api.client.rendering.v1;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.render.RenderTickCounter;
+
+public interface HudPreRenderCallback {
+	Event<HudPreRenderCallback> EVENT = EventFactory.createArrayBacked(HudPreRenderCallback.class, (listeners) -> (matrixStack, delta) -> {
+		for (HudPreRenderCallback event : listeners) {
+			event.onHudPreRender(matrixStack, delta);
+		}
+	});
+
+	/**
+	 * Called before rendering the whole hud, which is displayed in game, in a world.
+	 *
+	 * @param drawContext the {@link DrawContext} instance
+	 * @param tickCounter the {@link RenderTickCounter} instance
+	 */
+	void onHudPreRender(DrawContext drawContext, RenderTickCounter tickCounter);
+}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/HudRenderCallback.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/HudRenderCallback.java
@@ -16,24 +16,19 @@
 
 package net.fabricmc.fabric.api.client.rendering.v1;
 
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.render.RenderTickCounter;
-
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
+/**
+ * Callback for rendering the hud.
+ *
+ * @deprecated Use {@link HudPostRenderCallback} instead.
+ */
+@Deprecated
 public interface HudRenderCallback {
-	Event<HudRenderCallback> EVENT = EventFactory.createArrayBacked(HudRenderCallback.class, (listeners) -> (matrixStack, delta) -> {
-		for (HudRenderCallback event : listeners) {
-			event.onHudRender(matrixStack, delta);
+	Event<HudPostRenderCallback> EVENT = EventFactory.createArrayBacked(HudPostRenderCallback.class, (listeners) -> (matrixStack, delta) -> {
+		for (HudPostRenderCallback event : listeners) {
+			event.onHudPostRender(matrixStack, delta);
 		}
 	});
-
-	/**
-	 * Called after rendering the whole hud, which is displayed in game, in a world.
-	 *
-	 * @param drawContext the {@link DrawContext} instance
-	 * @param tickCounter the {@link RenderTickCounter} instance
-	 */
-	void onHudRender(DrawContext drawContext, RenderTickCounter tickCounter);
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/InGameHudMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/InGameHudMixin.java
@@ -16,6 +16,9 @@
 
 package net.fabricmc.fabric.mixin.client.rendering;
 
+import net.fabricmc.fabric.api.client.rendering.v1.HudPostRenderCallback;
+import net.fabricmc.fabric.api.client.rendering.v1.HudPreRenderCallback;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -25,12 +28,16 @@ import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.InGameHud;
 import net.minecraft.client.render.RenderTickCounter;
 
-import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
-
 @Mixin(InGameHud.class)
 public class InGameHudMixin {
+
+	@Inject(method = "render", at = @At(value = "HEAD"))
+	public void renderHead(DrawContext drawContext, RenderTickCounter tickCounter, CallbackInfo callbackInfo) {
+		HudPreRenderCallback.EVENT.invoker().onHudPreRender(drawContext, tickCounter);
+	}
+
 	@Inject(method = "render", at = @At(value = "TAIL"))
-	public void render(DrawContext drawContext, RenderTickCounter tickCounter, CallbackInfo callbackInfo) {
-		HudRenderCallback.EVENT.invoker().onHudRender(drawContext, tickCounter);
+	public void renderTail(DrawContext drawContext, RenderTickCounter tickCounter, CallbackInfo callbackInfo) {
+		HudPostRenderCallback.EVENT.invoker().onHudPostRender(drawContext, tickCounter);
 	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/InGameHudMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/InGameHudMixin.java
@@ -16,9 +16,6 @@
 
 package net.fabricmc.fabric.mixin.client.rendering;
 
-import net.fabricmc.fabric.api.client.rendering.v1.HudPostRenderCallback;
-import net.fabricmc.fabric.api.client.rendering.v1.HudPreRenderCallback;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -27,6 +24,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.InGameHud;
 import net.minecraft.client.render.RenderTickCounter;
+
+import net.fabricmc.fabric.api.client.rendering.v1.HudPostRenderCallback;
+import net.fabricmc.fabric.api.client.rendering.v1.HudPreRenderCallback;
 
 @Mixin(InGameHud.class)
 public class InGameHudMixin {

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/HudAndShaderTest.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/HudAndShaderTest.java
@@ -18,9 +18,6 @@ package net.fabricmc.fabric.test.rendering.client;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 
-import net.fabricmc.fabric.api.client.rendering.v1.HudPostRenderCallback;
-import net.fabricmc.fabric.api.client.rendering.v1.HudPreRenderCallback;
-
 import org.joml.Matrix4f;
 
 import net.minecraft.client.MinecraftClient;
@@ -35,6 +32,8 @@ import net.minecraft.util.Identifier;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.rendering.v1.CoreShaderRegistrationCallback;
+import net.fabricmc.fabric.api.client.rendering.v1.HudPostRenderCallback;
+import net.fabricmc.fabric.api.client.rendering.v1.HudPreRenderCallback;
 
 /**
  * Tests {@link HudPostRenderCallback}, {@link  HudPreRenderCallback} and {@link CoreShaderRegistrationCallback} by drawing a green rectangle

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/HudAndShaderTest.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/HudAndShaderTest.java
@@ -17,6 +17,10 @@
 package net.fabricmc.fabric.test.rendering.client;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+
+import net.fabricmc.fabric.api.client.rendering.v1.HudPostRenderCallback;
+import net.fabricmc.fabric.api.client.rendering.v1.HudPreRenderCallback;
+
 import org.joml.Matrix4f;
 
 import net.minecraft.client.MinecraftClient;
@@ -31,10 +35,9 @@ import net.minecraft.util.Identifier;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.rendering.v1.CoreShaderRegistrationCallback;
-import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
 
 /**
- * Tests {@link HudRenderCallback} and {@link CoreShaderRegistrationCallback} by drawing a green rectangle
+ * Tests {@link HudPostRenderCallback}, {@link  HudPreRenderCallback} and {@link CoreShaderRegistrationCallback} by drawing a green rectangle
  * in the lower-right corner of the screen.
  */
 public class HudAndShaderTest implements ClientModInitializer {
@@ -48,7 +51,25 @@ public class HudAndShaderTest implements ClientModInitializer {
 			context.register(id, VertexFormats.POSITION, program -> testShader = program);
 		});
 
-		HudRenderCallback.EVENT.register((drawContext, tickDelta) -> {
+		HudPreRenderCallback.EVENT.register((drawContext, tickDelta) -> {
+			MinecraftClient client = MinecraftClient.getInstance();
+			Window window = client.getWindow();
+			int x = 15;
+			int y = window.getScaledHeight() - 15;
+			RenderSystem.setShader(() -> testShader);
+			RenderSystem.setShaderColor(0f, 1f, 0f, 1f);
+			Matrix4f positionMatrix = drawContext.getMatrices().peek().getPositionMatrix();
+			BufferBuilder buffer = Tessellator.getInstance().begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION);
+			buffer.vertex(positionMatrix, x, y, 50);
+			buffer.vertex(positionMatrix, x, y + 10, 50);
+			buffer.vertex(positionMatrix, x + 10, y + 10, 50);
+			buffer.vertex(positionMatrix, x + 10, y, 50);
+			BufferRenderer.drawWithGlobalProgram(buffer.end());
+			// Reset shader color
+			RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
+		});
+
+		HudPostRenderCallback.EVENT.register((drawContext, tickDelta) -> {
 			MinecraftClient client = MinecraftClient.getInstance();
 			Window window = client.getWindow();
 			int x = window.getScaledWidth() - 15;


### PR DESCRIPTION
Adds in a Pre Render Callback to allow developers to render things with the hud appearing over them similar to how carved pumpkins show the hud over the texture.  With this addition I decided to rename HudRenderCallback.EVENT to HudPostRenderCallback.EVENT and then Deprecate HudRenderCallback and point devs to using the new Post one.