### PR TITLE
Client gametest threading tweaks

### DIFF
--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/package-info.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/package-info.java
@@ -11,8 +11,11 @@
  *
  * <p>Client gametests run on the client gametest thread. Use the functions inside
  * {@link net.fabricmc.fabric.api.client.gametest.v1.ClientGameTestContext ClientGameTestContext} and other test helper
- * classes to run code on the correct thread. The game remains paused unless you explicitly unpause it using various
- * waiting functions such as
+ * classes to run code on the correct thread. Exceptions are transparently rethrown on the test thread, and their stack
+ * traces are mutated to include the async stack trace, to make them easy to track. You can disable this behavior by
+ * setting the {@code fabric.client.gametest.disableJoinAsyncStackTraces} system property.
+ *
+ * <p>The game remains paused unless you explicitly unpause it using various waiting functions such as
  * {@link net.fabricmc.fabric.api.client.gametest.v1.ClientGameTestContext#waitTick() ClientGameTestContext.waitTick()}.
  *
  * <p>A few changes have been made to how the vanilla game threads run, to make tests more reproducible. Notably, there

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/FabricClientGameTestRunner.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/FabricClientGameTestRunner.java
@@ -40,15 +40,11 @@ public class FabricClientGameTestRunner {
 			for (FabricClientGameTest gameTest : gameTests) {
 				context.restoreDefaultGameOptions();
 
-				try {
-					gameTest.runTest(context);
-				} finally {
-					context.getInput().clearKeysDown();
-					checkFinalGameTestState(context, gameTest.getClass().getName());
-				}
-			}
+				gameTest.runTest(context);
 
-			context.clickScreenButton("menu.quit");
+				context.getInput().clearKeysDown();
+				checkFinalGameTestState(context, gameTest.getClass().getName());
+			}
 		});
 	}
 

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/ThreadingImpl.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/ThreadingImpl.java
@@ -26,6 +26,8 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.minecraft.client.MinecraftClient;
+
 /**
  * <h1>Implementation notes</h1>
  *
@@ -75,6 +77,7 @@ public final class ThreadingImpl {
 	private static final int PHASE_MASK = 3;
 
 	public static final Phaser PHASER = new Phaser();
+	private static volatile boolean enablePhases = true;
 
 	public static volatile boolean isClientRunning = false;
 	public static volatile boolean clientCanAcceptTasks = false;
@@ -87,19 +90,30 @@ public final class ThreadingImpl {
 	@Nullable
 	public static Thread testThread = null;
 	public static final Semaphore TEST_SEMAPHORE = new Semaphore(0);
+	@Nullable
+	public static Throwable testFailureException = null;
 
 	@Nullable
 	public static Runnable taskToRun = null;
 
+	private static volatile boolean gameCrashed = false;
+
 	public static void enterPhase(int phase) {
-		while ((PHASER.getPhase() & PHASE_MASK) != phase) {
+		while (enablePhases && (PHASER.getPhase() & PHASE_MASK) != phase) {
 			PHASER.arriveAndAwaitAdvance();
 		}
 
-		PHASER.arriveAndAwaitAdvance();
+		if (enablePhases) {
+			PHASER.arriveAndAwaitAdvance();
+		}
 	}
 
-	public static void runTestThread(Runnable test) {
+	public static void setGameCrashed() {
+		enablePhases = false;
+		gameCrashed = true;
+	}
+
+	public static void runTestThread(Runnable testRunner) {
 		Preconditions.checkState(testThread == null, "There is already a test thread running");
 
 		testThread = new Thread(() -> {
@@ -107,26 +121,39 @@ public final class ThreadingImpl {
 			enterPhase(PHASE_TEST);
 
 			try {
-				test.run();
+				testRunner.run();
 			} catch (Throwable e) {
-				LOGGER.error("Failed to run client gametests", e);
-				System.exit(1);
+				testFailureException = e;
 			} finally {
-				PHASER.arriveAndDeregister();
-
 				if (clientCanAcceptTasks) {
-					CLIENT_SEMAPHORE.release();
+					runOnClient(() -> MinecraftClient.getInstance().scheduleStop());
 				}
 
-				if (serverCanAcceptTasks) {
-					SERVER_SEMAPHORE.release();
+				if (testFailureException != null) {
+					// Log this now in case the client has stopped or is otherwise unable to rethrow our exception
+					LOGGER.error("Client gametests failed with an exception", testFailureException);
 				}
 
-				testThread = null;
+				deregisterTestThread();
 			}
 		});
 		testThread.setName("Test thread");
+		testThread.setDaemon(true);
 		testThread.start();
+	}
+
+	private static void deregisterTestThread() {
+		testThread = null;
+		enablePhases = false;
+		PHASER.arriveAndDeregister();
+
+		if (clientCanAcceptTasks) {
+			CLIENT_SEMAPHORE.release();
+		}
+
+		if (serverCanAcceptTasks) {
+			SERVER_SEMAPHORE.release();
+		}
 	}
 
 	public static void checkOnGametestThread(String methodName) {
@@ -207,5 +234,17 @@ public final class ThreadingImpl {
 		}
 
 		enterPhase(PHASE_TEST);
+
+		// Check if the game has crashed during this tick. If so, don't do any more work in the test
+		if (gameCrashed) {
+			deregisterTestThread();
+
+			try {
+				// wait until game is closed
+				new Semaphore(0).acquire();
+			} catch (InterruptedException e) {
+				throw new RuntimeException(e);
+			}
+		}
 	}
 }

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/ThreadingImpl.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/ThreadingImpl.java
@@ -70,6 +70,11 @@ public final class ThreadingImpl {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger("fabric-client-gametest-api-v1");
 
+	private static final boolean DISABLE_JOIN_ASYNC_STACK_TRACES = System.getProperty("fabric.client.gametest.disableJoinAsyncStackTraces") != null;
+	private static final String THREAD_IMPL_CLASS_NAME = ThreadingImpl.class.getName();
+	private static final String TASK_ON_THIS_THREAD_METHOD_NAME = "runTaskOnThisThread";
+	private static final String TASK_ON_OTHER_THREAD_METHOD_NAME = "runTaskOnOtherThread";
+
 	public static final int PHASE_TICK = 0;
 	public static final int PHASE_SERVER_TASKS = 1;
 	public static final int PHASE_CLIENT_TASKS = 2;
@@ -160,25 +165,25 @@ public final class ThreadingImpl {
 		Preconditions.checkState(Thread.currentThread() == testThread, "%s can only be called from the client gametest thread", methodName);
 	}
 
-	@SuppressWarnings("unchecked")
 	public static <E extends Throwable> void runOnClient(FailableRunnable<E> action) throws E {
 		Preconditions.checkNotNull(action, "action");
 		checkOnGametestThread("runOnClient");
 		Preconditions.checkState(clientCanAcceptTasks, "runOnClient called when no client is running");
+		runTaskOnOtherThread(action, CLIENT_SEMAPHORE);
+	}
 
+	public static <E extends Throwable> void runOnServer(FailableRunnable<E> action) throws E {
+		Preconditions.checkNotNull(action, "action");
+		checkOnGametestThread("runOnServer");
+		Preconditions.checkState(serverCanAcceptTasks, "runOnServer called when no server is running");
+		runTaskOnOtherThread(action, SERVER_SEMAPHORE);
+	}
+
+	private static <E extends Throwable> void runTaskOnOtherThread(FailableRunnable<E> action, Semaphore clientOrServerSemaphore) throws E {
 		MutableObject<E> thrown = new MutableObject<>();
-		taskToRun = () -> {
-			try {
-				action.run();
-			} catch (Throwable e) {
-				thrown.setValue((E) e);
-			} finally {
-				taskToRun = null;
-				TEST_SEMAPHORE.release();
-			}
-		};
+		taskToRun = () -> runTaskOnThisThread(action, thrown);
 
-		CLIENT_SEMAPHORE.release();
+		clientOrServerSemaphore.release();
 
 		try {
 			TEST_SEMAPHORE.acquire();
@@ -187,39 +192,73 @@ public final class ThreadingImpl {
 		}
 
 		if (thrown.getValue() != null) {
+			joinAsyncStackTrace(thrown.getValue());
 			throw thrown.getValue();
 		}
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <E extends Throwable> void runOnServer(FailableRunnable<E> action) throws E {
-		Preconditions.checkNotNull(action, "action");
-		checkOnGametestThread("runOnServer");
-		Preconditions.checkState(serverCanAcceptTasks, "runOnServer called when no server is running");
-
-		MutableObject<E> thrown = new MutableObject<>();
-		taskToRun = () -> {
-			try {
-				action.run();
-			} catch (Throwable e) {
-				thrown.setValue((E) e);
-			} finally {
-				taskToRun = null;
-				TEST_SEMAPHORE.release();
-			}
-		};
-
-		SERVER_SEMAPHORE.release();
-
+	private static <E extends Throwable> void runTaskOnThisThread(FailableRunnable<E> action, MutableObject<E> thrown) {
 		try {
-			TEST_SEMAPHORE.acquire();
-		} catch (InterruptedException e) {
-			throw new RuntimeException(e);
+			action.run();
+		} catch (Throwable e) {
+			thrown.setValue((E) e);
+		} finally {
+			taskToRun = null;
+			TEST_SEMAPHORE.release();
+		}
+	}
+
+	private static void joinAsyncStackTrace(Throwable e) {
+		if (DISABLE_JOIN_ASYNC_STACK_TRACES) {
+			return;
 		}
 
-		if (thrown.getValue() != null) {
-			throw thrown.getValue();
+		// find the end of the relevant part of the stack trace on the other thread
+		StackTraceElement[] taskStackTrace = e.getStackTrace();
+
+		if (taskStackTrace == null) {
+			return;
 		}
+
+		int taskRunOnThreadIndex = taskStackTrace.length - 1;
+
+		for (; taskRunOnThreadIndex >= 0; taskRunOnThreadIndex--) {
+			StackTraceElement element = taskStackTrace[taskRunOnThreadIndex];
+
+			if (THREAD_IMPL_CLASS_NAME.equals(element.getClassName()) && TASK_ON_THIS_THREAD_METHOD_NAME.equals(element.getMethodName())) {
+				break;
+			}
+		}
+
+		if (taskRunOnThreadIndex == -1) {
+			// couldn't find stack trace element
+			return;
+		}
+
+		// find the start of the relevant part of the stack trace on the test thread
+		StackTraceElement[] testStackTrace = Thread.currentThread().getStackTrace();
+		int testRunOnThreadIndex = 0;
+
+		for (; testRunOnThreadIndex < testStackTrace.length; testRunOnThreadIndex++) {
+			StackTraceElement element = testStackTrace[testRunOnThreadIndex];
+
+			if (THREAD_IMPL_CLASS_NAME.equals(element.getClassName()) && TASK_ON_OTHER_THREAD_METHOD_NAME.equals(element.getMethodName())) {
+				break;
+			}
+		}
+
+		if (testRunOnThreadIndex == testStackTrace.length) {
+			// couldn't find stack trace element
+			return;
+		}
+
+		// join the stack traces
+		StackTraceElement[] joinedStackTrace = new StackTraceElement[(taskRunOnThreadIndex + 1) + 1 + (testStackTrace.length - taskRunOnThreadIndex)];
+		System.arraycopy(taskStackTrace, 0, joinedStackTrace, 0, taskRunOnThreadIndex + 1);
+		joinedStackTrace[taskRunOnThreadIndex + 1] = new StackTraceElement("Async Stack Trace", ".", null, 1);
+		System.arraycopy(testStackTrace, testRunOnThreadIndex, joinedStackTrace, taskRunOnThreadIndex + 2, testStackTrace.length - testRunOnThreadIndex);
+		e.setStackTrace(joinedStackTrace);
 	}
 
 	public static void runTick() {

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/ThreadingImpl.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/ThreadingImpl.java
@@ -215,49 +215,49 @@ public final class ThreadingImpl {
 		}
 
 		// find the end of the relevant part of the stack trace on the other thread
-		StackTraceElement[] taskStackTrace = e.getStackTrace();
+		StackTraceElement[] otherThreadStackTrace = e.getStackTrace();
 
-		if (taskStackTrace == null) {
+		if (otherThreadStackTrace == null) {
 			return;
 		}
 
-		int taskRunOnThreadIndex = taskStackTrace.length - 1;
+		int otherThreadIndex = otherThreadStackTrace.length - 1;
 
-		for (; taskRunOnThreadIndex >= 0; taskRunOnThreadIndex--) {
-			StackTraceElement element = taskStackTrace[taskRunOnThreadIndex];
+		for (; otherThreadIndex >= 0; otherThreadIndex--) {
+			StackTraceElement element = otherThreadStackTrace[otherThreadIndex];
 
 			if (THREAD_IMPL_CLASS_NAME.equals(element.getClassName()) && TASK_ON_THIS_THREAD_METHOD_NAME.equals(element.getMethodName())) {
 				break;
 			}
 		}
 
-		if (taskRunOnThreadIndex == -1) {
+		if (otherThreadIndex == -1) {
 			// couldn't find stack trace element
 			return;
 		}
 
 		// find the start of the relevant part of the stack trace on the test thread
-		StackTraceElement[] testStackTrace = Thread.currentThread().getStackTrace();
-		int testRunOnThreadIndex = 0;
+		StackTraceElement[] thisThreadStackTrace = Thread.currentThread().getStackTrace();
+		int thisThreadIndex = 0;
 
-		for (; testRunOnThreadIndex < testStackTrace.length; testRunOnThreadIndex++) {
-			StackTraceElement element = testStackTrace[testRunOnThreadIndex];
+		for (; thisThreadIndex < thisThreadStackTrace.length; thisThreadIndex++) {
+			StackTraceElement element = thisThreadStackTrace[thisThreadIndex];
 
 			if (THREAD_IMPL_CLASS_NAME.equals(element.getClassName()) && TASK_ON_OTHER_THREAD_METHOD_NAME.equals(element.getMethodName())) {
 				break;
 			}
 		}
 
-		if (testRunOnThreadIndex == testStackTrace.length) {
+		if (thisThreadIndex == thisThreadStackTrace.length) {
 			// couldn't find stack trace element
 			return;
 		}
 
 		// join the stack traces
-		StackTraceElement[] joinedStackTrace = new StackTraceElement[(taskRunOnThreadIndex + 1) + 1 + (testStackTrace.length - taskRunOnThreadIndex)];
-		System.arraycopy(taskStackTrace, 0, joinedStackTrace, 0, taskRunOnThreadIndex + 1);
-		joinedStackTrace[taskRunOnThreadIndex + 1] = new StackTraceElement("Async Stack Trace", ".", null, 1);
-		System.arraycopy(testStackTrace, testRunOnThreadIndex, joinedStackTrace, taskRunOnThreadIndex + 2, testStackTrace.length - testRunOnThreadIndex);
+		StackTraceElement[] joinedStackTrace = new StackTraceElement[(otherThreadIndex + 1) + 1 + (thisThreadStackTrace.length - thisThreadIndex)];
+		System.arraycopy(otherThreadStackTrace, 0, joinedStackTrace, 0, otherThreadIndex + 1);
+		joinedStackTrace[otherThreadIndex + 1] = new StackTraceElement("Async Stack Trace", ".", null, 1);
+		System.arraycopy(thisThreadStackTrace, thisThreadIndex, joinedStackTrace, otherThreadIndex + 2, thisThreadStackTrace.length - thisThreadIndex);
 		e.setStackTrace(joinedStackTrace);
 	}
 

--- a/fabric-client-gametest-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/gametest/ClientGameTestTest.java
+++ b/fabric-client-gametest-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/gametest/ClientGameTestTest.java
@@ -143,7 +143,6 @@ public class ClientGameTestTest implements FabricClientGameTest {
 
 		{
 			context.waitForScreen(TitleScreen.class);
-			context.clickScreenButton("menu.quit");
 		}
 	}
 


### PR DESCRIPTION
- Fixed cases where the game didn't close properly when a test is thrown or an exception is thrown elsewhere.
- Mutate the stack traces of exceptions thrown in tasks to make them easier to track.

You can review the commits one at a time to make it easier to review.