### PR TITLE
Fix syncing block entity attachments on load.

### DIFF
--- a/fabric-data-attachment-api-v1/build.gradle
+++ b/fabric-data-attachment-api-v1/build.gradle
@@ -12,5 +12,6 @@ testDependencies(project, [
 	':fabric-biome-api-v1',
 	':fabric-command-api-v2',
 	':fabric-rendering-v1',
-	':fabric-client-gametest-api-v1'
+	':fabric-client-gametest-api-v1',
+	':fabric-events-interaction-v0',
 ])

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
@@ -28,6 +28,7 @@ import org.spongepowered.asm.mixin.Unique;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.Entity;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.registry.DynamicRegistryManager;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.world.World;
@@ -100,7 +101,7 @@ abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
 		if (this.fabric_shouldTryToSync() && this.fabric_dataAttachments != null) {
 			this.fabric_dataAttachments.forEach((type, value) -> {
 				if (type.isSynced()) {
-					acknowledgeSynced(type, value);
+					acknowledgeSynced(type, value, wrapperLookup);
 				}
 			});
 		}
@@ -117,8 +118,9 @@ abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
 	}
 
 	@Unique
-	private void acknowledgeSynced(AttachmentType<?> type, Object value) {
-		acknowledgeSyncedEntry(type, AttachmentChange.create(fabric_getSyncTargetInfo(), type, value, fabric_getDynamicRegistryManager()));
+	private void acknowledgeSynced(AttachmentType<?> type, Object value, RegistryWrapper.WrapperLookup wrapperLookup) {
+		DynamicRegistryManager dynamicRegistryManager = (wrapperLookup instanceof DynamicRegistryManager drm) ? drm : fabric_getDynamicRegistryManager();
+		acknowledgeSyncedEntry(type, AttachmentChange.create(fabric_getSyncTargetInfo(), type, value, dynamicRegistryManager));
 	}
 
 	@Unique

--- a/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
+++ b/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
@@ -20,12 +20,16 @@ import com.mojang.serialization.Codec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.network.codec.PacketCodecs;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
+import net.minecraft.text.Text;
+import net.minecraft.util.ActionResult;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.gen.GenerationStep;
 import net.minecraft.world.gen.feature.DefaultFeatureConfig;
@@ -36,6 +40,7 @@ import net.fabricmc.fabric.api.attachment.v1.AttachmentSyncPredicate;
 import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
 import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
 import net.fabricmc.fabric.api.biome.v1.BiomeSelectors;
+import net.fabricmc.fabric.api.event.player.UseBlockCallback;
 
 public class AttachmentTestMod implements ModInitializer {
 	public static final String MOD_ID = "fabric-data-attachment-api-v1-testmod";
@@ -92,5 +97,18 @@ public class AttachmentTestMod implements ModInitializer {
 				GenerationStep.Feature.VEGETAL_DECORATION,
 				RegistryKey.of(RegistryKeys.PLACED_FEATURE, Identifier.of(MOD_ID, "set_attachment"))
 		);
+
+		UseBlockCallback.EVENT.register((player, world, hand, hitResult) -> {
+			if (player.getStackInHand(hand).getItem() == Items.CARROT) {
+				BlockEntity blockEntity = world.getBlockEntity(hitResult.getBlockPos());
+
+				if (blockEntity != null) {
+					blockEntity.setAttached(SYNCED_WITH_ALL, true);
+					player.sendMessage(Text.literal("Attached"), false);
+				}
+			}
+
+			return ActionResult.PASS;
+		});
 	}
 }

--- a/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
+++ b/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
@@ -105,6 +105,7 @@ public class AttachmentTestMod implements ModInitializer {
 				if (blockEntity != null) {
 					blockEntity.setAttached(SYNCED_WITH_ALL, true);
 					player.sendMessage(Text.literal("Attached"), false);
+					return ActionResult.SUCCESS;
 				}
 			}
 


### PR DESCRIPTION
Not the cleanest change, but should do the job no worse than before.

Closes #4389

Needs backporting to 1.21.1