### PR TITLE
Rename "data" and "network" codecs to "server" and "client" codecs

### DIFF
--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/DynamicRegistries.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/DynamicRegistries.java
@@ -131,17 +131,22 @@ public final class DynamicRegistries {
 	 * <p>The entries of the registry will be loaded from data packs at the file path
 	 * {@code data/<entry namespace>/<registry namespace>/<registry path>/<entry path>.json}
 	 *
-	 * <p>The registry will be synced from the server to players' clients using the given network codec.
+	 * <p>The registry will be synced from the server to players' clients using the given client codec.
+	 * The client codec is also used for writing synced entries on the server, so it cannot depend on
+	 * client-only code.
+	 *
+	 * <p>The client codec must be able to read data encoded by the server codec.
+	 * This is because client-sided registry entries are sometimes read directly from a data pack using the client codec.
 	 *
 	 * @param key          the unique key of the registry
-	 * @param dataCodec    the codec used to load registry entries from data packs
-	 * @param networkCodec the codec used to load registry entries from the network
+	 * @param serverCodec  the codec used to load registry entries on the server
+	 * @param clientCodec  the codec used to load registry entries on the client and sync them from the server
 	 * @param options      options to configure syncing
 	 * @param <T>          the entry type of the registry
 	 */
-	public static <T> void registerSynced(RegistryKey<? extends Registry<T>> key, Codec<T> dataCodec, Codec<T> networkCodec, SyncOption... options) {
-		DynamicRegistriesImpl.register(key, dataCodec);
-		DynamicRegistriesImpl.addSyncedRegistry(key, networkCodec, options);
+	public static <T> void registerSynced(RegistryKey<? extends Registry<T>> key, Codec<T> serverCodec, Codec<T> clientCodec, SyncOption... options) {
+		DynamicRegistriesImpl.register(key, serverCodec);
+		DynamicRegistriesImpl.addSyncedRegistry(key, clientCodec, options);
 	}
 
 	/**

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/DynamicRegistriesImpl.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/DynamicRegistriesImpl.java
@@ -51,30 +51,30 @@ public final class DynamicRegistriesImpl {
 		return List.copyOf(DYNAMIC_REGISTRIES);
 	}
 
-	public static <T> RegistryLoader.Entry<T> register(RegistryKey<? extends Registry<T>> key, Codec<T> codec) {
+	public static <T> RegistryLoader.Entry<T> register(RegistryKey<? extends Registry<T>> key, Codec<T> serverCodec) {
 		Objects.requireNonNull(key, "Registry key cannot be null");
-		Objects.requireNonNull(codec, "Codec cannot be null");
+		Objects.requireNonNull(serverCodec, "Server codec cannot be null");
 
 		if (!DYNAMIC_REGISTRY_KEYS.add(key)) {
 			throw new IllegalArgumentException("Dynamic registry " + key + " has already been registered!");
 		}
 
-		var entry = new RegistryLoader.Entry<>(key, codec, false);
+		var entry = new RegistryLoader.Entry<>(key, serverCodec, false);
 		DYNAMIC_REGISTRIES.add(entry);
 		FABRIC_DYNAMIC_REGISTRY_KEYS.add(key);
 		return entry;
 	}
 
-	public static <T> void addSyncedRegistry(RegistryKey<? extends Registry<T>> key, Codec<T> networkCodec, DynamicRegistries.SyncOption... options) {
+	public static <T> void addSyncedRegistry(RegistryKey<? extends Registry<T>> key, Codec<T> clientCodec, DynamicRegistries.SyncOption... options) {
 		Objects.requireNonNull(key, "Registry key cannot be null");
-		Objects.requireNonNull(networkCodec, "Network codec cannot be null");
+		Objects.requireNonNull(clientCodec, "Client codec cannot be null");
 		Objects.requireNonNull(options, "Options cannot be null");
 
 		if (!(RegistryLoader.SYNCED_REGISTRIES instanceof ArrayList<RegistryLoader.Entry<?>>)) {
 			RegistryLoader.SYNCED_REGISTRIES = new ArrayList<>(RegistryLoader.SYNCED_REGISTRIES);
 		}
 
-		RegistryLoader.SYNCED_REGISTRIES.add(new RegistryLoader.Entry<>(key, networkCodec, false));
+		RegistryLoader.SYNCED_REGISTRIES.add(new RegistryLoader.Entry<>(key, clientCodec, false));
 
 		if (!(SerializableRegistries.SYNCED_REGISTRIES instanceof HashSet<RegistryKey<? extends Registry<?>>>)) {
 			SerializableRegistries.SYNCED_REGISTRIES = new HashSet<>(SerializableRegistries.SYNCED_REGISTRIES);


### PR DESCRIPTION
The sided names avoid confusing modders into thinking that the client codec is only used for syncing since it also reads data pack contents.

However, it also implies that the client codec is only used on the client (while the server also uses the encoder for network purposes), so I'm not sure if the new names are perfect either. On the other hand, "`serverDataPackCodec`" and "`networkAndClientDataPackCodec`" are accurate but way too verbose.