### PR TITLE
Disallow records as part of public API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,8 @@ Fabric API makes strong backwards compatibility guarantees, by which contributor
     - If vanilla exposes optionals in return types, then returning an optional is fine.
 - Avoid requiring the user to cast to a subtype if possible.
     - Adding methods to vanilla types can be done via interface injection.
+- Avoid exposing java `records` as public API
+    - Prefer to expose an interface that is implemented by an impl record.
 
 ### API design patterns to consider
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ Fabric API makes strong backwards compatibility guarantees, by which contributor
     - If vanilla exposes optionals in return types, then returning an optional is fine.
 - Avoid requiring the user to cast to a subtype if possible.
     - Adding methods to vanilla types can be done via interface injection.
-- Avoid exposing java `records` as public API.
+- Avoid exposing java `record`s as public API.
     - Records expose more than is necessary for most APIs, which makes them difficult to evolve.
     - Prefer to expose an interface that is implemented by an impl record.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,8 @@ Fabric API makes strong backwards compatibility guarantees, by which contributor
     - If vanilla exposes optionals in return types, then returning an optional is fine.
 - Avoid requiring the user to cast to a subtype if possible.
     - Adding methods to vanilla types can be done via interface injection.
-- Avoid exposing java `records` as public API
+- Avoid exposing java `records` as public API.
+    - Records expose more than is necessary for most APIs, which makes them difficult to evolve.
     - Prefer to expose an interface that is implemented by an impl record.
 
 ### API design patterns to consider

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -208,5 +208,10 @@
         <module name="MatchXpath">
             <property name="query" value="//VARIABLE_DEF[./TYPE/IDENT[@text='var'] and not(./ASSIGN/EXPR/LITERAL_NEW)]"/>
         </module>
+
+        <!-- Prevent public records in API packages -->
+        <module name="MatchXpath">
+            <property name="query" value="//RECORD_DEF[./MODIFIERS/LITERAL_PUBLIC][//PACKAGE_DEF//DOT/IDENT[@text='api']]"/>
+        </module>
 	</module>
 </module>

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/ResourceAmount.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/storage/base/ResourceAmount.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.transfer.v1.storage.base;
 
+//CHECKSTYLE.OFF: MatchXpath
+
 /**
  * An immutable object storing both a resource and an amount, provided for convenience.
  * @param <T> The type of the stored resource.


### PR DESCRIPTION
## Request for comment

Prevent the use of public records in API classes as this has come up a few times in reviews so would like to get some proper feedback on this. Its only a minor thing, but happens enough I think we should enforce it.

### Why
- Hard to expand/refactor, e.g removing a component isnt possible
- Adding a component can be error prone as you need to ensure that a suitable consturctor exists
- Often they arent supposed to be constructed by the API consumer
- Not as clear, e.g you cannot write documentation on each method

### Alternative
The following example record in an API class
```java
record Data(String example) { }
```
would become
```java
interface Data {
  String example();
}
 ```
and the actual record lives in an impl package:
```java
record DataImpl(String example) implements Data { }
```

Where it make a lot of sense to use a record e.g `ResourceAmount` we can opt allow it. If anyone has any thoughts (for or against) please let them be known in this PR.