### PR TITLE
Add custom unbaked block state model types

### DIFF
--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/CompositeBlockStateModel.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/CompositeBlockStateModel.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.client.model.loading.v1;
+
+import java.util.List;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Unmodifiable;
+
+import net.minecraft.client.render.item.model.CompositeItemModel;
+import net.minecraft.client.render.model.BlockStateModel;
+
+import net.fabricmc.fabric.impl.client.model.loading.CompositeBlockStateModelImpl;
+
+/**
+ * A custom block state model that is made of one or more other block state models. Analogous to
+ * {@link CompositeItemModel}. Uses the first submodel to determine the particle sprite.
+ */
+@ApiStatus.NonExtendable
+public interface CompositeBlockStateModel extends BlockStateModel {
+	/**
+	 * Creates a new composite model from the given non-empty list of submodels.
+	 */
+	static CompositeBlockStateModel of(List<BlockStateModel> models) {
+		return CompositeBlockStateModelImpl.of(models);
+	}
+
+	/**
+	 * Gets the models that make up this composite model. The returned list will contain at least one model.
+	 */
+	@Unmodifiable
+	List<BlockStateModel> models();
+
+	/**
+	 * An unbaked composite model made of one or more other unbaked models.
+	 *
+	 * <p>The JSON format is as follows:
+	 * <pre>{@code
+	 * {
+	 *     "fabric:type": "fabric:composite",
+	 *     "models": [
+	 *         // sub-model 1,
+	 *         // sub-model 2,
+	 *         // etc...
+	 *     ]
+	 * }
+	 * }</pre>
+	 */
+	@ApiStatus.NonExtendable
+	interface Unbaked extends CustomUnbakedBlockStateModel {
+		/**
+		 * Creates a new unbaked composite model from the given non-empty list of submodels.
+		 */
+		static Unbaked of(List<BlockStateModel.Unbaked> models) {
+			return CompositeBlockStateModelImpl.Unbaked.of(models);
+		}
+
+		/**
+		 * Gets the models that make up this unbaked composite model. The returned list will contain at least one model.
+		 */
+		@Unmodifiable
+		List<BlockStateModel.Unbaked> models();
+	}
+}

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/CustomUnbakedBlockStateModel.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/CustomUnbakedBlockStateModel.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.client.model.loading.v1;
+
+import com.mojang.serialization.MapCodec;
+
+import net.minecraft.client.render.model.BlockStateModel;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.impl.client.model.loading.CustomUnbakedBlockStateModelRegistry;
+
+public interface CustomUnbakedBlockStateModel extends BlockStateModel.Unbaked {
+	static void register(Identifier id, MapCodec<? extends CustomUnbakedBlockStateModel> codec) {
+		CustomUnbakedBlockStateModelRegistry.register(id, codec);
+	}
+
+	MapCodec<? extends CustomUnbakedBlockStateModel> codec();
+}

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/CustomUnbakedBlockStateModel.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/CustomUnbakedBlockStateModel.java
@@ -19,14 +19,47 @@ package net.fabricmc.fabric.api.client.model.loading.v1;
 import com.mojang.serialization.MapCodec;
 
 import net.minecraft.client.render.model.BlockStateModel;
+import net.minecraft.client.render.model.SimpleBlockStateModel;
+import net.minecraft.client.render.model.json.ModelVariant;
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.impl.client.model.loading.CustomUnbakedBlockStateModelRegistry;
 
+/**
+ * Allows defining custom unbaked block state model types which can be used within {@code blockstates/} files. <b>It is
+ * not necessary to implement this interface when using a custom subclass of {@link BlockStateModel.Unbaked} at runtime
+ * </b>, e.g. for {@link ModelModifier}.
+ *
+ * <p>The format for custom unbaked block state models is as follows:
+ * <pre>{@code
+ * {
+ *     "fabric:type": "<identifier of the type>",
+ *     // extra model data, dependent on the type
+ * }
+ * }</pre>
+ *
+ * <p>The above JSON object may be used in a {@code blockstates/} file wherever a {@link ModelVariant} or
+ * {@link SimpleBlockStateModel.Unbaked} is normally valid. Note that if the {@code "fabric:type"} key is present,
+ * the object will never be parsed as a {@link ModelVariant}, even if the custom type does not exist or is not able to
+ * parse the object.
+ *
+ * <p>{@link BlockStateModel.Unbaked#CODEC} and {@link BlockStateModel.Unbaked#WEIGHTED_CODEC} are automatically patched
+ * to support custom models. Custom types are encouraged to use {@link BlockStateModel.Unbaked#CODEC} to
+ * deserialize/serialize submodels.
+ *
+ * <p>All types must be registered using {@link #register} for deserialization/serialization to work.
+ */
 public interface CustomUnbakedBlockStateModel extends BlockStateModel.Unbaked {
+	/**
+	 * Registers a custom block state model type.
+	 */
 	static void register(Identifier id, MapCodec<? extends CustomUnbakedBlockStateModel> codec) {
 		CustomUnbakedBlockStateModelRegistry.register(id, codec);
 	}
 
+	/**
+	 * Returns the codec which can be used to serialize this model. Must match the codec passed to {@link #register}
+	 * which deserializes objects of this type.
+	 */
 	MapCodec<? extends CustomUnbakedBlockStateModel> codec();
 }

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/UnbakedModelDeserializer.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/UnbakedModelDeserializer.java
@@ -34,7 +34,9 @@ import net.minecraft.util.Identifier;
 import net.fabricmc.fabric.impl.client.model.loading.UnbakedModelDeserializerRegistry;
 
 /**
- * Allows creating custom unbaked models by overriding the parsing of JSON model files.
+ * Allows creating custom unbaked models by overriding the parsing of JSON model files. <b>It is not necessary to
+ * implement this interface when using a custom subclass of {@link UnbakedModel} at runtime</b>, e.g. for
+ * {@link ModelModifier}.
  *
  * <p>The format for custom unbaked models is as follows:
  * <pre>{@code

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/CompositeBlockStateModel.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/CompositeBlockStateModel.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.impl.client.model.loading;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -74,20 +75,20 @@ public class CompositeBlockStateModel implements BlockStateModel {
 			random.setSeed(seed);
 			return models[0].createGeometryKey(blockView, pos, state, random);
 		} else {
-			Object[] subkeys = new Object[count];
+			List<Object> subkeys = new ArrayList<>(count);
 
-			for (int i = 0; i < count; i++) {
+			for (BlockStateModel submodel : models) {
 				random.setSeed(seed);
-				Object subkey = models[i].createGeometryKey(blockView, pos, state, random);
+				Object subkey = submodel.createGeometryKey(blockView, pos, state, random);
 
 				if (subkey == null) {
 					return null;
 				}
 
-				subkeys[i] = subkey;
+				subkeys.add(subkey);
 			}
 
-			record Key(Object[] subkeys) {
+			record Key(List<Object> subkeys) {
 			}
 
 			return new Key(subkeys);

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/CompositeBlockStateModel.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/CompositeBlockStateModel.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.model.loading;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.client.render.model.Baker;
+import net.minecraft.client.render.model.BlockModelPart;
+import net.minecraft.client.render.model.BlockStateModel;
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.util.dynamic.Codecs;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.world.BlockRenderView;
+
+import net.fabricmc.fabric.api.client.model.loading.v1.CustomUnbakedBlockStateModel;
+import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
+
+public class CompositeBlockStateModel implements BlockStateModel {
+	private final BlockStateModel[] models;
+
+	public CompositeBlockStateModel(BlockStateModel[] models) {
+		this.models = models;
+	}
+
+	@Override
+	public void addParts(Random random, List<BlockModelPart> parts) {
+		long seed = random.nextLong();
+
+		for (BlockStateModel model : models) {
+			random.setSeed(seed);
+			model.addParts(random, parts);
+		}
+	}
+
+	@Override
+	public void emitQuads(QuadEmitter emitter, BlockRenderView blockView, BlockPos pos, BlockState state, Random random, Predicate<@Nullable Direction> cullTest) {
+		long seed = random.nextLong();
+
+		for (BlockStateModel model : models) {
+			random.setSeed(seed);
+			model.emitQuads(emitter, blockView, pos, state, random, cullTest);
+		}
+	}
+
+	@Override
+	@Nullable
+	public Object createGeometryKey(BlockRenderView blockView, BlockPos pos, BlockState state, Random random) {
+		int count = models.length;
+		long seed = random.nextLong();
+
+		if (count == 1) {
+			random.setSeed(seed);
+			return models[0].createGeometryKey(blockView, pos, state, random);
+		} else {
+			Object[] subkeys = new Object[count];
+
+			for (int i = 0; i < count; i++) {
+				random.setSeed(seed);
+				Object subkey = models[i].createGeometryKey(blockView, pos, state, random);
+
+				if (subkey == null) {
+					return null;
+				}
+
+				subkeys[i] = subkey;
+			}
+
+			record Key(Object[] subkeys) {
+			}
+
+			return new Key(subkeys);
+		}
+	}
+
+	@Override
+	public Sprite particleSprite() {
+		return models[0].particleSprite();
+	}
+
+	@Override
+	public Sprite particleSprite(BlockRenderView blockView, BlockPos pos, BlockState state) {
+		return models[0].particleSprite(blockView, pos, state);
+	}
+
+	public record Unbaked(List<BlockStateModel.Unbaked> models) implements CustomUnbakedBlockStateModel {
+		public static final MapCodec<Unbaked> CODEC = RecordCodecBuilder.mapCodec(
+				instance -> instance.group(
+						Codecs.nonEmptyList(BlockStateModel.Unbaked.CODEC.listOf()).fieldOf("models").forGetter(Unbaked::models)
+				).apply(instance, Unbaked::new)
+		);
+
+		public Unbaked {
+			if (models.isEmpty()) {
+				throw new IllegalArgumentException("Models list must not be empty");
+			}
+		}
+
+		@Override
+		public MapCodec<Unbaked> codec() {
+			return CODEC;
+		}
+
+		@Override
+		public BlockStateModel bake(Baker baker) {
+			BlockStateModel[] bakedModels = new BlockStateModel[models.size()];
+
+			for (int i = 0; i < models.size(); i++) {
+				bakedModels[i] = models.get(i).bake(baker);
+			}
+
+			return new CompositeBlockStateModel(bakedModels);
+		}
+
+		@Override
+		public void resolve(Resolver resolver) {
+			models.forEach(model -> model.resolve(resolver));
+		}
+	}
+}

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/CompositeBlockStateModelImpl.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/CompositeBlockStateModelImpl.java
@@ -17,12 +17,16 @@
 package net.fabricmc.fabric.impl.client.model.loading;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jetbrains.annotations.UnmodifiableView;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.client.render.model.Baker;
@@ -35,14 +39,32 @@ import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.random.Random;
 import net.minecraft.world.BlockRenderView;
 
-import net.fabricmc.fabric.api.client.model.loading.v1.CustomUnbakedBlockStateModel;
+import net.fabricmc.fabric.api.client.model.loading.v1.CompositeBlockStateModel;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 
-public class CompositeBlockStateModel implements BlockStateModel {
+public class CompositeBlockStateModelImpl implements CompositeBlockStateModel {
 	private final BlockStateModel[] models;
+	@UnmodifiableView
+	private final List<BlockStateModel> modelsView;
 
-	public CompositeBlockStateModel(BlockStateModel[] models) {
+	public CompositeBlockStateModelImpl(BlockStateModel[] models) {
 		this.models = models;
+		modelsView = Arrays.asList(models);
+	}
+
+	public static CompositeBlockStateModelImpl of(List<BlockStateModel> models) {
+		if (models.isEmpty()) {
+			throw new IllegalArgumentException("Models list must not be empty");
+		}
+
+		for (BlockStateModel model : models) Objects.requireNonNull(model, "Model cannot be null");
+		return new CompositeBlockStateModelImpl(models.toArray(BlockStateModel[]::new));
+	}
+
+	@Override
+	@Unmodifiable
+	public List<BlockStateModel> models() {
+		return modelsView;
 	}
 
 	@Override
@@ -105,17 +127,18 @@ public class CompositeBlockStateModel implements BlockStateModel {
 		return models[0].particleSprite(blockView, pos, state);
 	}
 
-	public record Unbaked(List<BlockStateModel.Unbaked> models) implements CustomUnbakedBlockStateModel {
-		public static final MapCodec<Unbaked> CODEC = RecordCodecBuilder.mapCodec(
-				instance -> instance.group(
-						Codecs.nonEmptyList(BlockStateModel.Unbaked.CODEC.listOf()).fieldOf("models").forGetter(Unbaked::models)
-				).apply(instance, Unbaked::new)
-		);
+	public record Unbaked(@Unmodifiable List<BlockStateModel.Unbaked> models) implements CompositeBlockStateModel.Unbaked {
+		public static final MapCodec<Unbaked> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+				Codecs.nonEmptyList(BlockStateModel.Unbaked.CODEC.listOf()).fieldOf("models").forGetter(Unbaked::models)
+		).apply(instance, Unbaked::new));
 
-		public Unbaked {
+		public static Unbaked of(List<BlockStateModel.Unbaked> models) {
 			if (models.isEmpty()) {
 				throw new IllegalArgumentException("Models list must not be empty");
 			}
+
+			for (BlockStateModel.Unbaked model : models) Objects.requireNonNull(model, "Model cannot be null");
+			return new Unbaked(List.copyOf(models));
 		}
 
 		@Override
@@ -131,7 +154,7 @@ public class CompositeBlockStateModel implements BlockStateModel {
 				bakedModels[i] = models.get(i).bake(baker);
 			}
 
-			return new CompositeBlockStateModel(bakedModels);
+			return new CompositeBlockStateModelImpl(bakedModels);
 		}
 
 		@Override

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/CustomUnbakedBlockStateModelInit.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/CustomUnbakedBlockStateModelInit.java
@@ -27,6 +27,6 @@ import net.fabricmc.fabric.api.client.model.loading.v1.CustomUnbakedBlockStateMo
 public class CustomUnbakedBlockStateModelInit implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
-		CustomUnbakedBlockStateModel.register(Identifier.of("fabric", "composite"), CompositeBlockStateModel.Unbaked.CODEC);
+		CustomUnbakedBlockStateModel.register(Identifier.of("fabric", "composite"), CompositeBlockStateModelImpl.Unbaked.CODEC);
 	}
 }

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/CustomUnbakedBlockStateModelInit.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/CustomUnbakedBlockStateModelInit.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.model.loading;
+
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.model.loading.v1.CustomUnbakedBlockStateModel;
+
+/**
+ * Register builtin custom unbaked block state models.
+ */
+public class CustomUnbakedBlockStateModelInit implements ClientModInitializer {
+	@Override
+	public void onInitializeClient() {
+		CustomUnbakedBlockStateModel.register(Identifier.of("fabric", "composite"), CompositeBlockStateModel.Unbaked.CODEC);
+	}
+}

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/CustomUnbakedBlockStateModelRegistry.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/CustomUnbakedBlockStateModelRegistry.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.model.loading;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import com.google.common.collect.Lists;
+import com.mojang.datafixers.util.Either;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.MapLike;
+import com.mojang.serialization.RecordBuilder;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import net.minecraft.client.render.model.BlockStateModel;
+import net.minecraft.client.render.model.SimpleBlockStateModel;
+import net.minecraft.client.render.model.WeightedBlockStateModel;
+import net.minecraft.client.render.model.json.ModelVariant;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.collection.Pool;
+import net.minecraft.util.collection.Weighted;
+import net.minecraft.util.dynamic.Codecs;
+
+import net.fabricmc.fabric.api.client.model.loading.v1.CustomUnbakedBlockStateModel;
+
+public class CustomUnbakedBlockStateModelRegistry {
+	private static final String TYPE_KEY = "fabric:type";
+	private static final Codecs.IdMapper<Identifier, MapCodec<? extends CustomUnbakedBlockStateModel>> ID_MAPPER = new Codecs.IdMapper<>();
+
+	/** Map codec for a custom model. Must be a map codec to allow combining with weighted model entry's "weight" field. */
+	private static final MapCodec<CustomUnbakedBlockStateModel> CUSTOM_MODEL_MAP_CODEC = ID_MAPPER.getCodec(Identifier.CODEC).dispatchMap(TYPE_KEY, CustomUnbakedBlockStateModel::codec, codec -> codec);
+	/** Map codec for a simple model. Must be a map codec to allow checking presence of type key before parsing. */
+	private static final MapCodec<SimpleBlockStateModel.Unbaked> SIMPLE_MODEL_MAP_CODEC = ModelVariant.MAP_CODEC
+			.xmap(SimpleBlockStateModel.Unbaked::new, SimpleBlockStateModel.Unbaked::variant);
+	/** Map codec for a custom model or a simple model. Uses {@link SimpleBlockStateModel.Unbaked} instead of {@link ModelVariant} like vanilla to also allow use in {@link #MODEL_CODEC} for convenience and consistent behavior. Must be a map codec to allow combining with weighted model entry's "weight" field. */
+	private static final MapCodec<Either<CustomUnbakedBlockStateModel, SimpleBlockStateModel.Unbaked>> VARIANT_MAP_CODEC = new KeyExistsCodec<>(TYPE_KEY, CUSTOM_MODEL_MAP_CODEC, SIMPLE_MODEL_MAP_CODEC);
+	/** Codec for a custom model or a simple model. */
+	private static final Codec<Either<CustomUnbakedBlockStateModel, SimpleBlockStateModel.Unbaked>> VARIANT_CODEC = VARIANT_MAP_CODEC.codec();
+	/** Codec for a weighted variant, with support for custom models. Used as list elements in a weighted model. */
+	private static final Codec<Weighted<Either<CustomUnbakedBlockStateModel, SimpleBlockStateModel.Unbaked>>> WEIGHTED_VARIANT_CODEC = RecordCodecBuilder.create(
+			instance -> instance.group(
+					VARIANT_MAP_CODEC.forGetter(Weighted::value),
+					Codecs.POSITIVE_INT.optionalFieldOf("weight", 1).forGetter(Weighted::weight)
+			).apply(instance, Weighted::new)
+	);
+	/** Extended codec for a vanilla weighted model that supports using custom models instead of regular variants. Replaces {@link BlockStateModel.Unbaked#WEIGHTED_CODEC}. */
+	public static final Codec<WeightedBlockStateModel.Unbaked> WEIGHTED_MODEL_CODEC = Codecs.nonEmptyList(WEIGHTED_VARIANT_CODEC.listOf())
+			.flatComapMap(
+					weightedVariants -> new WeightedBlockStateModel.Unbaked(Pool.of(Lists.transform(weightedVariants, weighted -> weighted.transform(either -> either.map(Function.identity(), Function.identity()))))),
+					model -> {
+						List<Weighted<BlockStateModel.Unbaked>> entries = model.entries().getEntries();
+						List<Weighted<Either<CustomUnbakedBlockStateModel, SimpleBlockStateModel.Unbaked>>> weightedVariants = new ArrayList<>(entries.size());
+
+						for (Weighted<BlockStateModel.Unbaked> weighted : entries) {
+							switch (weighted.value()) {
+								case CustomUnbakedBlockStateModel custom -> {
+									weightedVariants.add(new Weighted<>(Either.left(custom), weighted.weight()));
+								}
+								case SimpleBlockStateModel.Unbaked simple -> {
+									weightedVariants.add(new Weighted<>(Either.right(simple), weighted.weight()));
+								}
+								default -> {
+									return DataResult.error(() -> "Only custom models or single variants are supported");
+								}
+							}
+						}
+
+						return DataResult.success(weightedVariants);
+					}
+			);
+	/** Extended codec for an unbaked model that supports using a custom model directly or inside weighted entries. Replaces {@link BlockStateModel.Unbaked#CODEC}. */
+	public static final Codec<BlockStateModel.Unbaked> MODEL_CODEC = Codec.either(WEIGHTED_MODEL_CODEC, VARIANT_CODEC)
+			.flatComapMap(either -> either.map(Function.identity(), right -> right.map(Function.identity(), Function.identity())), model -> {
+				Objects.requireNonNull(model);
+
+				return switch (model) {
+				case CustomUnbakedBlockStateModel custom -> DataResult.success(Either.right(Either.left(custom)));
+				case SimpleBlockStateModel.Unbaked simple -> DataResult.success(Either.right(Either.right(simple)));
+				case WeightedBlockStateModel.Unbaked weighted -> DataResult.success(Either.left(weighted));
+				default -> DataResult.error(() -> "Only a custom model or a single variant or a list of variants are supported");
+				};
+			});
+
+	public static void register(Identifier id, MapCodec<? extends CustomUnbakedBlockStateModel> codec) {
+		ID_MAPPER.put(id, codec);
+	}
+
+	/** When decoding, uses a different codec depending on whether a certain key exists or not. */
+	private static class KeyExistsCodec<E, N> extends MapCodec<Either<E, N>> {
+		private final String key;
+		private final MapCodec<E> exists;
+		private final MapCodec<N> notExists;
+
+		KeyExistsCodec(String key, MapCodec<E> exists, MapCodec<N> notExists) {
+			this.key = key;
+			this.exists = exists;
+			this.notExists = notExists;
+		}
+
+		@Override
+		public <T> Stream<T> keys(DynamicOps<T> ops) {
+			return Stream.concat(exists.keys(ops), notExists.keys(ops));
+		}
+
+		@Override
+		public <T> DataResult<Either<E, N>> decode(DynamicOps<T> ops, MapLike<T> input) {
+			if (input.get(key) != null) {
+				return exists.decode(ops, input).map(Either::left);
+			} else {
+				return notExists.decode(ops, input).map(Either::right);
+			}
+		}
+
+		@Override
+		public <T> RecordBuilder<T> encode(Either<E, N> input, DynamicOps<T> ops, RecordBuilder<T> prefix) {
+			return input.map(
+					left -> exists.encode(left, ops, prefix),
+					right -> notExists.encode(right, ops, prefix)
+			);
+		}
+
+		@Override
+		public String toString() {
+			return "KeyExistsCodec[" + key + " " + exists + " " + notExists + "]";
+		}
+	}
+}

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/model/loading/UnbakedBlockStateModelMixin.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/model/loading/UnbakedBlockStateModelMixin.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.model.loading;
+
+import java.util.List;
+import java.util.function.Function;
+
+import com.mojang.datafixers.util.Either;
+import com.mojang.serialization.Codec;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.client.render.model.BlockStateModel;
+import net.minecraft.client.render.model.SimpleBlockStateModel;
+import net.minecraft.client.render.model.WeightedBlockStateModel;
+import net.minecraft.client.render.model.json.ModelVariant;
+import net.minecraft.util.collection.Weighted;
+
+import net.fabricmc.fabric.impl.client.model.loading.CustomUnbakedBlockStateModelRegistry;
+
+@Mixin(BlockStateModel.Unbaked.class)
+interface UnbakedBlockStateModelMixin {
+	@Redirect(method = "<clinit>()V", at = @At(value = "INVOKE", target = "com/mojang/serialization/Codec.flatComapMap(Ljava/util/function/Function;Ljava/util/function/Function;)Lcom/mojang/serialization/Codec;", remap = false, ordinal = 0))
+	private static Codec<WeightedBlockStateModel.Unbaked> replaceWeightedCodec(Codec<List<Weighted<ModelVariant>>> codec, Function<?, ?> to, Function<?, ?> from) {
+		return CustomUnbakedBlockStateModelRegistry.WEIGHTED_MODEL_CODEC;
+	}
+
+	@Redirect(method = "<clinit>()V", at = @At(value = "INVOKE", target = "com/mojang/serialization/Codec.flatComapMap(Ljava/util/function/Function;Ljava/util/function/Function;)Lcom/mojang/serialization/Codec;", remap = false, ordinal = 1))
+	private static Codec<BlockStateModel.Unbaked> replaceCodec(Codec<Either<WeightedBlockStateModel.Unbaked, SimpleBlockStateModel.Unbaked>> codec, Function<?, ?> to, Function<?, ?> from) {
+		return CustomUnbakedBlockStateModelRegistry.MODEL_CODEC;
+	}
+}

--- a/fabric-model-loading-api-v1/src/client/resources/fabric-model-loading-api-v1.mixins.json
+++ b/fabric-model-loading-api-v1/src/client/resources/fabric-model-loading-api-v1.mixins.json
@@ -6,7 +6,8 @@
     "BakedModelManagerMixin",
     "JsonUnbakedModelAccessor",
     "JsonUnbakedModelMixin",
-    "ModelBakerMixin"
+    "ModelBakerMixin",
+    "UnbakedBlockStateModelMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/fabric-model-loading-api-v1/src/client/resources/fabric.mod.json
+++ b/fabric-model-loading-api-v1/src/client/resources/fabric.mod.json
@@ -15,6 +15,11 @@
   "authors": [
     "FabricMC"
   ],
+  "entrypoints": {
+    "client": [
+      "net.fabricmc.fabric.impl.client.model.loading.CustomUnbakedBlockStateModelInit"
+    ]
+  },
   "depends": {
     "fabricloader": ">=0.16.10",
     "fabric-api-base": "*",

--- a/fabric-model-loading-api-v1/src/testmodClient/resources/assets/minecraft/blockstates/oak_slab.json
+++ b/fabric-model-loading-api-v1/src/testmodClient/resources/assets/minecraft/blockstates/oak_slab.json
@@ -1,0 +1,21 @@
+{
+  "variants": {
+    "type=bottom": {
+      "fabric:type": "fabric:composite",
+      "models": [
+        {
+          "model": "block/oak_slab"
+        },
+        {
+          "model": "block/torch"
+        }
+      ]
+    },
+    "type=double": {
+      "model": "minecraft:block/oak_planks"
+    },
+    "type=top": {
+      "model": "minecraft:block/oak_slab_top"
+    }
+  }
+}

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/block/model/MultipartBlockStateModelMixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/block/model/MultipartBlockStateModelMixin.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.mixin.renderer.client.block.model;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -77,7 +78,7 @@ abstract class MultipartBlockStateModelMixin implements BlockStateModel {
 			random.setSeed(seed);
 			return models.getFirst().createGeometryKey(blockView, pos, state, random);
 		} else {
-			Object[] subkeys = new Object[count];
+			List<Object> subkeys = new ArrayList<>(count);
 
 			for (int i = 0; i < count; i++) {
 				random.setSeed(seed);
@@ -87,10 +88,10 @@ abstract class MultipartBlockStateModelMixin implements BlockStateModel {
 					return null;
 				}
 
-				subkeys[i] = subkey;
+				subkeys.add(subkey);
 			}
 
-			record Key(Object[] subkeys) {
+			record Key(List<Object> subkeys) {
 			}
 
 			return new Key(subkeys);


### PR DESCRIPTION
This pull request adds the `CustomUnbakedBlockStateModel`, which allows using custom model types in blockstate files. Any place where a `ModelVariant` is normally allowed (including within a weighted list) can now use the `"fabric:type"` key and define a custom model.

The `fabric:composite` custom model type is registered by default. It simply combines the geometry from multiple submodels and is analogous to vanilla's `minecraft:composite` item model type. Submodels are defined using the `"models"` key, whose type is an array of arbitrary models.

### TODO

- [x] Consider moving the `CompositeBlockStateModel` into the API package, or at least expose static methods to construct the baked and unbaked instances.
  **Resolution:** Added `CompositeBlockStateModel` interface to API that exposes construction and inspection for both baked and unbaked types. Renamed implementation class.
- [x] Consider adding a default custom type that works like `ModelVariant` but accepts a much more flexible transform that allows rotation about the Z axis, non-90 degree rotations, scaling, and translation.
  **Resolution:** Will not be added in this PR due to exact format needing additional discussion and functional overlap with static model root transforms, which may be added in the future.
- [x] Documentation