### PR TITLE
Remove grgit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,11 +6,11 @@ jobs:
       matrix:
         java: [21-ubuntu]
     runs-on: ubuntu-22.04
-    container:
-      image: mcr.microsoft.com/openjdk/jdk:${{ matrix.java }}
-      options: --user root
     steps:
-      - run: apt update && apt install git -y && git --version
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'microsoft'
+          java-version: '21'
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: Maven Local ${{ matrix.java }}
-          path: /root/.m2/repository/net/fabricmc/
+          path: ~/.m2/repository/net/fabricmc/
 
   client_test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: gradle/wrapper-validation-action@v2
-      - run: ./gradlew check build publishToMavenLocal --stacktrace
+      - run: ./gradlew check build :buildSrc:check publishToMavenLocal --stacktrace
       - uses: Juuxel/publish-checkstyle-report@v1
         if: ${{ failure() }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,11 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-22.04
-    container:
-      image: mcr.microsoft.com/openjdk/jdk:21-ubuntu
-      options: --user root
     steps:
-      - run: apt update && apt install git -y && git --version
-      - run: git config --global --add safe.directory /__w/fabric/fabric
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'microsoft'
+          java-version: '21'
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ $RECYCLE.BIN/
 
 # Mac
 .DS_Store
+
+!/buildSrc/src/**

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,7 @@
 plugins {
 	id "java-library"
 	id "eclipse"
-	id "idea"
 	id "maven-publish"
-	id 'jacoco'
 	id "fabric-loom" version "1.9.2" apply false
 	id "com.diffplug.spotless" version "6.20.0"
 	id "org.ajoberstar.grgit" version "5.2.2"
@@ -13,7 +11,8 @@ plugins {
 
 def ENV = System.getenv()
 
-version = project.version + "+" + (ENV.GITHUB_RUN_NUMBER ? "" : "local-") + getBranch()
+def branchProvider = providers.of(GitBranchValueSource.class) {}
+version = project.version + "+" + (ENV.MAVEN_URL ? "" : "local-") + branchProvider.get()
 logger.lifecycle("Building Fabric: " + version)
 
 def metaProjects = [
@@ -29,9 +28,10 @@ def debugArgs = [
 	"-Dmixin.debug.countInjections=true",
 ]
 
-import net.fabricmc.loom.util.gradle.SourceSetHelper
 import groovy.json.JsonSlurper
 import org.apache.commons.codec.digest.DigestUtils
+import net.fabricmc.fabric.impl.build.CommitHashValueSource
+import net.fabricmc.fabric.impl.build.GitBranchValueSource
 
 def getSubprojectVersion(project) {
 	// Get the version from the gradle.properties file
@@ -41,32 +41,10 @@ def getSubprojectVersion(project) {
 		throw new NullPointerException("Could not find version for " + project.name)
 	}
 
-	if (grgit == null) {
-		return version + "+nogit"
+	def hashProvider = project.providers.of(CommitHashValueSource.class) {
+		parameters.directory = project.name
 	}
-
-	def latestCommits = grgit.log(paths: [project.name], maxCommits: 1)
-
-	if (latestCommits.isEmpty()) {
-		return version + "+uncommited"
-	}
-
-	return version + "+" + latestCommits.get(0).id.substring(0, 8) + DigestUtils.sha256Hex(project.rootProject.minecraft_version).substring(0, 2)
-}
-
-def getBranch() {
-	def ENV = System.getenv()
-	if (ENV.GITHUB_REF) {
-		def branch = ENV.GITHUB_REF
-		return branch.substring(branch.lastIndexOf("/") + 1)
-	}
-
-	if (grgit == null) {
-		return "unknown"
-	}
-
-	def branch = grgit.branch.current().name
-	return branch.substring(branch.lastIndexOf("/") + 1)
+	return version + "+" + hashProvider.get().substring(0, 8) + DigestUtils.sha256Hex(project.rootProject.minecraft_version).substring(0, 2)
 }
 
 def moduleDependencies(project, List<String> depNames) {
@@ -432,19 +410,6 @@ loom {
 			vmArg "-Dfabric-tag-conventions-v2.missingTagTranslationWarning=fail"
 			vmArg "-Dfabric-tag-conventions-v1.legacyTagWarning=fail"
 		}
-
-		// Create duplicate tasks for this, as jacoco slows things down a bit
-		gametestCoverage {
-			inherit gametest
-			name "Game Test Coverage"
-			ideConfigGenerated = false
-		}
-
-		clientGametestCoverage {
-			inherit clientGametest
-			name "Client Game Test Coverage"
-			ideConfigGenerated = false
-		}
 	}
 }
 
@@ -453,37 +418,6 @@ runGametest {
 }
 
 test.dependsOn runGametest
-
-def coverageTasks = [
-	runGametestCoverage,
-	runClientGametestCoverage
-]
-
-jacoco {
-	coverageTasks.forEach {
-		applyTo it
-	}
-}
-
-tasks.register('coverage', JacocoReport) {
-	dependsOn coverageTasks
-	coverageTasks.forEach {
-		executionData it
-	}
-
-	// Add all source as input
-	allprojects { p ->
-		if (p.path.startsWith(":deprecated") || metaProjects.contains(p.name)) {
-			return
-		}
-		sourceSets p.sourceSets.main, p.sourceSets.client, p.sourceSets.testmod, p.sourceSets.testmodClient
-	}
-
-	// Exclude mixins
-	classDirectories.setFrom(files(classDirectories.files.collect {
-		fileTree(dir: it, exclude: '**/mixin/**')
-	}))
-}
 
 configurations {
 	productionRuntime {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+	id 'checkstyle'
+	id "com.diffplug.spotless" version "6.20.0"
+}
+
+repositories {
+	mavenCentral()
+}
+
+checkstyle {
+	configFile = file("../checkstyle.xml")
+	toolVersion = "10.20.2"
+}
+
+spotless {
+	lineEndings = com.diffplug.spotless.LineEnding.UNIX
+
+	java {
+		licenseHeaderFile(file("../HEADER"))
+		removeUnusedImports()
+		importOrder('java', 'javax', '', 'net.minecraft', 'net.fabricmc')
+		indentWithTabs()
+		trimTrailingWhitespace()
+	}
+}

--- a/buildSrc/src/main/java/net/fabricmc/fabric/impl/build/AbstractGitValueSource.java
+++ b/buildSrc/src/main/java/net/fabricmc/fabric/impl/build/AbstractGitValueSource.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.build;
+
+import java.io.ByteArrayOutputStream;
+
+import javax.inject.Inject;
+
+import org.gradle.api.provider.ValueSource;
+import org.gradle.api.provider.ValueSourceParameters;
+import org.gradle.process.ExecOperations;
+import org.gradle.process.ExecResult;
+
+public abstract class AbstractGitValueSource<T, P extends ValueSourceParameters> implements ValueSource<T, P> {
+	@Inject
+	protected abstract ExecOperations getExecOperations();
+
+	protected String git(String... args) {
+		var outputStream = new ByteArrayOutputStream();
+		ExecResult result = getExecOperations().exec(spec -> {
+			spec.commandLine("git");
+			spec.args((Object[]) args);
+			spec.setStandardOutput(outputStream);
+		});
+		result.assertNormalExitValue();
+		return outputStream.toString().trim();
+	}
+}

--- a/buildSrc/src/main/java/net/fabricmc/fabric/impl/build/CommitHashValueSource.java
+++ b/buildSrc/src/main/java/net/fabricmc/fabric/impl/build/CommitHashValueSource.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.build;
+
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.ValueSourceParameters;
+
+public abstract class CommitHashValueSource extends AbstractGitValueSource<String, CommitHashValueSource.Parameters> {
+	public interface Parameters extends ValueSourceParameters {
+		Property<String> getDirectory();
+	}
+
+	@Override
+	public String obtain() {
+		return git("log", "-1", "--format=%H", "--", getParameters().getDirectory().get());
+	}
+}

--- a/buildSrc/src/main/java/net/fabricmc/fabric/impl/build/GitBranchValueSource.java
+++ b/buildSrc/src/main/java/net/fabricmc/fabric/impl/build/GitBranchValueSource.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.build;
+
+import org.gradle.api.provider.ValueSourceParameters;
+
+public abstract class GitBranchValueSource extends AbstractGitValueSource<String, ValueSourceParameters.None> {
+	@Override
+	public String obtain() {
+		return git("rev-parse", "--abbrev-ref", "HEAD");
+	}
+}


### PR DESCRIPTION
- Setup `buildSrc`
- Replace grgit with raw `git` cli commands in a configuration cache friendly way
- Remove jacoco coverage setup as I dont think it was that useful, and intelij has its own builtin solution.