### PR TITLE
Client gametest screenshot changes

### DIFF
--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/ClientGameTestContext.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/ClientGameTestContext.java
@@ -111,19 +111,13 @@ public interface ClientGameTestContext {
 	boolean tryClickScreenButton(String translationKey);
 
 	/**
-	 * Takes a screenshot after waiting 1 tick (for a frame to render) and saves it in the screenshots directory.
+	 * Takes a screenshot and saves it in the screenshots directory.
 	 *
 	 * @param name The name of the screenshot
 	 */
 	Path takeScreenshot(String name);
 
-	/**
-	 * Takes a screnshot after waiting {@code delay} ticks and saves it in the screenshots directory.
-	 *
-	 * @param name The name of the screenshot
-	 * @param delay The delay in ticks before taking the screenshot
-	 */
-	Path takeScreenshot(String name, int delay);
+	Path takeScreenshot(TestScreenshotOptions options);
 
 	/**
 	 * Gets the input handler used to simulate inputs to the client.

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/ClientGameTestContext.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/ClientGameTestContext.java
@@ -114,9 +114,16 @@ public interface ClientGameTestContext {
 	 * Takes a screenshot and saves it in the screenshots directory.
 	 *
 	 * @param name The name of the screenshot
+	 * @return The {@link Path} to the screenshot
 	 */
 	Path takeScreenshot(String name);
 
+	/**
+	 * Takes a screenshot with the given options.
+	 *
+	 * @param options The {@link TestScreenshotOptions} to take the screenshot with
+	 * @return The {@link Path} to the screenshot
+	 */
 	Path takeScreenshot(TestScreenshotOptions options);
 
 	/**

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/TestInput.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/TestInput.java
@@ -325,4 +325,14 @@ public interface TestInput {
 	 * @see #setCursorPos(double, double)
 	 */
 	void moveCursor(double deltaX, double deltaY);
+
+	/**
+	 * Resizes the window to match the given size. Also attempts to resize the physical window, but whether the physical
+	 * window was successfully resized or not, the window size accessible by the game will always be changed to the
+	 * value specified, causing widget layouts and screenshots to work as expected.
+	 *
+	 * @param width The new window width
+	 * @param height The new window height
+	 */
+	void resizeWindow(int width, int height);
 }

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/TestScreenshotOptions.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/TestScreenshotOptions.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.client.gametest.v1;
+
+import java.nio.file.Path;
+
+import com.google.common.base.Preconditions;
+import org.jetbrains.annotations.ApiStatus;
+
+import net.fabricmc.fabric.impl.client.gametest.TestScreenshotOptionsImpl;
+
+@ApiStatus.NonExtendable
+public interface TestScreenshotOptions {
+	static TestScreenshotOptions of(String name) {
+		Preconditions.checkNotNull(name, "name");
+		return new TestScreenshotOptionsImpl(name);
+	}
+
+	TestScreenshotOptions disableCounterPrefix();
+
+	TestScreenshotOptions withTickDelta(float tickDelta);
+
+	TestScreenshotOptions withSize(int width, int height);
+
+	TestScreenshotOptions withDestinationDir(Path destinationDir);
+}

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/TestScreenshotOptions.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/TestScreenshotOptions.java
@@ -23,18 +23,55 @@ import org.jetbrains.annotations.ApiStatus;
 
 import net.fabricmc.fabric.impl.client.gametest.TestScreenshotOptionsImpl;
 
+/**
+ * Options to customize a screenshot.
+ */
 @ApiStatus.NonExtendable
 public interface TestScreenshotOptions {
+	/**
+	 * Creates a {@link TestScreenshotOptions} with the given screenshot name.
+	 *
+	 * @param name The name of the screenshot
+	 * @return The new screenshot options instance
+	 */
 	static TestScreenshotOptions of(String name) {
 		Preconditions.checkNotNull(name, "name");
 		return new TestScreenshotOptionsImpl(name);
 	}
 
+	/**
+	 * By default, screenshot file names will be prefixed by a counter so that the screenshots appear in sequence in the
+	 * screenshots directory. Use this method to disable this behavior.
+	 *
+	 * @return This screenshot options instance
+	 */
 	TestScreenshotOptions disableCounterPrefix();
 
+	/**
+	 * Changes the tick delta to take this screenshot with. Tick delta controls interpolation between the previous tick and the
+	 * current tick to make objects appear to move more smoothly when there are multiple frames in a tick. Defaults to
+	 * {@code 1}, which renders all objects as their appear in the current tick.
+	 *
+	 * @param tickDelta The tick delta to take this screenshot with
+	 * @return This screenshot options instance
+	 */
 	TestScreenshotOptions withTickDelta(float tickDelta);
 
+	/**
+	 * Changes the resolution of the screenshot, which defaults to the resolution of the Minecraft window.
+	 *
+	 * @param width The width of the screenshot
+	 * @param height The height of the screenshot
+	 * @return This screenshot options instance
+	 */
 	TestScreenshotOptions withSize(int width, int height);
 
+	/**
+	 * Changes the directory in which this screenshot is saved, which defaults to the {@code screenshots} directory in
+	 * the game's run directory.
+	 *
+	 * @param destinationDir The directory in which to save the screenshot
+	 * @return This screenshot options instance
+	 */
 	TestScreenshotOptions withDestinationDir(Path destinationDir);
 }

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/ClientGameTestImpl.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/ClientGameTestImpl.java
@@ -31,6 +31,7 @@ import net.fabricmc.fabric.api.client.gametest.v1.ClientGameTestContext;
 
 public final class ClientGameTestImpl {
 	public static final Logger LOGGER = LoggerFactory.getLogger("fabric-client-gametest-api-v1");
+	public static int screenshotCounter = 0;
 
 	private ClientGameTestImpl() {
 	}

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/FabricClientGameTestRunner.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/FabricClientGameTestRunner.java
@@ -38,17 +38,24 @@ public class FabricClientGameTestRunner {
 			ClientGameTestContextImpl context = new ClientGameTestContextImpl();
 
 			for (FabricClientGameTest gameTest : gameTests) {
-				context.restoreDefaultGameOptions();
+				setupInitialGameTestState(context);
 
 				gameTest.runTest(context);
 
-				context.getInput().clearKeysDown();
-				checkFinalGameTestState(context, gameTest.getClass().getName());
+				setupAndCheckFinalGameTestState(context, gameTest.getClass().getName());
 			}
 		});
 	}
 
-	private static void checkFinalGameTestState(ClientGameTestContext context, String testClassName) {
+	private static void setupInitialGameTestState(ClientGameTestContext context) {
+		context.restoreDefaultGameOptions();
+	}
+
+	private static void setupAndCheckFinalGameTestState(ClientGameTestContextImpl context, String testClassName) {
+		context.getInput().clearKeysDown();
+		context.runOnClient(client -> ((WindowHooks) (Object) client.getWindow()).fabric_resetSize());
+		context.getInput().setCursorPos(context.computeOnClient(client -> client.getWindow().getWidth()) * 0.5, context.computeOnClient(client -> client.getWindow().getHeight()) * 0.5);
+
 		if (ThreadingImpl.isServerRunning) {
 			throw new AssertionError("Client gametest %s finished while a server is still running".formatted(testClassName));
 		}

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/TestInputImpl.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/TestInputImpl.java
@@ -321,6 +321,15 @@ public final class TestInputImpl implements TestInput {
 		});
 	}
 
+	@Override
+	public void resizeWindow(int width, int height) {
+		ThreadingImpl.checkOnGametestThread("resizeWindow");
+		Preconditions.checkArgument(width > 0, "width must be positive");
+		Preconditions.checkArgument(height > 0, "height must be positive");
+
+		context.runOnClient(client -> ((WindowHooks) (Object) client.getWindow()).fabric_resize(width, height));
+	}
+
 	private static InputUtil.Key getBoundKey(KeyBinding keyBinding, String action) {
 		InputUtil.Key boundKey = ((KeyBindingAccessor) keyBinding).getBoundKey();
 

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/TestScreenshotOptionsImpl.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/TestScreenshotOptionsImpl.java
@@ -45,7 +45,7 @@ public class TestScreenshotOptionsImpl implements TestScreenshotOptions {
 
 	@Override
 	public TestScreenshotOptions withTickDelta(float tickDelta) {
-		Preconditions.checkArgument(tickDelta >= 0 && tickDelta <= 1, "tickDelta should be between 0 and 1");
+		Preconditions.checkArgument(tickDelta >= 0 && tickDelta <= 1, "tickDelta must be between 0 and 1");
 
 		this.tickDelta = tickDelta;
 		return this;

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/TestScreenshotOptionsImpl.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/TestScreenshotOptionsImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.gametest;
+
+import java.nio.file.Path;
+
+import com.google.common.base.Preconditions;
+import org.jetbrains.annotations.Nullable;
+import org.joml.Vector2i;
+
+import net.fabricmc.fabric.api.client.gametest.v1.TestScreenshotOptions;
+
+public class TestScreenshotOptionsImpl implements TestScreenshotOptions {
+	public final String name;
+	public boolean counterPrefix = true;
+	public float tickDelta = 1;
+	@Nullable
+	public Vector2i size;
+	@Nullable
+	public Path destinationDir;
+
+	public TestScreenshotOptionsImpl(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public TestScreenshotOptions disableCounterPrefix() {
+		counterPrefix = false;
+		return this;
+	}
+
+	@Override
+	public TestScreenshotOptions withTickDelta(float tickDelta) {
+		Preconditions.checkArgument(tickDelta >= 0 && tickDelta <= 1, "tickDelta should be between 0 and 1");
+
+		this.tickDelta = tickDelta;
+		return this;
+	}
+
+	@Override
+	public TestScreenshotOptions withSize(int width, int height) {
+		Preconditions.checkArgument(width > 0, "width must be positive");
+		Preconditions.checkArgument(height > 0, "height must be positive");
+
+		this.size = new Vector2i(width, height);
+		return this;
+	}
+
+	@Override
+	public TestScreenshotOptions withDestinationDir(Path destinationDir) {
+		Preconditions.checkNotNull(destinationDir, "destinationDir");
+
+		this.destinationDir = destinationDir;
+		return this;
+	}
+}

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/WindowHooks.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/WindowHooks.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.gametest;
+
+public interface WindowHooks {
+	int fabric_getRealWidth();
+	int fabric_getRealHeight();
+	int fabric_getRealFramebufferWidth();
+	int fabric_getRealFramebufferHeight();
+	void fabric_resetSize();
+	void fabric_resize(int width, int height);
+}

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/gametest/FramebufferMixin.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/gametest/FramebufferMixin.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.gametest;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gl.Framebuffer;
+import net.minecraft.client.util.Window;
+
+import net.fabricmc.fabric.impl.client.gametest.WindowHooks;
+
+@Mixin(Framebuffer.class)
+public class FramebufferMixin {
+	@ModifyVariable(method = {"draw", "drawInternal"}, at = @At("HEAD"), ordinal = 0, argsOnly = true)
+	private int modifyWidth(int width) {
+		Window window = MinecraftClient.getInstance().getWindow();
+
+		if ((Object) this == MinecraftClient.getInstance().getFramebuffer() && width == window.getFramebufferWidth()) {
+			return ((WindowHooks) (Object) window).fabric_getRealFramebufferWidth();
+		}
+
+		return width;
+	}
+
+	@ModifyVariable(method = {"draw", "drawInternal"}, at = @At("HEAD"), ordinal = 1, argsOnly = true)
+	private int modifyHeight(int height) {
+		Window window = MinecraftClient.getInstance().getWindow();
+
+		if ((Object) this == MinecraftClient.getInstance().getFramebuffer() && height == window.getFramebufferHeight()) {
+			return ((WindowHooks) (Object) window).fabric_getRealFramebufferHeight();
+		}
+
+		return height;
+	}
+}

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/gametest/MonitorTrackerMixin.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/gametest/MonitorTrackerMixin.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.gametest;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.client.util.MonitorTracker;
+import net.minecraft.client.util.Window;
+
+import net.fabricmc.fabric.impl.client.gametest.WindowHooks;
+
+@Mixin(MonitorTracker.class)
+public class MonitorTrackerMixin {
+	@ModifyExpressionValue(method = "getMonitor(Lnet/minecraft/client/util/Window;)Lnet/minecraft/client/util/Monitor;", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/util/Window;getWidth()I"))
+	private int getRealWidth(int original, Window window) {
+		return ((WindowHooks) (Object) window).fabric_getRealWidth();
+	}
+
+	@ModifyExpressionValue(method = "getMonitor(Lnet/minecraft/client/util/Window;)Lnet/minecraft/client/util/Monitor;", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/util/Window;getHeight()I"))
+	private int getRealHeight(int original, Window window) {
+		return ((WindowHooks) (Object) window).fabric_getRealHeight();
+	}
+}

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/gametest/RenderTickCounterConstantAccessor.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/gametest/RenderTickCounterConstantAccessor.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.gametest;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import net.minecraft.client.render.RenderTickCounter;
+
+@Mixin(RenderTickCounter.Constant.class)
+public interface RenderTickCounterConstantAccessor {
+	@Invoker("<init>")
+	static RenderTickCounter.Constant create(float constant) {
+		throw new UnsupportedOperationException("Implemented via mixin");
+	}
+}

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/gametest/WindowMixin.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/gametest/WindowMixin.java
@@ -16,17 +16,205 @@
 
 package net.fabricmc.fabric.mixin.client.gametest;
 
+import java.util.Optional;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import net.minecraft.client.WindowEventHandler;
+import net.minecraft.client.WindowSettings;
+import net.minecraft.client.util.Monitor;
+import net.minecraft.client.util.MonitorTracker;
+import net.minecraft.client.util.VideoMode;
 import net.minecraft.client.util.Window;
 
+import net.fabricmc.fabric.impl.client.gametest.WindowHooks;
+
 @Mixin(Window.class)
-public class WindowMixin {
-	@Inject(method = {"onWindowFocusChanged", "onCursorEnterChanged"}, at = @At("HEAD"), cancellable = true)
+public abstract class WindowMixin implements WindowHooks {
+	@Shadow
+	private int x;
+	@Shadow
+	private int y;
+	@Shadow
+	private int windowedX;
+	@Shadow
+	private int windowedY;
+	@Shadow
+	private int width;
+	@Shadow
+	private int height;
+	@Shadow
+	private int windowedWidth;
+	@Shadow
+	private int windowedHeight;
+	@Shadow
+	private int framebufferWidth;
+	@Shadow
+	private int framebufferHeight;
+	@Shadow
+	private boolean fullscreen;
+	@Shadow
+	@Final
+	private WindowEventHandler eventHandler;
+	@Shadow
+	@Final
+	private MonitorTracker monitorTracker;
+	@Shadow
+	private Optional<VideoMode> fullscreenVideoMode;
+
+	@Shadow
+	protected abstract void updateWindowRegion();
+
+	@Unique
+	private int defaultWidth;
+	@Unique
+	private int defaultHeight;
+	@Unique
+	private int realWidth;
+	@Unique
+	private int realHeight;
+	@Unique
+	private int realFramebufferWidth;
+	@Unique
+	private int realFramebufferHeight;
+
+	@Inject(method = "<init>", at = @At("RETURN"))
+	private void onInit(WindowEventHandler eventHandler, MonitorTracker monitorTracker, WindowSettings settings, @Nullable String fullscreenVideoMode, String title, CallbackInfo ci) {
+		this.defaultWidth = settings.width;
+		this.defaultHeight = settings.height;
+		this.realWidth = this.width;
+		this.realHeight = this.height;
+		this.realFramebufferWidth = this.framebufferWidth;
+		this.realFramebufferHeight = this.framebufferHeight;
+
+		this.width = this.windowedWidth = this.framebufferWidth = defaultWidth;
+		this.height = this.windowedHeight = this.framebufferHeight = defaultHeight;
+	}
+
+	@Inject(method = {"onWindowFocusChanged", "onCursorEnterChanged", "onMinimizeChanged"}, at = @At("HEAD"), cancellable = true)
 	private void cancelEvents(CallbackInfo ci) {
 		ci.cancel();
+	}
+
+	@Inject(method = "onWindowSizeChanged", at = @At("HEAD"), cancellable = true)
+	private void cancelWindowSizeChanged(long window, int width, int height, CallbackInfo ci) {
+		realWidth = width;
+		realHeight = height;
+		ci.cancel();
+	}
+
+	@Inject(method = "onFramebufferSizeChanged", at = @At("HEAD"), cancellable = true)
+	private void cancelFramebufferSizeChanged(long window, int width, int height, CallbackInfo ci) {
+		realFramebufferWidth = width;
+		realFramebufferHeight = height;
+		ci.cancel();
+	}
+
+	@WrapMethod(method = "updateWindowRegion")
+	private void wrapUpdateWindowRegion(Operation<Void> original) {
+		int prevWidth = this.width;
+		int prevHeight = this.height;
+		int prevWindowedWidth = this.windowedWidth;
+		int prevWindowedHeight = this.windowedHeight;
+		int prevFramebufferWidth = this.framebufferWidth;
+		int prevFramebufferHeight = this.framebufferHeight;
+
+		original.call();
+
+		this.realWidth = this.width;
+		this.realHeight = this.height;
+		this.realFramebufferWidth = this.framebufferWidth;
+		this.realFramebufferHeight = this.framebufferHeight;
+
+		this.width = prevWidth;
+		this.height = prevHeight;
+		this.windowedWidth = prevWindowedWidth;
+		this.windowedHeight = prevWindowedHeight;
+		this.framebufferWidth = prevFramebufferWidth;
+		this.framebufferHeight = prevFramebufferHeight;
+	}
+
+	@Inject(method = "setWindowedSize", at = @At("HEAD"), cancellable = true)
+	private void setWindowedSize(int width, int height, CallbackInfo ci) {
+		this.fullscreen = false;
+		fabric_resize(width, height);
+		ci.cancel();
+	}
+
+	@Override
+	public int fabric_getRealWidth() {
+		return realWidth;
+	}
+
+	@Override
+	public int fabric_getRealHeight() {
+		return realHeight;
+	}
+
+	@Override
+	public int fabric_getRealFramebufferWidth() {
+		return realFramebufferWidth;
+	}
+
+	@Override
+	public int fabric_getRealFramebufferHeight() {
+		return realFramebufferHeight;
+	}
+
+	@Override
+	public void fabric_resetSize() {
+		fabric_resize(defaultWidth, defaultHeight);
+	}
+
+	@Override
+	public void fabric_resize(int width, int height) {
+		if (width == this.width && width == this.windowedWidth && width == this.framebufferWidth && height == this.height && height == this.windowedHeight && height == this.framebufferHeight) {
+			return;
+		}
+
+		// Move the top left corner of the window so that the window expands/contracts from its center, while also
+		// trying to keep the window within the monitor's bounds
+		Monitor monitor = this.monitorTracker.getMonitor((Window) (Object) this);
+
+		if (monitor != null) {
+			VideoMode videoMode = monitor.findClosestVideoMode(this.fullscreenVideoMode);
+
+			this.x += (this.windowedWidth - width) / 2;
+			this.y += (this.windowedHeight - height) / 2;
+
+			if (this.x + width > monitor.getViewportX() + videoMode.getWidth()) {
+				this.x = monitor.getViewportX() + videoMode.getWidth() - width;
+			}
+
+			if (this.x < monitor.getViewportX()) {
+				this.x = monitor.getViewportX();
+			}
+
+			if (this.y + height > monitor.getViewportY() + videoMode.getHeight()) {
+				this.y = monitor.getViewportY() + videoMode.getHeight() - height;
+			}
+
+			if (this.y < monitor.getViewportY()) {
+				this.y = monitor.getViewportY();
+			}
+
+			this.windowedX = this.x;
+			this.windowedY = this.y;
+		}
+
+		this.width = this.windowedWidth = this.framebufferWidth = width;
+		this.height = this.windowedHeight = this.framebufferHeight = height;
+
+		updateWindowRegion();
+		this.eventHandler.onResolutionChanged();
 	}
 }

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/gametest/WindowMixin.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/gametest/WindowMixin.java
@@ -205,8 +205,8 @@ public abstract class WindowMixin implements WindowHooks {
 			this.windowedY = this.y;
 		}
 
-		this.width = this.windowedWidth = width;
-		this.height = this.windowedHeight = height;
+		this.width = this.windowedWidth = this.framebufferWidth = width;
+		this.height = this.windowedHeight = this.framebufferHeight = height;
 
 		updateWindowRegion();
 		this.eventHandler.onResolutionChanged();

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/gametest/WindowMixin.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/gametest/WindowMixin.java
@@ -125,22 +125,16 @@ public abstract class WindowMixin implements WindowHooks {
 		int prevHeight = this.height;
 		int prevWindowedWidth = this.windowedWidth;
 		int prevWindowedHeight = this.windowedHeight;
-		int prevFramebufferWidth = this.framebufferWidth;
-		int prevFramebufferHeight = this.framebufferHeight;
 
 		original.call();
 
 		this.realWidth = this.width;
 		this.realHeight = this.height;
-		this.realFramebufferWidth = this.framebufferWidth;
-		this.realFramebufferHeight = this.framebufferHeight;
 
 		this.width = prevWidth;
 		this.height = prevHeight;
 		this.windowedWidth = prevWindowedWidth;
 		this.windowedHeight = prevWindowedHeight;
-		this.framebufferWidth = prevFramebufferWidth;
-		this.framebufferHeight = prevFramebufferHeight;
 	}
 
 	@Inject(method = "setWindowedSize", at = @At("HEAD"), cancellable = true)
@@ -211,8 +205,8 @@ public abstract class WindowMixin implements WindowHooks {
 			this.windowedY = this.y;
 		}
 
-		this.width = this.windowedWidth = this.framebufferWidth = width;
-		this.height = this.windowedHeight = this.framebufferHeight = height;
+		this.width = this.windowedWidth = width;
+		this.height = this.windowedHeight = height;
 
 		updateWindowRegion();
 		this.eventHandler.onResolutionChanged();

--- a/fabric-client-gametest-api-v1/src/client/resources/fabric-client-gametest-api-v1.mixins.json
+++ b/fabric-client-gametest-api-v1/src/client/resources/fabric-client-gametest-api-v1.mixins.json
@@ -26,6 +26,7 @@
     "ClientChunkMapAccessor",
     "ClientWorldAccessor",
     "CreateWorldScreenAccessor",
-    "CreateWorldScreenMixin"
+    "CreateWorldScreenMixin",
+    "RenderTickCounterConstantAccessor"
   ]
 }

--- a/fabric-client-gametest-api-v1/src/client/resources/fabric-client-gametest-api-v1.mixins.json
+++ b/fabric-client-gametest-api-v1/src/client/resources/fabric-client-gametest-api-v1.mixins.json
@@ -27,6 +27,8 @@
     "ClientWorldAccessor",
     "CreateWorldScreenAccessor",
     "CreateWorldScreenMixin",
+    "FramebufferMixin",
+    "MonitorTrackerMixin",
     "RenderTickCounterConstantAccessor"
   ]
 }

--- a/fabric-client-gametest-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/gametest/ClientGameTestTest.java
+++ b/fabric-client-gametest-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/gametest/ClientGameTestTest.java
@@ -56,6 +56,7 @@ public class ClientGameTestTest implements FabricClientGameTest {
 				context.waitTick();
 				context.getInput().typeChars("Hello, World!");
 				context.getInput().pressKey(InputUtil.GLFW_KEY_ENTER);
+				context.waitTick(); // wait for the server to receive the chat message
 				context.takeScreenshot("chat_message_sent");
 			}
 
@@ -70,6 +71,7 @@ public class ClientGameTestTest implements FabricClientGameTest {
 
 			{
 				context.getInput().pressKey(options -> options.inventoryKey);
+				context.waitTicks(2); // allow the client to process the key press, and then the server to receive the request
 				context.takeScreenshot("in_game_inventory");
 				context.setScreen(() -> null);
 			}

--- a/fabric-client-gametest-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/gametest/ClientGameTestTest.java
+++ b/fabric-client-gametest-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/gametest/ClientGameTestTest.java
@@ -37,7 +37,7 @@ public class ClientGameTestTest implements FabricClientGameTest {
 	public void runTest(ClientGameTestContext context) {
 		{
 			waitForTitleScreenFade(context);
-			context.takeScreenshot("title_screen", 0);
+			context.takeScreenshot("title_screen");
 		}
 
 		TestWorldSave spWorldSave;
@@ -48,7 +48,7 @@ public class ClientGameTestTest implements FabricClientGameTest {
 			{
 				enableDebugHud(context);
 				singleplayer.getClientWorld().waitForChunksRender();
-				context.takeScreenshot("in_game_overworld", 0);
+				context.takeScreenshot("in_game_overworld");
 			}
 
 			{
@@ -56,7 +56,7 @@ public class ClientGameTestTest implements FabricClientGameTest {
 				context.waitTick();
 				context.getInput().typeChars("Hello, World!");
 				context.getInput().pressKey(InputUtil.GLFW_KEY_ENTER);
-				context.takeScreenshot("chat_message_sent", 5);
+				context.takeScreenshot("chat_message_sent");
 			}
 
 			MixinEnvironment.getCurrentEnvironment().audit();
@@ -83,7 +83,7 @@ public class ClientGameTestTest implements FabricClientGameTest {
 		try (TestDedicatedServerContext server = context.worldBuilder().createServer()) {
 			try (TestServerConnection connection = server.connect()) {
 				connection.getClientWorld().waitForChunksRender();
-				context.takeScreenshot("server_in_game", 0);
+				context.takeScreenshot("server_in_game");
 
 				{ // Test that we can enter and exit configuration
 					final GameProfile profile = context.computeOnClient(MinecraftClient::getGameProfile);

--- a/fabric-client-gametest-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/gametest/ClientGameTestTest.java
+++ b/fabric-client-gametest-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/gametest/ClientGameTestTest.java
@@ -16,13 +16,20 @@
 
 package net.fabricmc.fabric.test.client.gametest;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import com.mojang.authlib.GameProfile;
 import org.spongepowered.asm.mixin.MixinEnvironment;
 
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gl.WindowFramebuffer;
 import net.minecraft.client.gui.screen.ReconfiguringScreen;
 import net.minecraft.client.gui.screen.world.WorldCreator;
 import net.minecraft.client.option.Perspective;
+import net.minecraft.client.texture.NativeImage;
 import net.minecraft.client.util.InputUtil;
 
 import net.fabricmc.fabric.api.client.gametest.v1.ClientGameTestContext;
@@ -38,6 +45,14 @@ public class ClientGameTestTest implements FabricClientGameTest {
 		{
 			waitForTitleScreenFade(context);
 			context.takeScreenshot("title_screen");
+		}
+
+		{
+			testScreenSize(context, WindowFramebuffer.DEFAULT_WIDTH, WindowFramebuffer.DEFAULT_HEIGHT);
+			context.getInput().resizeWindow(1000, 500);
+			context.waitTick();
+			testScreenSize(context, 1000, 500);
+			context.getInput().resizeWindow(WindowFramebuffer.DEFAULT_WIDTH, WindowFramebuffer.DEFAULT_HEIGHT);
 		}
 
 		TestWorldSave spWorldSave;
@@ -112,5 +127,27 @@ public class ClientGameTestTest implements FabricClientGameTest {
 
 	private static void setPerspective(ClientGameTestContext context, Perspective perspective) {
 		context.runOnClient(client -> client.options.setPerspective(perspective));
+	}
+
+	private static void testScreenSize(ClientGameTestContext context, int expectedWidth, int expectedHeight) {
+		context.runOnClient(client -> {
+			if (client.getWindow().getWidth() != expectedWidth || client.getWindow().getHeight() != expectedHeight) {
+				throw new AssertionError("Expected window size to be (%d, %d) but was (%d, %d)".formatted(expectedWidth, expectedHeight, client.getWindow().getWidth(), client.getWindow().getHeight()));
+			}
+
+			if (client.getWindow().getFramebufferWidth() != expectedWidth || client.getWindow().getFramebufferHeight() != expectedHeight) {
+				throw new AssertionError("Expected framebuffer size to be (%d, %d) but was (%d, %d)".formatted(expectedWidth, expectedHeight, client.getWindow().getFramebufferWidth(), client.getWindow().getFramebufferHeight()));
+			}
+		});
+
+		Path screenshotPath = context.takeScreenshot("screenshot_size_test");
+
+		try (NativeImage screenshot = NativeImage.read(Files.newInputStream(screenshotPath))) {
+			if (screenshot.getWidth() != expectedWidth || screenshot.getHeight() != expectedHeight) {
+				throw new AssertionError("Expected screenshot size to be (%d, %d) but was (%d, %d)".formatted(expectedWidth, expectedHeight, screenshot.getWidth(), screenshot.getHeight()));
+			}
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
 	}
 }


### PR DESCRIPTION
- Screenshots are now instant, you no longer have to wait a tick for them to render the current state.
   - The frame is re-rendered explicitly for the purpose of taking the screenshot. This allows us to set the `tickDelta` value to `1`, improving consistency.
   - The option to delay before taking a screenshot has been removed. You can still manually create a delay before a screenshot by using `context.waitTick()` and `context.waitTicks(delay)`.
   - This has exposed other footguns with client gametests, though. In some cases, the game needs to tick to be able to process an action, such as with some key binds which are polled, and when a packet needs to be sent to the server (which we have fixed to take exactly 1 tick in gametest singleplayer). To be able to see the effects of your actions, you may need to wait ticks before taking a screenshot. I have decided to not wait a tick before taking screenshots though, as this is observable in other ways than just this, and unlike before, the screenshots are a reflection of the real state of the game.
- Screenshots now add a counter prefix to their filename by default, so that they appear in the same order in the file explorer as they were taken.
- Added more configuration options to taking a screenshot:
   - Option to disable the counter prefix.
   - Option to change the `tickDelta` to something other than `1`.
   - Option to change the screenshot resolution.
   - Option to change the screenshot save directory.
- Consistent window sizes
   - The window size according to the game always starts at (854, 480) (or whatever is set in the command line options), regardless of if the window manager overrides the physical size of the window.
   - If the physical window is resized either by the user or window manager, this will not affect the game (e.g. how widgets are layed out in GUIs, the screenshot resolutions, etc). The content of the window may appear stretched to the user, but this does not affect screenshots.
   - Added a programmatic way to resize the window in a way that is visible to the game.
- Automated screenshot comparisons are left to a future PR.