### PR TITLE
Fix custom ingredient implementation

### DIFF
--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/api/recipe/v1/ingredient/CustomIngredient.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/api/recipe/v1/ingredient/CustomIngredient.java
@@ -25,7 +25,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.recipe.Ingredient;
 import net.minecraft.recipe.display.SlotDisplay;
 import net.minecraft.registry.entry.RegistryEntry;
-import net.minecraft.registry.entry.RegistryEntryList;
 
 import net.fabricmc.fabric.impl.recipe.ingredient.CustomIngredientImpl;
 
@@ -46,6 +45,9 @@ import net.fabricmc.fabric.impl.recipe.ingredient.CustomIngredientImpl;
  *     // extra ingredient data, dependent on the serializer
  * }
  * }</pre>
+ *
+ * <p>Implementors of this interface are strongly encouraged to also implement
+ * {@link Object#equals(Object)} and {@link Object#hashCode()}.
  *
  * @see CustomIngredientSerializer
  */
@@ -97,11 +99,7 @@ public interface CustomIngredient {
 	 */
 	default SlotDisplay toDisplay() {
 		// Matches the vanilla logic in Ingredient.toDisplay()
-		return RegistryEntryList.of(getMatchingItems().toList()).getStorage().map(
-				SlotDisplay.TagSlotDisplay::new,
-				(itemEntries) -> new SlotDisplay.CompositeSlotDisplay(
-						itemEntries.stream().map(Ingredient::createDisplayWithRemainder).toList()
-				));
+		return new SlotDisplay.CompositeSlotDisplay(getMatchingItems().map(Ingredient::createDisplayWithRemainder).toList());
 	}
 
 	/**

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/CustomIngredientImpl.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/CustomIngredientImpl.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.impl.recipe.ingredient;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -74,12 +75,22 @@ public class CustomIngredientImpl extends Ingredient {
 	// Actual custom ingredient logic
 
 	private final CustomIngredient customIngredient;
+	@Nullable
+	private List<RegistryEntry<Item>> customMatchingItems;
 
 	public CustomIngredientImpl(CustomIngredient customIngredient) {
 		// We must pass a registry entry list that contains something that isn't air. It doesn't actually get used.
 		super(RegistryEntryList.of(Items.STONE.getRegistryEntry()));
 
 		this.customIngredient = customIngredient;
+	}
+
+	private List<RegistryEntry<Item>> getCustomMatchingItems() {
+		if (customMatchingItems == null) {
+			customMatchingItems = customIngredient.getMatchingItems().toList();
+		}
+
+		return customMatchingItems;
 	}
 
 	@Override
@@ -94,16 +105,38 @@ public class CustomIngredientImpl extends Ingredient {
 
 	@Override
 	public Stream<RegistryEntry<Item>> getMatchingItems() {
-		return customIngredient.getMatchingItems();
+		return getCustomMatchingItems().stream();
 	}
 
 	@Override
-	public boolean test(@Nullable ItemStack stack) {
-		return stack != null && customIngredient.test(stack);
+	public boolean isEmpty() {
+		return getCustomMatchingItems().isEmpty();
+	}
+
+	@Override
+	public boolean test(ItemStack stack) {
+		return customIngredient.test(stack);
+	}
+
+	@Override
+	public boolean acceptsItem(RegistryEntry<Item> registryEntry) {
+		return getCustomMatchingItems().contains(registryEntry);
 	}
 
 	@Override
 	public SlotDisplay toDisplay() {
 		return customIngredient.toDisplay();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof CustomIngredientImpl that)) return false;
+		return customIngredient.equals(that.customIngredient);
+	}
+
+	@Override
+	public int hashCode() {
+		return customIngredient.hashCode();
 	}
 }

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/builtin/CombinedIngredient.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/builtin/CombinedIngredient.java
@@ -67,6 +67,18 @@ abstract class CombinedIngredient implements CustomIngredient {
 		);
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof CombinedIngredient that)) return false;
+		return ingredients.equals(that.ingredients);
+	}
+
+	@Override
+	public int hashCode() {
+		return ingredients.hashCode();
+	}
+
 	static class Serializer<I extends CombinedIngredient> implements CustomIngredientSerializer<I> {
 		private final Identifier identifier;
 		private final MapCodec<I> codec;

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/builtin/ComponentsIngredient.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/builtin/ComponentsIngredient.java
@@ -120,6 +120,19 @@ public class ComponentsIngredient implements CustomIngredient {
 		return components;
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		ComponentsIngredient that = (ComponentsIngredient) o;
+		return base.equals(that.base) && components.equals(that.components);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(base, components);
+	}
+
 	private static class Serializer implements CustomIngredientSerializer<ComponentsIngredient> {
 		private static final Identifier ID = Identifier.of("fabric", "components");
 		private static final MapCodec<ComponentsIngredient> CODEC = RecordCodecBuilder.mapCodec(instance ->

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/builtin/CustomDataIngredient.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/builtin/CustomDataIngredient.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.impl.recipe.ingredient.builtin;
 
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import com.mojang.serialization.MapCodec;
@@ -40,6 +41,7 @@ import net.fabricmc.fabric.api.recipe.v1.ingredient.CustomIngredientSerializer;
 
 public class CustomDataIngredient implements CustomIngredient {
 	public static final CustomIngredientSerializer<CustomDataIngredient> SERIALIZER = new Serializer();
+
 	private final Ingredient base;
 	private final NbtCompound nbt;
 
@@ -93,6 +95,19 @@ public class CustomDataIngredient implements CustomIngredient {
 
 	private NbtCompound getNbt() {
 		return nbt;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		CustomDataIngredient that = (CustomDataIngredient) o;
+		return base.equals(that.base) && nbt.equals(that.nbt);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(base, nbt);
 	}
 
 	private static class Serializer implements CustomIngredientSerializer<CustomDataIngredient> {

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/builtin/DifferenceIngredient.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/builtin/DifferenceIngredient.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.impl.recipe.ingredient.builtin;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import com.mojang.serialization.MapCodec;
@@ -72,6 +73,19 @@ public class DifferenceIngredient implements CustomIngredient {
 
 	private Ingredient getSubtracted() {
 		return subtracted;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		DifferenceIngredient that = (DifferenceIngredient) o;
+		return base.equals(that.base) && subtracted.equals(that.subtracted);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(base, subtracted);
 	}
 
 	private static class Serializer implements CustomIngredientSerializer<DifferenceIngredient> {


### PR DESCRIPTION
- Override `isEmpty` in `CustomIngredientImpl`
- Override `acceptsItem` in `CustomIngredientImpl`
- Override `equals` and `hashCode` in `CustomIngredientImpl` so `CustomIngredient`s can also implement them
  - Adjust the class doc of `CustomIngredient` to encourage implementors to do so
- Implement `Ingredient#hashCode`
- Remove incorrect `Nullable` annotation from `ItemStack` parameter in `CustomIngredientImpl#test`
- Simplify default implementation of `CustomIngredient#toDisplay` as created `RegistryEntryList` would always contain right storage
- Implement `equals` and `hashCode` on all builtin custom ingredient classes

Fixes #4270.