### PR TITLE
Fix block outline rendering

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderContext.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderContext.java
@@ -44,12 +44,6 @@ public interface WorldRenderContext {
 	 */
 	WorldRenderer worldRenderer();
 
-	/**
-	 * The matrix stack is only not null in {@link WorldRenderEvents#AFTER_ENTITIES} or later events.
-	 */
-	@Nullable
-	MatrixStack matrixStack();
-
 	RenderTickCounter tickCounter();
 
 	boolean blockOutlines();
@@ -58,9 +52,9 @@ public interface WorldRenderContext {
 
 	GameRenderer gameRenderer();
 
-	Matrix4f projectionMatrix();
-
 	Matrix4f positionMatrix();
+
+	Matrix4f projectionMatrix();
 
 	/**
 	 * Convenient access to {WorldRenderer.world}.
@@ -92,30 +86,39 @@ public interface WorldRenderContext {
 	 * possible, caller should use a separate "immediate" instance.
 	 *
 	 * <p>This property is {@code null} before {@link WorldRenderEvents#BEFORE_ENTITIES} and after
-	 * {@link WorldRenderEvents#BEFORE_DEBUG_RENDER} because the consumer buffers are not available before or
+	 * {@link WorldRenderEvents#BLOCK_OUTLINE} (translucent) because the consumer buffers are not available before or
 	 * drawn after that in vanilla world rendering.  Renders that cannot draw in one of the supported events
 	 * must be drawn directly to the frame buffer, preferably in {@link WorldRenderEvents#LAST} to avoid being
 	 * overdrawn or cleared.
 	 */
-	@Nullable VertexConsumerProvider consumers();
+	@Nullable
+	VertexConsumerProvider consumers();
 
 	/**
 	 * View frustum, after it is initialized. Will be {@code null} during
 	 * {@link WorldRenderEvents#START}.
 	 */
-	@Nullable Frustum frustum();
+	@Nullable
+	Frustum frustum();
 
 	/**
-	 * Used in {@code BLOCK_OUTLINE} to convey the parameters normally sent to
+	 * The matrix stack is only not null in {@link WorldRenderEvents#AFTER_ENTITIES} or later events.
+	 */
+	@Nullable
+	MatrixStack matrixStack();
+
+	/**
+	 * Meant to be used in {@link WorldRenderEvents#BEFORE_BLOCK_OUTLINE} and {@link WorldRenderEvents#BLOCK_OUTLINE}.
+	 * @return {@code true} if the current block outline is being rendered after translucent terrain; {@code false} if
+	 * it is being rendered after solid terrain
+	 */
+	boolean translucentBlockOutline();
+
+	/**
+	 * Used in {@link WorldRenderEvents#BLOCK_OUTLINE} to convey the parameters normally sent to
 	 * {@code WorldRenderer.drawBlockOutline}.
 	 */
 	interface BlockOutlineContext {
-		/**
-		 * @deprecated Use {@link #consumers()} directly.
-		 */
-		@Deprecated
-		VertexConsumer vertexConsumer();
-
 		Entity entity();
 
 		double cameraX();
@@ -127,5 +130,11 @@ public interface WorldRenderContext {
 		BlockPos blockPos();
 
 		BlockState blockState();
+
+		/**
+		 * @deprecated Use {@link #consumers()} directly.
+		 */
+		@Deprecated
+		VertexConsumer vertexConsumer();
 	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderContext.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderContext.java
@@ -24,6 +24,7 @@ import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.Frustum;
 import net.minecraft.client.render.GameRenderer;
 import net.minecraft.client.render.RenderTickCounter;
+import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.client.util.math.MatrixStack;
@@ -109,6 +110,12 @@ public interface WorldRenderContext {
 	 * {@code WorldRenderer.drawBlockOutline}.
 	 */
 	interface BlockOutlineContext {
+		/**
+		 * @deprecated Use {@link #consumers()} directly.
+		 */
+		@Deprecated
+		VertexConsumer vertexConsumer();
+
 		Entity entity();
 
 		double cameraX();

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderContext.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderContext.java
@@ -24,7 +24,6 @@ import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.Frustum;
 import net.minecraft.client.render.GameRenderer;
 import net.minecraft.client.render.RenderTickCounter;
-import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.client.util.math.MatrixStack;
@@ -110,12 +109,6 @@ public interface WorldRenderContext {
 	 * {@code WorldRenderer.drawBlockOutline}.
 	 */
 	interface BlockOutlineContext {
-		/**
-		 * @deprecated Use {@link #consumers()} directly.
-		 */
-		@Deprecated
-		VertexConsumer vertexConsumer();
-
 		Entity entity();
 
 		double cameraX();

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderEvents.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderEvents.java
@@ -139,11 +139,11 @@ public final class WorldRenderEvents {
 	 * renders.  Mods that replace the default block outline for specific blocks
 	 * should instead subscribe to {@link #BLOCK_OUTLINE}.
 	 */
-	public static final Event<BeforeBlockOutline> BEFORE_BLOCK_OUTLINE = EventFactory.createArrayBacked(BeforeBlockOutline.class, (context, hit) -> true, callbacks -> (context, hit) -> {
+	public static final Event<BeforeBlockOutline> BEFORE_BLOCK_OUTLINE = EventFactory.createArrayBacked(BeforeBlockOutline.class, (context, translucent, hit) -> true, callbacks -> (context, translucent, hit) -> {
 		boolean shouldRender = true;
 
 		for (final BeforeBlockOutline callback : callbacks) {
-			if (!callback.beforeBlockOutline(context, hit)) {
+			if (!callback.beforeBlockOutline(context, translucent, hit)) {
 				shouldRender = false;
 			}
 		}
@@ -279,13 +279,15 @@ public final class WorldRenderEvents {
 		 * Event signature for {@link WorldRenderEvents#BEFORE_BLOCK_OUTLINE}.
 		 *
 		 * @param context  Access to state and parameters available during world rendering.
+		 * @param translucent If {@code true}, current block outline is being rendered after translucent terrain.
+		 *                    Otherwise, it is being rendered after solid terrain.
 		 * @param hitResult The game object currently under the crosshair target.
 		 * Normally equivalent to {@link MinecraftClient#crosshairTarget}. Provided for convenience.
 		 * @return true if vanilla block outline rendering should happen.
 		 * Returning false prevents {@link WorldRenderEvents#BLOCK_OUTLINE} from invoking
 		 * and also skips the vanilla block outline render, but has no effect on other subscribers to this event.
 		 */
-		boolean beforeBlockOutline(WorldRenderContext context, @Nullable HitResult hitResult);
+		boolean beforeBlockOutline(WorldRenderContext context, boolean translucent, @Nullable HitResult hitResult);
 	}
 
 	@FunctionalInterface

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderEvents.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderEvents.java
@@ -37,9 +37,11 @@ import net.fabricmc.fabric.api.event.EventFactory;
  * <li>AFTER_SETUP
  * <li>BEFORE_ENTITIES
  * <li>AFTER_ENTITIES
- * <li>BEFORE_BLOCK_OUTLINE
- * <li>BLOCK_OUTLINE  (If not cancelled in BEFORE_BLOCK_OUTLINE)
+ * <li>BEFORE_BLOCK_OUTLINE (non-translucent)
+ * <li>BLOCK_OUTLINE (if not cancelled in non-translucent BEFORE_BLOCK_OUTLINE and vanilla checks pass)
  * <li>BEFORE_DEBUG_RENDER
+ * <li>BEFORE_BLOCK_OUTLINE (translucent)
+ * <li>BLOCK_OUTLINE (if not cancelled in translucent BEFORE_BLOCK_OUTLINE and vanilla checks pass)
  * <li>AFTER_TRANSLUCENT
  * <li>LAST
  * <li>END</ul>
@@ -139,11 +141,11 @@ public final class WorldRenderEvents {
 	 * renders.  Mods that replace the default block outline for specific blocks
 	 * should instead subscribe to {@link #BLOCK_OUTLINE}.
 	 */
-	public static final Event<BeforeBlockOutline> BEFORE_BLOCK_OUTLINE = EventFactory.createArrayBacked(BeforeBlockOutline.class, (context, translucent, hit) -> true, callbacks -> (context, translucent, hit) -> {
+	public static final Event<BeforeBlockOutline> BEFORE_BLOCK_OUTLINE = EventFactory.createArrayBacked(BeforeBlockOutline.class, (context, hit) -> true, callbacks -> (context, hit) -> {
 		boolean shouldRender = true;
 
 		for (final BeforeBlockOutline callback : callbacks) {
-			if (!callback.beforeBlockOutline(context, translucent, hit)) {
+			if (!callback.beforeBlockOutline(context, hit)) {
 				shouldRender = false;
 			}
 		}
@@ -279,15 +281,13 @@ public final class WorldRenderEvents {
 		 * Event signature for {@link WorldRenderEvents#BEFORE_BLOCK_OUTLINE}.
 		 *
 		 * @param context  Access to state and parameters available during world rendering.
-		 * @param translucent If {@code true}, current block outline is being rendered after translucent terrain.
-		 *                    Otherwise, it is being rendered after solid terrain.
 		 * @param hitResult The game object currently under the crosshair target.
 		 * Normally equivalent to {@link MinecraftClient#crosshairTarget}. Provided for convenience.
 		 * @return true if vanilla block outline rendering should happen.
 		 * Returning false prevents {@link WorldRenderEvents#BLOCK_OUTLINE} from invoking
 		 * and also skips the vanilla block outline render, but has no effect on other subscribers to this event.
 		 */
-		boolean beforeBlockOutline(WorldRenderContext context, boolean translucent, @Nullable HitResult hitResult);
+		boolean beforeBlockOutline(WorldRenderContext context, @Nullable HitResult hitResult);
 	}
 
 	@FunctionalInterface

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/WorldRenderContextImpl.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/WorldRenderContextImpl.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.impl.client.rendering;
 
+import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix4f;
 
 import net.minecraft.block.BlockState;
@@ -37,16 +38,20 @@ import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 public final class WorldRenderContextImpl implements WorldRenderContext.BlockOutlineContext, WorldRenderContext {
 	private WorldRenderer worldRenderer;
 	private RenderTickCounter tickCounter;
-	private MatrixStack matrixStack;
 	private boolean blockOutlines;
 	private Camera camera;
-	private Frustum frustum;
 	private GameRenderer gameRenderer;
-	private Matrix4f projectionMatrix;
 	private Matrix4f positionMatrix;
+	private Matrix4f projectionMatrix;
 	private VertexConsumerProvider consumers;
 	private boolean advancedTranslucency;
 	private ClientWorld world;
+
+	@Nullable
+	private Frustum frustum;
+	@Nullable
+	private MatrixStack matrixStack;
+	private boolean translucentBlockOutline;
 
 	private Entity entity;
 	private double cameraX;
@@ -59,27 +64,29 @@ public final class WorldRenderContextImpl implements WorldRenderContext.BlockOut
 
 	public void prepare(
 			WorldRenderer worldRenderer,
-			RenderTickCounter delta,
+			RenderTickCounter tickCounter,
 			boolean blockOutlines,
 			Camera camera,
 			GameRenderer gameRenderer,
-			Matrix4f projectionMatrix,
 			Matrix4f positionMatrix,
+			Matrix4f projectionMatrix,
 			VertexConsumerProvider consumers,
 			boolean advancedTranslucency,
 			ClientWorld world
 	) {
 		this.worldRenderer = worldRenderer;
-		this.tickCounter = delta;
-		this.matrixStack = null;
+		this.tickCounter = tickCounter;
 		this.blockOutlines = blockOutlines;
 		this.camera = camera;
 		this.gameRenderer = gameRenderer;
-		this.projectionMatrix = projectionMatrix;
 		this.positionMatrix = positionMatrix;
+		this.projectionMatrix = projectionMatrix;
 		this.consumers = consumers;
 		this.advancedTranslucency = advancedTranslucency;
 		this.world = world;
+
+		frustum = null;
+		matrixStack = null;
 	}
 
 	public void setFrustum(Frustum frustum) {
@@ -88,6 +95,10 @@ public final class WorldRenderContextImpl implements WorldRenderContext.BlockOut
 
 	public void setMatrixStack(MatrixStack matrixStack) {
 		this.matrixStack = matrixStack;
+	}
+
+	public void setTranslucentBlockOutline(boolean translucentBlockOutline) {
+		this.translucentBlockOutline = translucentBlockOutline;
 	}
 
 	public void prepareBlockOutline(
@@ -112,11 +123,6 @@ public final class WorldRenderContextImpl implements WorldRenderContext.BlockOut
 	}
 
 	@Override
-	public MatrixStack matrixStack() {
-		return matrixStack;
-	}
-
-	@Override
 	public RenderTickCounter tickCounter() {
 		return this.tickCounter;
 	}
@@ -132,8 +138,8 @@ public final class WorldRenderContextImpl implements WorldRenderContext.BlockOut
 	}
 
 	@Override
-	public Matrix4f projectionMatrix() {
-		return projectionMatrix;
+	public GameRenderer gameRenderer() {
+		return gameRenderer;
 	}
 
 	@Override
@@ -142,23 +148,13 @@ public final class WorldRenderContextImpl implements WorldRenderContext.BlockOut
 	}
 
 	@Override
+	public Matrix4f projectionMatrix() {
+		return projectionMatrix;
+	}
+
+	@Override
 	public ClientWorld world() {
 		return world;
-	}
-
-	@Override
-	public Frustum frustum() {
-		return frustum;
-	}
-
-	@Override
-	public VertexConsumerProvider consumers() {
-		return consumers;
-	}
-
-	@Override
-	public GameRenderer gameRenderer() {
-		return gameRenderer;
 	}
 
 	@Override
@@ -167,8 +163,25 @@ public final class WorldRenderContextImpl implements WorldRenderContext.BlockOut
 	}
 
 	@Override
-	public VertexConsumer vertexConsumer() {
-		return consumers.getBuffer(RenderLayer.getLines());
+	public VertexConsumerProvider consumers() {
+		return consumers;
+	}
+
+	@Override
+	@Nullable
+	public Frustum frustum() {
+		return frustum;
+	}
+
+	@Override
+	@Nullable
+	public MatrixStack matrixStack() {
+		return matrixStack;
+	}
+
+	@Override
+	public boolean translucentBlockOutline() {
+		return translucentBlockOutline;
 	}
 
 	@Override
@@ -199,5 +212,11 @@ public final class WorldRenderContextImpl implements WorldRenderContext.BlockOut
 	@Override
 	public BlockState blockState() {
 		return blockState;
+	}
+
+	@Deprecated
+	@Override
+	public VertexConsumer vertexConsumer() {
+		return consumers.getBuffer(RenderLayer.getLines());
 	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/WorldRenderContextImpl.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/WorldRenderContextImpl.java
@@ -22,7 +22,9 @@ import net.minecraft.block.BlockState;
 import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.Frustum;
 import net.minecraft.client.render.GameRenderer;
+import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.RenderTickCounter;
+import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.client.util.math.MatrixStack;
@@ -162,6 +164,11 @@ public final class WorldRenderContextImpl implements WorldRenderContext.BlockOut
 	@Override
 	public boolean advancedTranslucency() {
 		return advancedTranslucency;
+	}
+
+	@Override
+	public VertexConsumer vertexConsumer() {
+		return consumers.getBuffer(RenderLayer.getLines());
 	}
 
 	@Override

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/WorldRenderContextImpl.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/WorldRenderContextImpl.java
@@ -22,9 +22,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.Frustum;
 import net.minecraft.client.render.GameRenderer;
-import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.RenderTickCounter;
-import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.client.util.math.MatrixStack;
@@ -164,11 +162,6 @@ public final class WorldRenderContextImpl implements WorldRenderContext.BlockOut
 	@Override
 	public boolean advancedTranslucency() {
 		return advancedTranslucency;
-	}
-
-	@Override
-	public VertexConsumer vertexConsumer() {
-		return consumers.getBuffer(RenderLayer.getLines());
 	}
 
 	@Override

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
@@ -69,7 +69,7 @@ public abstract class WorldRendererMixin {
 
 	@Inject(method = "render", at = @At("HEAD"))
 	private void beforeRender(ObjectAllocator objectAllocator, RenderTickCounter tickCounter, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, Matrix4f positionMatrix, Matrix4f projectionMatrix, CallbackInfo ci) {
-		context.prepare((WorldRenderer) (Object) this, tickCounter, renderBlockOutline, camera, gameRenderer, projectionMatrix, positionMatrix, bufferBuilders.getEntityVertexConsumers(), MinecraftClient.isFabulousGraphicsOrBetter(), world);
+		context.prepare((WorldRenderer) (Object) this, tickCounter, renderBlockOutline, camera, gameRenderer, positionMatrix, projectionMatrix, bufferBuilders.getEntityVertexConsumers(), MinecraftClient.isFabulousGraphicsOrBetter(), world);
 		WorldRenderEvents.START.invoker().onStart(context);
 	}
 
@@ -117,7 +117,8 @@ public abstract class WorldRendererMixin {
 
 	@Inject(method = "renderTargetBlockOutline", at = @At("HEAD"))
 	private void beforeRenderOutline(Camera camera, VertexConsumerProvider.Immediate vertexConsumers, MatrixStack matrices, boolean translucent, CallbackInfo ci) {
-		context.renderBlockOutline = WorldRenderEvents.BEFORE_BLOCK_OUTLINE.invoker().beforeBlockOutline(context, translucent, client.crosshairTarget);
+		context.setTranslucentBlockOutline(translucent);
+		context.renderBlockOutline = WorldRenderEvents.BEFORE_BLOCK_OUTLINE.invoker().beforeBlockOutline(context, client.crosshairTarget);
 	}
 
 	@SuppressWarnings("ConstantConditions")

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
@@ -26,7 +26,6 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.At.Shift;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.block.BlockState;
@@ -39,15 +38,13 @@ import net.minecraft.client.render.Fog;
 import net.minecraft.client.render.FrameGraphBuilder;
 import net.minecraft.client.render.Frustum;
 import net.minecraft.client.render.GameRenderer;
-import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.RenderPass;
 import net.minecraft.client.render.RenderTickCounter;
-import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.client.util.ObjectAllocator;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.client.world.ClientWorld;
-import net.minecraft.entity.Entity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 
@@ -118,41 +115,27 @@ public abstract class WorldRendererMixin {
 		WorldRenderEvents.AFTER_ENTITIES.invoker().afterEntities(context);
 	}
 
-	@Inject(
-			method = "renderTargetBlockOutline",
-			at = @At(
-				value = "FIELD",
-				target = "Lnet/minecraft/client/MinecraftClient;crosshairTarget:Lnet/minecraft/util/hit/HitResult;",
-				shift = At.Shift.AFTER,
-				ordinal = 0
-			)
-	)
-	private void beforeRenderOutline(CallbackInfo ci) {
-		context.renderBlockOutline = WorldRenderEvents.BEFORE_BLOCK_OUTLINE.invoker().beforeBlockOutline(context, client.crosshairTarget);
+	@Inject(method = "renderTargetBlockOutline", at = @At("HEAD"))
+	private void beforeRenderOutline(Camera camera, VertexConsumerProvider.Immediate vertexConsumers, MatrixStack matrices, boolean translucent, CallbackInfo ci) {
+		context.renderBlockOutline = WorldRenderEvents.BEFORE_BLOCK_OUTLINE.invoker().beforeBlockOutline(context, translucent, client.crosshairTarget);
 	}
 
 	@SuppressWarnings("ConstantConditions")
-	@Inject(method = "drawBlockOutline", at = @At("HEAD"), cancellable = true)
-	private void onDrawBlockOutline(MatrixStack matrixStack, VertexConsumer vertexConsumer, Entity entity, double cameraX, double cameraY, double cameraZ, BlockPos blockPos, BlockState blockState, int color, CallbackInfo ci) {
+	@Inject(method = "renderTargetBlockOutline", at = @At(value = "INVOKE", target = "net/minecraft/client/option/GameOptions.getHighContrastBlockOutline()Lnet/minecraft/client/option/SimpleOption;"), cancellable = true)
+	private void onDrawBlockOutline(Camera camera, VertexConsumerProvider.Immediate vertexConsumers, MatrixStack matrices, boolean translucent, CallbackInfo ci, @Local BlockPos blockPos, @Local BlockState blockState, @Local Vec3d cameraPos) {
 		if (!context.renderBlockOutline) {
 			// Was cancelled before we got here, so do not
 			// fire the BLOCK_OUTLINE event per contract of the API.
 			ci.cancel();
-		} else {
-			context.prepareBlockOutline(entity, cameraX, cameraY, cameraZ, blockPos, blockState);
-
-			if (!WorldRenderEvents.BLOCK_OUTLINE.invoker().onBlockOutline(context, context)) {
-				ci.cancel();
-			}
+			return;
 		}
-	}
 
-	@SuppressWarnings("ConstantConditions")
-	@ModifyVariable(method = "drawBlockOutline", at = @At("HEAD"))
-	private VertexConsumer resetBlockOutlineBuffer(VertexConsumer vertexConsumer) {
-		// The original VertexConsumer may have been ended during the block outlines event, so we
-		// have to re-request it to prevent a crash when the vanilla block overlay is submitted.
-		return context.consumers().getBuffer(RenderLayer.getLines());
+		context.prepareBlockOutline(camera.getFocusedEntity(), cameraPos.x, cameraPos.y, cameraPos.z, blockPos, blockState);
+
+		if (!WorldRenderEvents.BLOCK_OUTLINE.invoker().onBlockOutline(context, context)) {
+			vertexConsumers.drawCurrentLayer();
+			ci.cancel();
+		}
 	}
 
 	@Inject(


### PR DESCRIPTION
- Move outline event invoker to before either normal or high contrast outlines are rendered
- Remove outline layer reset, fixing high contrast outline being rendered with wrong layer
- Pass translucent parameter as `WorldRenderContext#translucentBlockOutline`, usable in the `BEFORE_BLOCK_OUTLINE` and `BLOCK_OUTLINE` events

Fixes #4285.