### PR TITLE
[1.21.5] Remove deprecated BlockOutlineContext#vertexConsumer & Pass translucent parameter to BEFORE_BLOCK_OUTLINE event

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderContext.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderContext.java
@@ -24,7 +24,6 @@ import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.Frustum;
 import net.minecraft.client.render.GameRenderer;
 import net.minecraft.client.render.RenderTickCounter;
-import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.client.util.math.MatrixStack;
@@ -130,11 +129,5 @@ public interface WorldRenderContext {
 		BlockPos blockPos();
 
 		BlockState blockState();
-
-		/**
-		 * @deprecated Use {@link #consumers()} directly.
-		 */
-		@Deprecated
-		VertexConsumer vertexConsumer();
 	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderEvents.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderEvents.java
@@ -141,11 +141,11 @@ public final class WorldRenderEvents {
 	 * renders.  Mods that replace the default block outline for specific blocks
 	 * should instead subscribe to {@link #BLOCK_OUTLINE}.
 	 */
-	public static final Event<BeforeBlockOutline> BEFORE_BLOCK_OUTLINE = EventFactory.createArrayBacked(BeforeBlockOutline.class, (context, hit) -> true, callbacks -> (context, hit) -> {
+	public static final Event<BeforeBlockOutline> BEFORE_BLOCK_OUTLINE = EventFactory.createArrayBacked(BeforeBlockOutline.class, (context, translucent, hit) -> true, callbacks -> (context, translucent, hit) -> {
 		boolean shouldRender = true;
 
 		for (final BeforeBlockOutline callback : callbacks) {
-			if (!callback.beforeBlockOutline(context, hit)) {
+			if (!callback.beforeBlockOutline(context, translucent, hit)) {
 				shouldRender = false;
 			}
 		}
@@ -281,13 +281,15 @@ public final class WorldRenderEvents {
 		 * Event signature for {@link WorldRenderEvents#BEFORE_BLOCK_OUTLINE}.
 		 *
 		 * @param context  Access to state and parameters available during world rendering.
+		 * @param translucent If {@code true}, current block outline is being rendered after translucent terrain.
+		 *                    Otherwise, it is being rendered after solid terrain.
 		 * @param hitResult The game object currently under the crosshair target.
 		 * Normally equivalent to {@link MinecraftClient#crosshairTarget}. Provided for convenience.
 		 * @return true if vanilla block outline rendering should happen.
 		 * Returning false prevents {@link WorldRenderEvents#BLOCK_OUTLINE} from invoking
 		 * and also skips the vanilla block outline render, but has no effect on other subscribers to this event.
 		 */
-		boolean beforeBlockOutline(WorldRenderContext context, @Nullable HitResult hitResult);
+		boolean beforeBlockOutline(WorldRenderContext context, boolean translucent, @Nullable HitResult hitResult);
 	}
 
 	@FunctionalInterface

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/WorldRenderContextImpl.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/WorldRenderContextImpl.java
@@ -213,10 +213,4 @@ public final class WorldRenderContextImpl implements WorldRenderContext.BlockOut
 	public BlockState blockState() {
 		return blockState;
 	}
-
-	@Deprecated
-	@Override
-	public VertexConsumer vertexConsumer() {
-		return consumers.getBuffer(RenderLayer.getLines());
-	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
@@ -118,7 +118,7 @@ public abstract class WorldRendererMixin {
 	@Inject(method = "renderTargetBlockOutline", at = @At("HEAD"))
 	private void beforeRenderOutline(Camera camera, VertexConsumerProvider.Immediate vertexConsumers, MatrixStack matrices, boolean translucent, CallbackInfo ci) {
 		context.setTranslucentBlockOutline(translucent);
-		context.renderBlockOutline = WorldRenderEvents.BEFORE_BLOCK_OUTLINE.invoker().beforeBlockOutline(context, client.crosshairTarget);
+		context.renderBlockOutline = WorldRenderEvents.BEFORE_BLOCK_OUTLINE.invoker().beforeBlockOutline(context, translucent, client.crosshairTarget);
 	}
 
 	@SuppressWarnings("ConstantConditions")


### PR DESCRIPTION
- Remove deprecated BlockOutlineContext#vertexConsumer
- Pass translucent parameter to BEFORE_BLOCK_OUTLINE event

Taken from: https://github.com/FabricMC/fabric/pull/4286/commits/2f117f74eb7948489e0293ef2fbd963a3587cd92

Co-authored-by: PepperCode1 <44146161+peppercode1@users.noreply.github.com>