### PR TITLE
Add vararg helper methods for multi-tag support in the FabricTagBuilder

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
@@ -404,7 +404,7 @@ public abstract class FabricTagProvider<T> extends TagProvider<T> {
 		}
 
 		/**
-		 * Add another optional tags to this tag.
+		 * Add optional tags to this tag.
 		 *
 		 * @return the {@link FabricTagBuilder} instance
 		 */
@@ -428,7 +428,7 @@ public abstract class FabricTagProvider<T> extends TagProvider<T> {
 		}
 
 		/**
-		 * Add another tags to this tag, ignoring any warning.
+		 * Add tags to this tag, ignoring any warning.
 		 *
 		 * <p><b>Note:</b> only use this method if you sure that the tags will be always available at runtime.
 		 * If not, use {@link #addOptionalTags(TagKey[])} instead.

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
@@ -379,7 +379,9 @@ public abstract class FabricTagProvider<T> extends TagProvider<T> {
 		 */
 		@SafeVarargs
 		public final FabricTagBuilder addTags(TagKey<T>... tags) {
-			Stream.of(tags).forEach(this::addTag);
+			for (TagKey<T> tag : tags) {
+				addTag(tag);
+			}
 			return this;
 		}
 
@@ -410,7 +412,9 @@ public abstract class FabricTagProvider<T> extends TagProvider<T> {
 		 */
 		@SafeVarargs
 		public final FabricTagBuilder addOptionalTags(TagKey<T>... tags) {
-			Stream.of(tags).forEach(this::addOptionalTag);
+			for (TagKey<T> tag : tags) {
+				addOptionalTag(tag);
+			}
 			return this;
 		}
 
@@ -437,7 +441,9 @@ public abstract class FabricTagProvider<T> extends TagProvider<T> {
 		 */
 		@SafeVarargs
 		public final FabricTagBuilder forceAddTags(TagKey<T>... tags) {
-			Stream.of(tags).forEach(this::forceAddTag);
+			for (TagKey<T> tag : tags) {
+				forceAddTag(tag);
+			}
 			return this;
 		}
 

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
@@ -404,7 +404,7 @@ public abstract class FabricTagProvider<T> extends TagProvider<T> {
 		}
 
 		/**
-		 * Add optional tags to this tag.
+		 * Add multiple optional tags to this tag.
 		 *
 		 * @return the {@link FabricTagBuilder} instance
 		 */
@@ -428,7 +428,7 @@ public abstract class FabricTagProvider<T> extends TagProvider<T> {
 		}
 
 		/**
-		 * Add tags to this tag, ignoring any warning.
+		 * Add multiple tags to this tag, ignoring any warning.
 		 *
 		 * <p><b>Note:</b> only use this method if you sure that the tags will be always available at runtime.
 		 * If not, use {@link #addOptionalTags(TagKey[])} instead.

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
@@ -423,7 +423,7 @@ public abstract class FabricTagProvider<T> extends TagProvider<T> {
 		/**
 		 * Add another tag to this tag, ignoring any warning.
 		 *
-		 * <p><b>Note:</b> only use this method if you sure that the tag will be always available at runtime.
+		 * <p><b>Note:</b> only use this method if you are sure that the tag will be always available at runtime.
 		 * If not, use {@link #addOptionalTag(TagKey)} instead.
 		 *
 		 * @return the {@link FabricTagBuilder} instance
@@ -436,7 +436,7 @@ public abstract class FabricTagProvider<T> extends TagProvider<T> {
 		/**
 		 * Add multiple tags to this tag, ignoring any warning.
 		 *
-		 * <p><b>Note:</b> only use this method if you sure that the tags will be always available at runtime.
+		 * <p><b>Note:</b> only use this method if you are sure that the tags will be always available at runtime.
 		 * If not, use {@link #addOptionalTags(TagKey[])} instead.
 		 *
 		 * @return the {@link FabricTagBuilder} instance

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
@@ -373,6 +373,17 @@ public abstract class FabricTagProvider<T> extends TagProvider<T> {
 		}
 
 		/**
+		 * Add multiple tags to this tag.
+		 *
+		 * @return the {@link FabricTagBuilder} instance
+		 */
+		@SafeVarargs
+		public final FabricTagBuilder addTags(TagKey<T>... tags) {
+			Stream.of(tags).forEach(this::addTag);
+			return this;
+		}
+
+		/**
 		 * Add another optional tag to this tag.
 		 *
 		 * @return the {@link FabricTagBuilder} instance
@@ -393,15 +404,40 @@ public abstract class FabricTagProvider<T> extends TagProvider<T> {
 		}
 
 		/**
+		 * Add another optional tags to this tag.
+		 *
+		 * @return the {@link FabricTagBuilder} instance
+		 */
+		@SafeVarargs
+		public final FabricTagBuilder addOptionalTags(TagKey<T>... tags) {
+			Stream.of(tags).forEach(this::addOptionalTag);
+			return this;
+		}
+
+		/**
 		 * Add another tag to this tag, ignoring any warning.
 		 *
 		 * <p><b>Note:</b> only use this method if you sure that the tag will be always available at runtime.
-		 * If not, use {@link #addOptionalTag(Identifier)} instead.
+		 * If not, use {@link #addOptionalTag(TagKey)} instead.
 		 *
 		 * @return the {@link FabricTagBuilder} instance
 		 */
 		public FabricTagBuilder forceAddTag(TagKey<T> tag) {
 			builder.add(new ForcedTagEntry(TagEntry.create(tag.id())));
+			return this;
+		}
+
+		/**
+		 * Add another tags to this tag, ignoring any warning.
+		 *
+		 * <p><b>Note:</b> only use this method if you sure that the tags will be always available at runtime.
+		 * If not, use {@link #addOptionalTags(TagKey[])} instead.
+		 *
+		 * @return the {@link FabricTagBuilder} instance
+		 */
+		@SafeVarargs
+		public final FabricTagBuilder forceAddTags(TagKey<T>... tags) {
+			Stream.of(tags).forEach(this::forceAddTag);
 			return this;
 		}
 

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
@@ -25,7 +25,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
-import java.util.stream.Stream;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -304,8 +303,11 @@ public abstract class FabricTagProvider<T> extends TagProvider<T> {
 		 * @return the {@link FabricTagBuilder} instance
 		 */
 		@SafeVarargs
-		public final FabricTagBuilder add(T... element) {
-			Stream.of(element).map(FabricTagProvider.this::reverseLookup).forEach(this::add);
+		public final FabricTagBuilder add(T... elements) {
+			for (T element : elements) {
+				add(reverseLookup(element));
+			}
+
 			return this;
 		}
 

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagProvider.java
@@ -382,6 +382,7 @@ public abstract class FabricTagProvider<T> extends TagProvider<T> {
 			for (TagKey<T> tag : tags) {
 				addTag(tag);
 			}
+
 			return this;
 		}
 
@@ -415,6 +416,7 @@ public abstract class FabricTagProvider<T> extends TagProvider<T> {
 			for (TagKey<T> tag : tags) {
 				addOptionalTag(tag);
 			}
+
 			return this;
 		}
 
@@ -444,6 +446,7 @@ public abstract class FabricTagProvider<T> extends TagProvider<T> {
 			for (TagKey<T> tag : tags) {
 				forceAddTag(tag);
 			}
+
 			return this;
 		}
 


### PR DESCRIPTION
This makes it possible to use multiple arguments in the new addTags methods so that modders using datagen <sub><sub>(like me)</sub></sub> no loger have to call the `addTag()` method for each `TagKey<T>`.

This PR will add the following vararg methods:
```java
/**
 * Add multiple tags to this tag.
 *
 * @return the {@link FabricTagBuilder} instance
 */
@SafeVarargs
public final FabricTagBuilder addTags(TagKey<T>... tags) {
	for (TagKey<T> tag : tags) {
		addTag(tag);
	}

	return this;
}

/**
 * Add multiple optional tags to this tag.
 *
 * @return the {@link FabricTagBuilder} instance
 */
@SafeVarargs
public final FabricTagBuilder addOptionalTags(TagKey<T>... tags) {
	for (TagKey<T> tag : tags) {
		addOptionalTag(tag);
	}

	return this;
}

/**
 * Add multiple tags to this tag, ignoring any warning.
 *
 * <p><b>Note:</b> only use this method if you are sure that the tags will be always available at runtime.
 * If not, use {@link #addOptionalTags(TagKey[])} instead.
 *
 * @return the {@link FabricTagBuilder} instance
 */
@SafeVarargs
public final FabricTagBuilder forceAddTags(TagKey<T>... tags) {
	for (TagKey<T> tag : tags) {
		forceAddTag(tag);
	}

	return this;
}
```

Also changed the JavaDocs at line 421 to link the `addOptionalTag(TagKey<T>)` instead of `* If not, use {@link #addOptionalTag(Identifier)} instead.`

Also changed the `add(T... elements)` method to use a for loop instead of a `Stream.of()`:
```java
@SafeVarargs
public final FabricTagBuilder add(T... elements) {
	for (T element : elements) {
		add(reverseLookup(element));
	}

	return this;
}
```