### PR TITLE
Clarify the player's networking state when COPY_FROM is called

### DIFF
--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -26,8 +26,10 @@ public final class ServerPlayerEvents {
 	/**
 	 * An event that is called when the data from an old player is copied to a new player.
 	 *
-	 * <p>This event is typically called before a player is completely respawned.
+	 * <p>This event is called <strong>after</strong> the old player is removed and untracked, but <strong>before</strong> the new player is added and tracked.
 	 * Mods may use this event to copy old player data to a new player.
+	 *
+	 * @see ServerPlayerEvents#AFTER_RESPAWN
 	 */
 	public static final Event<ServerPlayerEvents.CopyFrom> COPY_FROM = EventFactory.createArrayBacked(ServerPlayerEvents.CopyFrom.class, callbacks -> (oldPlayer, newPlayer, alive) -> {
 		for (CopyFrom callback : callbacks) {


### PR DESCRIPTION
Updates the documentation for ServerPlayerEvents.COPY_FROM to reduce chances of issues like #4483 happening to us or someone else in the future