### PR TITLE
Add `UnbakedModelDeserializer`

### DIFF
--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/UnbakedModelDeserializer.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/UnbakedModelDeserializer.java
@@ -63,8 +63,8 @@ public interface UnbakedModelDeserializer {
 	}
 
 	/**
-	 * @return the custom model deserializer registered with the given identifier, or {@code null} if there is no such
-	 * deserializer
+	 * {@return the custom model deserializer registered with the given identifier, or {@code null} if there is no such
+	 * deserializer}
 	 */
 	@Nullable
 	static UnbakedModelDeserializer get(Identifier id) {

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/UnbakedModelDeserializer.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/UnbakedModelDeserializer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.client.model.loading.v1;
+
+import java.io.Reader;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.client.render.model.UnbakedModel;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.impl.client.model.loading.UnbakedModelDeserializerRegistry;
+
+public interface UnbakedModelDeserializer {
+	static void register(Identifier id, UnbakedModelDeserializer deserializer) {
+		UnbakedModelDeserializerRegistry.register(id, deserializer);
+	}
+
+	@Nullable
+	static UnbakedModelDeserializer get(Identifier id) {
+		return UnbakedModelDeserializerRegistry.get(id);
+	}
+
+	static UnbakedModel deserialize(Reader reader) throws JsonParseException {
+		return UnbakedModelDeserializerRegistry.deserialize(reader);
+	}
+
+	UnbakedModel deserialize(JsonObject jsonObject, JsonDeserializationContext context) throws RuntimeException;
+}

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/UnbakedModelDeserializer.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/UnbakedModelDeserializer.java
@@ -24,23 +24,77 @@ import com.google.gson.JsonParseException;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.client.render.model.UnbakedModel;
+import net.minecraft.client.render.model.json.JsonUnbakedModel;
+import net.minecraft.client.render.model.json.ModelElement;
+import net.minecraft.client.render.model.json.ModelElementFace;
+import net.minecraft.client.render.model.json.ModelElementTexture;
+import net.minecraft.client.render.model.json.ModelTransformation;
+import net.minecraft.client.render.model.json.Transformation;
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.impl.client.model.loading.UnbakedModelDeserializerRegistry;
 
+/**
+ * Allows creating custom unbaked models by overriding the parsing of JSON model files.
+ *
+ * <p>The format for custom unbaked models is as follows:
+ * <pre>{@code
+ * {
+ *     "fabric:type": "<identifier of the deserializer>",
+ *     // extra model data, dependent on the deserializer
+ * }
+ * }</pre>
+ *
+ * <p>All instances must be registered using {@link #register} for deserialization to work.
+ */
 public interface UnbakedModelDeserializer {
+	/**
+	 * Registers a custom model deserializer.
+	 *
+	 * @throws IllegalArgumentException if the deserializer is already registered
+	 */
 	static void register(Identifier id, UnbakedModelDeserializer deserializer) {
 		UnbakedModelDeserializerRegistry.register(id, deserializer);
 	}
 
+	/**
+	 * @return the custom model deserializer registered with the given identifier, or {@code null} if there is no such
+	 * deserializer
+	 */
 	@Nullable
 	static UnbakedModelDeserializer get(Identifier id) {
 		return UnbakedModelDeserializerRegistry.get(id);
 	}
 
+	/**
+	 * Deserializes an {@link UnbakedModel} from a {@link Reader}, respecting custom deserializers. Prefer using this
+	 * method to {@link JsonUnbakedModel#deserialize(Reader)}.
+	 */
 	static UnbakedModel deserialize(Reader reader) throws JsonParseException {
 		return UnbakedModelDeserializerRegistry.deserialize(reader);
 	}
 
-	UnbakedModel deserialize(JsonObject jsonObject, JsonDeserializationContext context) throws RuntimeException;
+	/**
+	 * Deserialize an {@link UnbakedModel} given a {@link JsonObject} representing the entire model file.
+	 *
+	 * <p>The provided deserialization context is able to deserialize objects of the following types:
+	 * <ul>
+	 *     <li>{@link UnbakedModel}</li>
+	 *     <li>{@link ModelElement}</li>
+	 *     <li>{@link ModelElementFace}</li>
+	 *     <li>{@link ModelElementTexture}</li>
+	 *     <li>{@link Transformation}</li>
+	 *     <li>{@link ModelTransformation}</li>
+	 * </ul>
+	 *
+	 * <p>For example, to deserialize a nested {@link UnbakedModel}, use
+	 * {@code context.deserialize(nestedModelJson, UnbakedModel.class)}.
+	 *
+	 * <p>This method is allowed and encouraged to throw exceptions, as they will be caught and logged by the caller.
+	 *
+	 * @param jsonObject the JSON object representing the entire model file
+	 * @param context the deserialization context
+	 * @return the unbaked model
+	 */
+	UnbakedModel deserialize(JsonObject jsonObject, JsonDeserializationContext context);
 }

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/UnbakedModelDeserializer.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/UnbakedModelDeserializer.java
@@ -45,6 +45,11 @@ import net.fabricmc.fabric.impl.client.model.loading.UnbakedModelDeserializerReg
  * }
  * }</pre>
  *
+ * <p>Alternatively, {@code "fabric:type"} may be an object with the required string field {@code "id"}, specifying the
+ * identifier of the deserializer, and the optional boolean field {@code "optional"} with default {@code false},
+ * specifying whether the model should fail loading ({@code false}) or continue loading as a vanilla model
+ * ({@code true}) when the specified deserializer has not been registered.
+ *
  * <p>All instances must be registered using {@link #register} for deserialization to work.
  */
 public interface UnbakedModelDeserializer {

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/UnbakedModelDeserializerRegistry.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/UnbakedModelDeserializerRegistry.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.model.loading;
+
+import java.io.Reader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import com.google.gson.JsonParseException;
+
+import net.minecraft.client.render.model.UnbakedModel;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.JsonHelper;
+
+import net.fabricmc.fabric.api.client.model.loading.v1.UnbakedModelDeserializer;
+import net.fabricmc.fabric.mixin.client.model.loading.JsonUnbakedModelAccessor;
+
+public class UnbakedModelDeserializerRegistry {
+	private static final Map<Identifier, UnbakedModelDeserializer> DESERIALIZERS = new HashMap<>();
+
+	public static void register(Identifier id, UnbakedModelDeserializer deserializer) {
+		Objects.requireNonNull(id, "id cannot be null");
+		Objects.requireNonNull(id, "deserializer cannot be null");
+
+		if (DESERIALIZERS.putIfAbsent(id, deserializer) != null) {
+			throw new IllegalArgumentException("UnbakedModelDeserializer with identifier '" + id + "' already registered");
+		}
+	}
+
+	public static UnbakedModelDeserializer get(Identifier id) {
+		Objects.requireNonNull(id, "id cannot be null");
+
+		return DESERIALIZERS.get(id);
+	}
+
+	public static UnbakedModel deserialize(Reader reader) throws JsonParseException {
+		return JsonHelper.deserialize(JsonUnbakedModelAccessor.fabric_getGson(), reader, UnbakedModel.class);
+	}
+}

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/UnbakedModelJsonDeserializer.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/UnbakedModelJsonDeserializer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.model.loading;
+
+import java.lang.reflect.Type;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import net.minecraft.client.render.model.UnbakedModel;
+import net.minecraft.client.render.model.json.JsonUnbakedModel;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.JsonHelper;
+
+import net.fabricmc.fabric.api.client.model.loading.v1.UnbakedModelDeserializer;
+
+public class UnbakedModelJsonDeserializer implements JsonDeserializer<UnbakedModel> {
+	private static final String TYPE_KEY = "fabric:type";
+
+	@Override
+	public UnbakedModel deserialize(JsonElement jsonElement, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+		JsonObject jsonObject = jsonElement.getAsJsonObject();
+
+		if (jsonObject.has(TYPE_KEY)) {
+			Identifier id = Identifier.of(JsonHelper.getString(jsonObject, TYPE_KEY));
+			UnbakedModelDeserializer deserializer = UnbakedModelDeserializer.get(id);
+
+			if (deserializer == null) {
+				throw new JsonParseException("Cannot deserialize custom unbaked model of unknown type '" + id + "'");
+			}
+
+			return deserializer.deserialize(jsonObject, context);
+		}
+
+		return context.deserialize(jsonElement, JsonUnbakedModel.class);
+	}
+}

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/UnbakedModelJsonDeserializer.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/UnbakedModelJsonDeserializer.java
@@ -23,6 +23,7 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
 
 import net.minecraft.client.render.model.UnbakedModel;
 import net.minecraft.client.render.model.json.JsonUnbakedModel;
@@ -33,20 +34,37 @@ import net.fabricmc.fabric.api.client.model.loading.v1.UnbakedModelDeserializer;
 
 public class UnbakedModelJsonDeserializer implements JsonDeserializer<UnbakedModel> {
 	private static final String TYPE_KEY = "fabric:type";
+	private static final String TYPE_ID_KEY = "id";
+	private static final String TYPE_OPTIONAL_KEY = "optional";
 
 	@Override
 	public UnbakedModel deserialize(JsonElement jsonElement, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
 		JsonObject jsonObject = jsonElement.getAsJsonObject();
 
 		if (jsonObject.has(TYPE_KEY)) {
-			Identifier id = Identifier.of(JsonHelper.getString(jsonObject, TYPE_KEY));
-			UnbakedModelDeserializer deserializer = UnbakedModelDeserializer.get(id);
+			JsonElement typeElement = jsonObject.get(TYPE_KEY);
+			String idStr;
+			boolean optional;
 
-			if (deserializer == null) {
-				throw new JsonParseException("Cannot deserialize custom unbaked model of unknown type '" + id + "'");
+			if (typeElement.isJsonPrimitive()) {
+				idStr = typeElement.getAsString();
+				optional = false;
+			} else if (typeElement.isJsonObject()) {
+				JsonObject typeObject = typeElement.getAsJsonObject();
+				idStr = JsonHelper.getString(typeObject, TYPE_ID_KEY);
+				optional = JsonHelper.getBoolean(typeObject, TYPE_OPTIONAL_KEY, false);
+			} else {
+				throw new JsonSyntaxException("Expected " + TYPE_KEY + " to be a string or object, was " + JsonHelper.getType(typeElement));
 			}
 
-			return deserializer.deserialize(jsonObject, context);
+			Identifier id = Identifier.of(idStr);
+			UnbakedModelDeserializer deserializer = UnbakedModelDeserializer.get(id);
+
+			if (deserializer != null) {
+				return deserializer.deserialize(jsonObject, context);
+			} else if (!optional) {
+				throw new JsonParseException("Cannot deserialize custom unbaked model of unknown type '" + id + "'");
+			}
 		}
 
 		return context.deserialize(jsonElement, JsonUnbakedModel.class);

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/model/loading/JsonUnbakedModelAccessor.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/model/loading/JsonUnbakedModelAccessor.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.model.loading;
+
+import com.google.gson.Gson;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.client.render.model.json.JsonUnbakedModel;
+
+@Mixin(JsonUnbakedModel.class)
+public interface JsonUnbakedModelAccessor {
+	@Accessor("GSON")
+	static Gson fabric_getGson() {
+		throw new AssertionError();
+	}
+}

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/model/loading/JsonUnbakedModelMixin.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/model/loading/JsonUnbakedModelMixin.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.model.loading;
+
+import com.google.gson.GsonBuilder;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.client.render.model.UnbakedModel;
+import net.minecraft.client.render.model.json.JsonUnbakedModel;
+
+import net.fabricmc.fabric.impl.client.model.loading.UnbakedModelJsonDeserializer;
+
+@Mixin(JsonUnbakedModel.class)
+abstract class JsonUnbakedModelMixin {
+	@ModifyExpressionValue(method = "<clinit>()V", at = @At(value = "NEW", target = "com/google/gson/GsonBuilder", remap = false))
+	private static GsonBuilder addUnbakedModelAdapter(GsonBuilder builder) {
+		return builder.registerTypeHierarchyAdapter(UnbakedModel.class, new UnbakedModelJsonDeserializer());
+	}
+}

--- a/fabric-model-loading-api-v1/src/client/resources/fabric-model-loading-api-v1.mixins.json
+++ b/fabric-model-loading-api-v1/src/client/resources/fabric-model-loading-api-v1.mixins.json
@@ -4,6 +4,8 @@
   "compatibilityLevel": "JAVA_21",
   "client": [
     "BakedModelManagerMixin",
+    "JsonUnbakedModelAccessor",
+    "JsonUnbakedModelMixin",
     "ModelBakerBakedModelsMixin",
     "ModelBakerMixin",
     "ReferencedModelsCollectorMixin",

--- a/fabric-model-loading-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/model/loading/UnbakedModelDeserializerTest.java
+++ b/fabric-model-loading-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/model/loading/UnbakedModelDeserializerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.model.loading;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
+import com.mojang.serialization.JsonOps;
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.render.model.Baker;
+import net.minecraft.client.render.model.ModelBakeSettings;
+import net.minecraft.client.render.model.ModelTextures;
+import net.minecraft.client.render.model.UnbakedModel;
+import net.minecraft.client.render.model.json.ModelTransformation;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.JsonHelper;
+import net.minecraft.util.math.AffineTransformation;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.model.loading.v1.UnbakedModelDeserializer;
+
+public class UnbakedModelDeserializerTest implements ClientModInitializer {
+	@Override
+	public void onInitializeClient() {
+		UnbakedModelDeserializer.register(ModelTestModClient.id("transformed"), TransformedModelDeserializer.INSTANCE);
+	}
+
+	private static class TransformedModelDeserializer implements UnbakedModelDeserializer {
+		public static final TransformedModelDeserializer INSTANCE = new TransformedModelDeserializer();
+
+		@Override
+		public UnbakedModel deserialize(JsonObject jsonObject, JsonDeserializationContext context) throws JsonParseException {
+			JsonElement transformationElement = JsonHelper.getElement(jsonObject, "transformation");
+			AffineTransformation transformation = AffineTransformation.ANY_CODEC.parse(JsonOps.INSTANCE, transformationElement).getOrThrow();
+
+			JsonElement parentElement = JsonHelper.getElement(jsonObject, "parent");
+
+			if (JsonHelper.isString(parentElement)) {
+				Identifier parentId = Identifier.of(parentElement.getAsString());
+				return new TransformedUnbakedModel(transformation, parentId);
+			} else if (parentElement.isJsonObject()) {
+				UnbakedModel parent = context.deserialize(parentElement, UnbakedModel.class);
+				return new TransformedUnbakedModel(transformation, parent);
+			} else {
+				throw new JsonSyntaxException("parent must be string or object");
+			}
+		}
+	}
+
+	private static class TransformedUnbakedModel implements UnbakedModel {
+		private final AffineTransformation transformation;
+		@Nullable
+		private final Identifier parentId;
+		private UnbakedModel parent;
+
+		private TransformedUnbakedModel(AffineTransformation transformation, Identifier parentId) {
+			this.transformation = transformation;
+			this.parentId = parentId;
+		}
+
+		private TransformedUnbakedModel(AffineTransformation transformation, UnbakedModel parent) {
+			this.transformation = transformation;
+			parentId = null;
+			this.parent = parent;
+		}
+
+		@Override
+		public void resolve(Resolver resolver) {
+			if (parentId != null) {
+				parent = resolver.resolve(parentId);
+			}
+		}
+
+		@Override
+		public UnbakedModel getParent() {
+			return parent;
+		}
+
+		@Override
+		public BakedModel bake(ModelTextures textures, Baker baker, ModelBakeSettings settings, boolean ambientOcclusion, boolean isSideLit, ModelTransformation transformation) {
+			settings = new SimpleModelBakeSettings(settings.getRotation().multiply(this.transformation), settings.isUvLocked());
+			return parent.bake(textures, baker, settings, ambientOcclusion, isSideLit, transformation);
+		}
+	}
+
+	private record SimpleModelBakeSettings(AffineTransformation transformation, boolean uvLocked) implements ModelBakeSettings {
+		@Override
+		public AffineTransformation getRotation() {
+			return transformation;
+		}
+
+		@Override
+		public boolean isUvLocked() {
+			return uvLocked;
+		}
+	}
+}

--- a/fabric-model-loading-api-v1/src/testmodClient/resources/assets/fabric-model-loading-api-v1-testmod/models/block/emerald_block.json
+++ b/fabric-model-loading-api-v1/src/testmodClient/resources/assets/fabric-model-loading-api-v1-testmod/models/block/emerald_block.json
@@ -1,5 +1,8 @@
 {
-  "fabric:type": "fabric-model-loading-api-v1-testmod:transformed",
+  "fabric:type": {
+    "id": "fabric-model-loading-api-v1-testmod:transformed",
+    "optional": false
+  },
   "parent": "minecraft:block/emerald_block",
   "transformation": {
     "translation": [ 0, 0.5, 0 ],

--- a/fabric-model-loading-api-v1/src/testmodClient/resources/assets/fabric-model-loading-api-v1-testmod/models/block/emerald_block.json
+++ b/fabric-model-loading-api-v1/src/testmodClient/resources/assets/fabric-model-loading-api-v1-testmod/models/block/emerald_block.json
@@ -1,0 +1,13 @@
+{
+  "fabric:type": "fabric-model-loading-api-v1-testmod:transformed",
+  "parent": "minecraft:block/emerald_block",
+  "transformation": {
+    "translation": [ 0, 0.5, 0 ],
+    "left_rotation": [ 0, 0, 0, 1 ],
+    "scale": [ 0.8, 1.2, 0.8 ],
+    "right_rotation": {
+      "angle": 1.57079632679,
+      "axis": [ 0, 0, 1 ]
+    }
+  }
+}

--- a/fabric-model-loading-api-v1/src/testmodClient/resources/assets/minecraft/blockstates/emerald_block.json
+++ b/fabric-model-loading-api-v1/src/testmodClient/resources/assets/minecraft/blockstates/emerald_block.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "fabric-model-loading-api-v1-testmod:block/emerald_block"
+    }
+  }
+}

--- a/fabric-model-loading-api-v1/src/testmodClient/resources/fabric.mod.json
+++ b/fabric-model-loading-api-v1/src/testmodClient/resources/fabric.mod.json
@@ -12,7 +12,8 @@
   "entrypoints": {
     "client": [
       "net.fabricmc.fabric.test.model.loading.ModelTestModClient",
-      "net.fabricmc.fabric.test.model.loading.PreparablePluginTest"
+      "net.fabricmc.fabric.test.model.loading.PreparablePluginTest",
+      "net.fabricmc.fabric.test.model.loading.UnbakedModelDeserializerTest"
     ]
   }
 }


### PR DESCRIPTION
This pull request introduces the `UnbakedModelDeserializer` interface, which allows overriding the deserialization process of a JSON model file based on its `fabric:type` JSON key.

### Points to Discuss

- [x] Should optional types be allowed? That is, if a type is declared as optional in the JSON file and the type does not exist, the file will be loaded as if no type were declared instead of failing to load. I am not familiar with how Fabric API load conditions work or whether they are used when deserializing models, but if they are, then they could be an alternative approach to this idea.
  Resolution: Yes. The behavior and syntax of this feature matches those of NeoForge and is explained in the documentation of this pull request. Resource conditions may in theory work as a functionally equivalent alternative but would be significantly less convenient to use, requiring the creation of multiple files per model.
- [x] Should utilities to deserialize vanilla model elements (`elements`, `parent`, `textures`, `ambientocclusion`, `display`, `gui_light`) be provided? If so, how?
  Resolution: They will not be included in this pull request but may be added in a later one.
- [x] Should data generation classes be extended to make it easier to generate models of custom types? If so, how?
  Resolution: They will not be included in this pull request but may be added in a later one.
- [x] Which default custom types should be registered by Fabric API, if any? NeoForge provides a composite model type and an OBJ model type.
  Resolution: None will be included in this pull request but some may be added in a later one.
- [x] Should `UnbakedModelDeserializer` have a method to retrieve its `Identifier` like `CustomIngredientSerializer` instead of the ID being passed to the `register` method directly?
  Resolution: No; not necessary.
- [x] Should `UnbakedModelDeserializer` be generic? It represents a "type" which can create instances, and such classes are almost always generic both in Fabric API and vanilla.
  Resolution: No; not necessary.
- [x] Are there better names for certain things?
  Resolution: Only naming of the single added API class, `UnbakedModelDeserializer`, and its members matters. These names are already good. Class and member names in the implementation can be changed at any later time.

### TODO

- [x] Documentation
- [x] Optional types