### PR TITLE
Include template name in the error message if possible

### DIFF
--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/screenshot/TestScreenshotComparisonOptions.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/screenshot/TestScreenshotComparisonOptions.java
@@ -77,6 +77,7 @@ public interface TestScreenshotComparisonOptions extends TestScreenshotCommonOpt
 	 * as the one that is compared against in this screenshot comparison.
 	 *
 	 * @return This screenshot comparison options instance
+	 * @throws java.util.NoSuchElementException if template image is not provided by path
 	 */
 	TestScreenshotComparisonOptions save();
 

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/context/ClientGameTestContextImpl.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/context/ClientGameTestContextImpl.java
@@ -418,7 +418,7 @@ public final class ClientGameTestContextImpl implements ClientGameTestContext {
 
 	private static void onTemplateImageDoesntExist(NativeImage subScreenshot, TestScreenshotComparisonOptionsImpl options) {
 		if (TestSystemProperties.TEST_MOD_RESOURCES_PATH != null) {
-			Path savePath = Path.of(TestSystemProperties.TEST_MOD_RESOURCES_PATH).resolve("templates").resolve(options.getTemplateImagePathOrElseThrow() + ".png");
+			Path savePath = Path.of(TestSystemProperties.TEST_MOD_RESOURCES_PATH).resolve("templates").resolve(options.getTemplateImagePathOrThrow() + ".png");
 
 			try {
 				Files.createDirectories(savePath.getParent());

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/context/ClientGameTestContextImpl.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/context/ClientGameTestContextImpl.java
@@ -361,7 +361,7 @@ public final class ClientGameTestContextImpl implements ClientGameTestContext {
 					}
 
 					if (result == null) {
-						throw new AssertionError("Screenshot does not contain template");
+						throw new AssertionError("Screenshot does not contain template" + optionsImpl.getTemplateImagePath().map(" '%s'"::formatted).orElse(""));
 					}
 
 					return result.add(region.getX(), region.getY());
@@ -418,7 +418,7 @@ public final class ClientGameTestContextImpl implements ClientGameTestContext {
 
 	private static void onTemplateImageDoesntExist(NativeImage subScreenshot, TestScreenshotComparisonOptionsImpl options) {
 		if (TestSystemProperties.TEST_MOD_RESOURCES_PATH != null) {
-			Path savePath = Path.of(TestSystemProperties.TEST_MOD_RESOURCES_PATH).resolve("templates").resolve(options.getTemplateImagePath() + ".png");
+			Path savePath = Path.of(TestSystemProperties.TEST_MOD_RESOURCES_PATH).resolve("templates").resolve(options.getTemplateImagePathOrElseThrow() + ".png");
 
 			try {
 				Files.createDirectories(savePath.getParent());

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/screenshot/TestScreenshotComparisonOptionsImpl.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/screenshot/TestScreenshotComparisonOptionsImpl.java
@@ -53,7 +53,7 @@ public final class TestScreenshotComparisonOptionsImpl extends TestScreenshotCom
 
 	@Override
 	public TestScreenshotComparisonOptions save() {
-		return saveWithFileName(getTemplateImagePathOrElseThrow());
+		return saveWithFileName(getTemplateImagePathOrThrow());
 	}
 
 	@Override
@@ -99,8 +99,10 @@ public final class TestScreenshotComparisonOptionsImpl extends TestScreenshotCom
 
 	/**
 	 * Gets the path to the template image, relative to the {@code templates} directory, if one was provided.
+	 *
+	 * @throws java.util.NoSuchElementException if template image is not provided by path
 	 */
-	public String getTemplateImagePathOrElseThrow() {
+	public String getTemplateImagePathOrThrow() {
 		return this.getTemplateImagePath().orElseThrow();
 	}
 

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/screenshot/TestScreenshotComparisonOptionsImpl.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/screenshot/TestScreenshotComparisonOptionsImpl.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 
 import com.google.common.base.Preconditions;
 import com.mojang.datafixers.util.Either;
@@ -52,7 +53,7 @@ public final class TestScreenshotComparisonOptionsImpl extends TestScreenshotCom
 
 	@Override
 	public TestScreenshotComparisonOptions save() {
-		return saveWithFileName(getTemplateImagePath());
+		return saveWithFileName(getTemplateImagePathOrElseThrow());
 	}
 
 	@Override
@@ -89,8 +90,18 @@ public final class TestScreenshotComparisonOptionsImpl extends TestScreenshotCom
 		return this;
 	}
 
-	public String getTemplateImagePath() {
-		return this.templateImage.left().orElseThrow();
+	/**
+	 * Gets the path to the template image, relative to the {@code templates} directory, if one was provided.
+	 */
+	public Optional<String> getTemplateImagePath() {
+		return this.templateImage.left();
+	}
+
+	/**
+	 * Gets the path to the template image, relative to the {@code templates} directory, if one was provided.
+	 */
+	public String getTemplateImagePathOrElseThrow() {
+		return this.getTemplateImagePath().orElseThrow();
 	}
 
 	@Nullable


### PR DESCRIPTION
Quality of life feature which makes it easy to identify which screenshot went wrong at a glance.

Ex:
<img width="820" alt="Caused by: java.lang.AssertionError: Screenshot does not contain template 'hud_layer_test_before_chat'" src="https://github.com/user-attachments/assets/5baf000f-7ba8-4a36-b418-0e53990c394e" />
