### PR TITLE
AttSync: Use correct event for transferring attachments during respawn

### DIFF
--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentEntrypoint.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentEntrypoint.java
@@ -29,7 +29,7 @@ public class AttachmentEntrypoint implements ModInitializer {
 
 	@Override
 	public void onInitialize() {
-		ServerPlayerEvents.COPY_FROM.register((oldPlayer, newPlayer, alive) ->
+		ServerPlayerEvents.AFTER_RESPAWN.register((oldPlayer, newPlayer, alive) ->
 				AttachmentTargetImpl.transfer(oldPlayer, newPlayer, !alive)
 		);
 		ServerEntityWorldChangeEvents.AFTER_ENTITY_CHANGE_WORLD.register(((originalEntity, newEntity, origin, destination) ->


### PR DESCRIPTION
Closes #4475
cc @Syst3ms @bejker123

**What does this PR do?**
This PR changes the event used to transfer attachments when a player is respawned from `COPY_FROM` to `AFTER_RESPAWN`

**Why did this issue happen?**
To understand what exactly happened, we will need to trace our steps from the `COPY_FROM` event to it's caller.
1) The event is called at the [`TAIL` of `ServerPlayerEntity#copyFrom`](https://github.com/FabricMC/fabric/blob/c0029d6179011efb655905b57a22e2d234e5ec47/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/ServerPlayerEntityMixin.java#L88)
2) The `copyFrom` method is called by `PlayerManager#respawnPlayer`:
![image](https://github.com/user-attachments/assets/aaa8cf36-2069-4019-b2ce-19b99b95ef0a)
Let's take a closer look at line 403: `player.getServerWorld().removePlayer(player, removalReason);`. The method will call `Entity#remove` on the old player, which will call `Entity#changeListener#remove`. 
3) The server's `changeListener` is implemented in `ServerEntityManager`:
![image](https://github.com/user-attachments/assets/cb8bf7c8-84fc-4e0e-a092-8ebad95e3696)
The server will **stop tracking** the old player entity. There's a long chain of method calls that I won't cover in detail because otherwise this PR will be 14 pages long:
`ServerEntityManager#stopTracking` -> `ServerWorld#stopTracking` -> `ServerChunkManager#unloadEntity` -> `ServerChunkLoadingManager#unloadEntity` -> `ServerChunkLoadingManager#stopTracking` -> `EntityTrackerEntry#stopTracking` -> --hold on, let's stop here.
4) `EntityTrackerEntry#stopTracking`
![image](https://github.com/user-attachments/assets/d49350ed-ffe7-4b3a-9f6b-4b502f7c570e)
Here's our culprit! The server will order the clients to **destroy the old player entity** before calling `copyFrom`, and `copyFrom` is called before the new player is spawned in (this happens when `ServerWorld#onPlayerRespawned` is called at `PlayerManager#respawnPlayer#L439` is called).
When the client receives the attachment sync packet, **the old entity is destroyed, but the new one hasn't been received yet**, so `AttachmentTargetInfo.getTarget` returns null, causing the issue.

**Why does `AFTER_RESPAWN` work?**
It's simple. `AFTER_RESPAWN` is called at the [`TAIL` of `PlayerManager#respawnPlayer`](https://github.com/FabricMC/fabric/blob/c0029d6179011efb655905b57a22e2d234e5ec47/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/PlayerManagerMixin.java#L32), and as I've said before, that method will call `ServerWorld#onPlayerRespawned`, adding the new player entity to the world and tracking it (syncing to clients), so now AttSync can add the attachments to the new player entity.