### PR TITLE
Use a single datagen cache for all entrypoints.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,4 +78,7 @@ jobs:
           distribution: 'microsoft'
           java-version: '21'
       - run: ./gradlew generateResources --stacktrace --warning-mode=fail
-      - run: if [ -n "$(git status --porcelain)" ]; then exit 1; fi
+      - run: |
+          git add -A
+          git status
+          if [ -n "$(git status --porcelain)" ]; then exit 1; fi

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricDataGenerator.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricDataGenerator.java
@@ -36,7 +36,8 @@ import net.fabricmc.loader.api.ModContainer;
 /**
  * An extension to vanilla's {@link DataGenerator} providing mod specific data, and helper functions.
  */
-public final class FabricDataGenerator extends DataGenerator {
+@ApiStatus.NonExtendable
+public abstract class FabricDataGenerator extends DataGenerator {
 	private final ModContainer modContainer;
 	private final boolean strictValidation;
 	private final FabricDataOutput fabricOutput;

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataCache.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataCache.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.datagen;
+
+public interface FabricDataCache {
+	void fabric_prepare(FabricDataGeneratorImpl dataGenerator);
+}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGenHelper.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGenHelper.java
@@ -35,15 +35,13 @@ import com.mojang.logging.LogUtils;
 import com.mojang.serialization.JsonOps;
 import com.mojang.serialization.Lifecycle;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
-
-import net.minecraft.SharedConstants;
-import net.minecraft.data.DataCache;
-
 import org.apache.commons.lang3.ArrayUtils;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.minecraft.SharedConstants;
+import net.minecraft.data.DataCache;
 import net.minecraft.data.DataProvider;
 import net.minecraft.registry.BuiltinRegistries;
 import net.minecraft.registry.DynamicRegistryManager;
@@ -56,7 +54,6 @@ import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.util.Util;
 
 import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;
-import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
 import net.fabricmc.fabric.api.event.registry.DynamicRegistries;
 import net.fabricmc.fabric.api.resource.conditions.v1.ResourceCondition;
 import net.fabricmc.fabric.api.resource.conditions.v1.ResourceConditions;

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGeneratorImpl.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGeneratorImpl.java
@@ -16,16 +16,15 @@
 
 package net.fabricmc.fabric.impl.datagen;
 
-import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
-
-import net.fabricmc.loader.api.ModContainer;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import net.minecraft.data.DataCache;
 import net.minecraft.registry.RegistryWrapper;
 
-import java.nio.file.Path;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
+import net.fabricmc.loader.api.ModContainer;
 
 public class FabricDataGeneratorImpl extends FabricDataGenerator {
 	private final DataCache dataCache;

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGeneratorImpl.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGeneratorImpl.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.datagen;
+
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
+
+import net.fabricmc.loader.api.ModContainer;
+
+import net.minecraft.data.DataCache;
+import net.minecraft.registry.RegistryWrapper;
+
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+public class FabricDataGeneratorImpl extends FabricDataGenerator {
+	private final DataCache dataCache;
+	private final Set<String> providerNames;
+
+	public FabricDataGeneratorImpl(Path output, ModContainer mod, boolean strictValidation, CompletableFuture<RegistryWrapper.WrapperLookup> registriesFuture, DataCache dataCache, Set<String> providerNames) {
+		super(output, mod, strictValidation, registriesFuture);
+		this.dataCache = dataCache;
+		this.providerNames = providerNames;
+	}
+
+	public DataCache getDataCache() {
+		return dataCache;
+	}
+
+	public Set<String> getProviderNames() {
+		return providerNames;
+	}
+}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DataCacheCachedDataMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DataCacheCachedDataMixin.java
@@ -27,9 +27,11 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 
-@Mixin(targets = "net.minecraft.data.DataCache$CachedData")
+import net.minecraft.data.DataCache;
+
+@Mixin(DataCache.CachedData.class)
 public abstract class DataCacheCachedDataMixin {
-	@ModifyExpressionValue(method = "write", at = @At(value = "INVOKE", target = "Lcom/google/common/collect/ImmutableMap;entrySet()Lcom/google/common/collect/ImmutableSet;"))
+	@ModifyExpressionValue(method = "write", at = @At(value = "INVOKE", target = "Lcom/google/common/collect/ImmutableMap;entrySet()Lcom/google/common/collect/ImmutableSet;", remap = false))
 	private ImmutableSet<Map.Entry<Path, HashCode>> sortPaths(ImmutableSet<Map.Entry<Path, HashCode>> original) {
 		return original.stream()
 				.sorted(Map.Entry.comparingByKey(Comparator.comparing(k -> normalizePath(k.toString()))))

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DataCacheMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DataCacheMixin.java
@@ -16,20 +16,67 @@
 
 package net.fabricmc.fabric.mixin.datagen;
 
+import java.nio.file.Path;
 import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Set;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 import net.minecraft.data.DataCache;
 
+import net.fabricmc.fabric.impl.datagen.FabricDataCache;
+import net.fabricmc.fabric.impl.datagen.FabricDataGeneratorImpl;
+
 @Mixin(DataCache.class)
-public abstract class DataCacheMixin {
+abstract class DataCacheMixin implements FabricDataCache {
+	@Shadow
+	@Final
+	Set<Path> paths;
+
+	@Shadow
+	@Final
+	private Map<String, DataCache.CachedData> cachedDatas;
+
+	@Shadow
+	@Final
+	private Path root;
+
+	@Shadow
+	@Final
+	@Mutable
+	private int totalSize;
+
+	@Shadow
+	protected abstract Path getPath(String providerName);
+
+	@Shadow
+	private static DataCache.CachedData parseOrCreateCache(Path root, Path dataProviderPath) {
+		throw new IllegalStateException();
+	}
+
 	// Lambda in write()V
 	@Redirect(method = "method_46571", at = @At(value = "INVOKE", target = "Ljava/time/LocalDateTime;now()Ljava/time/LocalDateTime;"))
 	private LocalDateTime constantTime() {
 		// Write a constant time to the .cache file to ensure datagen output is reproducible
 		return LocalDateTime.MIN;
+	}
+
+	@Override
+	public void fabric_prepare(FabricDataGeneratorImpl dataGenerator) {
+		Set<String> providerNames = dataGenerator.getProviderNames();
+
+		for (String providerName : providerNames) {
+			Path path = getPath(providerName);
+			paths.add(path);
+			cachedDatas.put(providerName, parseOrCreateCache(root, path));
+		}
+
+		totalSize += providerNames.size();
 	}
 }

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DataGeneratorMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DataGeneratorMixin.java
@@ -34,7 +34,7 @@ import net.fabricmc.fabric.impl.datagen.FabricDataGeneratorImpl;
 public class DataGeneratorMixin {
 	@WrapOperation(method = "run", at = @At(value = "NEW", target = "(Ljava/nio/file/Path;Ljava/util/Collection;Lnet/minecraft/GameVersion;)Lnet/minecraft/data/DataCache;"))
 	private DataCache newDataCache(Path root, Collection<String> providerNames, GameVersion gameVersion, Operation<DataCache> original) {
-		if ((Object)(this) instanceof FabricDataGeneratorImpl fabricDataGenerator) {
+		if ((Object) (this) instanceof FabricDataGeneratorImpl fabricDataGenerator) {
 			return fabricDataGenerator.getDataCache();
 		}
 
@@ -43,7 +43,7 @@ public class DataGeneratorMixin {
 
 	@WrapOperation(method = "run", at = @At(value = "INVOKE", target = "Lnet/minecraft/data/DataCache;write()V"))
 	private void dataCacheWrite(DataCache instance, Operation<Void> original) {
-		if ((Object)(this) instanceof FabricDataGeneratorImpl) {
+		if ((Object) (this) instanceof FabricDataGeneratorImpl) {
 			// Skip this for now, we will run it for all data generators in FabricDataGenHelper
 			return;
 		}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DataGeneratorMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DataGeneratorMixin.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.datagen;
+
+import java.nio.file.Path;
+import java.util.Collection;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.GameVersion;
+import net.minecraft.data.DataCache;
+import net.minecraft.data.DataGenerator;
+
+import net.fabricmc.fabric.impl.datagen.FabricDataGeneratorImpl;
+
+@Mixin(DataGenerator.class)
+public class DataGeneratorMixin {
+	@WrapOperation(method = "run", at = @At(value = "NEW", target = "(Ljava/nio/file/Path;Ljava/util/Collection;Lnet/minecraft/GameVersion;)Lnet/minecraft/data/DataCache;"))
+	private DataCache newDataCache(Path root, Collection<String> providerNames, GameVersion gameVersion, Operation<DataCache> original) {
+		if ((Object)(this) instanceof FabricDataGeneratorImpl fabricDataGenerator) {
+			return fabricDataGenerator.getDataCache();
+		}
+
+		return original.call(root, providerNames, gameVersion);
+	}
+
+	@WrapOperation(method = "run", at = @At(value = "INVOKE", target = "Lnet/minecraft/data/DataCache;write()V"))
+	private void dataCacheWrite(DataCache instance, Operation<Void> original) {
+		if ((Object)(this) instanceof FabricDataGeneratorImpl) {
+			// Skip this for now, we will run it for all data generators in FabricDataGenHelper
+			return;
+		}
+
+		original.call(instance);
+	}
+}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DataGeneratorPackMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DataGeneratorPackMixin.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.datagen;
+
+import java.util.Set;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.data.DataGenerator;
+
+import net.fabricmc.fabric.impl.datagen.FabricDataGeneratorImpl;
+
+@Mixin(DataGenerator.Pack.class)
+public class DataGeneratorPackMixin {
+	@WrapOperation(method = "addProvider", at = @At(value = "FIELD", target = "Lnet/minecraft/data/DataGenerator;providerNames:Ljava/util/Set;"))
+	private Set<String> addProvider(DataGenerator instance, Operation<Set<String>> original) {
+		if ((Object)(instance) instanceof FabricDataGeneratorImpl fabricDataGenerator) {
+			return fabricDataGenerator.getProviderNames();
+		}
+
+		return original.call(instance);
+	}
+}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DataGeneratorPackMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/DataGeneratorPackMixin.java
@@ -31,7 +31,7 @@ import net.fabricmc.fabric.impl.datagen.FabricDataGeneratorImpl;
 public class DataGeneratorPackMixin {
 	@WrapOperation(method = "addProvider", at = @At(value = "FIELD", target = "Lnet/minecraft/data/DataGenerator;providerNames:Ljava/util/Set;"))
 	private Set<String> addProvider(DataGenerator instance, Operation<Set<String>> original) {
-		if ((Object)(instance) instanceof FabricDataGeneratorImpl fabricDataGenerator) {
+		if ((Object) (instance) instanceof FabricDataGeneratorImpl fabricDataGenerator) {
 			return fabricDataGenerator.getProviderNames();
 		}
 

--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.accesswidener
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.accesswidener
@@ -56,6 +56,8 @@ transitive-accessible class net/minecraft/client/data/BlockStateModelGenerator$C
 accessible class net/minecraft/client/data/ModelProvider$ItemAssets
 accessible class net/minecraft/client/data/ModelProvider$BlockStateSuppliers
 
+accessible class net/minecraft/data/DataCache$CachedData
+
 ### Generated access wideners below
 
 transitive-accessible	method	net/minecraft/data/recipe/RecipeGenerator	generate	()V

--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
@@ -5,6 +5,8 @@
   "mixins": [
     "DataCacheCachedDataMixin",
     "DataCacheMixin",
+    "DataGeneratorMixin",
+    "DataGeneratorPackMixin",
     "DataProviderMixin",
     "TagBuilderMixin",
     "TagProviderMixin",

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorEmptyTestEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorEmptyTestEntrypoint.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.test.datagen;
 
 import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorEmptyTestEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorEmptyTestEntrypoint.java
@@ -1,0 +1,11 @@
+package net.fabricmc.fabric.test.datagen;
+
+import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
+
+public class DataGeneratorEmptyTestEntrypoint implements DataGeneratorEntrypoint {
+	@Override
+	public void onInitializeDataGenerator(FabricDataGenerator dataGenerator) {
+		final FabricDataGenerator.Pack pack = dataGenerator.createPack();
+	}
+}

--- a/fabric-data-generation-api-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-data-generation-api-v1/src/testmod/resources/fabric.mod.json
@@ -12,7 +12,8 @@
       "net.fabricmc.fabric.test.datagen.DataGeneratorTestContent"
     ],
     "fabric-datagen": [
-      "net.fabricmc.fabric.test.datagen.DataGeneratorTestEntrypoint"
+      "net.fabricmc.fabric.test.datagen.DataGeneratorTestEntrypoint",
+      "net.fabricmc.fabric.test.datagen.DataGeneratorEmptyTestEntrypoint"
     ]
   }
 }

--- a/fabric-data-generation-api-v1/template.accesswidener
+++ b/fabric-data-generation-api-v1/template.accesswidener
@@ -51,4 +51,6 @@ transitive-accessible class net/minecraft/client/data/BlockStateModelGenerator$C
 accessible class net/minecraft/client/data/ModelProvider$ItemAssets
 accessible class net/minecraft/client/data/ModelProvider$BlockStateSuppliers
 
+accessible class net/minecraft/data/DataCache$CachedData
+
 ### Generated access wideners below


### PR DESCRIPTION
This should allow mods to have multiple datagenerator entrypoints.

Fixes #4330

Draft as I need to properly test it.