### PR TITLE
Skip publishing previously published artifacts.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -666,10 +666,6 @@ void setupRepositories(RepositoryHandler repositories) {
 			}
 		}
 	}
-
-	repositories.maven {
-		url = "https://localhost"
-	}
 }
 
 subprojects.each {

--- a/build.gradle
+++ b/build.gradle
@@ -569,14 +569,15 @@ subprojects {
 
 			def artifactPath = "https://maven.fabricmc.net/net/fabricmc/fabric-api/${projectName}/${projectVersion}/${projectName}-${projectVersion}.pom"
 
-			def client = HttpClient.newHttpClient()
-			def request = HttpRequest.newBuilder()
-					.uri(URI.create(artifactPath))
-					.method("HEAD", HttpRequest.BodyPublishers.noBody())
-					.build()
+			boolean exists = HttpClient.newHttpClient().withCloseable { client ->
+				def request = HttpRequest.newBuilder()
+						.uri(URI.create(artifactPath))
+						.method("HEAD", HttpRequest.BodyPublishers.noBody())
+						.build()
 
-			def response = client.send(request, HttpResponse.BodyHandlers.discarding())
-			boolean exists = response.statusCode() == 200
+				def response = client.send(request, HttpResponse.BodyHandlers.discarding())
+				response.statusCode() == 200
+			}
 
 			if (exists) {
 				logger.lifecycle("${projectName}-${projectVersion}.pom has already been published")

--- a/build.gradle
+++ b/build.gradle
@@ -571,9 +571,9 @@ subprojects {
 
 			def client = HttpClient.newHttpClient()
 			def request = HttpRequest.newBuilder()
-				.uri(URI.create(artifactPath))
-				.method("HEAD", HttpRequest.BodyPublishers.noBody())
-				.build()
+					.uri(URI.create(artifactPath))
+					.method("HEAD", HttpRequest.BodyPublishers.noBody())
+					.build()
 
 			def response = client.send(request, HttpResponse.BodyHandlers.discarding())
 			boolean exists = response.statusCode() == 200

--- a/build.gradle
+++ b/build.gradle
@@ -553,6 +553,34 @@ subprojects {
 		}
 	}
 
+	def projectName = it.name
+	def projectVersion = getSubprojectVersion(it)
+
+	// Skip publishing if the artifact already exists on the maven server
+	tasks.withType(PublishToMavenRepository).configureEach {
+		onlyIf {
+			if (!providers.environmentVariable("MAVEN_URL").present) {
+				// Always try to publish if the maven url is not set (e.g locally)
+				return true
+			}
+
+			def artifactPath = "https://maven.fabricmc.net/net/fabricmc/fabric-api/${projectName}/${projectVersion}/${projectName}-${projectVersion}.pom"
+
+			def connection = URI.create(artifactPath).toURL().openConnection() as HttpURLConnection
+			connection.setRequestMethod("HEAD")
+			connection.connect()
+			def exists = connection.responseCode == 200
+
+			if (exists) {
+				logger.lifecycle("${projectName}-${projectVersion}.pom has already been published")
+			} else {
+				logger.lifecycle("${projectName}-${projectVersion}.pom does not exist, publishing")
+			}
+
+			return !exists
+		}
+	}
+
 	// We manually handle the pom generation
 	loom.disableDeprecatedPomGeneration(publishing.publications.mavenJava)
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ import groovy.json.JsonSlurper
 import org.apache.commons.codec.digest.DigestUtils
 import net.fabricmc.fabric.impl.build.CommitHashValueSource
 import net.fabricmc.fabric.impl.build.GitBranchValueSource
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 
 def getSubprojectVersion(Project project) {
 	// Get the version from the gradle.properties file
@@ -566,10 +569,14 @@ subprojects {
 
 			def artifactPath = "https://maven.fabricmc.net/net/fabricmc/fabric-api/${projectName}/${projectVersion}/${projectName}-${projectVersion}.pom"
 
-			def connection = URI.create(artifactPath).toURL().openConnection() as HttpURLConnection
-			connection.setRequestMethod("HEAD")
-			connection.connect()
-			def exists = connection.responseCode == 200
+			def client = HttpClient.newHttpClient()
+			def request = HttpRequest.newBuilder()
+				.uri(URI.create(artifactPath))
+				.method("HEAD", HttpRequest.BodyPublishers.noBody())
+				.build()
+
+			def response = client.send(request, HttpResponse.BodyHandlers.discarding())
+			boolean exists = response.statusCode() == 200
 
 			if (exists) {
 				logger.lifecycle("${projectName}-${projectVersion}.pom has already been published")
@@ -658,6 +665,10 @@ void setupRepositories(RepositoryHandler repositories) {
 				password = providers.environmentVariable("MAVEN_PASSWORD").get()
 			}
 		}
+	}
+
+	repositories.maven {
+		url = "https://localhost"
 	}
 }
 


### PR DESCRIPTION
Im not 100% sure about this, but this change has 2 benefits:

- Faster releses
- Further reduces the chance of accidently overriding existing versions. This should already be impossible as far as I can see.