### PR TITLE
Add contains method to FabricComponentMapBuilder

### DIFF
--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricComponentMapBuilder.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricComponentMapBuilder.java
@@ -73,7 +73,7 @@ public interface FabricComponentMapBuilder {
 	}
 
 	/**
-	 * Checks if a component type has been registered to this builder
+	 * Checks if a component type has been registered to this builder.
 	 *
 	 * @param type The component type to check
 	 * @return Returns true if the type has been registered to this builder, false otherwise

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricComponentMapBuilder.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricComponentMapBuilder.java
@@ -71,4 +71,14 @@ public interface FabricComponentMapBuilder {
 	default <T> List<T> getOrEmpty(ComponentType<List<T>> type) {
 		throw new AssertionError("Implemented in Mixin");
 	}
+
+	/**
+	 * Checks if a component type has been registered to this builder
+	 *
+	 * @param type The component type to check
+	 * @return Returns true if the type has been registered to this builder, false otherwise
+	 */
+	default boolean contains(ComponentType<?> type) {
+		throw new AssertionError("Implemented in Mixin");
+	}
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ComponentMapBuilderMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ComponentMapBuilderMixin.java
@@ -62,4 +62,9 @@ abstract class ComponentMapBuilderMixin implements FabricComponentMapBuilder {
 		this.add(type, existing);
 		return existing;
 	}
+
+	@Override
+	public boolean contains(ComponentType<?> type) {
+		return this.components.containsKey(type);
+	}
 }

--- a/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/gametest/DefaultItemComponentGameTest.java
+++ b/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/gametest/DefaultItemComponentGameTest.java
@@ -18,8 +18,10 @@ package net.fabricmc.fabric.test.item.gametest;
 
 import java.util.function.Consumer;
 
+import net.minecraft.component.ComponentMap;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.FireworksComponent;
+import net.minecraft.component.type.UnbreakableComponent;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -88,6 +90,34 @@ public class DefaultItemComponentGameTest implements FabricGameTest {
 		// if they contain each other, then they are equal
 		context.assertTrue(itemName.contains(expectedName), errorMessage.formatted(expectedName, itemName));
 		context.assertTrue(expectedName.contains(itemName), errorMessage.formatted(itemName, expectedName));
+		context.complete();
+	}
+
+	@GameTest(templateName = EMPTY_STRUCTURE)
+	public void emptyComponentMapDoesNotContainUnbreakable(TestContext context) {
+		ComponentMap.Builder builder = ComponentMap.builder();
+
+		context.assertFalse(builder.contains(DataComponentTypes.UNBREAKABLE), "Empty component map contains unbreakable type");
+		context.complete();
+	}
+
+	@GameTest(templateName = EMPTY_STRUCTURE)
+	public void componentMapWithItemNameDoesNotContainUnbreakable(TestContext context) {
+		ComponentMap.Builder builder = ComponentMap.builder();
+
+		builder.add(DataComponentTypes.ITEM_NAME, Text.of("Weird Name"));
+
+		context.assertFalse(builder.contains(DataComponentTypes.UNBREAKABLE), "Component map should not contain unbreakable type");
+		context.complete();
+	}
+
+	@GameTest(templateName = EMPTY_STRUCTURE)
+	public void componentMapWithUnbreakableContainsUnbreakable(TestContext context) {
+		ComponentMap.Builder builder = ComponentMap.builder();
+
+		builder.add(DataComponentTypes.UNBREAKABLE, new UnbreakableComponent(true));
+
+		context.assertTrue(builder.contains(DataComponentTypes.UNBREAKABLE), "Component map does not contain unbreakable type");
 		context.complete();
 	}
 }


### PR DESCRIPTION
A handful of components (such as `minecraft:unbreakable` ) work based on presence in the map - they do not store a boolean flag in the component. Using the `get` methods have the side effect of adding the component to the builder map. So, if one of the presence-based components tries to be checked using one of those methods, then it will add them to the map even if that is not the intention. This PR aims to address that by adding a simple `contains` method that does not add the component and has no side effects.