### PR TITLE
Biomemodifications: Check to make sure Feature isn't present before adding it

### DIFF
--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/modification/BiomeModificationContextImpl.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/modification/BiomeModificationContextImpl.java
@@ -282,7 +282,14 @@ public class BiomeModificationContextImpl implements BiomeModificationContext {
 				featureSteps.add(RegistryEntryList.of(Collections.emptyList()));
 			}
 
-			featureSteps.set(index, plus(featureSteps.get(index), getEntry(features, entry)));
+			RegistryEntry.Reference<PlacedFeature> feature = getEntry(features, entry);
+
+			// Don't add the feature if it's already present
+			if (featureSteps.get(index).contains(feature)) {
+				return;
+			}
+
+			featureSteps.set(index, plus(featureSteps.get(index), feature));
 
 			// Ensure the list of flower features is up-to-date
 			rebuildFeatures = true;


### PR DESCRIPTION
Fixes an issue where a feature order cycle error will happen because a feature may be added to a biome twice.  This can occur if a biome appears in more than one tag and you want a feature in biomes from both tags, currently it gets added twice to the biome causing a feature order cycle error