### PR TITLE
Add getAllMatches and getAllOfType method to ServerRecipeManager

### DIFF
--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/api/recipe/v1/FabricServerRecipeManager.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/api/recipe/v1/FabricServerRecipeManager.java
@@ -1,7 +1,22 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.api.recipe.v1;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.stream.Stream;
 
 import net.minecraft.recipe.Recipe;
@@ -24,13 +39,13 @@ public interface FabricServerRecipeManager {
 	 * @return the stream of matching recipes
 	 */
 	default <I extends RecipeInput, T extends Recipe<I>> Stream<RecipeEntry<T>> getAllMatches(RecipeType<T> type, I input, World world) {
-		return Stream.of();
+		throw new AssertionError("Implemented in Mixin");
 	}
 
 	/**
 	 * @return the collection of recipe entries of given type
 	 */
 	default <I extends RecipeInput, T extends Recipe<I>> Collection<RecipeEntry<T>> getAllOfType(RecipeType<T> type) {
-		return List.of();
+		throw new AssertionError("Implemented in Mixin");
 	}
 }

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/api/recipe/v1/FabricServerRecipeManager.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/api/recipe/v1/FabricServerRecipeManager.java
@@ -1,0 +1,36 @@
+package net.fabricmc.fabric.api.recipe.v1;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+
+import net.minecraft.recipe.Recipe;
+import net.minecraft.recipe.RecipeEntry;
+import net.minecraft.recipe.RecipeType;
+import net.minecraft.recipe.ServerRecipeManager;
+import net.minecraft.recipe.input.RecipeInput;
+import net.minecraft.world.World;
+
+/**
+ * General-purpose Fabric-provided extensions for {@link ServerRecipeManager} class.
+ */
+public interface FabricServerRecipeManager {
+	/**
+	 * Creates a stream of all recipe entries of the given {@code type} that match the
+	 * given {@code input} and {@code world}.
+	 *
+	 * <p>If {@code input.isEmpty()} returns true, the returned stream will be always empty.
+	 *
+	 * @return the stream of matching recipes
+	 */
+	default <I extends RecipeInput, T extends Recipe<I>> Stream<RecipeEntry<T>> getAllMatches(RecipeType<T> type, I input, World world) {
+		return Stream.of();
+	}
+
+	/**
+	 * @return the collection of recipe entries of given type
+	 */
+	default <I extends RecipeInput, T extends Recipe<I>> Collection<RecipeEntry<T>> getAllOfType(RecipeType<T> type) {
+		return List.of();
+	}
+}

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/mixin/recipe/ServerRecipeManagerMixin.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/mixin/recipe/ServerRecipeManagerMixin.java
@@ -1,0 +1,33 @@
+package net.fabricmc.fabric.mixin.recipe;
+
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.recipe.PreparedRecipes;
+import net.minecraft.recipe.Recipe;
+import net.minecraft.recipe.RecipeEntry;
+import net.minecraft.recipe.RecipeType;
+import net.minecraft.recipe.ServerRecipeManager;
+import net.minecraft.recipe.input.RecipeInput;
+import net.minecraft.world.World;
+
+import net.fabricmc.fabric.api.recipe.v1.FabricServerRecipeManager;
+
+@Mixin(ServerRecipeManager.class)
+public abstract class ServerRecipeManagerMixin implements FabricServerRecipeManager {
+	@Shadow
+	private PreparedRecipes preparedRecipes;
+
+	@Override
+	public <I extends RecipeInput, T extends Recipe<I>> Collection<RecipeEntry<T>> getAllOfType(RecipeType<T> type) {
+		return this.preparedRecipes.getAll(type);
+	}
+
+	@Override
+	public <I extends RecipeInput, T extends Recipe<I>> Stream<RecipeEntry<T>> getAllMatches(RecipeType<T> type, I input, World world) {
+		return this.preparedRecipes.find(type, input, world);
+	}
+}

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/mixin/recipe/ServerRecipeManagerMixin.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/mixin/recipe/ServerRecipeManagerMixin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.recipe;
 
 import java.util.Collection;

--- a/fabric-recipe-api-v1/src/main/resources/fabric-recipe-api-v1.mixins.json
+++ b/fabric-recipe-api-v1/src/main/resources/fabric-recipe-api-v1.mixins.json
@@ -3,6 +3,7 @@
   "package": "net.fabricmc.fabric.mixin.recipe",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
+    "ServerRecipeManagerMixin",
     "ingredient.ClientConnectionMixin",
     "ingredient.EncoderHandlerMixin",
     "ingredient.IngredientMixin",

--- a/fabric-recipe-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-recipe-api-v1/src/main/resources/fabric.mod.json
@@ -36,7 +36,8 @@
   "custom": {
     "fabric-api:module-lifecycle": "stable",
     "loom:injected_interfaces": {
-      "net/minecraft/class_1856": ["net/fabricmc/fabric/api/recipe/v1/ingredient/FabricIngredient"]
+      "net/minecraft/class_1856": ["net/fabricmc/fabric/api/recipe/v1/ingredient/FabricIngredient"],
+      "net/minecraft/class_1863": ["net/fabricmc/fabric/api/recipe/v1/FabricServerRecipeManager"]
     }
   }
 }


### PR DESCRIPTION
Adds 2 methods to ServerRecipeManager via interface injection:
- Stream<RecipeEntry> getAllMatches(RecipeType, RecipeInput, World) - gets all matches of a recipe, instead of only first one (like getFirstMatch)
- Collection<RecipeEntry> getAllOfType(RecipeType type) - returns all recipes of selected type.

Both of these are just simple accessors to methods provided by PreparedRecipes class.