### PR TITLE
Fix AFTER_ENTITY_CHANGE_WORLD being invoked for entities teleporting within the same world.

### DIFF
--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/EntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/EntityMixin.java
@@ -16,11 +16,11 @@
 
 package net.fabricmc.fabric.mixin.entity.event;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.server.world.ServerWorld;
@@ -34,13 +34,15 @@ abstract class EntityMixin {
 	@Shadow
 	private World world;
 
-	@Inject(method = "teleportTo", at = @At("RETURN"))
-	private void afterWorldChanged(TeleportTarget target, CallbackInfoReturnable<Entity> cir) {
+	@WrapOperation(method = "teleportTo", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;teleportCrossDimension(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/world/TeleportTarget;)Lnet/minecraft/entity/Entity;"))
+	private Entity afterWorldChanged(Entity instance, ServerWorld targetWorld, TeleportTarget teleportTarget, Operation<Entity> original) {
 		// Ret will only have an entity if the teleport worked (entity not removed, teleportTarget was valid, entity was successfully created)
-		Entity ret = cir.getReturnValue();
+		Entity ret = original.call(instance, targetWorld, teleportTarget);
 
 		if (ret != null) {
 			ServerEntityWorldChangeEvents.AFTER_ENTITY_CHANGE_WORLD.invoker().afterChangeWorld((Entity) (Object) this, ret, (ServerWorld) this.world, (ServerWorld) ret.getWorld());
 		}
+
+		return ret;
 	}
 }


### PR DESCRIPTION
Fix `ServerEntityWorldChangeEvents.AFTER_ENTITY_CHANGE_WORLD` being invoked for entities teleporting within the same world.