### PR TITLE
Fix `MutableQuadViewImpl#fromVanilla` methods not setting correct normal flags

### DIFF
--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
@@ -300,6 +300,8 @@ public interface MutableQuadView extends QuadView {
 	 * <p>The {@linkplain BakedQuad#getLightEmission() baked quad's light emission} will be applied to the lightmap
 	 * values from the vertex data after copying.
 	 *
+	 * <p>Calling this method resets the {@link #tag()}.
+	 *
 	 * <p>Calling this method does not emit the quad.
 	 */
 	MutableQuadView fromVanilla(BakedQuad quad, RenderMaterial material, @Nullable Direction cullFace);

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
@@ -213,20 +213,30 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 		System.arraycopy(quadData, startIndex, data, baseIndex + HEADER_STRIDE, VANILLA_QUAD_STRIDE);
 		isGeometryInvalid = true;
 
+		int normalFlags = 0;
 		int colorIndex = baseIndex + VERTEX_COLOR;
+		int normalIndex = baseIndex + VERTEX_NORMAL;
 
 		for (int i = 0; i < 4; i++) {
 			data[colorIndex] = ColorHelper.fromVanillaColor(data[colorIndex]);
+
+			// Set normal flag if normal is not zero, ignoring W component
+			if ((data[normalIndex] & 0xFFFFFF) != 0) {
+				normalFlags |= 1 << i;
+			}
+
 			colorIndex += VERTEX_STRIDE;
+			normalIndex += VERTEX_STRIDE;
 		}
 
+		normalFlags(normalFlags);
 		return this;
 	}
 
 	@Override
 	public final MutableQuadViewImpl fromVanilla(BakedQuad quad, RenderMaterial material, @Nullable Direction cullFace) {
 		fromVanilla(quad.getVertexData(), 0);
-		data[baseIndex + HEADER_BITS] = EncodingFormat.cullFace(0, cullFace);
+		cullFace(cullFace);
 		nominalFace(quad.getFace());
 		tintIndex(quad.getTintIndex());
 


### PR DESCRIPTION
- The `(int[], int)` overload used to keep the normal flags as is
- The `(BakedQuad, RenderMaterial, Direction)` overload used to reset all normal flags
- The normal flag for a vertex is now set if and only if the normal is not zero, ignoring the W component
- Clarify that `MutableQuadView#fromVanilla(BakedQuad, ...)` resets the quad tag