### PR TITLE
[1.20.1] Fix overriding vanilla translations (Backport of #4187)

### DIFF
--- a/fabric-resource-loader-v0/src/testmod/java/net/fabricmc/fabric/test/resource/loader/LanguageTestMod.java
+++ b/fabric-resource-loader-v0/src/testmod/java/net/fabricmc/fabric/test/resource/loader/LanguageTestMod.java
@@ -27,6 +27,8 @@ public class LanguageTestMod implements DedicatedServerModInitializer {
 	}
 
 	private static void testTranslationLoaded() {
+		testTranslationLoaded("item.minecraft.potato", "Potato"); // Test that vanilla translation loads
+		testTranslationLoaded("text.fabric-resource-loader-v0-testmod.server.lang.override", "Vanilla override test");
 		testTranslationLoaded("pack.source.fabricmod", "Fabric mod");
 		testTranslationLoaded("text.fabric-resource-loader-v0-testmod.server.lang.test0", "Test from fabric-resource-loader-v0-testmod");
 		testTranslationLoaded("text.fabric-resource-loader-v0-testmod.server.lang.test1", "Test from fabric-resource-loader-v0-testmod-test1");

--- a/fabric-resource-loader-v0/src/testmod/resources/assets/minecraft/lang/en_us.json
+++ b/fabric-resource-loader-v0/src/testmod/resources/assets/minecraft/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+  "text.fabric-resource-loader-v0-testmod.server.lang.override": "Vanilla override test"
+}


### PR DESCRIPTION
This is a direct cherry pick of the changes made to 1.21.1 to 1.20.1. I've tested it with a modified copy of Pyrite for 1.20.1 that overrides the vanilla Crafting Table translation, and without this change server translations are completely overridden. As 1.20.1 is still a popular version, and this is bug was marked as high priority, I've opted to backport the fix.

(cherry picked from commit e82f21f7e92545027a4dec8081c1bcac860a8259)