### PR TITLE
Add `c:seeds/pitcher_plant` and add Pitcher Pods to `c:seeds`

### DIFF
--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/EnglishTagLangGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/EnglishTagLangGenerator.java
@@ -399,6 +399,7 @@ public class EnglishTagLangGenerator extends FabricLanguageProvider {
 		translationBuilder.add(ConventionalItemTags.MELON_SEEDS, "Melon Seeds");
 		translationBuilder.add(ConventionalItemTags.PUMPKIN_SEEDS, "Pumpkin Seeds");
 		translationBuilder.add(ConventionalItemTags.TORCHFLOWER_SEEDS, "Torchflower Seeds");
+		translationBuilder.add(ConventionalItemTags.PITCHER_PLANT_SEEDS, "Pitcher Plant Seeds");
 		translationBuilder.add(ConventionalItemTags.WHEAT_SEEDS, "Wheat Seeds");
 		translationBuilder.add(ConventionalItemTags.PLAYER_WORKSTATIONS_CRAFTING_TABLES, "Crafting Tables");
 		translationBuilder.add(ConventionalItemTags.PLAYER_WORKSTATIONS_FURNACES, "Furnaces");

--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/ItemTagGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/ItemTagGenerator.java
@@ -767,6 +767,7 @@ public final class ItemTagGenerator extends FabricTagProvider.ItemTagProvider {
 				.addOptionalTag(ConventionalItemTags.MELON_SEEDS)
 				.addOptionalTag(ConventionalItemTags.PUMPKIN_SEEDS)
 				.addOptionalTag(ConventionalItemTags.TORCHFLOWER_SEEDS)
+				.addOptionalTag(ConventionalItemTags.PITCHER_PLANT_SEEDS)
 				.addOptionalTag(ConventionalItemTags.WHEAT_SEEDS);
 		getOrCreateTagBuilder(ConventionalItemTags.BEETROOT_SEEDS)
 				.add(Items.BEETROOT_SEEDS);
@@ -776,6 +777,8 @@ public final class ItemTagGenerator extends FabricTagProvider.ItemTagProvider {
 				.add(Items.PUMPKIN_SEEDS);
 		getOrCreateTagBuilder(ConventionalItemTags.TORCHFLOWER_SEEDS)
 				.add(Items.TORCHFLOWER_SEEDS);
+		getOrCreateTagBuilder(ConventionalItemTags.PITCHER_PLANT_SEEDS)
+				.add(Items.PITCHER_POD);
 		getOrCreateTagBuilder(ConventionalItemTags.WHEAT_SEEDS)
 				.add(Items.WHEAT_SEEDS);
 	}

--- a/fabric-convention-tags-v2/src/generated/resources/assets/fabric-convention-tags-v2/lang/en_us.json
+++ b/fabric-convention-tags-v2/src/generated/resources/assets/fabric-convention-tags-v2/lang/en_us.json
@@ -352,6 +352,7 @@
   "tag.item.c.seeds": "Seeds",
   "tag.item.c.seeds.beetroot": "Beetroot Seeds",
   "tag.item.c.seeds.melon": "Melon Seeds",
+  "tag.item.c.seeds.pitcher_plant": "Pitcher Plant Seeds",
   "tag.item.c.seeds.pumpkin": "Pumpkin Seeds",
   "tag.item.c.seeds.torchflower": "Torchflower Seeds",
   "tag.item.c.seeds.wheat": "Wheat Seeds",

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/seeds.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/seeds.json
@@ -17,6 +17,10 @@
       "required": false
     },
     {
+      "id": "#c:seeds/pitcher_plant",
+      "required": false
+    },
+    {
       "id": "#c:seeds/wheat",
       "required": false
     }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/seeds/pitcher_plant.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/seeds/pitcher_plant.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:pitcher_pod"
+  ]
+}

--- a/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalItemTags.java
+++ b/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalItemTags.java
@@ -447,6 +447,7 @@ public final class ConventionalItemTags {
 	public static final TagKey<Item> MELON_SEEDS = register("seeds/melon");
 	public static final TagKey<Item> PUMPKIN_SEEDS = register("seeds/pumpkin");
 	public static final TagKey<Item> TORCHFLOWER_SEEDS = register("seeds/torchflower");
+	public static final TagKey<Item> PITCHER_PLANT_SEEDS = register("seeds/pitcher_plant");
 	public static final TagKey<Item> WHEAT_SEEDS = register("seeds/wheat");
 
 	// Other


### PR DESCRIPTION
NeoForge PR: https://github.com/neoforged/NeoForge/pull/1860

With the seeds tag already including Torchflower seeds, Pitcher Pods should also be considered seeds, as they are only used as seeds to grow Pitcher Plants. 

This PR adds a `c:seeds/pitcher_plant` tag include Pitcher Pods, which is included by `c:seeds`.