### PR TITLE
Fix Client Registry Remapping Only Remapping One Registry

### DIFF
--- a/fabric-registry-sync-v0/src/client/java/net/fabricmc/fabric/impl/client/registry/sync/ClientRegistrySyncHandler.java
+++ b/fabric-registry-sync-v0/src/client/java/net/fabricmc/fabric/impl/client/registry/sync/ClientRegistrySyncHandler.java
@@ -105,10 +105,9 @@ public final class ClientRegistrySyncHandler {
 
 			if (registry instanceof RemappableRegistry remappableRegistry) {
 				remappableRegistry.remap(entry.getValue(), RemappableRegistry.RemapMode.REMOTE);
-				return;
+			} else {
+				throw new RemapException("Registry " + registryId + " is not remappable");
 			}
-
-			throw new RemapException("Registry " + registryId + " is not remappable");
 		}
 	}
 

--- a/fabric-registry-sync-v0/src/client/java/net/fabricmc/fabric/impl/client/registry/sync/ClientRegistrySyncHandler.java
+++ b/fabric-registry-sync-v0/src/client/java/net/fabricmc/fabric/impl/client/registry/sync/ClientRegistrySyncHandler.java
@@ -103,11 +103,11 @@ public final class ClientRegistrySyncHandler {
 				}
 			}
 
-			if (registry instanceof RemappableRegistry remappableRegistry) {
-				remappableRegistry.remap(entry.getValue(), RemappableRegistry.RemapMode.REMOTE);
-			} else {
+			if (!(registry instanceof RemappableRegistry remappableRegistry)) {
 				throw new RemapException("Registry " + registryId + " is not remappable");
 			}
+
+			remappableRegistry.remap(entry.getValue(), RemappableRegistry.RemapMode.REMOTE);
 		}
 	}
 


### PR DESCRIPTION
- return was used instead of continue, causing only the last modified registry to sync to the client.
Fix is simply using an if-else statement instead of calling return within the if statement.