### PR TITLE
Add internal API to get the configuration channels the client accepts during play.

### DIFF
--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/FabricRegistryByteBuf.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/FabricRegistryByteBuf.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.networking;
+
+import java.util.Set;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.util.Identifier;
+
+public interface FabricRegistryByteBuf {
+	void fabric_setSendableConfigurationChannels(Set<Identifier> globalChannels);
+
+	@Nullable
+	Set<Identifier> fabric_getSendableConfigurationChannels();
+}

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/DebugConfigCommandMixin.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/DebugConfigCommandMixin.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.networking;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.server.command.DebugConfigCommand;
+import net.minecraft.server.network.ServerConfigurationNetworkHandler;
+
+@Mixin(DebugConfigCommand.class)
+public class DebugConfigCommandMixin {
+	// endConfiguration() does not re-run the configuration tasks. This means we loose the state such as what channels we can send on when in the play phase.
+	@Redirect(method = "executeUnconfig", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerConfigurationNetworkHandler;endConfiguration()V"))
+	private static void sendConfigurations(ServerConfigurationNetworkHandler networkHandler) {
+		networkHandler.sendConfigurations();
+	}
+}

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/RegistryByteBufMixin.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/RegistryByteBufMixin.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.networking;
+
+import java.util.Objects;
+import java.util.Set;
+
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.impl.networking.FabricRegistryByteBuf;
+
+@Mixin(RegistryByteBuf.class)
+public class RegistryByteBufMixin implements FabricRegistryByteBuf {
+	@Unique
+	private Set<Identifier> sendableConfigurationChannels = null;
+
+	@Override
+	public void fabric_setSendableConfigurationChannels(Set<Identifier> globalChannels) {
+		this.sendableConfigurationChannels = Objects.requireNonNull(globalChannels);
+	}
+
+	@Override
+	public @Nullable Set<Identifier> fabric_getSendableConfigurationChannels() {
+		return this.sendableConfigurationChannels;
+	}
+}

--- a/fabric-networking-api-v1/src/main/resources/fabric-networking-api-v1.mixins.json
+++ b/fabric-networking-api-v1/src/main/resources/fabric-networking-api-v1.mixins.json
@@ -13,6 +13,7 @@
     "LoginQueryRequestS2CPacketMixin",
     "LoginQueryResponseC2SPacketMixin",
     "PlayerManagerMixin",
+    "RegistryByteBufMixin",
     "ServerCommonNetworkHandlerMixin",
     "ServerConfigurationNetworkHandlerMixin",
     "ServerLoginNetworkHandlerMixin",

--- a/fabric-networking-api-v1/src/main/resources/fabric-networking-api-v1.mixins.json
+++ b/fabric-networking-api-v1/src/main/resources/fabric-networking-api-v1.mixins.json
@@ -9,6 +9,7 @@
     "CustomPayloadC2SPacketMixin",
     "CustomPayloadS2CPacketMixin",
     "CustomPayloadPacketCodecMixin",
+    "DebugConfigCommandMixin",
     "EntityTrackerEntryMixin",
     "LoginQueryRequestS2CPacketMixin",
     "LoginQueryResponseC2SPacketMixin",

--- a/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/play/NetworkingPlayPacketTest.java
+++ b/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/play/NetworkingPlayPacketTest.java
@@ -20,7 +20,9 @@ import static com.mojang.brigadier.arguments.StringArgumentType.string;
 import static net.minecraft.server.command.CommandManager.argument;
 import static net.minecraft.server.command.CommandManager.literal;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
@@ -37,6 +39,7 @@ import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 import net.minecraft.text.TextCodecs;
+import net.minecraft.util.Identifier;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.ModInitializer;
@@ -45,7 +48,9 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.fabricmc.fabric.impl.networking.FabricRegistryByteBuf;
 import net.fabricmc.fabric.test.networking.NetworkingTestmods;
+import net.fabricmc.fabric.test.networking.common.NetworkingCommonTest;
 import net.fabricmc.loader.api.FabricLoader;
 
 public final class NetworkingPlayPacketTest implements ModInitializer {
@@ -132,6 +137,15 @@ public final class NetworkingPlayPacketTest implements ModInitializer {
 		}
 
 		public void write(RegistryByteBuf buf) {
+			// Test that we can get the configuration channels that the client accepts
+			FabricRegistryByteBuf fabricRegistryByteBuf = (FabricRegistryByteBuf) buf;
+			Collection<Identifier> channels = fabricRegistryByteBuf.fabric_getSendableConfigurationChannels();
+			Objects.requireNonNull(channels);
+
+			if (!channels.contains(NetworkingCommonTest.CommonPayload.ID.id())) {
+				throw new IllegalStateException("Expected common payload channel to be sent");
+			}
+
 			TextCodecs.REGISTRY_PACKET_CODEC.encode(buf, this.message);
 		}
 


### PR DESCRIPTION
This is a quick and dirty solution to allow Fabric API modules to encode packets diffrently depending on if the client can accept it or not. A Fabric API module should register a dummy configuration channel and then check to see if its included in `fabric_getSendableConfigurationChannels`.

In the longer term I think this should be replaced by something more robust and open for other mods to use, where configuration tasks can attach arbitrary data to the RegistryByteBuf.