### PR TITLE
Fix Object Builder API classloading `TexturedRenderLayers` too early

### DIFF
--- a/fabric-object-builder-api-v1/src/client/java/net/fabricmc/fabric/impl/object/builder/client/SignTypeTextureHelper.java
+++ b/fabric-object-builder-api-v1/src/client/java/net/fabricmc/fabric/impl/object/builder/client/SignTypeTextureHelper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.object.builder.client;
+
+import net.minecraft.block.WoodType;
+import net.minecraft.client.render.TexturedRenderLayers;
+
+public final class SignTypeTextureHelper {
+	/**
+	 * Set to true after {@link TexturedRenderLayers} has been classloaded. If any new {@link WoodType}s are registered
+	 * after this point, they need to be added to the texture maps manually. Always adding textures manually classloads
+	 * {@link TexturedRenderLayers} too early, which causes issues such as decorated pot pattern textures not being
+	 * initialized correctly.
+	 */
+	public static boolean shouldAddTextures = false;
+}

--- a/fabric-object-builder-api-v1/src/client/java/net/fabricmc/fabric/mixin/object/builder/client/TexturedRenderLayersMixin.java
+++ b/fabric-object-builder-api-v1/src/client/java/net/fabricmc/fabric/mixin/object/builder/client/TexturedRenderLayersMixin.java
@@ -16,37 +16,31 @@
 
 package net.fabricmc.fabric.mixin.object.builder.client;
 
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import net.minecraft.block.WoodType;
 import net.minecraft.client.render.TexturedRenderLayers;
-import net.minecraft.client.util.SpriteIdentifier;
 import net.minecraft.util.Identifier;
 
-@Mixin(TexturedRenderLayers.class)
-public class TexturedRenderLayersMixin {
-	@Shadow
-	@Final
-	public static Identifier SIGNS_ATLAS_TEXTURE;
+import net.fabricmc.fabric.impl.object.builder.client.SignTypeTextureHelper;
 
-	@Inject(method = "createSignTextureId", at = @At("HEAD"), cancellable = true)
-	private static void modifyTextureId(WoodType type, CallbackInfoReturnable<SpriteIdentifier> cir) {
-		if (type.name().indexOf(Identifier.NAMESPACE_SEPARATOR) != -1) {
-			Identifier identifier = Identifier.of(type.name());
-			cir.setReturnValue(new SpriteIdentifier(SIGNS_ATLAS_TEXTURE, Identifier.of(identifier.getNamespace(), "entity/signs/" + identifier.getPath())));
-		}
+@Mixin(TexturedRenderLayers.class)
+abstract class TexturedRenderLayersMixin {
+	@Inject(method = "<clinit>*", at = @At("RETURN"))
+	private static void onReturnClinit(CallbackInfo ci) {
+		SignTypeTextureHelper.shouldAddTextures = true;
 	}
 
-	@Inject(method = "createHangingSignTextureId", at = @At("HEAD"), cancellable = true)
-	private static void modifyHangingTextureId(WoodType type, CallbackInfoReturnable<SpriteIdentifier> cir) {
-		if (type.name().indexOf(Identifier.NAMESPACE_SEPARATOR) != -1) {
-			Identifier identifier = Identifier.of(type.name());
-			cir.setReturnValue(new SpriteIdentifier(SIGNS_ATLAS_TEXTURE, Identifier.of(identifier.getNamespace(), "entity/signs/hanging/" + identifier.getPath())));
-		}
+	@Redirect(method = "createSignTextureId", at = @At(value = "INVOKE", target = "net/minecraft/util/Identifier.ofVanilla(Ljava/lang/String;)Lnet/minecraft/util/Identifier;"))
+	private static Identifier redirectSignVanillaId(String name) {
+		return Identifier.of(name);
+	}
+
+	@Redirect(method = "createHangingSignTextureId", at = @At(value = "INVOKE", target = "net/minecraft/util/Identifier.ofVanilla(Ljava/lang/String;)Lnet/minecraft/util/Identifier;"))
+	private static Identifier redirectHangingVanillaId(String name) {
+		return Identifier.of(name);
 	}
 }

--- a/fabric-object-builder-api-v1/src/client/java/net/fabricmc/fabric/mixin/object/builder/client/WoodTypeMixin.java
+++ b/fabric-object-builder-api-v1/src/client/java/net/fabricmc/fabric/mixin/object/builder/client/WoodTypeMixin.java
@@ -25,12 +25,16 @@ import net.minecraft.block.WoodType;
 import net.minecraft.client.render.TexturedRenderLayers;
 import net.minecraft.util.Identifier;
 
+import net.fabricmc.fabric.impl.object.builder.client.SignTypeTextureHelper;
+
 @Mixin(WoodType.class)
-public abstract class WoodTypeMixin {
+abstract class WoodTypeMixin {
 	@Inject(method = "register", at = @At("RETURN"))
-	private static void register(WoodType type, CallbackInfoReturnable<WoodType> cir) {
-		final Identifier identifier = Identifier.of(type.name());
-		TexturedRenderLayers.SIGN_TYPE_TEXTURES.put(type, TexturedRenderLayers.createSignTextureId(identifier));
-		TexturedRenderLayers.HANGING_SIGN_TYPE_TEXTURES.put(type, TexturedRenderLayers.createHangingSignTextureId(identifier));
+	private static void onReturnRegister(WoodType type, CallbackInfoReturnable<WoodType> cir) {
+		if (SignTypeTextureHelper.shouldAddTextures) {
+			final Identifier identifier = Identifier.of(type.name());
+			TexturedRenderLayers.SIGN_TYPE_TEXTURES.put(type, TexturedRenderLayers.createSignTextureId(identifier));
+			TexturedRenderLayers.HANGING_SIGN_TYPE_TEXTURES.put(type, TexturedRenderLayers.createHangingSignTextureId(identifier));
+		}
 	}
 }


### PR DESCRIPTION
- This caused decorated pot pattern textures to not be initialized correctly
- Now, `WoodTypeMixin` only manually adds textures after `TexturedRenderLayers` has been classloaded

Fixes #4272.