### PR TITLE
Add ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE

### DIFF
--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkEvents.java
@@ -67,7 +67,10 @@ public final class ServerChunkEvents {
 	/**
 	 * Called when a chunk changes its {@link ChunkLevelType}.
 	 *
-	 * <p>When this event is called, the chunk's level type has already changed.
+	 * <p>For chunk level type promotions, this event is called only when the chunk's behavior actually aligns with its level type.
+	 * This means the event is usually called later than when the chunk's level type first gets promoted.
+	 *
+	 * <p>For chunk level type demotions, this event is called immediately when the chunk's level type first gets demoted.
 	 */
 	public static final Event<LevelTypeChange> CHUNK_LEVEL_TYPE_CHANGE = EventFactory.createArrayBacked(LevelTypeChange.class, callbacks -> (serverWorld, chunkPos, oldLevelType, newLevelType) -> {
 		for (LevelTypeChange callback : callbacks) {

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkEvents.java
@@ -67,7 +67,7 @@ public final class ServerChunkEvents {
 	 * Called when a chunk changes its {@link ChunkLevelType}.
 	 *
 	 * <p>When this event is called, the chunk's {@link WorldChunk#getLevelType()} has already changed. However, the chunk's actual ticking behavior may not fully align with its level type yet.
-	 * Additionally, it is not guaranteed that entities from the chunk are immediately accessible when this event is called, though they are already loaded.
+	 * Additionally, it is not guaranteed that entities from the chunk are immediately accessible when this event is called.
 	 */
 	public static final Event<LevelTypeChange> CHUNK_LEVEL_TYPE_CHANGE = EventFactory.createArrayBacked(LevelTypeChange.class, (world, chunk, oldLevelType, newLevelType) -> { }, callbacks -> (serverWorld, chunk, oldLevelType, newLevelType) -> {
 		for (LevelTypeChange callback : callbacks) {

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkEvents.java
@@ -16,7 +16,9 @@
 
 package net.fabricmc.fabric.api.event.lifecycle.v1;
 
+import net.minecraft.server.world.ChunkLevelType;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.chunk.WorldChunk;
 
 import net.fabricmc.fabric.api.event.Event;
@@ -59,6 +61,17 @@ public final class ServerChunkEvents {
 		}
 	});
 
+	/**
+	 * Called when a chunk changes its {@link ChunkLevelType}.
+	 *
+	 * <p>When this event is called, the chunk's level type has already changed.
+	 */
+	public static final Event<LevelTypeChange> CHUNK_LEVEL_TYPE_CHANGE = EventFactory.createArrayBacked(LevelTypeChange.class, callbacks -> (serverWorld, chunkPos, oldLevelType, newLevelType) -> {
+		for (LevelTypeChange callback : callbacks) {
+			callback.onChunkLevelTypeChange(serverWorld, chunkPos, oldLevelType, newLevelType);
+		}
+	});
+
 	@FunctionalInterface
 	public interface Load {
 		void onChunkLoad(ServerWorld world, WorldChunk chunk);
@@ -72,5 +85,10 @@ public final class ServerChunkEvents {
 	@FunctionalInterface
 	public interface Unload {
 		void onChunkUnload(ServerWorld world, WorldChunk chunk);
+	}
+
+	@FunctionalInterface
+	public interface LevelTypeChange {
+		void onChunkLevelTypeChange(ServerWorld world, ChunkPos chunkPos, ChunkLevelType oldLevelType, ChunkLevelType newLevelType);
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkEvents.java
@@ -18,7 +18,6 @@ package net.fabricmc.fabric.api.event.lifecycle.v1;
 
 import net.minecraft.server.world.ChunkLevelType;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.chunk.WorldChunk;
 
 import net.fabricmc.fabric.api.event.Event;
@@ -67,14 +66,12 @@ public final class ServerChunkEvents {
 	/**
 	 * Called when a chunk changes its {@link ChunkLevelType}.
 	 *
-	 * <p>For chunk level type promotions, this event is called only when the chunk's behavior actually aligns with its level type.
-	 * This means the event is usually called later than when the chunk's level type first gets promoted.
-	 *
-	 * <p>For chunk level type demotions, this event is called immediately when the chunk's level type first gets demoted.
+	 * <p>When this event is called, the chunk's {@link WorldChunk#getLevelType()} has already changed. However, the chunk's actual ticking behavior may not fully align with its level type yet.
+	 * Additionally, it is not guaranteed that entities from the chunk are immediately accessible when this event is called, though they are already loaded.
 	 */
-	public static final Event<LevelTypeChange> CHUNK_LEVEL_TYPE_CHANGE = EventFactory.createArrayBacked(LevelTypeChange.class, callbacks -> (serverWorld, chunkPos, oldLevelType, newLevelType) -> {
+	public static final Event<LevelTypeChange> CHUNK_LEVEL_TYPE_CHANGE = EventFactory.createArrayBacked(LevelTypeChange.class, (world, chunk, oldLevelType, newLevelType) -> { }, callbacks -> (serverWorld, chunk, oldLevelType, newLevelType) -> {
 		for (LevelTypeChange callback : callbacks) {
-			callback.onChunkLevelTypeChange(serverWorld, chunkPos, oldLevelType, newLevelType);
+			callback.onChunkLevelTypeChange(serverWorld, chunk, oldLevelType, newLevelType);
 		}
 	});
 
@@ -95,6 +92,6 @@ public final class ServerChunkEvents {
 
 	@FunctionalInterface
 	public interface LevelTypeChange {
-		void onChunkLevelTypeChange(ServerWorld world, ChunkPos chunkPos, ChunkLevelType oldLevelType, ChunkLevelType newLevelType);
+		void onChunkLevelTypeChange(ServerWorld world, WorldChunk chunk, ChunkLevelType oldLevelType, ChunkLevelType newLevelType);
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkEvents.java
@@ -16,8 +16,11 @@
 
 package net.fabricmc.fabric.api.event.lifecycle.v1;
 
+import net.minecraft.server.world.ChunkHolder;
 import net.minecraft.server.world.ChunkLevelType;
+import net.minecraft.server.world.ServerChunkManager;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.world.chunk.ChunkStatus;
 import net.minecraft.world.chunk.WorldChunk;
 
 import net.fabricmc.fabric.api.event.Event;
@@ -31,6 +34,10 @@ public final class ServerChunkEvents {
 	 * Called when a chunk is loaded into a ServerWorld.
 	 *
 	 * <p>When this event is called, the chunk is already in the world.
+	 *
+	 * <p>Note that this event is not called for chunks that become accessible without previously being unloaded.
+	 *
+	 * @see ServerChunkEvents#CHUNK_LEVEL_TYPE_CHANGE
 	 */
 	public static final Event<ServerChunkEvents.Load> CHUNK_LOAD = EventFactory.createArrayBacked(ServerChunkEvents.Load.class, callbacks -> (serverWorld, chunk) -> {
 		for (Load callback : callbacks) {
@@ -64,10 +71,15 @@ public final class ServerChunkEvents {
 	});
 
 	/**
-	 * Called when a chunk changes its {@link ChunkLevelType}.
+	 * Called when a chunk's actual ticking behavior is about to align with its updated {@link ChunkLevelType}.
 	 *
-	 * <p>When this event is called, the chunk's {@link WorldChunk#getLevelType()} has already changed. However, the chunk's actual ticking behavior may not fully align with its level type yet.
-	 * Additionally, it is not guaranteed that entities from the chunk are immediately accessible when this event is called.
+	 * <p>When this event is being called:
+	 * <ul>
+	 * <li>The chunk's {@link WorldChunk#getLevelType()} has already changed.</li>
+	 * <li>Entities within the chunk are not guaranteed to be accessible.</li>
+	 * <li>The chunk's corresponding level type future in {@link ChunkHolder} is not guaranteed to be done.</li>
+	 * <li>When transitioning from {@link ChunkLevelType#INACCESSIBLE} to {@link ChunkLevelType#FULL}, calling {@link ServerChunkManager#getChunkFutureSyncOnMainThread(int, int, ChunkStatus, boolean)} to fetch the current chunk at {@link ChunkStatus#FULL} status results in undefined behavior.</li>
+	 * </ul>
 	 */
 	public static final Event<LevelTypeChange> CHUNK_LEVEL_TYPE_CHANGE = EventFactory.createArrayBacked(LevelTypeChange.class, (world, chunk, oldLevelType, newLevelType) -> { }, callbacks -> (serverWorld, chunk, oldLevelType, newLevelType) -> {
 		for (LevelTypeChange callback : callbacks) {

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkEvents.java
@@ -54,6 +54,9 @@ public final class ServerChunkEvents {
 	 * Called when a chunk is unloaded from a ServerWorld.
 	 *
 	 * <p>When this event is called, the chunk is still present in the world.
+	 *
+	 * <p>Note that the server typically unloads chunks when the chunk's level goes above 45 (and not immediately when the chunk becomes inaccessible).
+	 * To know when a chunk first becomes inaccessible, see {@link ServerChunkEvents#CHUNK_LEVEL_TYPE_CHANGE}.
 	 */
 	public static final Event<ServerChunkEvents.Unload> CHUNK_UNLOAD = EventFactory.createArrayBacked(ServerChunkEvents.Unload.class, callbacks -> (serverWorld, chunk) -> {
 		for (Unload callback : callbacks) {

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/impl/event/lifecycle/ChunkLevelTypeEventTracker.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/impl/event/lifecycle/ChunkLevelTypeEventTracker.java
@@ -1,0 +1,14 @@
+package net.fabricmc.fabric.impl.event.lifecycle;
+
+import net.minecraft.server.world.ChunkLevelType;
+
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
+
+/**
+ * A marker interface that tracks the current {@link ServerChunkEvents#CHUNK_LEVEL_TYPE_CHANGE} level type.
+ */
+public interface ChunkLevelTypeEventTracker {
+	void fabric_setCurrentEventLevelType(ChunkLevelType levelType);
+
+	ChunkLevelType fabric_getCurrentEventLevelType();
+}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/impl/event/lifecycle/ChunkLevelTypeEventTracker.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/impl/event/lifecycle/ChunkLevelTypeEventTracker.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.impl.event.lifecycle;
 
 import net.minecraft.server.world.ChunkLevelType;

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkGeneratingMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkGeneratingMixin.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.mixin.event.lifecycle;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -34,20 +35,28 @@ import net.fabricmc.fabric.impl.event.lifecycle.ChunkLevelTypeEventTracker;
 
 @Mixin(ChunkGenerating.class)
 abstract class ChunkGeneratingMixin {
+	@Unique
+	private static final ChunkLevelType[] fabric_CHUNK_LEVEL_TYPES = ChunkLevelType.values(); // values() clones the internal array each call, so cache the return
+
 	@Inject(method = "method_60553", at = @At("TAIL"))
 	private static void onChunkLoad(Chunk chunk, ChunkGenerationContext chunkGenerationContext, AbstractChunkHolder chunkHolder, CallbackInfoReturnable<Chunk> callbackInfoReturnable) {
-		// We fire the event at TAIL since the chunk is guaranteed to be a WorldChunk then.
-		ServerChunkEvents.CHUNK_LOAD.invoker().onChunkLoad(chunkGenerationContext.world(), (WorldChunk) callbackInfoReturnable.getReturnValue());
+		WorldChunk worldChunk = (WorldChunk) callbackInfoReturnable.getReturnValue();
 
-		// Handles the case where the chunk becomes accessible from being completed unloaded
-		ChunkLevelTypeEventTracker levelTypeTracker = (ChunkLevelTypeEventTracker) chunkHolder;
-		if (levelTypeTracker.fabric_getCurrentEventLevelType() == ChunkLevelType.INACCESSIBLE) { // prevent duplicate events with ChunkHolderMixin
-			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange(chunkGenerationContext.world(), chunk.getPos(), ChunkLevelType.INACCESSIBLE, ChunkLevelType.FULL);
-			levelTypeTracker.fabric_setCurrentEventLevelType(ChunkLevelType.FULL);
-		}
+		// We fire the event at TAIL since the chunk is guaranteed to be a WorldChunk then.
+		ServerChunkEvents.CHUNK_LOAD.invoker().onChunkLoad(chunkGenerationContext.world(), worldChunk);
 
 		if (!(chunk instanceof WrapperProtoChunk)) {
-			ServerChunkEvents.CHUNK_GENERATE.invoker().onChunkGenerate(chunkGenerationContext.world(), (WorldChunk) callbackInfoReturnable.getReturnValue());
+			ServerChunkEvents.CHUNK_GENERATE.invoker().onChunkGenerate(chunkGenerationContext.world(), worldChunk);
+		}
+
+		// Handles the case where the chunk becomes accessible from being completed unloaded, only fires if chunkHolder has been set to at least that level type
+		ChunkLevelTypeEventTracker levelTypeTracker = (ChunkLevelTypeEventTracker) chunkHolder;
+
+		for (int i = levelTypeTracker.fabric_getCurrentEventLevelType().ordinal(); i < chunkHolder.getLevelType().ordinal(); i++) {
+			ChunkLevelType oldLevelType = fabric_CHUNK_LEVEL_TYPES[i];
+			ChunkLevelType newLevelType = fabric_CHUNK_LEVEL_TYPES[i+1];
+			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange(chunkGenerationContext.world(), worldChunk, oldLevelType, newLevelType);
+			levelTypeTracker.fabric_setCurrentEventLevelType(newLevelType);
 		}
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkGeneratingMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkGeneratingMixin.java
@@ -16,22 +16,21 @@
 
 package net.fabricmc.fabric.mixin.event.lifecycle;
 
-import net.fabricmc.fabric.impl.event.lifecycle.ChunkLevelTypeEventTracker;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import net.minecraft.server.world.ChunkLevelType;
 import net.minecraft.world.chunk.AbstractChunkHolder;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkGenerating;
 import net.minecraft.world.chunk.ChunkGenerationContext;
 import net.minecraft.world.chunk.WorldChunk;
 import net.minecraft.world.chunk.WrapperProtoChunk;
-import net.minecraft.server.world.ChunkLevelType;
 
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
+import net.fabricmc.fabric.impl.event.lifecycle.ChunkLevelTypeEventTracker;
 
 @Mixin(ChunkGenerating.class)
 abstract class ChunkGeneratingMixin {

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkGeneratingMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkGeneratingMixin.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.mixin.event.lifecycle;
 
+import net.fabricmc.fabric.impl.event.lifecycle.ChunkLevelTypeEventTracker;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -27,6 +29,7 @@ import net.minecraft.world.chunk.ChunkGenerating;
 import net.minecraft.world.chunk.ChunkGenerationContext;
 import net.minecraft.world.chunk.WorldChunk;
 import net.minecraft.world.chunk.WrapperProtoChunk;
+import net.minecraft.server.world.ChunkLevelType;
 
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
 
@@ -36,6 +39,13 @@ abstract class ChunkGeneratingMixin {
 	private static void onChunkLoad(Chunk chunk, ChunkGenerationContext chunkGenerationContext, AbstractChunkHolder chunkHolder, CallbackInfoReturnable<Chunk> callbackInfoReturnable) {
 		// We fire the event at TAIL since the chunk is guaranteed to be a WorldChunk then.
 		ServerChunkEvents.CHUNK_LOAD.invoker().onChunkLoad(chunkGenerationContext.world(), (WorldChunk) callbackInfoReturnable.getReturnValue());
+
+		// Handles the case where the chunk becomes accessible from being completed unloaded
+		ChunkLevelTypeEventTracker levelTypeTracker = (ChunkLevelTypeEventTracker) chunkHolder;
+		if (levelTypeTracker.fabric_getCurrentEventLevelType() == ChunkLevelType.INACCESSIBLE) { // prevent duplicate events with ChunkHolderMixin
+			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange(chunkGenerationContext.world(), chunk.getPos(), ChunkLevelType.INACCESSIBLE, ChunkLevelType.FULL);
+			levelTypeTracker.fabric_setCurrentEventLevelType(ChunkLevelType.FULL);
+		}
 
 		if (!(chunk instanceof WrapperProtoChunk)) {
 			ServerChunkEvents.CHUNK_GENERATE.invoker().onChunkGenerate(chunkGenerationContext.world(), (WorldChunk) callbackInfoReturnable.getReturnValue());

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
@@ -63,13 +63,13 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 	protected abstract void combineSavingFuture(CompletableFuture<?> savingFuture);
 
 	@Unique
-	private static final ChunkLevelType[] CHUNK_LEVEL_TYPES = ChunkLevelType.values(); // values() clones the internal array each call, so cache the return
+	private static final ChunkLevelType[] fabric_CHUNK_LEVEL_TYPES = ChunkLevelType.values(); // values() clones the internal array each call, so cache the return
 
 	@Unique
-	private CompletableFuture<Void> fullToBlockTickingEvent;
+	private CompletableFuture<Void> fabric_fullToBlockTickingEvent;
 
 	@Unique
-	private ChunkLevelType currentEventLevelType = INACCESSIBLE;
+	private ChunkLevelType fabric_currentEventLevelType = INACCESSIBLE;
 
 	private ChunkHolderMixin(ChunkPos pos) {
 		super(pos);
@@ -80,9 +80,9 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 	 */
 	@Inject(method = "updateFutures", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;combineSavingFuture(Ljava/util/concurrent/CompletableFuture;)V", shift = At.Shift.AFTER, ordinal = 0))
 	private void updateFutures$inaccessibleToFull(ServerChunkLoadingManager chunkLoadingManager, Executor executor, CallbackInfo ci) {
-		if (this.getUncheckedOrNull(ChunkStatus.FULL) instanceof WorldChunk && this.currentEventLevelType == INACCESSIBLE) { // prevent duplicate events with ChunkGeneratingMixin
+		if (this.getUncheckedOrNull(ChunkStatus.FULL) instanceof WorldChunk && this.fabric_currentEventLevelType == INACCESSIBLE) { // prevent duplicate events with ChunkGeneratingMixin
 			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, INACCESSIBLE, FULL);
-			this.currentEventLevelType = FULL;
+			this.fabric_currentEventLevelType = FULL;
 		}
 	}
 
@@ -91,22 +91,22 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 	 */
 	@Inject(method = "updateFutures", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;combineSavingFuture(Ljava/util/concurrent/CompletableFuture;)V", shift = At.Shift.AFTER, ordinal = 1))
 	private void updateFutures$fullToBlockTicking(ServerChunkLoadingManager chunkLoadingManager, Executor executor, CallbackInfo ci) {
-		this.fullToBlockTickingEvent = this.tickingFuture.thenAccept(optionalChunk -> {
+		this.fabric_fullToBlockTickingEvent = this.tickingFuture.thenAccept(optionalChunk -> {
 			optionalChunk.ifPresent(worldChunk -> {
 				ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, FULL, BLOCK_TICKING);
-				this.currentEventLevelType = BLOCK_TICKING;
+				this.fabric_currentEventLevelType = BLOCK_TICKING;
 			});
 		});
 	}
 
 	/**
-	 * Handles FULL -> BLOCK_TICKING.
+	 * Handles BLOCK_TICKING -> ENTITY_TICKING.
 	 */
 	@Inject(method = "updateFutures", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;combineSavingFuture(Ljava/util/concurrent/CompletableFuture;)V", shift = At.Shift.AFTER, ordinal = 2))
 	private void updateFutures$blockTickingToEntityTicking(ServerChunkLoadingManager chunkLoadingManager, Executor executor, CallbackInfo ci) {
-		this.fullToBlockTickingEvent.thenAccept(optionalChunk -> {
+		this.fabric_fullToBlockTickingEvent.thenAccept(optionalChunk -> {
 			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, BLOCK_TICKING, ENTITY_TICKING);
-			this.currentEventLevelType = ENTITY_TICKING;
+			this.fabric_currentEventLevelType = ENTITY_TICKING;
 		});
 	}
 
@@ -119,22 +119,22 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 		ServerWorld serverWorld = (ServerWorld) world;
 
 		for (int i = previous.ordinal(); i > target.ordinal(); i--) {
-			ChunkLevelType oldLevelType = CHUNK_LEVEL_TYPES[i];
-			ChunkLevelType newLevelType = CHUNK_LEVEL_TYPES[i-1];
-			if (this.currentEventLevelType.isAfter(oldLevelType)) { // if a promotion event got cancelled or never finished, then do _not_ fire an equivalent demotion event
+			ChunkLevelType oldLevelType = fabric_CHUNK_LEVEL_TYPES[i];
+			ChunkLevelType newLevelType = fabric_CHUNK_LEVEL_TYPES[i-1];
+			if (this.fabric_currentEventLevelType.isAfter(oldLevelType)) { // if a promotion event got cancelled or never finished, then do _not_ fire an equivalent demotion event
 				ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange(serverWorld, this.pos, oldLevelType, newLevelType);
-				this.currentEventLevelType = newLevelType;
+				this.fabric_currentEventLevelType = newLevelType;
 			}
 		}
 	}
 
 	@Unique
 	public void fabric_setCurrentEventLevelType(ChunkLevelType levelType) {
-		this.currentEventLevelType = levelType;
+		this.fabric_currentEventLevelType = levelType;
 	}
 
 	@Unique
 	public ChunkLevelType fabric_getCurrentEventLevelType() {
-		return this.currentEventLevelType;
+		return this.fabric_currentEventLevelType;
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
@@ -1,9 +1,32 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.event.lifecycle;
 
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.server.world.ChunkHolder;
-
 import net.minecraft.server.world.ChunkLevelType;
 import net.minecraft.server.world.ChunkLevels;
 import net.minecraft.server.world.OptionalChunk;
@@ -14,15 +37,7 @@ import net.minecraft.world.HeightLimitView;
 import net.minecraft.world.chunk.AbstractChunkHolder;
 import net.minecraft.world.chunk.WorldChunk;
 
-import org.spongepowered.asm.mixin.Final;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
 
 @Mixin(ChunkHolder.class)
 public abstract class ChunkHolderMixin extends AbstractChunkHolder {

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
@@ -24,8 +24,6 @@ import static net.minecraft.server.world.ChunkLevelType.INACCESSIBLE;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
-import com.mojang.logging.LogUtils;
-import org.slf4j.Logger;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -37,7 +35,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import net.minecraft.server.world.ChunkHolder;
 import net.minecraft.server.world.ChunkLevelType;
 import net.minecraft.server.world.ChunkLevels;
-import net.minecraft.server.world.OptionalChunk;
 import net.minecraft.server.world.ServerChunkLoadingManager;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.ChunkPos;
@@ -59,19 +56,10 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 	private int lastTickLevel;
 
 	@Shadow
-	private volatile CompletableFuture<OptionalChunk<WorldChunk>> tickingFuture;
-
-	@Shadow
 	protected abstract void combineSavingFuture(CompletableFuture<?> savingFuture);
 
 	@Unique
 	private static final ChunkLevelType[] fabric_CHUNK_LEVEL_TYPES = ChunkLevelType.values(); // values() clones the internal array each call, so cache the return
-
-	@Unique
-	private static final Logger fabric_LOGGER = LogUtils.getLogger();
-
-	@Unique
-	private CompletableFuture<Void> fabric_fullToBlockTickingEvent;
 
 	@Unique
 	private ChunkLevelType fabric_currentEventLevelType = INACCESSIBLE;
@@ -86,7 +74,7 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 	@Inject(method = "updateFutures", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;combineSavingFuture(Ljava/util/concurrent/CompletableFuture;)V", shift = At.Shift.AFTER, ordinal = 0))
 	private void updateFutures$inaccessibleToFull(ServerChunkLoadingManager chunkLoadingManager, Executor executor, CallbackInfo ci) {
 		if (this.getUncheckedOrNull(ChunkStatus.FULL) instanceof WorldChunk && this.fabric_currentEventLevelType == INACCESSIBLE) { // prevent duplicate events with ChunkGeneratingMixin
-			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, INACCESSIBLE, FULL);
+			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, (WorldChunk) this.getUncheckedOrNull(ChunkStatus.FULL), INACCESSIBLE, FULL);
 			this.fabric_currentEventLevelType = FULL;
 		}
 	}
@@ -96,16 +84,10 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 	 */
 	@Inject(method = "updateFutures", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;combineSavingFuture(Ljava/util/concurrent/CompletableFuture;)V", shift = At.Shift.AFTER, ordinal = 1))
 	private void updateFutures$fullToBlockTicking(ServerChunkLoadingManager chunkLoadingManager, Executor executor, CallbackInfo ci) {
-		this.fabric_fullToBlockTickingEvent = this.tickingFuture.thenAccept(optionalChunk -> {
-			try {
-				optionalChunk.ifPresent(worldChunk -> {
-					ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, FULL, BLOCK_TICKING);
-					this.fabric_currentEventLevelType = BLOCK_TICKING;
-				});
-			} catch (Throwable t) {
-				fabric_LOGGER.error("Exception thrown from CHUNK_LEVEL_TYPE_CHANGE event listener.", t);
-			}
-		});
+		if (fabric_currentEventLevelType == FULL) { // if INACCESSIBLE->FULL did not fire immediately, then ChunkGeneratingMixin will handle this later.
+			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, (WorldChunk) this.getUncheckedOrNull(ChunkStatus.FULL), FULL, BLOCK_TICKING);
+			this.fabric_currentEventLevelType = BLOCK_TICKING;
+		}
 	}
 
 	/**
@@ -113,20 +95,16 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 	 */
 	@Inject(method = "updateFutures", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;combineSavingFuture(Ljava/util/concurrent/CompletableFuture;)V", shift = At.Shift.AFTER, ordinal = 2))
 	private void updateFutures$blockTickingToEntityTicking(ServerChunkLoadingManager chunkLoadingManager, Executor executor, CallbackInfo ci) {
-		this.fabric_fullToBlockTickingEvent.thenRun(() -> {
-			try {
-				ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, BLOCK_TICKING, ENTITY_TICKING);
-				this.fabric_currentEventLevelType = ENTITY_TICKING;
-			} catch (Throwable t) {
-				fabric_LOGGER.error("Exception thrown from CHUNK_LEVEL_TYPE_CHANGE event listener.", t);
-			}
-		});
+		if (fabric_currentEventLevelType == BLOCK_TICKING) { // if INACCESSIBLE->FULL->BLOCK_TICKING did not fire immediately, then ChunkGeneratingMixin will handle this later.
+			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, (WorldChunk) this.getUncheckedOrNull(ChunkStatus.FULL), BLOCK_TICKING, ENTITY_TICKING);
+			this.fabric_currentEventLevelType = ENTITY_TICKING;
+		}
 	}
 
 	/**
-	 * Really means increase level (chunk load type demotion).
+	 * Really means increase level (chunk load type demotion). Fire right before onChunkStatusChange() is called.
 	 */
-	@Inject(method = "decreaseLevel", at = @At("TAIL"))
+	@Inject(method = "decreaseLevel", at = @At("HEAD"))
 	private void decreaseLevel(ServerChunkLoadingManager chunkLoadingManager, ChunkLevelType target, CallbackInfo ci) {
 		ChunkLevelType previous = ChunkLevels.getType(this.lastTickLevel);
 		ServerWorld serverWorld = (ServerWorld) world;
@@ -135,7 +113,7 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 			ChunkLevelType oldLevelType = fabric_CHUNK_LEVEL_TYPES[i];
 			ChunkLevelType newLevelType = fabric_CHUNK_LEVEL_TYPES[i-1];
 			if (this.fabric_currentEventLevelType.isAfter(oldLevelType)) { // if a promotion event got cancelled or never finished, then do _not_ fire an equivalent demotion event
-				ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange(serverWorld, this.pos, oldLevelType, newLevelType);
+				ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange(serverWorld, (WorldChunk) this.getUncheckedOrNull(ChunkStatus.FULL), oldLevelType, newLevelType);
 				this.fabric_currentEventLevelType = newLevelType;
 			}
 		}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
@@ -16,12 +16,17 @@
 
 package net.fabricmc.fabric.mixin.event.lifecycle;
 
+import static net.minecraft.server.world.ChunkLevelType.INACCESSIBLE;
 import static net.minecraft.server.world.ChunkLevelType.BLOCK_TICKING;
 import static net.minecraft.server.world.ChunkLevelType.FULL;
-import static net.minecraft.server.world.ChunkLevelType.INACCESSIBLE;
+import static net.minecraft.server.world.ChunkLevelType.ENTITY_TICKING;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+
+import net.fabricmc.fabric.impl.event.lifecycle.ChunkLevelTypeEventTracker;
+
+import net.minecraft.world.chunk.ChunkStatus;
 
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -31,8 +36,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.ServerTask;
 import net.minecraft.server.world.ChunkHolder;
 import net.minecraft.server.world.ChunkLevelType;
 import net.minecraft.server.world.ChunkLevels;
@@ -47,7 +50,7 @@ import net.minecraft.world.chunk.WorldChunk;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
 
 @Mixin(ChunkHolder.class)
-public abstract class ChunkHolderMixin extends AbstractChunkHolder {
+public abstract class ChunkHolderMixin extends AbstractChunkHolder implements ChunkLevelTypeEventTracker {
 	@Shadow
 	@Final
 	private HeightLimitView world;
@@ -55,40 +58,64 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder {
 	@Shadow
 	private int lastTickLevel;
 
+	@Shadow
+	private volatile CompletableFuture<OptionalChunk<WorldChunk>> tickingFuture;
+
+	@Shadow
+	private volatile CompletableFuture<OptionalChunk<WorldChunk>> entityTickingFuture;
+
+	@Shadow
+	protected abstract void combineSavingFuture(CompletableFuture<?> savingFuture);
+
 	@Unique
 	private static final ChunkLevelType[] CHUNK_LEVEL_TYPES = ChunkLevelType.values(); // values() clones the internal array each call, so cache the return
+
+	@Unique
+	private CompletableFuture<Void> fullToBlockTickingEvent;
+
+	@Unique
+	private ChunkLevelType currentEventLevelType = INACCESSIBLE;
 
 	private ChunkHolderMixin(ChunkPos pos) {
 		super(pos);
 	}
 
 	/**
-	 * Really means decrease level (chunk load type promotion).
+	 * Handles INACCESSIBLE -> FULL for chunks that are immediately loaded and available. {@link ChunkGeneratingMixin} handles the rest.
 	 */
-	@Inject(method = "increaseLevel", at = @At("TAIL"))
-	private void increaseLevel(ServerChunkLoadingManager chunkLoadingManager, CompletableFuture<OptionalChunk<WorldChunk>> chunkFuture, Executor executor, ChunkLevelType target, CallbackInfo ci) {
-		ServerWorld serverWorld = (ServerWorld) world;
-		MinecraftServer server = serverWorld.getServer();
-		ChunkLevelType previous = switch (target) {
-		case INACCESSIBLE -> throw new IllegalStateException("target must at least be FULL");
-		case FULL -> INACCESSIBLE;
-		case BLOCK_TICKING -> FULL;
-		case ENTITY_TICKING -> BLOCK_TICKING;
-		};
+	@Inject(method = "updateFutures", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;combineSavingFuture(Ljava/util/concurrent/CompletableFuture;)V", shift = At.Shift.AFTER, ordinal = 0))
+	private void updateFutures$inaccessibleToFull(ServerChunkLoadingManager chunkLoadingManager, Executor executor, CallbackInfo ci) {
+		if (this.getUncheckedOrNull(ChunkStatus.FULL) instanceof WorldChunk && this.currentEventLevelType == INACCESSIBLE) { // prevent duplicate events with ChunkGeneratingMixin
+			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, INACCESSIBLE, FULL);
+			this.currentEventLevelType = FULL;
+		}
+	}
 
-		Runnable runnable = () -> {
-			if (this.getLevelType().isAfter(target)) { // If chunk level type got demoted before promotion event fires, then don't fire it. This almost never happens tho.
-				ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange(serverWorld, this.pos, previous, target);
-			}
-		};
+	/**
+	 * Handles FULL -> BLOCK_TICKING
+	 */
+	@Inject(method = "updateFutures", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;combineSavingFuture(Ljava/util/concurrent/CompletableFuture;)V", shift = At.Shift.AFTER, ordinal = 1))
+	private void updateFutures$fullToBlockTicking(ServerChunkLoadingManager chunkLoadingManager, Executor executor, CallbackInfo ci) {
+		this.fullToBlockTickingEvent = this.tickingFuture.thenAccept(optionalChunk -> {
+			optionalChunk.ifPresent(worldChunk -> {
+				ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, FULL, BLOCK_TICKING);
+				this.currentEventLevelType = BLOCK_TICKING;
+			});
+		});
+	}
 
-		chunkFuture.thenAccept(optionalChunk -> optionalChunk.ifPresent(worldChunk -> {
-			if (!server.isOnThread()) {
-				server.send(new ServerTask(server.getTicks()-10, runnable)); // ensure the server thread runs it within this tick
-			} else {
-				runnable.run();
-			}
-		}));
+	/**
+	 * Handles BLOCK_TICKING -> ENTITY_TICKING
+	 */
+	@Inject(method = "updateFutures", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;combineSavingFuture(Ljava/util/concurrent/CompletableFuture;)V", shift = At.Shift.AFTER, ordinal = 2))
+	private void updateFutures$blockTickingToEntityTicking(ServerChunkLoadingManager chunkLoadingManager, Executor executor, CallbackInfo ci) {
+		this.fullToBlockTickingEvent.thenCombine(this.entityTickingFuture, (tickingOptionalChunk,entityTickingOptionalChunk) -> {
+			entityTickingOptionalChunk.ifPresent(worldChunk -> {
+				ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, BLOCK_TICKING, ENTITY_TICKING);
+				this.currentEventLevelType = ENTITY_TICKING;
+			});
+			return entityTickingOptionalChunk.orElse(null);
+		});
 	}
 
 	/**
@@ -100,7 +127,22 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder {
 		ServerWorld serverWorld = (ServerWorld) world;
 
 		for (int i = previous.ordinal(); i > target.ordinal(); i--) {
-			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange(serverWorld, this.pos, CHUNK_LEVEL_TYPES[i], CHUNK_LEVEL_TYPES[i-1]);
+			ChunkLevelType oldLevelType = CHUNK_LEVEL_TYPES[i];
+			ChunkLevelType newLevelType = CHUNK_LEVEL_TYPES[i-1];
+			if (this.currentEventLevelType.isAfter(oldLevelType)) { // if a promotion event got cancelled, then do _not_ fire an equivalent demotion event
+				ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange(serverWorld, this.pos, oldLevelType, newLevelType);
+				this.currentEventLevelType = newLevelType;
+			}
 		}
+	}
+
+	@Unique
+	public void fabric_setCurrentEventLevelType(ChunkLevelType levelType) {
+		this.currentEventLevelType = levelType;
+	}
+
+	@Unique
+	public ChunkLevelType fabric_getCurrentEventLevelType() {
+		return this.currentEventLevelType;
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
@@ -26,6 +26,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import static net.minecraft.server.world.ChunkLevelType.*;
 import net.minecraft.server.world.ChunkHolder;
 import net.minecraft.server.world.ChunkLevelType;
 import net.minecraft.server.world.ChunkLevels;
@@ -52,13 +53,23 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder {
 		super(pos);
 	}
 
+	/**
+	 * Really means decrease level (chunk load type promotion)
+	 */
 	@Inject(method = "increaseLevel", at = @At("TAIL"))
 	private void increaseLevel(ServerChunkLoadingManager chunkLoadingManager, CompletableFuture<OptionalChunk<WorldChunk>> chunkFuture, Executor executor, ChunkLevelType target, CallbackInfo ci) {
-		ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, ChunkLevels.getType(this.lastTickLevel), target);
+		ChunkLevelType previous = ChunkLevels.getType(this.lastTickLevel); // get it immediately before it gets updated to target
+		chunkFuture.thenAcceptAsync(optionalChunk -> optionalChunk.ifPresent(worldChunk -> ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, previous, target)), executor);
 	}
 
+	/**
+	 * Really means increase level (chunk load type demotion)
+	 */
 	@Inject(method = "decreaseLevel", at = @At("TAIL"))
 	private void decreaseLevel(ServerChunkLoadingManager chunkLoadingManager, ChunkLevelType target, CallbackInfo ci) {
-		ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, ChunkLevels.getType(this.lastTickLevel), target);
+		ChunkLevelType previous = ChunkLevels.getType(this.lastTickLevel);
+		if (previous.isAfter(ENTITY_TICKING) && !target.isAfter(ENTITY_TICKING)) ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, ENTITY_TICKING, BLOCK_TICKING);
+		if (previous.isAfter(BLOCK_TICKING) && !target.isAfter(BLOCK_TICKING)) ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, BLOCK_TICKING, FULL);
+		if (previous.isAfter(FULL) && !target.isAfter(FULL)) ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, FULL, INACCESSIBLE);
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
@@ -17,7 +17,6 @@
 package net.fabricmc.fabric.mixin.event.lifecycle;
 
 import static net.minecraft.server.world.ChunkLevelType.BLOCK_TICKING;
-import static net.minecraft.server.world.ChunkLevelType.ENTITY_TICKING;
 import static net.minecraft.server.world.ChunkLevelType.FULL;
 import static net.minecraft.server.world.ChunkLevelType.INACCESSIBLE;
 
@@ -27,6 +26,7 @@ import java.util.concurrent.Executor;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -54,6 +54,9 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder {
 
 	@Shadow
 	private int lastTickLevel;
+
+	@Unique
+	private static final ChunkLevelType[] CHUNK_LEVEL_TYPES = ChunkLevelType.values(); // values() clones the internal array each call, so cache the return
 
 	private ChunkHolderMixin(ChunkPos pos) {
 		super(pos);
@@ -94,17 +97,10 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder {
 	@Inject(method = "decreaseLevel", at = @At("TAIL"))
 	private void decreaseLevel(ServerChunkLoadingManager chunkLoadingManager, ChunkLevelType target, CallbackInfo ci) {
 		ChunkLevelType previous = ChunkLevels.getType(this.lastTickLevel);
+		ServerWorld serverWorld = (ServerWorld) world;
 
-		if (previous.isAfter(ENTITY_TICKING) && !target.isAfter(ENTITY_TICKING)) {
-			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, ENTITY_TICKING, BLOCK_TICKING);
-		}
-
-		if (previous.isAfter(BLOCK_TICKING) && !target.isAfter(BLOCK_TICKING)) {
-			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, BLOCK_TICKING, FULL);
-		}
-
-		if (previous.isAfter(FULL) && !target.isAfter(FULL)) {
-			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, FULL, INACCESSIBLE);
+		for (int i = previous.ordinal(); i > target.ordinal(); i--) {
+			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange(serverWorld, this.pos, CHUNK_LEVEL_TYPES[i], CHUNK_LEVEL_TYPES[i-1]);
 		}
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
@@ -19,6 +19,10 @@ package net.fabricmc.fabric.mixin.event.lifecycle;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.ServerTask;
+
+import org.slf4j.LoggerFactory;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -58,8 +62,17 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder {
 	 */
 	@Inject(method = "increaseLevel", at = @At("TAIL"))
 	private void increaseLevel(ServerChunkLoadingManager chunkLoadingManager, CompletableFuture<OptionalChunk<WorldChunk>> chunkFuture, Executor executor, ChunkLevelType target, CallbackInfo ci) {
-		ChunkLevelType previous = ChunkLevels.getType(this.lastTickLevel); // get it immediately before it gets updated to target
-		chunkFuture.thenAcceptAsync(optionalChunk -> optionalChunk.ifPresent(worldChunk -> ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, previous, target)), executor);
+		ChunkLevelType previous = ChunkLevels.getType(this.lastTickLevel);
+		ServerWorld serverWorld = (ServerWorld) world;
+		MinecraftServer server = serverWorld.getServer();
+		Runnable runnable = () -> ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange(serverWorld, this.pos, previous, target);
+		chunkFuture.thenAccept(optionalChunk -> optionalChunk.ifPresent(worldChunk -> {
+			if (!server.isOnThread()) {
+				LoggerFactory.getLogger(ChunkHolderMixin.class).warn("{} {} -> {} INITIALLY NOT ON SERVER THREAD", this.pos, previous, target); // temp check
+				server.send(new ServerTask(server.getTicks()-10, runnable)); // ensure the server thread runs it within this tick
+			}
+			else runnable.run();
+		}));
 	}
 
 	/**

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
@@ -16,26 +16,22 @@
 
 package net.fabricmc.fabric.mixin.event.lifecycle;
 
-import static net.minecraft.server.world.ChunkLevelType.INACCESSIBLE;
 import static net.minecraft.server.world.ChunkLevelType.BLOCK_TICKING;
-import static net.minecraft.server.world.ChunkLevelType.FULL;
 import static net.minecraft.server.world.ChunkLevelType.ENTITY_TICKING;
+import static net.minecraft.server.world.ChunkLevelType.FULL;
+import static net.minecraft.server.world.ChunkLevelType.INACCESSIBLE;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
-import net.fabricmc.fabric.impl.event.lifecycle.ChunkLevelTypeEventTracker;
-
-import net.minecraft.world.chunk.ChunkStatus;
-
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
-import com.llamalad7.mixinextras.sugar.Local;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.server.world.ChunkHolder;
@@ -43,13 +39,16 @@ import net.minecraft.server.world.ChunkLevelType;
 import net.minecraft.server.world.ChunkLevels;
 import net.minecraft.server.world.OptionalChunk;
 import net.minecraft.server.world.ServerChunkLoadingManager;
+import net.minecraft.server.world.ServerEntityManager;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.HeightLimitView;
 import net.minecraft.world.chunk.AbstractChunkHolder;
+import net.minecraft.world.chunk.ChunkStatus;
 import net.minecraft.world.chunk.WorldChunk;
 
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
+import net.fabricmc.fabric.impl.event.lifecycle.ChunkLevelTypeEventTracker;
 
 @Mixin(ChunkHolder.class)
 public abstract class ChunkHolderMixin extends AbstractChunkHolder implements ChunkLevelTypeEventTracker {
@@ -64,13 +63,7 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 	private volatile CompletableFuture<OptionalChunk<WorldChunk>> tickingFuture;
 
 	@Shadow
-	private volatile CompletableFuture<OptionalChunk<WorldChunk>> entityTickingFuture;
-
-	@Shadow
 	protected abstract void combineSavingFuture(CompletableFuture<?> savingFuture);
-
-	@Shadow
-	private CompletableFuture<?> levelIncreaseFuture;
 
 	@Unique
 	private static final ChunkLevelType[] CHUNK_LEVEL_TYPES = ChunkLevelType.values(); // values() clones the internal array each call, so cache the return
@@ -97,7 +90,7 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 	}
 
 	/**
-	 * Handles FULL -> BLOCK_TICKING
+	 * Handles FULL -> BLOCK_TICKING.
 	 */
 	@Inject(method = "updateFutures", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;combineSavingFuture(Ljava/util/concurrent/CompletableFuture;)V", shift = At.Shift.AFTER, ordinal = 1))
 	private void updateFutures$fullToBlockTicking(ServerChunkLoadingManager chunkLoadingManager, Executor executor, CallbackInfo ci) {
@@ -110,13 +103,15 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 	}
 
 	/**
-	 * Handles BLOCK_TICKING -> ENTITY_TICKING
+	 * Handles BLOCK_TICKING -> ENTITY_TICKING. Fire after entity tracking statuses have been updated.
+	 *
+	 * @param original The call to onChunkStatusChange(), which calls {@link ServerEntityManager#updateTrackingStatus(ChunkPos, ChunkLevelType)}.
 	 */
 	@ModifyExpressionValue(method = "increaseLevel", at = @At(value = "INVOKE", target = "Ljava/util/concurrent/CompletableFuture;thenRunAsync(Ljava/lang/Runnable;Ljava/util/concurrent/Executor;)Ljava/util/concurrent/CompletableFuture;"))
 	private CompletableFuture<Void> increaseLevel$$blockTickingToEntityTicking(CompletableFuture<Void> original, @Local(argsOnly = true) ChunkLevelType target) {
 		if (target != ENTITY_TICKING) return original;
 
-		this.fullToBlockTickingEvent.thenCombine(original, (void0,void1) -> {
+		this.fullToBlockTickingEvent.thenCombine(original, (void0, void1) -> {
 			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, BLOCK_TICKING, ENTITY_TICKING);
 			this.currentEventLevelType = ENTITY_TICKING;
 			return null;
@@ -136,7 +131,7 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 		for (int i = previous.ordinal(); i > target.ordinal(); i--) {
 			ChunkLevelType oldLevelType = CHUNK_LEVEL_TYPES[i];
 			ChunkLevelType newLevelType = CHUNK_LEVEL_TYPES[i-1];
-			if (this.currentEventLevelType.isAfter(oldLevelType)) { // if a promotion event got cancelled, then do _not_ fire an equivalent demotion event
+			if (this.currentEventLevelType.isAfter(oldLevelType)) { // if a promotion event got cancelled or never finished, then do _not_ fire an equivalent demotion event
 				ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange(serverWorld, this.pos, oldLevelType, newLevelType);
 				this.currentEventLevelType = newLevelType;
 			}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
@@ -24,8 +24,6 @@ import static net.minecraft.server.world.ChunkLevelType.INACCESSIBLE;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
-import com.llamalad7.mixinextras.sugar.Local;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -39,7 +37,6 @@ import net.minecraft.server.world.ChunkLevelType;
 import net.minecraft.server.world.ChunkLevels;
 import net.minecraft.server.world.OptionalChunk;
 import net.minecraft.server.world.ServerChunkLoadingManager;
-import net.minecraft.server.world.ServerEntityManager;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.HeightLimitView;
@@ -103,21 +100,14 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 	}
 
 	/**
-	 * Handles BLOCK_TICKING -> ENTITY_TICKING. Fire after entity tracking statuses have been updated, cause that's what makes entities actually start ticking.
-	 *
-	 * @param original The call to onChunkStatusChange(), which calls {@link ServerEntityManager#updateTrackingStatus(ChunkPos, ChunkLevelType)}.
+	 * Handles FULL -> BLOCK_TICKING.
 	 */
-	@ModifyExpressionValue(method = "increaseLevel", at = @At(value = "INVOKE", target = "Ljava/util/concurrent/CompletableFuture;thenRunAsync(Ljava/lang/Runnable;Ljava/util/concurrent/Executor;)Ljava/util/concurrent/CompletableFuture;"))
-	private CompletableFuture<Void> increaseLevel$$blockTickingToEntityTicking(CompletableFuture<Void> original, @Local(argsOnly = true) ChunkLevelType target) {
-		if (target != ENTITY_TICKING) return original;
-
-		this.fullToBlockTickingEvent.thenCombine(original, (void0, void1) -> {
+	@Inject(method = "updateFutures", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;combineSavingFuture(Ljava/util/concurrent/CompletableFuture;)V", shift = At.Shift.AFTER, ordinal = 2))
+	private void updateFutures$blockTickingToEntityTicking(ServerChunkLoadingManager chunkLoadingManager, Executor executor, CallbackInfo ci) {
+		this.fullToBlockTickingEvent.thenAccept(optionalChunk -> {
 			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, BLOCK_TICKING, ENTITY_TICKING);
 			this.currentEventLevelType = ENTITY_TICKING;
-			return null;
 		});
-
-		return original;
 	}
 
 	/**

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
@@ -16,13 +16,14 @@
 
 package net.fabricmc.fabric.mixin.event.lifecycle;
 
+import static net.minecraft.server.world.ChunkLevelType.BLOCK_TICKING;
+import static net.minecraft.server.world.ChunkLevelType.ENTITY_TICKING;
+import static net.minecraft.server.world.ChunkLevelType.FULL;
+import static net.minecraft.server.world.ChunkLevelType.INACCESSIBLE;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.ServerTask;
-
-import org.slf4j.LoggerFactory;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -30,7 +31,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import static net.minecraft.server.world.ChunkLevelType.*;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.ServerTask;
 import net.minecraft.server.world.ChunkHolder;
 import net.minecraft.server.world.ChunkLevelType;
 import net.minecraft.server.world.ChunkLevels;
@@ -58,36 +60,51 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder {
 	}
 
 	/**
-	 * Really means decrease level (chunk load type promotion)
+	 * Really means decrease level (chunk load type promotion).
 	 */
 	@Inject(method = "increaseLevel", at = @At("TAIL"))
 	private void increaseLevel(ServerChunkLoadingManager chunkLoadingManager, CompletableFuture<OptionalChunk<WorldChunk>> chunkFuture, Executor executor, ChunkLevelType target, CallbackInfo ci) {
 		ServerWorld serverWorld = (ServerWorld) world;
 		MinecraftServer server = serverWorld.getServer();
 		ChunkLevelType previous = switch (target) {
-			case INACCESSIBLE -> throw new IllegalStateException("target must at least be FULL");
-			case FULL -> INACCESSIBLE;
-			case BLOCK_TICKING -> FULL;
-			case ENTITY_TICKING -> BLOCK_TICKING;
+		case INACCESSIBLE -> throw new IllegalStateException("target must at least be FULL");
+		case FULL -> INACCESSIBLE;
+		case BLOCK_TICKING -> FULL;
+		case ENTITY_TICKING -> BLOCK_TICKING;
 		};
-		Runnable runnable = () -> ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange(serverWorld, this.pos, previous, target);
+
+		Runnable runnable = () -> {
+			if (this.getLevelType().isAfter(target)) { // If chunk level type got demoted before promotion event fires, then don't fire it. This almost never happens tho.
+				ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange(serverWorld, this.pos, previous, target);
+			}
+		};
+
 		chunkFuture.thenAccept(optionalChunk -> optionalChunk.ifPresent(worldChunk -> {
 			if (!server.isOnThread()) {
-				LoggerFactory.getLogger(ChunkHolderMixin.class).warn("{} {} -> {} INITIALLY NOT ON SERVER THREAD", this.pos, previous, target); // temp check
 				server.send(new ServerTask(server.getTicks()-10, runnable)); // ensure the server thread runs it within this tick
+			} else {
+				runnable.run();
 			}
-			else runnable.run();
 		}));
 	}
 
 	/**
-	 * Really means increase level (chunk load type demotion)
+	 * Really means increase level (chunk load type demotion).
 	 */
 	@Inject(method = "decreaseLevel", at = @At("TAIL"))
 	private void decreaseLevel(ServerChunkLoadingManager chunkLoadingManager, ChunkLevelType target, CallbackInfo ci) {
 		ChunkLevelType previous = ChunkLevels.getType(this.lastTickLevel);
-		if (previous.isAfter(ENTITY_TICKING) && !target.isAfter(ENTITY_TICKING)) ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, ENTITY_TICKING, BLOCK_TICKING);
-		if (previous.isAfter(BLOCK_TICKING) && !target.isAfter(BLOCK_TICKING)) ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, BLOCK_TICKING, FULL);
-		if (previous.isAfter(FULL) && !target.isAfter(FULL)) ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, FULL, INACCESSIBLE);
+
+		if (previous.isAfter(ENTITY_TICKING) && !target.isAfter(ENTITY_TICKING)) {
+			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, ENTITY_TICKING, BLOCK_TICKING);
+		}
+
+		if (previous.isAfter(BLOCK_TICKING) && !target.isAfter(BLOCK_TICKING)) {
+			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, BLOCK_TICKING, FULL);
+		}
+
+		if (previous.isAfter(FULL) && !target.isAfter(FULL)) {
+			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, FULL, INACCESSIBLE);
+		}
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
@@ -62,9 +62,14 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder {
 	 */
 	@Inject(method = "increaseLevel", at = @At("TAIL"))
 	private void increaseLevel(ServerChunkLoadingManager chunkLoadingManager, CompletableFuture<OptionalChunk<WorldChunk>> chunkFuture, Executor executor, ChunkLevelType target, CallbackInfo ci) {
-		ChunkLevelType previous = ChunkLevels.getType(this.lastTickLevel);
 		ServerWorld serverWorld = (ServerWorld) world;
 		MinecraftServer server = serverWorld.getServer();
+		ChunkLevelType previous = switch (target) {
+			case INACCESSIBLE -> throw new IllegalStateException("target must at least be FULL");
+			case FULL -> INACCESSIBLE;
+			case BLOCK_TICKING -> FULL;
+			case ENTITY_TICKING -> BLOCK_TICKING;
+		};
 		Runnable runnable = () -> ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange(serverWorld, this.pos, previous, target);
 		chunkFuture.thenAccept(optionalChunk -> optionalChunk.ifPresent(worldChunk -> {
 			if (!server.isOnThread()) {

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
@@ -1,0 +1,49 @@
+package net.fabricmc.fabric.mixin.event.lifecycle;
+
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
+
+import net.minecraft.server.world.ChunkHolder;
+
+import net.minecraft.server.world.ChunkLevelType;
+import net.minecraft.server.world.ChunkLevels;
+import net.minecraft.server.world.OptionalChunk;
+import net.minecraft.server.world.ServerChunkLoadingManager;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.HeightLimitView;
+import net.minecraft.world.chunk.AbstractChunkHolder;
+import net.minecraft.world.chunk.WorldChunk;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+@Mixin(ChunkHolder.class)
+public abstract class ChunkHolderMixin extends AbstractChunkHolder {
+	@Shadow
+	@Final
+	private HeightLimitView world;
+
+	@Shadow
+	private int lastTickLevel;
+
+	private ChunkHolderMixin(ChunkPos pos) {
+		super(pos);
+	}
+
+	@Inject(method = "increaseLevel", at = @At("TAIL"))
+	private void increaseLevel(ServerChunkLoadingManager chunkLoadingManager, CompletableFuture<OptionalChunk<WorldChunk>> chunkFuture, Executor executor, ChunkLevelType target, CallbackInfo ci) {
+		ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, ChunkLevels.getType(this.lastTickLevel), target);
+	}
+
+	@Inject(method = "decreaseLevel", at = @At("TAIL"))
+	private void decreaseLevel(ServerChunkLoadingManager chunkLoadingManager, ChunkLevelType target, CallbackInfo ci) {
+		ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, ChunkLevels.getType(this.lastTickLevel), target);
+	}
+}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
@@ -34,6 +34,8 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.server.world.ChunkHolder;
@@ -66,6 +68,9 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 
 	@Shadow
 	protected abstract void combineSavingFuture(CompletableFuture<?> savingFuture);
+
+	@Shadow
+	private CompletableFuture<?> levelIncreaseFuture;
 
 	@Unique
 	private static final ChunkLevelType[] CHUNK_LEVEL_TYPES = ChunkLevelType.values(); // values() clones the internal array each call, so cache the return
@@ -107,15 +112,17 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 	/**
 	 * Handles BLOCK_TICKING -> ENTITY_TICKING
 	 */
-	@Inject(method = "updateFutures", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;combineSavingFuture(Ljava/util/concurrent/CompletableFuture;)V", shift = At.Shift.AFTER, ordinal = 2))
-	private void updateFutures$blockTickingToEntityTicking(ServerChunkLoadingManager chunkLoadingManager, Executor executor, CallbackInfo ci) {
-		this.fullToBlockTickingEvent.thenCombine(this.entityTickingFuture, (tickingOptionalChunk,entityTickingOptionalChunk) -> {
-			entityTickingOptionalChunk.ifPresent(worldChunk -> {
-				ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, BLOCK_TICKING, ENTITY_TICKING);
-				this.currentEventLevelType = ENTITY_TICKING;
-			});
-			return entityTickingOptionalChunk.orElse(null);
+	@ModifyExpressionValue(method = "increaseLevel", at = @At(value = "INVOKE", target = "Ljava/util/concurrent/CompletableFuture;thenRunAsync(Ljava/lang/Runnable;Ljava/util/concurrent/Executor;)Ljava/util/concurrent/CompletableFuture;"))
+	private CompletableFuture<Void> increaseLevel$$blockTickingToEntityTicking(CompletableFuture<Void> original, @Local(argsOnly = true) ChunkLevelType target) {
+		if (target != ENTITY_TICKING) return original;
+
+		this.fullToBlockTickingEvent.thenCombine(original, (void0,void1) -> {
+			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, BLOCK_TICKING, ENTITY_TICKING);
+			this.currentEventLevelType = ENTITY_TICKING;
+			return null;
 		});
+
+		return original;
 	}
 
 	/**

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
@@ -115,12 +115,12 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 		}
 	}
 
-	@Unique
+	@Override
 	public void fabric_setCurrentEventLevelType(ChunkLevelType levelType) {
 		this.fabric_currentEventLevelType = levelType;
 	}
 
-	@Unique
+	@Override
 	public ChunkLevelType fabric_getCurrentEventLevelType() {
 		return this.fabric_currentEventLevelType;
 	}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
@@ -103,7 +103,7 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 	}
 
 	/**
-	 * Handles BLOCK_TICKING -> ENTITY_TICKING. Fire after entity tracking statuses have been updated.
+	 * Handles BLOCK_TICKING -> ENTITY_TICKING. Fire after entity tracking statuses have been updated, cause that's what makes entities actually start ticking.
 	 *
 	 * @param original The call to onChunkStatusChange(), which calls {@link ServerEntityManager#updateTrackingStatus(ChunkPos, ChunkLevelType)}.
 	 */

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
@@ -21,7 +21,6 @@ import static net.minecraft.server.world.ChunkLevelType.ENTITY_TICKING;
 import static net.minecraft.server.world.ChunkLevelType.FULL;
 import static net.minecraft.server.world.ChunkLevelType.INACCESSIBLE;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 import org.spongepowered.asm.mixin.Final;
@@ -54,9 +53,6 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 
 	@Shadow
 	private int lastTickLevel;
-
-	@Shadow
-	protected abstract void combineSavingFuture(CompletableFuture<?> savingFuture);
 
 	@Unique
 	private static final ChunkLevelType[] fabric_CHUNK_LEVEL_TYPES = ChunkLevelType.values(); // values() clones the internal array each call, so cache the return

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
@@ -24,6 +24,8 @@ import static net.minecraft.server.world.ChunkLevelType.INACCESSIBLE;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
+import com.mojang.logging.LogUtils;
+import org.slf4j.Logger;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -66,6 +68,9 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 	private static final ChunkLevelType[] fabric_CHUNK_LEVEL_TYPES = ChunkLevelType.values(); // values() clones the internal array each call, so cache the return
 
 	@Unique
+	private static final Logger fabric_LOGGER = LogUtils.getLogger();
+
+	@Unique
 	private CompletableFuture<Void> fabric_fullToBlockTickingEvent;
 
 	@Unique
@@ -92,10 +97,14 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 	@Inject(method = "updateFutures", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;combineSavingFuture(Ljava/util/concurrent/CompletableFuture;)V", shift = At.Shift.AFTER, ordinal = 1))
 	private void updateFutures$fullToBlockTicking(ServerChunkLoadingManager chunkLoadingManager, Executor executor, CallbackInfo ci) {
 		this.fabric_fullToBlockTickingEvent = this.tickingFuture.thenAccept(optionalChunk -> {
-			optionalChunk.ifPresent(worldChunk -> {
-				ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, FULL, BLOCK_TICKING);
-				this.fabric_currentEventLevelType = BLOCK_TICKING;
-			});
+			try {
+				optionalChunk.ifPresent(worldChunk -> {
+					ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, FULL, BLOCK_TICKING);
+					this.fabric_currentEventLevelType = BLOCK_TICKING;
+				});
+			} catch (Throwable t) {
+				fabric_LOGGER.error("Exception thrown from CHUNK_LEVEL_TYPE_CHANGE event listener.", t);
+			}
 		});
 	}
 
@@ -104,9 +113,13 @@ public abstract class ChunkHolderMixin extends AbstractChunkHolder implements Ch
 	 */
 	@Inject(method = "updateFutures", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;combineSavingFuture(Ljava/util/concurrent/CompletableFuture;)V", shift = At.Shift.AFTER, ordinal = 2))
 	private void updateFutures$blockTickingToEntityTicking(ServerChunkLoadingManager chunkLoadingManager, Executor executor, CallbackInfo ci) {
-		this.fabric_fullToBlockTickingEvent.thenAccept(optionalChunk -> {
-			ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, BLOCK_TICKING, ENTITY_TICKING);
-			this.fabric_currentEventLevelType = ENTITY_TICKING;
+		this.fabric_fullToBlockTickingEvent.thenRun(() -> {
+			try {
+				ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.invoker().onChunkLevelTypeChange((ServerWorld) world, this.pos, BLOCK_TICKING, ENTITY_TICKING);
+				this.fabric_currentEventLevelType = ENTITY_TICKING;
+			} catch (Throwable t) {
+				fabric_LOGGER.error("Exception thrown from CHUNK_LEVEL_TYPE_CHANGE event listener.", t);
+			}
 		});
 	}
 

--- a/fabric-lifecycle-events-v1/src/main/resources/fabric-lifecycle-events-v1.mixins.json
+++ b/fabric-lifecycle-events-v1/src/main/resources/fabric-lifecycle-events-v1.mixins.json
@@ -4,13 +4,14 @@
   "compatibilityLevel": "JAVA_21",
   "mixins": [
     "ChunkGeneratingMixin",
+    "ChunkHolderMixin",
     "DataPackContentsMixin",
     "LivingEntityMixin",
     "MinecraftServerMixin",
     "PlayerManagerMixin",
-    "ServerWorldServerEntityHandlerMixin",
-    "ServerWorldMixin",
     "ServerChunkLoadingManagerMixin",
+    "ServerWorldMixin",
+    "ServerWorldServerEntityHandlerMixin",
     "WorldMixin"
   ],
   "server": [

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
@@ -92,7 +92,7 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 
 			ChunkLevelType trackedOld = worldsChunkLevelTypeTracker.computeIfAbsent(worldKey, obj -> new Long2ObjectOpenHashMap<>()).computeIfAbsent(chunkPos.toLong(), l -> ChunkLevelType.INACCESSIBLE);
 
-			if (trackedOld != oldLevelType) { // check if the oldLevelType == the newLevelType from the previous event for this chunk
+			if (trackedOld != oldLevelType) { // check if newLevelType from the previous event == oldLevelType for this current event. Catches any out-of-sync firing issues.
 				AssertionError error = new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " " + oldLevelType + "->" + newLevelType + " / TRACKED_OLD: " + trackedOld);
 				LOGGER.error(error.getMessage(), error);
 				world.getServer().stop(false);

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
@@ -21,11 +21,6 @@ import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
-
-import net.minecraft.util.TriState;
-
-import net.minecraft.world.chunk.ChunkStatus;
-
 import org.slf4j.Logger;
 
 import net.minecraft.server.world.ChunkLevelType;
@@ -77,6 +72,7 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 			if (Thread.currentThread() != world.getServer().getThread()) LOGGER.error("{} NOT ON SERVER THREAD", chunkPos);
 			if (oldLevelType == newLevelType) LOGGER.error("{} {} SAME LEVEL TYPE", chunkPos, oldLevelType);
 
+			/* not sure how useful these tests are...
 			if (newLevelType.isAfter(ChunkLevelType.FULL)) {
 				if (world.getChunk(chunkPos.x, chunkPos.z, ChunkStatus.FULL, false) == null) LOGGER.error("{} {} BUT NOT WORLD CHUNK ACCESSIBLE", chunkPos, newLevelType);
 			}
@@ -87,7 +83,7 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 				//if (world.getChunkManager().chunkLoadingManager.getLevelManager().shouldTick(chunkPos.toLong()) == TriState.FALSE) LOGGER.error("{} {} BUT NOT TICKING CHUNKS", chunkPos, newLevelType);
 				if (!world.shouldTickEntityAt(chunkPos.getCenterAtY(0))) LOGGER.error("{} {} BUT NOT TICKING ENTITIES", chunkPos, newLevelType);
 				if (!world.canSpawnEntitiesAt(chunkPos)) LOGGER.error("{} {} BUT CANNOT SPAWN ENTITIES", chunkPos, newLevelType);
-			}
+			}*/
 
 			worlds.putIfAbsent(world.getRegistryKey().getValue(), new Object2IntOpenHashMap<>());
 			worlds.get(world.getRegistryKey().getValue()).mergeInt(newLevelType, 1, Integer::sum);

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
@@ -74,8 +74,7 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 		final Object2ObjectMap<Identifier, Long2ObjectOpenHashMap<ChunkLevelTypeEvent>> worldsChunkLevelTypeTracker = new Object2ObjectOpenHashMap<>();
 
 		/*
-		Since this event is frequently called within the server's main thread executor, simply throwing the AssertionError does not actually crash the game.
-		Instead it gets silently ignored. So log the error and call stop() manually.
+		Ensure game crashes when any tests fails.
 		 */
 		ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.register((world, chunkPos, oldLevelType, newLevelType) -> {
 			final Identifier worldKey = world.getRegistryKey().getValue();

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
@@ -32,11 +32,9 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 
-
 public final class ServerChunkLifecycleTests implements ModInitializer {
 	private static final Logger LOGGER = LogUtils.getLogger();
-
-	private record ChunkLevelTypeEvent(ChunkLevelType oldLevelType, ChunkLevelType newLevelType) {}
+	private record ChunkLevelTypeEvent(ChunkLevelType oldLevelType, ChunkLevelType newLevelType) { }
 
 	@Override
 	public void onInitialize() {

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
@@ -21,6 +21,11 @@ import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+
+import net.minecraft.util.TriState;
+
+import net.minecraft.world.chunk.ChunkStatus;
+
 import org.slf4j.Logger;
 
 import net.minecraft.server.world.ChunkLevelType;
@@ -69,6 +74,21 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 	private static void setupChunkLevelTypeChangeTest() {
 		final Object2ObjectMap<Identifier, Object2IntMap<ChunkLevelType>> worlds = new Object2ObjectOpenHashMap<>();
 		ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.register((world, chunkPos, oldLevelType, newLevelType) -> {
+			if (Thread.currentThread() != world.getServer().getThread()) LOGGER.error("{} NOT ON SERVER THREAD", chunkPos);
+			if (oldLevelType == newLevelType) LOGGER.error("{} {} SAME LEVEL TYPE", chunkPos, oldLevelType);
+
+			if (newLevelType.isAfter(ChunkLevelType.FULL)) {
+				if (world.getChunk(chunkPos.x, chunkPos.z, ChunkStatus.FULL, false) == null) LOGGER.error("{} {} BUT NOT WORLD CHUNK ACCESSIBLE", chunkPos, newLevelType);
+			}
+			if (newLevelType.isAfter(ChunkLevelType.BLOCK_TICKING)) {
+				if (!world.shouldTickBlocksInChunk(chunkPos.toLong())) LOGGER.error("{} {} BUT NOT TICKING BLOCKS", chunkPos, newLevelType);
+			}
+			if (newLevelType.isAfter(ChunkLevelType.ENTITY_TICKING)) {
+				//if (world.getChunkManager().chunkLoadingManager.getLevelManager().shouldTick(chunkPos.toLong()) == TriState.FALSE) LOGGER.error("{} {} BUT NOT TICKING CHUNKS", chunkPos, newLevelType);
+				if (!world.shouldTickEntityAt(chunkPos.getCenterAtY(0))) LOGGER.error("{} {} BUT NOT TICKING ENTITIES", chunkPos, newLevelType);
+				if (!world.canSpawnEntitiesAt(chunkPos)) LOGGER.error("{} {} BUT CANNOT SPAWN ENTITIES", chunkPos, newLevelType);
+			}
+
 			worlds.putIfAbsent(world.getRegistryKey().getValue(), new Object2IntOpenHashMap<>());
 			worlds.get(world.getRegistryKey().getValue()).mergeInt(newLevelType, 1, Integer::sum);
 		});

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 
 import net.minecraft.server.world.ChunkLevelType;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.ChunkPos;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
@@ -73,11 +74,18 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 		final Object2ObjectMap<Identifier, Object2IntMap<ChunkLevelType>> worldsChunkLevelEvents = new Object2ObjectOpenHashMap<>();
 		final Object2ObjectMap<Identifier, Long2ObjectOpenHashMap<ChunkLevelTypeEvent>> worldsChunkLevelTypeTracker = new Object2ObjectOpenHashMap<>();
 
-		/*
-		Ensure game crashes when any tests fails.
-		 */
-		ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.register((world, chunkPos, oldLevelType, newLevelType) -> {
+		// Ensure game crashes when any tests fails.
+		ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.register((world, worldChunk, oldLevelType, newLevelType) -> {
 			final Identifier worldKey = world.getRegistryKey().getValue();
+
+			if (worldChunk == null) {
+				AssertionError error = new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " NULL WORLD CHUNK: " + oldLevelType + "->" + newLevelType);
+				LOGGER.error(error.getMessage(), error);
+				world.getServer().stop(false);
+				return;
+			}
+
+			final ChunkPos chunkPos = worldChunk.getPos();
 
 			if (Thread.currentThread() != world.getServer().getThread()) {
 				AssertionError error = new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " NOT ON SERVER THREAD: " + oldLevelType + "->" + newLevelType);
@@ -120,6 +128,19 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 				levelTypes.forEach((newLevelType, numOfEvents) -> sb.append(newLevelType).append(": ").append(numOfEvents).append(", "));
 				LOGGER.info(sb.toString());
 				levelTypes.clear();
+			}
+
+			final Object2IntMap<ChunkLevelType> total = new Object2IntOpenHashMap<>();
+
+			if (world.getTime() % 100 != 0) { // limit to 5 per second
+				worldsChunkLevelTypeTracker.get(world.getRegistryKey().getValue()).forEach((chunkPos, chunkLevelTypeEvent) -> {
+					total.mergeInt(chunkLevelTypeEvent.newLevelType, 1, Integer::sum);
+				});
+				StringBuilder msg = new StringBuilder(world.getRegistryKey().getValue().toString() + " ");
+				total.forEach((chunkLevelType, t) -> {
+					msg.append(chunkLevelType).append(": ").append(t).append(", ");
+				});
+				LOGGER.warn(msg.toString());
 			}
 		});
 

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
@@ -103,27 +103,36 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 		});
 
 		ServerTickEvents.END_WORLD_TICK.register(world -> {
-			if (world.getTime() % 20 != 0) { // limit to 1 per second
-				return;
-			}
+			if (world.getTime() % 20 == 0) { // limit to 1 per second
+				Object2IntMap<ChunkLevelType> levelTypes = worldsChunkLevelEvents.get(world.getRegistryKey().getValue());
 
-			Object2IntMap<ChunkLevelType> levelTypes = worldsChunkLevelEvents.get(world.getRegistryKey().getValue());
-
-			if (levelTypes == null) {
-				return;
-			}
-
-			if (!levelTypes.isEmpty()) {
-				StringBuilder sb = new StringBuilder(world.getRegistryKey().getValue() + " ");
-				// Logs the number of level type changes for each ChunkLevelType, only logs the newLevelType
-				levelTypes.forEach((newLevelType, numOfEvents) -> sb.append(newLevelType).append(": ").append(numOfEvents).append(", "));
-				LOGGER.info(sb.toString());
-				levelTypes.clear();
+				if (levelTypes != null && !levelTypes.isEmpty()) {
+					StringBuilder sb = new StringBuilder(world.getRegistryKey().getValue() + " ");
+					// Logs the number of level type changes for each ChunkLevelType, only logs the newLevelType
+					levelTypes.forEach((newLevelType, numOfEvents) -> sb.append(newLevelType).append(": ").append(numOfEvents).append(", "));
+					LOGGER.info(sb.toString());
+					levelTypes.clear();
+				}
 			}
 		});
 
 		ServerLifecycleEvents.SERVER_STOPPED.register(server -> {
-			// clear everything otherwise it will trip the test incorrectly when you open another world
+			worldsChunkLevelTypeTracker.forEach((id, chunks) -> {
+				final Object2IntMap<ChunkLevelType> totals = new Object2IntOpenHashMap<>();
+				chunks.forEach((chunkPos, chunkLevelTypeEvent) -> {
+					totals.mergeInt(chunkLevelTypeEvent.newLevelType(), 1, Integer::sum);
+				});
+
+				if (totals.containsKey(ChunkLevelType.FULL) || totals.containsKey(ChunkLevelType.BLOCK_TICKING) || totals.containsKey(ChunkLevelType.ENTITY_TICKING)) {
+					StringBuilder sb = new StringBuilder("CHUNK_LEVEL_TYPE_CHANGE expected all chunks to be INACCESSIBLE for " + id + ", instead got ");
+					totals.forEach((chunkLevelType, finalTotal) -> {
+						sb.append(chunkLevelType).append(": ").append(finalTotal);
+					});
+					LOGGER.error(sb.toString());
+				}
+			});
+
+			// clear everything otherwise it may trip the test incorrectly when you open another world
 			worldsChunkLevelEvents.clear();
 			worldsChunkLevelTypeTracker.clear();
 		});

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
@@ -69,28 +69,22 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 	private static void setupChunkLevelTypeChangeTest() {
 		final Object2ObjectMap<Identifier, Object2IntMap<ChunkLevelType>> worlds = new Object2ObjectOpenHashMap<>();
 		ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.register((world, chunkPos, oldLevelType, newLevelType) -> {
-			if (Thread.currentThread() != world.getServer().getThread()) LOGGER.error("{} NOT ON SERVER THREAD", chunkPos);
-			if (oldLevelType == newLevelType) LOGGER.error("{} {} SAME LEVEL TYPE", chunkPos, oldLevelType);
+			if (Thread.currentThread() != world.getServer().getThread()) {
+				LOGGER.error("{} {} -> {} NOT ON SERVER THREAD", chunkPos, oldLevelType, newLevelType);
+			}
 
-			/* not sure how useful these tests are...
-			if (newLevelType.isAfter(ChunkLevelType.FULL)) {
-				if (world.getChunk(chunkPos.x, chunkPos.z, ChunkStatus.FULL, false) == null) LOGGER.error("{} {} BUT NOT WORLD CHUNK ACCESSIBLE", chunkPos, newLevelType);
+			if (oldLevelType == newLevelType) {
+				LOGGER.error("{} {} SAME LEVEL TYPE", chunkPos, oldLevelType);
 			}
-			if (newLevelType.isAfter(ChunkLevelType.BLOCK_TICKING)) {
-				if (!world.shouldTickBlocksInChunk(chunkPos.toLong())) LOGGER.error("{} {} BUT NOT TICKING BLOCKS", chunkPos, newLevelType);
-			}
-			if (newLevelType.isAfter(ChunkLevelType.ENTITY_TICKING)) {
-				//if (world.getChunkManager().chunkLoadingManager.getLevelManager().shouldTick(chunkPos.toLong()) == TriState.FALSE) LOGGER.error("{} {} BUT NOT TICKING CHUNKS", chunkPos, newLevelType);
-				if (!world.shouldTickEntityAt(chunkPos.getCenterAtY(0))) LOGGER.error("{} {} BUT NOT TICKING ENTITIES", chunkPos, newLevelType);
-				if (!world.canSpawnEntitiesAt(chunkPos)) LOGGER.error("{} {} BUT CANNOT SPAWN ENTITIES", chunkPos, newLevelType);
-			}*/
 
 			worlds.putIfAbsent(world.getRegistryKey().getValue(), new Object2IntOpenHashMap<>());
 			worlds.get(world.getRegistryKey().getValue()).mergeInt(newLevelType, 1, Integer::sum);
 		});
 
 		ServerTickEvents.END_WORLD_TICK.register(world -> {
-			if (world.getTime() % 20 != 0) return; // limit to 1 per second
+			if (world.getTime() % 20 != 0) { // limit to 1 per second
+				return;
+			}
 
 			worlds.putIfAbsent(world.getRegistryKey().getValue(), new Object2IntOpenHashMap<>());
 			Object2IntMap<ChunkLevelType> levelTypes = worlds.get(world.getRegistryKey().getValue());

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
@@ -70,15 +70,14 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 		final Object2ObjectMap<Identifier, Object2IntMap<ChunkLevelType>> worlds = new Object2ObjectOpenHashMap<>();
 		ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.register((world, chunkPos, oldLevelType, newLevelType) -> {
 			if (Thread.currentThread() != world.getServer().getThread()) {
-				LOGGER.error("{} {} -> {} NOT ON SERVER THREAD", chunkPos, oldLevelType, newLevelType);
+				throw new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + chunkPos + " " + oldLevelType + "->" + newLevelType + " NOT ON SERVER THREAD");
 			}
 
 			if (oldLevelType == newLevelType) {
-				LOGGER.error("{} {} SAME LEVEL TYPE", chunkPos, oldLevelType);
+				throw new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + chunkPos + " " + oldLevelType + " SAME LEVEL TYPE");
 			}
 
-			worlds.putIfAbsent(world.getRegistryKey().getValue(), new Object2IntOpenHashMap<>());
-			worlds.get(world.getRegistryKey().getValue()).mergeInt(newLevelType, 1, Integer::sum);
+			worlds.computeIfAbsent(world.getRegistryKey().getValue(), obj -> new Object2IntOpenHashMap<>()).mergeInt(newLevelType, 1, Integer::sum);
 		});
 
 		ServerTickEvents.END_WORLD_TICK.register(world -> {
@@ -86,12 +85,16 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 				return;
 			}
 
-			worlds.putIfAbsent(world.getRegistryKey().getValue(), new Object2IntOpenHashMap<>());
 			Object2IntMap<ChunkLevelType> levelTypes = worlds.get(world.getRegistryKey().getValue());
+
+			if (levelTypes == null) {
+				return;
+			}
 
 			if (!levelTypes.isEmpty()) {
 				StringBuilder sb = new StringBuilder(world.getRegistryKey().getValue() + " ");
-				levelTypes.forEach((levelType, integer) -> sb.append(levelType).append(": ").append(integer).append(", "));
+				// Logs the number of level type changes for each ChunkLevelType, only logs the newLevelType
+				levelTypes.forEach((newLevelType, numOfEvents) -> sb.append(newLevelType).append(": ").append(numOfEvents).append(", "));
 				LOGGER.info(sb.toString());
 				levelTypes.clear();
 			}

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
@@ -79,10 +79,9 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 			final Identifier worldKey = world.getRegistryKey().getValue();
 
 			if (Thread.currentThread() != world.getServer().getThread()) {
-				//AssertionError error = new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " NOT ON SERVER THREAD: " + oldLevelType + "->" + newLevelType);
-				//LOGGER.error(error.getMessage(), error);
-				//world.getServer().stop(false);
-				LOGGER.warn("NOT ON SERVER THREAD {} -> {}", oldLevelType, newLevelType);
+				AssertionError error = new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " NOT ON SERVER THREAD: " + oldLevelType + "->" + newLevelType);
+				LOGGER.error(error.getMessage(), error);
+				world.getServer().stop(false);
 			}
 
 			if (oldLevelType == newLevelType) {
@@ -100,7 +99,6 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 			}
 
 			if (Math.abs(oldLevelType.ordinal() - newLevelType.ordinal()) != 1) { // check if the levelTypes are actually sequential
-				LOGGER.error("not sequential {} {}", oldLevelType, newLevelType);
 				AssertionError error = new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " NOT SEQUENTIAL: " + oldLevelType + "->" + newLevelType);
 				LOGGER.error(error.getMessage(), error);
 				world.getServer().stop(false);

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
@@ -40,7 +40,7 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		setupChunkGenerateTest();
-		setupChunkStatusChangeTest();
+		setupChunkLevelTypeChangeTest();
 	}
 
 	/**
@@ -70,7 +70,7 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 	 * Moving around within the same chunk (use F3+G) should not log anything.
 	 * Moving into another chunk should trigger some logs.
 	 */
-	private static void setupChunkStatusChangeTest() {
+	private static void setupChunkLevelTypeChangeTest() {
 		final Object2ObjectMap<Identifier, Object2IntMap<ChunkLevelType>> worlds = new Object2ObjectOpenHashMap<>();
 		ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.register((world, chunkPos, oldLevelType, newLevelType) -> {
 			worlds.putIfAbsent(world.getRegistryKey().getValue(), new Object2IntOpenHashMap<>());

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
@@ -19,6 +19,13 @@ package net.fabricmc.fabric.test.event.lifecycle;
 import com.mojang.logging.LogUtils;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+
+import net.minecraft.server.world.ChunkLevelType;
+
 import org.slf4j.Logger;
 
 import net.minecraft.util.Identifier;
@@ -33,6 +40,7 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		setupChunkGenerateTest();
+		setupChunkStatusChangeTest();
 	}
 
 	/**
@@ -53,6 +61,33 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 
 		ServerChunkEvents.CHUNK_GENERATE.register((world, chunk) -> {
 			generated.mergeInt(world.getRegistryKey().getValue(), 1, Integer::sum);
+		});
+	}
+
+	/**
+	 * While the world is loading in, this will log a few times.
+	 * Once all chunks within (and just outside) simulation distance have loaded in, logging stops.
+	 * Moving around within the same chunk (use F3+G) should not log anything.
+	 * Moving into another chunk should trigger some logs.
+	 */
+	private static void setupChunkStatusChangeTest() {
+		final Object2ObjectMap<Identifier, Object2IntMap<ChunkLevelType>> worlds = new Object2ObjectOpenHashMap<>();
+		ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.register((world, chunkPos, oldLevelType, newLevelType) -> {
+			worlds.putIfAbsent(world.getRegistryKey().getValue(), new Object2IntOpenHashMap<>());
+			worlds.get(world.getRegistryKey().getValue()).mergeInt(newLevelType, 1, Integer::sum);
+		});
+
+		ServerTickEvents.END_WORLD_TICK.register(world -> {
+			if(world.getTime() % 20 != 0) return; // limit to 1 per second
+
+			worlds.putIfAbsent(world.getRegistryKey().getValue(), new Object2IntOpenHashMap<>());
+			Object2IntMap<ChunkLevelType> levelTypes = worlds.get(world.getRegistryKey().getValue());
+			if(!levelTypes.isEmpty()) {
+				StringBuilder sb = new StringBuilder(world.getRegistryKey().getValue() + " ");
+				levelTypes.forEach((levelType, integer) -> sb.append(levelType).append(": ").append(integer).append(", "));
+				LOGGER.info(sb.toString());
+				levelTypes.clear();
+			}
 		});
 	}
 }

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
@@ -19,15 +19,11 @@ package net.fabricmc.fabric.test.event.lifecycle;
 import com.mojang.logging.LogUtils;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
-
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
-
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
-
-import net.minecraft.server.world.ChunkLevelType;
-
 import org.slf4j.Logger;
 
+import net.minecraft.server.world.ChunkLevelType;
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.api.ModInitializer;
@@ -78,11 +74,12 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 		});
 
 		ServerTickEvents.END_WORLD_TICK.register(world -> {
-			if(world.getTime() % 20 != 0) return; // limit to 1 per second
+			if (world.getTime() % 20 != 0) return; // limit to 1 per second
 
 			worlds.putIfAbsent(world.getRegistryKey().getValue(), new Object2IntOpenHashMap<>());
 			Object2IntMap<ChunkLevelType> levelTypes = worlds.get(world.getRegistryKey().getValue());
-			if(!levelTypes.isEmpty()) {
+
+			if (!levelTypes.isEmpty()) {
 				StringBuilder sb = new StringBuilder(world.getRegistryKey().getValue() + " ");
 				levelTypes.forEach((levelType, integer) -> sb.append(levelType).append(": ").append(integer).append(", "));
 				LOGGER.info(sb.toString());

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
@@ -74,37 +74,28 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 		final Object2ObjectMap<Identifier, Object2IntMap<ChunkLevelType>> worldsChunkLevelEvents = new Object2ObjectOpenHashMap<>();
 		final Object2ObjectMap<Identifier, Long2ObjectOpenHashMap<ChunkLevelTypeEvent>> worldsChunkLevelTypeTracker = new Object2ObjectOpenHashMap<>();
 
-		// Ensure game crashes when any tests fails.
 		ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.register((world, worldChunk, oldLevelType, newLevelType) -> {
 			final Identifier worldKey = world.getRegistryKey().getValue();
 
+			if (!world.getServer().isOnThread()) {
+				world.getServer().stop(false); // make sure the server actually "crashes", the throw below will just log the error.
+				throw new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " NOT ON SERVER THREAD: " + oldLevelType + "->" + newLevelType);
+			}
+
 			if (worldChunk == null) {
-				AssertionError error = new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " NULL WORLD CHUNK: " + oldLevelType + "->" + newLevelType);
-				LOGGER.error(error.getMessage(), error);
-				world.getServer().stop(false);
-				return;
+				throw new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " NULL WORLD CHUNK: " + oldLevelType + "->" + newLevelType);
 			}
 
 			final ChunkPos chunkPos = worldChunk.getPos();
 
-			if (Thread.currentThread() != world.getServer().getThread()) {
-				AssertionError error = new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " NOT ON SERVER THREAD: " + oldLevelType + "->" + newLevelType);
-				LOGGER.error(error.getMessage(), error);
-				world.getServer().stop(false);
-			}
-
 			if (Math.abs(oldLevelType.ordinal() - newLevelType.ordinal()) != 1) { // check if the levelTypes are actually sequential, also ensures levelTypes are not the same
-				AssertionError error = new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " NOT SEQUENTIAL: " + oldLevelType + "->" + newLevelType);
-				LOGGER.error(error.getMessage(), error);
-				world.getServer().stop(false);
+				throw new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " NOT SEQUENTIAL: " + oldLevelType + "->" + newLevelType);
 			}
 
 			ChunkLevelTypeEvent prevEvent = worldsChunkLevelTypeTracker.computeIfAbsent(worldKey, obj -> new Long2ObjectOpenHashMap<>()).computeIfAbsent(chunkPos.toLong(), l -> new ChunkLevelTypeEvent(ChunkLevelType.INACCESSIBLE, ChunkLevelType.INACCESSIBLE));
 
 			if (prevEvent.newLevelType() != oldLevelType) { // check if newLevelType from the previous event == oldLevelType for this current event. Catches any out-of-sync firing issues.
-				AssertionError error = new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " PREVIOUS_EVENT: " + prevEvent.oldLevelType() + "->" + prevEvent.newLevelType() + " / CURRENT_EVENT: " + oldLevelType + "->" + newLevelType);
-				LOGGER.error(error.getMessage(), error);
-				world.getServer().stop(false);
+				throw new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " PREVIOUS_EVENT: " + prevEvent.oldLevelType() + "->" + prevEvent.newLevelType() + " / CURRENT_EVENT: " + oldLevelType + "->" + newLevelType);
 			}
 
 			worldsChunkLevelTypeTracker.get(worldKey).put(chunkPos.toLong(), new ChunkLevelTypeEvent(oldLevelType, newLevelType));
@@ -129,23 +120,10 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 				LOGGER.info(sb.toString());
 				levelTypes.clear();
 			}
-
-			final Object2IntMap<ChunkLevelType> total = new Object2IntOpenHashMap<>();
-
-			if (world.getTime() % 100 != 0) { // limit to 5 per second
-				worldsChunkLevelTypeTracker.get(world.getRegistryKey().getValue()).forEach((chunkPos, chunkLevelTypeEvent) -> {
-					total.mergeInt(chunkLevelTypeEvent.newLevelType, 1, Integer::sum);
-				});
-				StringBuilder msg = new StringBuilder(world.getRegistryKey().getValue().toString() + " ");
-				total.forEach((chunkLevelType, t) -> {
-					msg.append(chunkLevelType).append(": ").append(t).append(", ");
-				});
-				LOGGER.warn(msg.toString());
-			}
 		});
 
 		ServerLifecycleEvents.SERVER_STOPPED.register(server -> {
-			// clear everything otherwise it WILL crash when you open another world
+			// clear everything otherwise it will trip the test incorrectly when you open another world
 			worldsChunkLevelEvents.clear();
 			worldsChunkLevelTypeTracker.clear();
 		});

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
@@ -84,8 +84,8 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 				world.getServer().stop(false);
 			}
 
-			if (oldLevelType == newLevelType) {
-				AssertionError error = new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " SAME LEVEL TYPE: " + oldLevelType);
+			if (Math.abs(oldLevelType.ordinal() - newLevelType.ordinal()) != 1) { // check if the levelTypes are actually sequential, also ensures levelTypes are not the same
+				AssertionError error = new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " NOT SEQUENTIAL: " + oldLevelType + "->" + newLevelType);
 				LOGGER.error(error.getMessage(), error);
 				world.getServer().stop(false);
 			}
@@ -94,12 +94,6 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 
 			if (trackedOld != oldLevelType) { // check if the oldLevelType == the newLevelType from the previous event for this chunk
 				AssertionError error = new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " " + oldLevelType + "->" + newLevelType + " / TRACKED_OLD: " + trackedOld);
-				LOGGER.error(error.getMessage(), error);
-				world.getServer().stop(false);
-			}
-
-			if (Math.abs(oldLevelType.ordinal() - newLevelType.ordinal()) != 1) { // check if the levelTypes are actually sequential
-				AssertionError error = new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " NOT SEQUENTIAL: " + oldLevelType + "->" + newLevelType);
 				LOGGER.error(error.getMessage(), error);
 				world.getServer().stop(false);
 			}

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
@@ -29,10 +29,14 @@ import net.minecraft.util.Identifier;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+
 
 public final class ServerChunkLifecycleTests implements ModInitializer {
 	private static final Logger LOGGER = LogUtils.getLogger();
+
+	private record ChunkLevelTypeEvent(ChunkLevelType oldLevelType, ChunkLevelType newLevelType) {}
 
 	@Override
 	public void onInitialize() {
@@ -69,7 +73,7 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 	 */
 	private static void setupChunkLevelTypeChangeTest() {
 		final Object2ObjectMap<Identifier, Object2IntMap<ChunkLevelType>> worldsChunkLevelEvents = new Object2ObjectOpenHashMap<>();
-		final Object2ObjectMap<Identifier, Long2ObjectOpenHashMap<ChunkLevelType>> worldsChunkLevelTypeTracker = new Object2ObjectOpenHashMap<>();
+		final Object2ObjectMap<Identifier, Long2ObjectOpenHashMap<ChunkLevelTypeEvent>> worldsChunkLevelTypeTracker = new Object2ObjectOpenHashMap<>();
 
 		/*
 		Since this event is frequently called within the server's main thread executor, simply throwing the AssertionError does not actually crash the game.
@@ -90,15 +94,15 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 				world.getServer().stop(false);
 			}
 
-			ChunkLevelType trackedOld = worldsChunkLevelTypeTracker.computeIfAbsent(worldKey, obj -> new Long2ObjectOpenHashMap<>()).computeIfAbsent(chunkPos.toLong(), l -> ChunkLevelType.INACCESSIBLE);
+			ChunkLevelTypeEvent prevEvent = worldsChunkLevelTypeTracker.computeIfAbsent(worldKey, obj -> new Long2ObjectOpenHashMap<>()).computeIfAbsent(chunkPos.toLong(), l -> new ChunkLevelTypeEvent(ChunkLevelType.INACCESSIBLE, ChunkLevelType.INACCESSIBLE));
 
-			if (trackedOld != oldLevelType) { // check if newLevelType from the previous event == oldLevelType for this current event. Catches any out-of-sync firing issues.
-				AssertionError error = new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " " + oldLevelType + "->" + newLevelType + " / TRACKED_OLD: " + trackedOld);
+			if (prevEvent.newLevelType() != oldLevelType) { // check if newLevelType from the previous event == oldLevelType for this current event. Catches any out-of-sync firing issues.
+				AssertionError error = new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " PREVIOUS_EVENT: " + prevEvent.oldLevelType() + "->" + prevEvent.newLevelType() + " / CURRENT_EVENT: " + oldLevelType + "->" + newLevelType);
 				LOGGER.error(error.getMessage(), error);
 				world.getServer().stop(false);
 			}
 
-			worldsChunkLevelTypeTracker.get(worldKey).put(chunkPos.toLong(), newLevelType);
+			worldsChunkLevelTypeTracker.get(worldKey).put(chunkPos.toLong(), new ChunkLevelTypeEvent(oldLevelType, newLevelType));
 			worldsChunkLevelEvents.computeIfAbsent(worldKey, obj -> new Object2IntOpenHashMap<>()).mergeInt(newLevelType, 1, Integer::sum);
 		});
 
@@ -120,6 +124,12 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 				LOGGER.info(sb.toString());
 				levelTypes.clear();
 			}
+		});
+
+		ServerLifecycleEvents.SERVER_STOPPED.register(server -> {
+			// clear everything otherwise it WILL crash when you open another world
+			worldsChunkLevelEvents.clear();
+			worldsChunkLevelTypeTracker.clear();
 		});
 	}
 }

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
@@ -71,26 +71,42 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 		final Object2ObjectMap<Identifier, Object2IntMap<ChunkLevelType>> worldsChunkLevelEvents = new Object2ObjectOpenHashMap<>();
 		final Object2ObjectMap<Identifier, Long2ObjectOpenHashMap<ChunkLevelType>> worldsChunkLevelTypeTracker = new Object2ObjectOpenHashMap<>();
 
+		/*
+		Since this event is frequently called within the server's main thread executor, simply throwing the AssertionError does not actually crash the game.
+		Instead it gets silently ignored. So log the error and call stop() manually.
+		 */
 		ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.register((world, chunkPos, oldLevelType, newLevelType) -> {
-			Identifier worldKey = world.getRegistryKey().getValue();
+			final Identifier worldKey = world.getRegistryKey().getValue();
+
 			if (Thread.currentThread() != world.getServer().getThread()) {
-				throw new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " NOT ON SERVER THREAD: " + oldLevelType + "->" + newLevelType);
+				//AssertionError error = new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " NOT ON SERVER THREAD: " + oldLevelType + "->" + newLevelType);
+				//LOGGER.error(error.getMessage(), error);
+				//world.getServer().stop(false);
+				LOGGER.warn("NOT ON SERVER THREAD {} -> {}", oldLevelType, newLevelType);
 			}
 
 			if (oldLevelType == newLevelType) {
-				throw new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " SAME LEVEL TYPE: " + oldLevelType);
+				AssertionError error = new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " SAME LEVEL TYPE: " + oldLevelType);
+				LOGGER.error(error.getMessage(), error);
+				world.getServer().stop(false);
 			}
 
-			ChunkLevelType trackedPrev = worldsChunkLevelTypeTracker.computeIfAbsent(worldKey, obj -> new Long2ObjectOpenHashMap<>()).computeIfAbsent(chunkPos.toLong(), l -> ChunkLevelType.INACCESSIBLE);
+			ChunkLevelType trackedOld = worldsChunkLevelTypeTracker.computeIfAbsent(worldKey, obj -> new Long2ObjectOpenHashMap<>()).computeIfAbsent(chunkPos.toLong(), l -> ChunkLevelType.INACCESSIBLE);
 
-			if (trackedPrev != oldLevelType) { // check if the oldLevelType == the newLevelType from the previous event for this chunk
-				throw new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " TRACKED: " + trackedPrev + " != EVENT_OLD: " + oldLevelType);
+			if (trackedOld != oldLevelType) { // check if the oldLevelType == the newLevelType from the previous event for this chunk
+				AssertionError error = new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " " + oldLevelType + "->" + newLevelType + " / TRACKED_OLD: " + trackedOld);
+				LOGGER.error(error.getMessage(), error);
+				world.getServer().stop(false);
 			}
 
 			if (Math.abs(oldLevelType.ordinal() - newLevelType.ordinal()) != 1) { // check if the levelTypes are actually sequential
-				throw new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " NOT SEQUENTIAL: " + oldLevelType + "->" + newLevelType);
+				LOGGER.error("not sequential {} {}", oldLevelType, newLevelType);
+				AssertionError error = new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " NOT SEQUENTIAL: " + oldLevelType + "->" + newLevelType);
+				LOGGER.error(error.getMessage(), error);
+				world.getServer().stop(false);
 			}
 
+			worldsChunkLevelTypeTracker.get(worldKey).put(chunkPos.toLong(), newLevelType);
 			worldsChunkLevelEvents.computeIfAbsent(worldKey, obj -> new Object2IntOpenHashMap<>()).mergeInt(newLevelType, 1, Integer::sum);
 		});
 

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.test.event.lifecycle;
 
 import com.mojang.logging.LogUtils;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
@@ -67,17 +68,30 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 	 * Moving into another chunk should trigger some logs.
 	 */
 	private static void setupChunkLevelTypeChangeTest() {
-		final Object2ObjectMap<Identifier, Object2IntMap<ChunkLevelType>> worlds = new Object2ObjectOpenHashMap<>();
+		final Object2ObjectMap<Identifier, Object2IntMap<ChunkLevelType>> worldsChunkLevelEvents = new Object2ObjectOpenHashMap<>();
+		final Object2ObjectMap<Identifier, Long2ObjectOpenHashMap<ChunkLevelType>> worldsChunkLevelTypeTracker = new Object2ObjectOpenHashMap<>();
+
 		ServerChunkEvents.CHUNK_LEVEL_TYPE_CHANGE.register((world, chunkPos, oldLevelType, newLevelType) -> {
+			Identifier worldKey = world.getRegistryKey().getValue();
 			if (Thread.currentThread() != world.getServer().getThread()) {
-				throw new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + chunkPos + " " + oldLevelType + "->" + newLevelType + " NOT ON SERVER THREAD");
+				throw new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " NOT ON SERVER THREAD: " + oldLevelType + "->" + newLevelType);
 			}
 
 			if (oldLevelType == newLevelType) {
-				throw new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + chunkPos + " " + oldLevelType + " SAME LEVEL TYPE");
+				throw new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " SAME LEVEL TYPE: " + oldLevelType);
 			}
 
-			worlds.computeIfAbsent(world.getRegistryKey().getValue(), obj -> new Object2IntOpenHashMap<>()).mergeInt(newLevelType, 1, Integer::sum);
+			ChunkLevelType trackedPrev = worldsChunkLevelTypeTracker.computeIfAbsent(worldKey, obj -> new Long2ObjectOpenHashMap<>()).computeIfAbsent(chunkPos.toLong(), l -> ChunkLevelType.INACCESSIBLE);
+
+			if (trackedPrev != oldLevelType) { // check if the oldLevelType == the newLevelType from the previous event for this chunk
+				throw new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " TRACKED: " + trackedPrev + " != EVENT_OLD: " + oldLevelType);
+			}
+
+			if (Math.abs(oldLevelType.ordinal() - newLevelType.ordinal()) != 1) { // check if the levelTypes are actually sequential
+				throw new AssertionError("CHUNK_LEVEL_TYPE_CHANGE for " + worldKey + " " + chunkPos + " NOT SEQUENTIAL: " + oldLevelType + "->" + newLevelType);
+			}
+
+			worldsChunkLevelEvents.computeIfAbsent(worldKey, obj -> new Object2IntOpenHashMap<>()).mergeInt(newLevelType, 1, Integer::sum);
 		});
 
 		ServerTickEvents.END_WORLD_TICK.register(world -> {
@@ -85,7 +99,7 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 				return;
 			}
 
-			Object2IntMap<ChunkLevelType> levelTypes = worlds.get(world.getRegistryKey().getValue());
+			Object2IntMap<ChunkLevelType> levelTypes = worldsChunkLevelEvents.get(world.getRegistryKey().getValue());
 
 			if (levelTypes == null) {
 				return;


### PR DESCRIPTION
Add a new event that fires when a chunk's level type changes. (Relates to #4507)

Changed the name from `CHUNK_STATUS_CHANGE` as to not confuse it with the `ChunkStatus` class which refers to chunk generation stages.

The event only provides a `ChunkPos` and not a `WorldChunk`. If really needed, a potentially null `WorldChunk` can be obtained via `ChunkHolder#getLatest()` but I do not think it's necessary.

The documentation of `CHUNK_UNLOAD` has also been updated to clarify server chunk unload timing.