### PR TITLE
Reintroduce `BeforeBake*` and `AfterBake*` model modifiers

### DIFF
--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/ModelLoadingPlugin.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/ModelLoadingPlugin.java
@@ -82,12 +82,38 @@ public interface ModelLoadingPlugin {
 
 		/**
 		 * Event access to monitor unbaked model loads and replace the loaded model.
+		 *
+		 * <p>Replacements done by listeners of this callback <b>do</b> affect child models (that is, models whose
+		 * parent hierarchy contains the replaced model), unlike {@link #modifyModelBeforeBake}.
 		 */
 		Event<ModelModifier.OnLoad> modifyModelOnLoad();
+
+		/**
+		 * Event access to replace the unbaked model used for baking without replacing the cached model.
+		 *
+		 * <p>Replacements done by listeners of this callback <b>do not</b> affect child models (that is, models whose
+		 * parent hierarchy contains the replaced model), unlike {@link #modifyModelOnLoad}.
+		 */
+		Event<ModelModifier.BeforeBake> modifyModelBeforeBake();
+
+		/**
+		 * Event access to replace the baked model.
+		 */
+		Event<ModelModifier.AfterBake> modifyModelAfterBake();
 
 		/**
 		 * Event access to monitor unbaked block model loads and replace the loaded model.
 		 */
 		Event<ModelModifier.OnLoadBlock> modifyBlockModelOnLoad();
+
+		/**
+		 * Event access to replace the unbaked block model used for baking.
+		 */
+		Event<ModelModifier.BeforeBakeBlock> modifyBlockModelBeforeBake();
+
+		/**
+		 * Event access to replace the baked block model.
+		 */
+		Event<ModelModifier.AfterBakeBlock> modifyBlockModelAfterBake();
 	}
 }

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/ModelBakerHooks.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/ModelBakerHooks.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.model.loading;
+
+import org.jetbrains.annotations.Nullable;
+
+public interface ModelBakerHooks {
+	@Nullable
+	ModelLoadingEventDispatcher fabric_getDispatcher();
+}

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/ModelLoadingPluginContextImpl.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/ModelLoadingPluginContextImpl.java
@@ -57,12 +57,56 @@ public class ModelLoadingPluginContextImpl implements ModelLoadingPlugin.Context
 
 		return model;
 	}, MODEL_MODIFIER_PHASES);
+	private final Event<ModelModifier.BeforeBake> beforeBakeModifiers = EventFactory.createWithPhases(ModelModifier.BeforeBake.class, modifiers -> (model, context) -> {
+		for (ModelModifier.BeforeBake modifier : modifiers) {
+			try {
+				model = modifier.modifyModelBeforeBake(model, context);
+			} catch (Exception exception) {
+				LOGGER.error("Failed to modify unbaked model before bake", exception);
+			}
+		}
+
+		return model;
+	}, MODEL_MODIFIER_PHASES);
+	private final Event<ModelModifier.AfterBake> afterBakeModifiers = EventFactory.createWithPhases(ModelModifier.AfterBake.class, modifiers -> (model, context) -> {
+		for (ModelModifier.AfterBake modifier : modifiers) {
+			try {
+				model = modifier.modifyModelAfterBake(model, context);
+			} catch (Exception exception) {
+				LOGGER.error("Failed to modify baked model after bake", exception);
+			}
+		}
+
+		return model;
+	}, MODEL_MODIFIER_PHASES);
 	private final Event<ModelModifier.OnLoadBlock> onLoadBlockModifiers = EventFactory.createWithPhases(ModelModifier.OnLoadBlock.class, modifiers -> (model, context) -> {
 		for (ModelModifier.OnLoadBlock modifier : modifiers) {
 			try {
 				model = modifier.modifyModelOnLoad(model, context);
 			} catch (Exception exception) {
 				LOGGER.error("Failed to modify unbaked block model on load", exception);
+			}
+		}
+
+		return model;
+	}, MODEL_MODIFIER_PHASES);
+	private final Event<ModelModifier.BeforeBakeBlock> beforeBakeBlockModifiers = EventFactory.createWithPhases(ModelModifier.BeforeBakeBlock.class, modifiers -> (model, context) -> {
+		for (ModelModifier.BeforeBakeBlock modifier : modifiers) {
+			try {
+				model = modifier.modifyModelBeforeBake(model, context);
+			} catch (Exception exception) {
+				LOGGER.error("Failed to modify unbaked block model before bake", exception);
+			}
+		}
+
+		return model;
+	}, MODEL_MODIFIER_PHASES);
+	private final Event<ModelModifier.AfterBakeBlock> afterBakeBlockModifiers = EventFactory.createWithPhases(ModelModifier.AfterBakeBlock.class, modifiers -> (model, context) -> {
+		for (ModelModifier.AfterBakeBlock modifier : modifiers) {
+			try {
+				model = modifier.modifyModelAfterBake(model, context);
+			} catch (Exception exception) {
+				LOGGER.error("Failed to modify baked block model after bake", exception);
 			}
 		}
 
@@ -103,7 +147,27 @@ public class ModelLoadingPluginContextImpl implements ModelLoadingPlugin.Context
 	}
 
 	@Override
+	public Event<ModelModifier.BeforeBake> modifyModelBeforeBake() {
+		return beforeBakeModifiers;
+	}
+
+	@Override
+	public Event<ModelModifier.AfterBake> modifyModelAfterBake() {
+		return afterBakeModifiers;
+	}
+
+	@Override
 	public Event<ModelModifier.OnLoadBlock> modifyBlockModelOnLoad() {
 		return onLoadBlockModifiers;
+	}
+
+	@Override
+	public Event<ModelModifier.BeforeBakeBlock> modifyBlockModelBeforeBake() {
+		return beforeBakeBlockModifiers;
+	}
+
+	@Override
+	public Event<ModelModifier.AfterBakeBlock> modifyBlockModelAfterBake() {
+		return afterBakeBlockModifiers;
 	}
 }

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/model/loading/ModelBakerBakerImplMixin.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/model/loading/ModelBakerBakerImplMixin.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.model.loading;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Coerce;
+
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.render.model.Baker;
+import net.minecraft.client.render.model.ModelBakeSettings;
+import net.minecraft.client.render.model.ModelBaker;
+import net.minecraft.client.render.model.UnbakedModel;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.impl.client.model.loading.ModelBakerHooks;
+import net.fabricmc.fabric.impl.client.model.loading.ModelLoadingEventDispatcher;
+
+@Mixin(ModelBaker.BakerImpl.class)
+abstract class ModelBakerBakerImplMixin {
+	@Shadow
+	@Final
+	private ModelBaker field_40571;
+
+	@WrapOperation(method = "bake(Lnet/minecraft/util/Identifier;Lnet/minecraft/client/render/model/ModelBakeSettings;)Lnet/minecraft/client/render/model/BakedModel;", at = @At(value = "INVOKE", target = "net/minecraft/client/render/model/UnbakedModel.bake(Lnet/minecraft/client/render/model/UnbakedModel;Lnet/minecraft/client/render/model/Baker;Lnet/minecraft/client/render/model/ModelBakeSettings;)Lnet/minecraft/client/render/model/BakedModel;"))
+	private BakedModel wrapModelBake(UnbakedModel unbakedModel, @Coerce Baker baker, ModelBakeSettings settings, Operation<BakedModel> operation, Identifier id) {
+		ModelLoadingEventDispatcher dispatcher = ((ModelBakerHooks) this.field_40571).fabric_getDispatcher();
+
+		if (dispatcher == null) {
+			return operation.call(unbakedModel, baker, settings);
+		}
+
+		unbakedModel = dispatcher.modifyModelBeforeBake(unbakedModel, id, settings, baker);
+		BakedModel model = operation.call(unbakedModel, baker, settings);
+		return dispatcher.modifyModelAfterBake(model, id, unbakedModel, settings, baker);
+	}
+}

--- a/fabric-model-loading-api-v1/src/client/resources/fabric-model-loading-api-v1.mixins.json
+++ b/fabric-model-loading-api-v1/src/client/resources/fabric-model-loading-api-v1.mixins.json
@@ -5,6 +5,7 @@
   "client": [
     "BakedModelManagerMixin",
     "ModelBakerBakedModelsMixin",
+    "ModelBakerBakerImplMixin",
     "ModelBakerMixin",
     "ReferencedModelsCollectorMixin",
     "WrapperBakedModelMixin"

--- a/fabric-model-loading-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/model/loading/ModelTestModClient.java
+++ b/fabric-model-loading-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/model/loading/ModelTestModClient.java
@@ -58,8 +58,8 @@ public class ModelTestModClient implements ClientModInitializer {
 	public static final String ID = "fabric-model-loading-api-v1-testmod";
 
 	public static final Identifier HALF_RED_SAND_MODEL_ID = id("half_red_sand");
-	public static final Identifier GOLD_BLOCK_MODEL_ID = Identifier.ofVanilla("block/gold_block");
 	public static final Identifier BROWN_GLAZED_TERRACOTTA_MODEL_ID = Identifier.ofVanilla("block/brown_glazed_terracotta");
+	public static final Identifier GOLD_BLOCK_MODEL_ID = Identifier.ofVanilla("block/gold_block");
 
 	@Override
 	public void onInitializeClient() {
@@ -114,14 +114,9 @@ public class ModelTestModClient implements ClientModInitializer {
 			});
 
 			// Remove bottom face of gold blocks
-			pluginContext.modifyModelOnLoad().register(ModelModifier.WRAP_PHASE, (model, context) -> {
+			pluginContext.modifyModelAfterBake().register(ModelModifier.WRAP_PHASE, (model, context) -> {
 				if (context.id().equals(GOLD_BLOCK_MODEL_ID)) {
-					return new WrapperUnbakedModel(model) {
-						@Override
-						public BakedModel bake(ModelTextures textures, Baker baker, ModelBakeSettings settings, boolean ambientOcclusion, boolean isSideLit, ModelTransformation transformation) {
-							return new DownQuadRemovingModel(super.bake(textures, baker, settings, ambientOcclusion, isSideLit, transformation));
-						}
-					};
+					return new DownQuadRemovingModel(model);
 				}
 
 				return model;


### PR DESCRIPTION
This pull request effectively reverts https://github.com/FabricMC/fabric/pull/4243/commits/2424258f8c97a1a3c43eb775f6969de063960dc6 and adds some minor improvements, including a fix for #4310 and documentation improvements.

The decision to reintroduce these events was made due to the following reasons.

- Wrapping unbaked models could lead to duplicate baked model wrapping. An unbaked model with no elements and a non-null parent delegates baking to the parent, so if both the child model and parent model are wrapped, the baked model produced by the parent will be double wrapped, even though that's usually not preferable. This is not too much of an issue for simple wrappers in an isolated environment, but in the general case with multiple mods doing arbitrary wrapping, correctly handling duplicate wrapping becomes complex or impossible.
- Mods may need to wrap certain models based on conditions that cannot be computed as early as when the `OnLoad*` events run. While such mods can still use the `OnLoad*` events to accomplish their goal, it requires wrapping the unbaked model unconditionally and doing the real wrapping within `UnbakedModel#bake` or `GroupableModel#bake`. This pollutes the vanilla code path with model wrappers even when it's not necessary and can increase the amount of allocations.
  Additionally, such mods cannot benefit from two of the three main reasons previously used as the basis for the removal of the `*Bake*` events (those being the one related to model resolution and the one related to block model groups).
  One specific mod for this reason is Continuity, which only wraps models based on which sprites are present in the atlas. Model loading and atlas loading/stitching happen concurrently, but model baking happens after both.