### PR TITLE
Fix more custom ingredient implementation issues

### DIFF
--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/CustomIngredientImpl.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/CustomIngredientImpl.java
@@ -85,7 +85,7 @@ public class CustomIngredientImpl extends Ingredient {
 		this.customIngredient = customIngredient;
 	}
 
-	private List<RegistryEntry<Item>> getCustomMatchingItems() {
+	public List<RegistryEntry<Item>> getCustomMatchingItems() {
 		if (customMatchingItems == null) {
 			customMatchingItems = customIngredient.getMatchingItems().toList();
 		}

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/mixin/recipe/ingredient/ShapelessRecipeMixin.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/mixin/recipe/ingredient/ShapelessRecipeMixin.java
@@ -60,7 +60,7 @@ public class ShapelessRecipeMixin {
 		if (fabric_requiresTesting) {
 			List<ItemStack> nonEmptyStacks = new ArrayList<>(recipeInput.getStackCount());
 
-			for (int i = 0; i < recipeInput.getStackCount(); ++i) {
+			for (int i = 0; i < recipeInput.size(); ++i) {
 				ItemStack stack = recipeInput.getStackInSlot(i);
 
 				if (!stack.isEmpty()) {


### PR DESCRIPTION
- Fix `Ingredient.OPTIONAL_PACKET_CODEC` not being modified to work with custom ingredients
- Fix `ShapelessRecipeMixin` sometimes not collecting all non-empty item stacks
- If client does not support certain custom ingredient, send `CustomIngredientImpl#getCustomMatchingItems` instead of dummy default (stone)

Likely fixes #4225.