### PR TITLE
[1.21.1-1.21.4] Custom Ingredients sync fix

### DIFF
--- a/fabric-recipe-api-v1/build.gradle
+++ b/fabric-recipe-api-v1/build.gradle
@@ -5,9 +5,9 @@ loom {
 }
 
 moduleDependencies(project, [
-	"fabric-networking-api-v1",
+	'fabric-networking-api-v1',
 ])
 
 testDependencies(project, [
-		':fabric-lifecycle-events-v1',
+	':fabric-lifecycle-events-v1',
 ])

--- a/fabric-recipe-api-v1/build.gradle
+++ b/fabric-recipe-api-v1/build.gradle
@@ -7,3 +7,7 @@ loom {
 moduleDependencies(project, [
 	"fabric-networking-api-v1",
 ])
+
+testDependencies(project, [
+		':fabric-lifecycle-events-v1',
+])

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/CustomIngredientSync.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/CustomIngredientSync.java
@@ -88,7 +88,7 @@ public class CustomIngredientSync implements ModInitializer {
 
 		ServerConfigurationNetworking.registerGlobalReceiver(CustomIngredientPayloadC2S.ID, (payload, context) -> {
 			Set<Identifier> supportedCustomIngredients = decodeResponsePayload(payload);
-			((SupportedIngredientsPacketEncoder) ((ServerCommonNetworkHandlerAccessor) context.networkHandler()).getConnection()).fabric_setSupportedCustomIngredients(supportedCustomIngredients);
+			((SupportedIngredientsClientConnection) ((ServerCommonNetworkHandlerAccessor) context.networkHandler()).getConnection()).fabric_setSupportedCustomIngredients(supportedCustomIngredients);
 			context.networkHandler().completeTask(IngredientSyncTask.KEY);
 		});
 	}

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/CustomIngredientSync.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/CustomIngredientSync.java
@@ -19,8 +19,6 @@ package net.fabricmc.fabric.impl.recipe.ingredient;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import io.netty.channel.ChannelHandler;
-
 import net.minecraft.network.handler.EncoderHandler;
 import net.minecraft.network.packet.Packet;
 import net.minecraft.server.network.ServerPlayerConfigurationTask;
@@ -90,12 +88,7 @@ public class CustomIngredientSync implements ModInitializer {
 
 		ServerConfigurationNetworking.registerGlobalReceiver(CustomIngredientPayloadC2S.ID, (payload, context) -> {
 			Set<Identifier> supportedCustomIngredients = decodeResponsePayload(payload);
-			ChannelHandler packetEncoder = ((ServerCommonNetworkHandlerAccessor) context.networkHandler()).getConnection().channel.pipeline().get("encoder");
-
-			if (packetEncoder != null) { // Null in singleplayer
-				((SupportedIngredientsPacketEncoder) packetEncoder).fabric_setSupportedCustomIngredients(supportedCustomIngredients);
-			}
-
+			((SupportedIngredientsPacketEncoder) ((ServerCommonNetworkHandlerAccessor) context.networkHandler()).getConnection()).fabric_setSupportedCustomIngredients(supportedCustomIngredients);
 			context.networkHandler().completeTask(IngredientSyncTask.KEY);
 		});
 	}

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/SupportedIngredientsClientConnection.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/SupportedIngredientsClientConnection.java
@@ -18,13 +18,13 @@ package net.fabricmc.fabric.impl.recipe.ingredient;
 
 import java.util.Set;
 
-import net.minecraft.network.handler.EncoderHandler;
+import net.minecraft.network.ClientConnection;
 import net.minecraft.util.Identifier;
 
 /**
- * Implemented on {@link EncoderHandler} to store which custom ingredients the client supports.
+ * Implemented on {@link ClientConnection} to store which custom ingredients the client supports.
  */
-public interface SupportedIngredientsPacketEncoder {
+public interface SupportedIngredientsClientConnection {
 	void fabric_setSupportedCustomIngredients(Set<Identifier> supportedCustomIngredients);
 
 	Set<Identifier> fabric_getSupportedCustomIngredients();

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/SupportedIngredientsPacketEncoder.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/SupportedIngredientsPacketEncoder.java
@@ -26,4 +26,6 @@ import net.minecraft.util.Identifier;
  */
 public interface SupportedIngredientsPacketEncoder {
 	void fabric_setSupportedCustomIngredients(Set<Identifier> supportedCustomIngredients);
+
+	Set<Identifier> fabric_getSupportedCustomIngredients();
 }

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/mixin/recipe/ingredient/ClientConnectionMixin.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/mixin/recipe/ingredient/ClientConnectionMixin.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.recipe.ingredient;
+
+import java.util.Set;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+import net.minecraft.network.ClientConnection;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.impl.recipe.ingredient.SupportedIngredientsPacketEncoder;
+
+@Mixin(ClientConnection.class)
+public abstract class ClientConnectionMixin implements SupportedIngredientsPacketEncoder {
+	@Unique
+	private Set<Identifier> fabric_supportedCustomIngredients = Set.of();
+
+	@Override
+	public void fabric_setSupportedCustomIngredients(Set<Identifier> supportedCustomIngredients) {
+		fabric_supportedCustomIngredients = supportedCustomIngredients;
+	}
+
+	@Override
+	public Set<Identifier> fabric_getSupportedCustomIngredients() {
+		return fabric_supportedCustomIngredients;
+	}
+}

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/mixin/recipe/ingredient/ClientConnectionMixin.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/mixin/recipe/ingredient/ClientConnectionMixin.java
@@ -24,10 +24,10 @@ import org.spongepowered.asm.mixin.Unique;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.util.Identifier;
 
-import net.fabricmc.fabric.impl.recipe.ingredient.SupportedIngredientsPacketEncoder;
+import net.fabricmc.fabric.impl.recipe.ingredient.SupportedIngredientsClientConnection;
 
 @Mixin(ClientConnection.class)
-public abstract class ClientConnectionMixin implements SupportedIngredientsPacketEncoder {
+public abstract class ClientConnectionMixin implements SupportedIngredientsClientConnection {
 	@Unique
 	private Set<Identifier> fabric_supportedCustomIngredients = Set.of();
 

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/mixin/recipe/ingredient/EncoderHandlerMixin.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/mixin/recipe/ingredient/EncoderHandlerMixin.java
@@ -19,14 +19,16 @@ package net.fabricmc.fabric.mixin.recipe.ingredient;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
-import net.fabricmc.fabric.impl.recipe.ingredient.CustomIngredientSync;
-import net.fabricmc.fabric.impl.recipe.ingredient.SupportedIngredientsPacketEncoder;
-import net.minecraft.network.handler.EncoderHandler;
-import net.minecraft.network.packet.Packet;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.network.handler.EncoderHandler;
+import net.minecraft.network.packet.Packet;
+
+import net.fabricmc.fabric.impl.recipe.ingredient.CustomIngredientSync;
+import net.fabricmc.fabric.impl.recipe.ingredient.SupportedIngredientsPacketEncoder;
 
 @Mixin(EncoderHandler.class)
 public class EncoderHandlerMixin {
@@ -39,6 +41,7 @@ public class EncoderHandlerMixin {
 	)
 	private void capturePacketEncoder(ChannelHandlerContext channelHandlerContext, Packet<?> packet, ByteBuf byteBuf, CallbackInfo ci) {
 		ChannelHandler client = channelHandlerContext.pipeline().get("packet_handler");
+
 		if (client != null) {
 			CustomIngredientSync.CURRENT_SUPPORTED_INGREDIENTS.set(((SupportedIngredientsPacketEncoder) client).fabric_getSupportedCustomIngredients());
 		}

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/mixin/recipe/ingredient/EncoderHandlerMixin.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/mixin/recipe/ingredient/EncoderHandlerMixin.java
@@ -28,7 +28,7 @@ import net.minecraft.network.handler.EncoderHandler;
 import net.minecraft.network.packet.Packet;
 
 import net.fabricmc.fabric.impl.recipe.ingredient.CustomIngredientSync;
-import net.fabricmc.fabric.impl.recipe.ingredient.SupportedIngredientsPacketEncoder;
+import net.fabricmc.fabric.impl.recipe.ingredient.SupportedIngredientsClientConnection;
 
 @Mixin(EncoderHandler.class)
 public class EncoderHandlerMixin {
@@ -40,10 +40,10 @@ public class EncoderHandlerMixin {
 			method = "encode(Lio/netty/channel/ChannelHandlerContext;Lnet/minecraft/network/packet/Packet;Lio/netty/buffer/ByteBuf;)V"
 	)
 	private void capturePacketEncoder(ChannelHandlerContext channelHandlerContext, Packet<?> packet, ByteBuf byteBuf, CallbackInfo ci) {
-		ChannelHandler client = channelHandlerContext.pipeline().get("packet_handler");
+		ChannelHandler channelHandler = channelHandlerContext.pipeline().get("packet_handler");
 
-		if (client != null) {
-			CustomIngredientSync.CURRENT_SUPPORTED_INGREDIENTS.set(((SupportedIngredientsPacketEncoder) client).fabric_getSupportedCustomIngredients());
+		if (channelHandler instanceof SupportedIngredientsClientConnection) {
+			CustomIngredientSync.CURRENT_SUPPORTED_INGREDIENTS.set(((SupportedIngredientsClientConnection) channelHandler).fabric_getSupportedCustomIngredients());
 		}
 	}
 

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/mixin/recipe/ingredient/EncoderHandlerMixin.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/mixin/recipe/ingredient/EncoderHandlerMixin.java
@@ -16,33 +16,20 @@
 
 package net.fabricmc.fabric.mixin.recipe.ingredient;
 
-import java.util.Set;
-
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
+import net.fabricmc.fabric.impl.recipe.ingredient.CustomIngredientSync;
+import net.fabricmc.fabric.impl.recipe.ingredient.SupportedIngredientsPacketEncoder;
+import net.minecraft.network.handler.EncoderHandler;
+import net.minecraft.network.packet.Packet;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import net.minecraft.network.handler.EncoderHandler;
-import net.minecraft.network.packet.Packet;
-import net.minecraft.util.Identifier;
-
-import net.fabricmc.fabric.impl.recipe.ingredient.CustomIngredientSync;
-import net.fabricmc.fabric.impl.recipe.ingredient.SupportedIngredientsPacketEncoder;
-
 @Mixin(EncoderHandler.class)
-public class EncoderHandlerMixin implements SupportedIngredientsPacketEncoder {
-	@Unique
-	private Set<Identifier> fabric_supportedCustomIngredients = Set.of();
-
-	@Override
-	public void fabric_setSupportedCustomIngredients(Set<Identifier> supportedCustomIngredients) {
-		fabric_supportedCustomIngredients = supportedCustomIngredients;
-	}
-
+public class EncoderHandlerMixin {
 	@Inject(
 			at = @At(
 					value = "INVOKE",
@@ -51,7 +38,10 @@ public class EncoderHandlerMixin implements SupportedIngredientsPacketEncoder {
 			method = "encode(Lio/netty/channel/ChannelHandlerContext;Lnet/minecraft/network/packet/Packet;Lio/netty/buffer/ByteBuf;)V"
 	)
 	private void capturePacketEncoder(ChannelHandlerContext channelHandlerContext, Packet<?> packet, ByteBuf byteBuf, CallbackInfo ci) {
-		CustomIngredientSync.CURRENT_SUPPORTED_INGREDIENTS.set(fabric_supportedCustomIngredients);
+		ChannelHandler client = channelHandlerContext.pipeline().get("packet_handler");
+		if (client != null) {
+			CustomIngredientSync.CURRENT_SUPPORTED_INGREDIENTS.set(((SupportedIngredientsPacketEncoder) client).fabric_getSupportedCustomIngredients());
+		}
 	}
 
 	@Inject(

--- a/fabric-recipe-api-v1/src/main/resources/fabric-recipe-api-v1.mixins.json
+++ b/fabric-recipe-api-v1/src/main/resources/fabric-recipe-api-v1.mixins.json
@@ -1,14 +1,14 @@
 {
-    "required": true,
-    "package": "net.fabricmc.fabric.mixin.recipe",
-    "compatibilityLevel": "JAVA_17",
-    "mixins": [
-        "ingredient.ClientConnectionMixin",
-        "ingredient.EncoderHandlerMixin",
-        "ingredient.IngredientMixin",
-        "ingredient.ShapelessRecipeMixin"
-    ],
-    "injectors": {
-        "defaultRequire": 1
+  "required": true,
+  "package": "net.fabricmc.fabric.mixin.recipe",
+  "compatibilityLevel": "JAVA_17",
+  "mixins": [
+    "ingredient.ClientConnectionMixin",
+    "ingredient.EncoderHandlerMixin",
+    "ingredient.IngredientMixin",
+    "ingredient.ShapelessRecipeMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
   }
 }

--- a/fabric-recipe-api-v1/src/main/resources/fabric-recipe-api-v1.mixins.json
+++ b/fabric-recipe-api-v1/src/main/resources/fabric-recipe-api-v1.mixins.json
@@ -1,13 +1,14 @@
 {
-  "required": true,
-  "package": "net.fabricmc.fabric.mixin.recipe",
-  "compatibilityLevel": "JAVA_17",
-  "mixins": [
-    "ingredient.IngredientMixin",
-    "ingredient.EncoderHandlerMixin",
-    "ingredient.ShapelessRecipeMixin"
-  ],
-  "injectors": {
-    "defaultRequire": 1
+    "required": true,
+    "package": "net.fabricmc.fabric.mixin.recipe",
+    "compatibilityLevel": "JAVA_17",
+    "mixins": [
+        "ingredient.ClientConnectionMixin",
+        "ingredient.EncoderHandlerMixin",
+        "ingredient.IngredientMixin",
+        "ingredient.ShapelessRecipeMixin"
+    ],
+    "injectors": {
+        "defaultRequire": 1
   }
 }

--- a/fabric-recipe-api-v1/src/testmod/resources/data/fabric-recipe-api-v1-testmod/recipe/test_customingredients_sync.json
+++ b/fabric-recipe-api-v1/src/testmod/resources/data/fabric-recipe-api-v1-testmod/recipe/test_customingredients_sync.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "fabric:type": "fabric:components",
+      "base": {
+        "item": "minecraft:diamond_pickaxe"
+      },
+      "components": {
+        "minecraft:damage": 0
+      },
+      "strict": false
+    }
+  ],
+  "result": {
+    "id": "minecraft:diamond_block"
+  }
+}

--- a/fabric-recipe-api-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-recipe-api-v1/src/testmod/resources/fabric.mod.json
@@ -13,6 +13,9 @@
       "net.fabricmc.fabric.test.recipe.ingredient.IngredientMatchTests",
       "net.fabricmc.fabric.test.recipe.ingredient.SerializationTests",
       "net.fabricmc.fabric.test.recipe.ingredient.ShapelessRecipeMatchTests"
+    ],
+    "client": [
+      "net.fabricmc.fabric.test.recipe.ingredient.client.ClientCustomIngredientSyncTests"
     ]
   }
 }

--- a/fabric-recipe-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/recipe/ingredient/client/ClientCustomIngredientSyncTests.java
+++ b/fabric-recipe-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/recipe/ingredient/client/ClientCustomIngredientSyncTests.java
@@ -1,12 +1,29 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.test.recipe.ingredient.client;
+
+import net.minecraft.recipe.ShapelessRecipe;
+import net.minecraft.test.GameTestException;
+import net.minecraft.util.Identifier;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.impl.recipe.ingredient.CustomIngredientImpl;
 import net.fabricmc.fabric.impl.recipe.ingredient.builtin.ComponentsIngredient;
-import net.minecraft.recipe.ShapelessRecipe;
-import net.minecraft.test.GameTestException;
-import net.minecraft.util.Identifier;
 
 public class ClientCustomIngredientSyncTests implements ClientModInitializer {
 	/**
@@ -17,9 +34,11 @@ public class ClientCustomIngredientSyncTests implements ClientModInitializer {
 		ClientTickEvents.END_WORLD_TICK.register(world -> {
 			Identifier recipeId = Identifier.of("fabric-recipe-api-v1-testmod", "test_customingredients_sync");
 			ShapelessRecipe recipe = (ShapelessRecipe) world.getRecipeManager().get(recipeId).get().value();
+
 			if (!(recipe.getIngredients().getFirst() instanceof CustomIngredientImpl customIngredient)) {
 				throw new GameTestException("Expected the first ingredient to be a CustomIngredientImpl");
 			}
+
 			if (!(customIngredient.getCustomIngredient() instanceof ComponentsIngredient)) {
 				throw new GameTestException("Expected the custom ingredient to be a ComponentsIngredient");
 			}

--- a/fabric-recipe-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/recipe/ingredient/client/ClientCustomIngredientSyncTests.java
+++ b/fabric-recipe-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/recipe/ingredient/client/ClientCustomIngredientSyncTests.java
@@ -1,0 +1,28 @@
+package net.fabricmc.fabric.test.recipe.ingredient.client;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.impl.recipe.ingredient.CustomIngredientImpl;
+import net.fabricmc.fabric.impl.recipe.ingredient.builtin.ComponentsIngredient;
+import net.minecraft.recipe.ShapelessRecipe;
+import net.minecraft.test.GameTestException;
+import net.minecraft.util.Identifier;
+
+public class ClientCustomIngredientSyncTests implements ClientModInitializer {
+	/**
+	 * The recipe requires a custom ingredient.
+	 */
+	@Override
+	public void onInitializeClient() {
+		ClientTickEvents.END_WORLD_TICK.register(world -> {
+			Identifier recipeId = Identifier.of("fabric-recipe-api-v1-testmod", "test_customingredients_sync");
+			ShapelessRecipe recipe = (ShapelessRecipe) world.getRecipeManager().get(recipeId).get().value();
+			if (!(recipe.getIngredients().getFirst() instanceof CustomIngredientImpl customIngredient)) {
+				throw new GameTestException("Expected the first ingredient to be a CustomIngredientImpl");
+			}
+			if (!(customIngredient.getCustomIngredient() instanceof ComponentsIngredient)) {
+				throw new GameTestException("Expected the custom ingredient to be a ComponentsIngredient");
+			}
+		});
+	}
+}


### PR DESCRIPTION
Fixes #4225.
The synced ```fabric_supportedCustomIngredients``` list was lost due to minecraft removing the ```EncoderHandler``` before joining the world.
Therefore all recipes were synced with the fallback method instead.
This PR fixes that issue by storing the list in the ```ClientConnection``` class instead and making use of the ```packet_handler``` pipeline which points to the ```ClientConnection``` instance.

@MerchantPug could you maybe test this fix against your implementation?