### PR TITLE
Add a method for overriding modelId in item settings.

### DIFF
--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
@@ -22,6 +22,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.Hand;
+import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.impl.item.FabricItemInternals;
 
@@ -141,6 +142,16 @@ public interface FabricItem {
 		 */
 		default Item.Settings customDamage(CustomDamageHandler handler) {
 			FabricItemInternals.computeExtraData((Item.Settings) this).customDamage(handler);
+			return (Item.Settings) this;
+		}
+
+		/**
+		 * Sets the model of the item to static Identifier.
+		 *
+		 * @param modelId the model id item should use
+		 * @return this builder
+		 */
+		default Item.Settings modelId(Identifier modelId) {
 			return (Item.Settings) this;
 		}
 	}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemSettingsMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemSettingsMixin.java
@@ -17,11 +17,22 @@
 package net.fabricmc.fabric.mixin.item;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 
 import net.minecraft.item.Item;
+import net.minecraft.registry.RegistryKeyedValue;
+import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.api.item.v1.FabricItem;
 
 @Mixin(Item.Settings.class)
 public class ItemSettingsMixin implements FabricItem.Settings {
+	@Shadow
+	private RegistryKeyedValue<Item, Identifier> modelId;
+
+	@Override
+	public Item.Settings modelId(Identifier modelId) {
+		this.modelId = RegistryKeyedValue.fixed(modelId);
+		return FabricItem.Settings.super.modelId(modelId);
+	}
 }

--- a/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/CustomModelIdTest.java
+++ b/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/CustomModelIdTest.java
@@ -16,14 +16,14 @@
 
 package net.fabricmc.fabric.test.item;
 
-import net.fabricmc.api.ModInitializer;
-
-import net.minecraft.item.*;
+import net.minecraft.item.Item;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.util.Identifier;
+
+import net.fabricmc.api.ModInitializer;
 
 public class CustomModelIdTest implements ModInitializer {
 	public static final RegistryKey<Item> NOT_A_DIAMOND_KEY = RegistryKey.of(RegistryKeys.ITEM, Identifier.of("fabric-item-api-v1-testmod", "not_a_diamond"));

--- a/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/CustomModelIdTest.java
+++ b/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/CustomModelIdTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.item;
+
+import net.fabricmc.api.ModInitializer;
+
+import net.minecraft.item.*;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.util.Identifier;
+
+public class CustomModelIdTest implements ModInitializer {
+	public static final RegistryKey<Item> NOT_A_DIAMOND_KEY = RegistryKey.of(RegistryKeys.ITEM, Identifier.of("fabric-item-api-v1-testmod", "not_a_diamond"));
+	public static final Item NOT_A_DIAMOND = new Item(new Item.Settings().registryKey(NOT_A_DIAMOND_KEY).modelId(Identifier.ofVanilla("diamond")));
+
+	@Override
+	public void onInitialize() {
+		Registry.register(Registries.ITEM, NOT_A_DIAMOND_KEY, NOT_A_DIAMOND);
+	}
+}

--- a/fabric-item-api-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-item-api-v1/src/testmod/resources/fabric.mod.json
@@ -12,6 +12,7 @@
     "main": [
       "net.fabricmc.fabric.test.item.CustomDamageTest",
       "net.fabricmc.fabric.test.item.DefaultItemComponentTest",
+      "net.fabricmc.fabric.test.item.CustomModelIdTest",
       "net.fabricmc.fabric.test.item.ItemUpdateAnimationTest",
       "net.fabricmc.fabric.test.item.ArmorKnockbackResistanceTest",
       "net.fabricmc.fabric.test.item.CustomEnchantmentEffectsTest"


### PR DESCRIPTION
Pretty simple addition. This method existed in 1.21.2, but got removed by Mojang for some reason, leaving no way to modify the item model it created by Item.Settings (without using an accessor that is).

![2025-02-08_20 37 46](https://github.com/user-attachments/assets/cee5ffdc-c84e-4c89-9dbd-9040cb58ebca)
