### PR TITLE
Fix world closing in client gametests

### DIFF
--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/TestServerConnectionImpl.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/TestServerConnectionImpl.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.fabric.impl.client.gametest;
 
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.TitleScreen;
 
 import net.fabricmc.fabric.api.client.gametest.v1.ClientGameTestContext;
@@ -45,9 +44,11 @@ public class TestServerConnectionImpl implements TestServerConnection {
 			if (client.world == null) {
 				throw new AssertionError("Disconnected from server before closing the test server connection");
 			}
+
+			client.world.disconnect();
+			client.disconnect();
 		});
 
-		context.runOnClient(MinecraftClient::disconnect);
 		context.waitFor(client -> client.world == null);
 		context.setScreen(TitleScreen::new);
 	}

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/TestSingleplayerContextImpl.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/TestSingleplayerContextImpl.java
@@ -17,9 +17,10 @@
 package net.fabricmc.fabric.impl.client.gametest;
 
 import net.minecraft.SharedConstants;
-import net.minecraft.client.gui.screen.GameMenuScreen;
+import net.minecraft.client.gui.screen.MessageScreen;
 import net.minecraft.client.gui.screen.TitleScreen;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.text.Text;
 
 import net.fabricmc.fabric.api.client.gametest.v1.ClientGameTestContext;
 import net.fabricmc.fabric.api.client.gametest.v1.TestClientWorldContext;
@@ -63,11 +64,12 @@ public class TestSingleplayerContextImpl implements TestSingleplayerContext {
 			if (client.world == null) {
 				throw new IllegalStateException("Exited the world before closing singleplayer context");
 			}
+
+			client.world.disconnect();
+			client.disconnect(new MessageScreen(Text.translatable("menu.savingLevel")));
 		});
 
-		context.setScreen(() -> new GameMenuScreen(true));
-		context.clickScreenButton("menu.returnToMenu");
-		context.waitForScreen(TitleScreen.class);
 		context.waitFor(client -> !ThreadingImpl.isServerRunning && client.world == null, SharedConstants.TICKS_PER_MINUTE);
+		context.setScreen(TitleScreen::new);
 	}
 }


### PR DESCRIPTION
There was an issue where the assertion that the game is on the title screen would fail when ending a test by closing a singleplayer world (via a try-with-resources close of `TestSingleplayerContext`).

This was caused by the threading system deferring the `client.disconnect` call until after the client thread task wait loop (i.e. until the gametest thread waits a tick). Therefore, the order of operations inside `GameMenuScreen.disconnect` was reversed and the title screen was shown first before disconnecting. Moreover, the title screen was visible to the gametest thread until ticks were waited, which allowed `context.waitForScreen(TitleScreen.class)` to return immediately after waiting 0 ticks.

Rather than relying on navigating the game menu which may have been changed by mods, I thought it was better to refactor the code to disconnect directly, and I've written it in a way which waits for the `world` to be `null` directly after calling `client.disconnect`, which allows for the deferred call to run.