### PR TITLE
Fix cyclic dependency between fabric-api and fabric-api-deprecated

### DIFF
--- a/deprecated/build.gradle
+++ b/deprecated/build.gradle
@@ -40,13 +40,6 @@ publishing {
 					depNode.appendNode("version", dep['version'])
 					depNode.appendNode("scope", dep['scope'])
 				}
-
-				// Depend on the main project.
-				def depNode = depsNode.appendNode("dependency")
-				depNode.appendNode("groupId", thisGroup)
-				depNode.appendNode("artifactId", "fabric-api")
-				depNode.appendNode("version", thisVersion)
-				depNode.appendNode("scope", "compile")
 			}
 		}
 	}


### PR DESCRIPTION
See #4513

Does not affect Gradle, but causes issues in Bazel.