### PR TITLE
Change elytra event mixin injection point

### DIFF
--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/elytra/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/elytra/LivingEntityMixin.java
@@ -41,7 +41,7 @@ abstract class LivingEntityMixin extends Entity {
 	 * Handle ALLOW and CUSTOM {@link EntityElytraEvents} when an entity is fall flying.
 	 */
 	@SuppressWarnings("ConstantConditions")
-	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;getEquippedStack(Lnet/minecraft/entity/EquipmentSlot;)Lnet/minecraft/item/ItemStack;"), method = "tickGliding()V", allow = 1, cancellable = true)
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Util;getRandom(Ljava/util/List;Lnet/minecraft/util/math/random/Random;)Ljava/lang/Object;"), method = "tickGliding()V", allow = 1, cancellable = true)
 	void injectElytraTick(CallbackInfo info) {
 		LivingEntity self = (LivingEntity) (Object) this;
 


### PR DESCRIPTION
The `EntityElytraEvents.CUSTOM` allows specifying your own condition for enabling elytra gliding. However, vanilla code checks all applicable slots for items that allow gliding. If you are using a custom condition instead of an item then an empty list is supplied which causes a crash due to an index check in `Util.getRandom`.

Moved the injection point for the `EntityElytraEvents` to avoid this issue.