### PR TITLE
Fix BlockView API v2 not applying `WorldViewMixin`

### DIFF
--- a/fabric-block-view-api-v2/src/main/resources/fabric-block-view-api-v2.mixins.json
+++ b/fabric-block-view-api-v2/src/main/resources/fabric-block-view-api-v2.mixins.json
@@ -4,7 +4,8 @@
   "compatibilityLevel": "JAVA_21",
   "mixins": [
     "BlockEntityMixin",
-    "BlockViewMixin"
+    "BlockViewMixin",
+    "WorldViewMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Fix #4499.

 This fix should be backported to as many versions as possible.