### PR TITLE
Allow setting `canPotentiallyExecuteCommands` in BE/E type builders

### DIFF
--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/entity/FabricBlockEntityTypeBuilder.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/entity/FabricBlockEntityTypeBuilder.java
@@ -16,12 +16,13 @@
 
 package net.fabricmc.fabric.api.object.builder.v1.block.entity;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
+import java.util.Set;
 
 import com.mojang.datafixers.types.Type;
+import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -29,24 +30,22 @@ import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.util.math.BlockPos;
 
+import net.fabricmc.fabric.impl.object.builder.ExtendedBlockEntityType;
+
 /**
- * Fabric's version of BlockEntityType.Builder with additional convenience methods.
- *
+ * Use this builder to create a {@link BlockEntityType}.
  */
 public final class FabricBlockEntityTypeBuilder<T extends BlockEntity> {
 	private final Factory<? extends T> factory;
-	private final List<Block> blocks;
+	private final Set<Block> blocks = new HashSet<>();
+	private boolean canPotentiallyExecuteCommands = false;
 
-	private FabricBlockEntityTypeBuilder(Factory<? extends T> factory, List<Block> blocks) {
+	private FabricBlockEntityTypeBuilder(Factory<? extends T> factory) {
 		this.factory = factory;
-		this.blocks = blocks;
 	}
 
 	public static <T extends BlockEntity> FabricBlockEntityTypeBuilder<T> create(Factory<? extends T> factory, Block... blocks) {
-		List<Block> blocksList = new ArrayList<>(blocks.length);
-		Collections.addAll(blocksList, blocks);
-
-		return new FabricBlockEntityTypeBuilder<>(factory, blocksList);
+		return new FabricBlockEntityTypeBuilder<T>(factory).addBlocks(blocks);
 	}
 
 	/**
@@ -71,12 +70,38 @@ public final class FabricBlockEntityTypeBuilder<T extends BlockEntity> {
 		return this;
 	}
 
-	public BlockEntityType<T> build() {
-		return build(null);
+	/**
+	 * Adds supported blocks for the block entity type.
+	 *
+	 * @param blocks the supported blocks
+	 * @return this builder
+	 */
+	public FabricBlockEntityTypeBuilder<T> addBlocks(Collection<? extends Block> blocks) {
+		this.blocks.addAll(blocks);
+		return this;
 	}
 
-	public BlockEntityType<T> build(Type<?> type) {
-		return new BlockEntityType<T>(factory::create, new HashSet<>(blocks));
+	/**
+	 * Makes the built {@link BlockEntityType} return {@code true} from
+	 * {@link BlockEntityType#canPotentiallyExecuteCommands()}.
+	 *
+	 * @return this builder
+	 */
+	public FabricBlockEntityTypeBuilder<T> canPotentiallyExecuteCommands() {
+		canPotentiallyExecuteCommands = true;
+		return this;
+	}
+
+	public BlockEntityType<T> build() {
+		return new ExtendedBlockEntityType<>(factory::create, new HashSet<>(blocks), canPotentiallyExecuteCommands);
+	}
+
+	/**
+	 * @deprecated Use {@link #build()} instead.
+	 */
+	@Deprecated
+	public BlockEntityType<T> build(@Nullable Type<?> type) {
+		return build();
 	}
 
 	@FunctionalInterface

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/entity/FabricBlockEntityTypeBuilder.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/entity/FabricBlockEntityTypeBuilder.java
@@ -85,10 +85,11 @@ public final class FabricBlockEntityTypeBuilder<T extends BlockEntity> {
 	 * Makes the built {@link BlockEntityType} return {@code true} from
 	 * {@link BlockEntityType#canPotentiallyExecuteCommands()}.
 	 *
+	 * @param canPotentiallyExecuteCommands whether the block entity is able to execute commands
 	 * @return this builder
 	 */
-	public FabricBlockEntityTypeBuilder<T> canPotentiallyExecuteCommands() {
-		canPotentiallyExecuteCommands = true;
+	public FabricBlockEntityTypeBuilder<T> canPotentiallyExecuteCommands(boolean canPotentiallyExecuteCommands) {
+		this.canPotentiallyExecuteCommands = canPotentiallyExecuteCommands;
 		return this;
 	}
 

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/entity/FabricEntityType.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/entity/FabricEntityType.java
@@ -52,6 +52,16 @@ public interface FabricEntityType {
 		}
 
 		/**
+		 * Sets whether the entity is able to execute commands.
+		 *
+		 * @param canPotentiallyExecuteCommands whether the entity is able to execute commands
+		 * @return this builder
+		 */
+		default EntityType.Builder<T> canPotentiallyExecuteCommands(boolean canPotentiallyExecuteCommands) {
+			throw new AssertionError("Implemented in Mixin");
+		}
+
+		/**
 		 * Creates an entity type builder for a living entity.
 		 *
 		 * <p>This entity's spawn group will automatically be set to {@link SpawnGroup#MISC}.

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/impl/object/builder/ExtendedBlockEntityType.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/impl/object/builder/ExtendedBlockEntityType.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.object.builder;
+
+import java.util.Set;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.BlockEntityType;
+
+public class ExtendedBlockEntityType<T extends BlockEntity> extends BlockEntityType<T> {
+	private final boolean canPotentiallyExecuteCommands;
+
+	public ExtendedBlockEntityType(BlockEntityFactory<? extends T> factory, Set<Block> blocks, boolean canPotentiallyExecuteCommands) {
+		super(factory, blocks);
+		this.canPotentiallyExecuteCommands = canPotentiallyExecuteCommands;
+	}
+
+	@Override
+	public boolean canPotentiallyExecuteCommands() {
+		if (canPotentiallyExecuteCommands) {
+			return true;
+		}
+
+		return super.canPotentiallyExecuteCommands();
+	}
+}

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/impl/object/builder/FabricEntityTypeImpl.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/impl/object/builder/FabricEntityTypeImpl.java
@@ -37,6 +37,8 @@ import net.fabricmc.fabric.api.object.builder.v1.entity.FabricEntityType;
 public interface FabricEntityTypeImpl {
 	void fabric_setAlwaysUpdateVelocity(Boolean alwaysUpdateVelocity);
 
+	void fabric_setCanPotentiallyExecuteCommands(Boolean canPotentiallyExecuteCommands);
+
 	interface Builder {
 		void fabric_setLivingEntityBuilder(Living<? extends LivingEntity> livingBuilder);
 

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/BlockEntityTypeMixin.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/BlockEntityTypeMixin.java
@@ -43,7 +43,9 @@ public class BlockEntityTypeMixin<T extends BlockEntity> implements FabricBlockE
 
 	@Inject(method = "<init>", at = @At("RETURN"))
 	private void mutableBlocks(BlockEntityType.BlockEntityFactory<? extends T> factory, Set<Block> blocks, CallbackInfo ci) {
-		this.blocks = new HashSet<>(this.blocks);
+		if (!(this.blocks instanceof HashSet)) {
+			this.blocks = new HashSet<>(this.blocks);
+		}
 	}
 
 	@Override

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/EntityTypeBuilderMixin.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/EntityTypeBuilderMixin.java
@@ -48,6 +48,8 @@ public abstract class EntityTypeBuilderMixin<T extends Entity> implements Fabric
 
 	@Unique
 	private Boolean alwaysUpdateVelocity = null;
+	@Unique
+	private Boolean canPotentiallyExecuteCommands = null;
 
 	@Unique
 	private FabricEntityTypeImpl.Builder.Living<? extends LivingEntity> livingBuilder = null;
@@ -55,8 +57,14 @@ public abstract class EntityTypeBuilderMixin<T extends Entity> implements Fabric
 	private FabricEntityTypeImpl.Builder.Mob<? extends MobEntity> mobBuilder = null;
 
 	@Override
-	public EntityType.Builder<T> alwaysUpdateVelocity(boolean forceTrackedVelocityUpdates) {
-		alwaysUpdateVelocity = forceTrackedVelocityUpdates;
+	public EntityType.Builder<T> alwaysUpdateVelocity(boolean alwaysUpdateVelocity) {
+		this.alwaysUpdateVelocity = alwaysUpdateVelocity;
+		return (EntityType.Builder<T>) (Object) this;
+	}
+
+	@Override
+	public EntityType.Builder<T> canPotentiallyExecuteCommands(boolean canPotentiallyExecuteCommands) {
+		this.canPotentiallyExecuteCommands = canPotentiallyExecuteCommands;
 		return (EntityType.Builder<T>) (Object) this;
 	}
 
@@ -67,6 +75,7 @@ public abstract class EntityTypeBuilderMixin<T extends Entity> implements Fabric
 		}
 
 		entityType.fabric_setAlwaysUpdateVelocity(alwaysUpdateVelocity);
+		entityType.fabric_setCanPotentiallyExecuteCommands(canPotentiallyExecuteCommands);
 
 		if (livingBuilder != null) {
 			livingBuilder.onBuild(castLiving(cir.getReturnValue()));

--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/EntityTypeMixin.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/EntityTypeMixin.java
@@ -30,16 +30,30 @@ import net.fabricmc.fabric.impl.object.builder.FabricEntityTypeImpl;
 public abstract class EntityTypeMixin implements FabricEntityTypeImpl {
 	@Unique
 	private Boolean alwaysUpdateVelocity;
+	@Unique
+	private Boolean canPotentiallyExecuteCommands;
 
 	@Inject(method = "alwaysUpdateVelocity", at = @At("HEAD"), cancellable = true)
-	public void alwaysUpdateVelocity(CallbackInfoReturnable<Boolean> cir) {
+	public void onAlwaysUpdateVelocity(CallbackInfoReturnable<Boolean> cir) {
 		if (alwaysUpdateVelocity != null) {
 			cir.setReturnValue(alwaysUpdateVelocity);
+		}
+	}
+
+	@Inject(method = "canPotentiallyExecuteCommands", at = @At("HEAD"), cancellable = true)
+	public void onCanPotentiallyExecuteCommands(CallbackInfoReturnable<Boolean> cir) {
+		if (canPotentiallyExecuteCommands != null) {
+			cir.setReturnValue(canPotentiallyExecuteCommands);
 		}
 	}
 
 	@Override
 	public void fabric_setAlwaysUpdateVelocity(Boolean alwaysUpdateVelocity) {
 		this.alwaysUpdateVelocity = alwaysUpdateVelocity;
+	}
+
+	@Override
+	public void fabric_setCanPotentiallyExecuteCommands(Boolean canPotentiallyExecuteCommands) {
+		this.canPotentiallyExecuteCommands = canPotentiallyExecuteCommands;
 	}
 }


### PR DESCRIPTION
- Add `FabricBlockEntityTypeBuilder#canPotentiallyExecuteCommands`
- Add `FabricEntityType.Builder#canPotentiallyExecuteCommands`
- Add `FabricBlockEntityTypeBuilder#addBlocks(Collection)`
- Deprecate `FabricBlockEntityTypeBuilder#build(Type)`