### PR TITLE
Implement toString() for materials to help with debugging

### DIFF
--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/material/MaterialFinderImpl.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/material/MaterialFinderImpl.java
@@ -109,4 +109,9 @@ public class MaterialFinderImpl extends MaterialViewImpl implements MaterialFind
 	public RenderMaterial find() {
 		return RenderMaterialImpl.byIndex(bits);
 	}
+
+	@Override
+	public String toString() {
+		return "MaterialFinderImpl{" + contentsToString() + "}";
+	}
 }

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/material/MaterialViewImpl.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/material/MaterialViewImpl.java
@@ -18,6 +18,8 @@ package net.fabricmc.fabric.impl.client.indigo.renderer.material;
 
 import static net.fabricmc.fabric.impl.client.indigo.renderer.mesh.EncodingFormat.bitMask;
 
+import java.util.Locale;
+
 import net.minecraft.util.math.MathHelper;
 
 import net.fabricmc.fabric.api.renderer.v1.material.BlendMode;
@@ -110,5 +112,19 @@ public class MaterialViewImpl implements MaterialView {
 	@Override
 	public ShadeMode shadeMode() {
 		return SHADE_MODES[(bits & SHADE_MODE_MASK) >>> SHADE_MODE_BIT_OFFSET];
+	}
+
+	/**
+	 * Returns a string representation of the material properties.
+	 * To be used in {@link #toString} overrides so they show in the debugger.
+	 */
+	String contentsToString() {
+		return String.format("blend=%s, emissive=%b, disable diffuse=%b, ao=%s, glint=%s, shade=%s",
+				blendMode().toString().toLowerCase(Locale.ROOT),
+				emissive(),
+				disableDiffuse(),
+				ambientOcclusion().toString().toLowerCase(Locale.ROOT),
+				glintMode().toString().toLowerCase(Locale.ROOT),
+				shadeMode().toString().toLowerCase(Locale.ROOT));
 	}
 }

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/material/RenderMaterialImpl.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/material/RenderMaterialImpl.java
@@ -38,6 +38,11 @@ public class RenderMaterialImpl extends MaterialViewImpl implements RenderMateri
 		return bits;
 	}
 
+	@Override
+	public String toString() {
+		return "RenderMaterialImpl{" + contentsToString() + "}";
+	}
+
 	public static RenderMaterialImpl byIndex(int index) {
 		return BY_INDEX[index];
 	}


### PR DESCRIPTION
Example:
![image](https://github.com/user-attachments/assets/f423343d-8061-403a-81f5-f2da76db2489)

Without this PR only the `bits` are showed. Overriding `toString()` allows all of the properties to be seen at a glance.