### PR TITLE
Ensure `BlockDustParticle` always uses accurate `BlockPos`

### DIFF
--- a/fabric-particles-v1/build.gradle
+++ b/fabric-particles-v1/build.gradle
@@ -4,7 +4,10 @@ loom {
 	accessWidenerPath = file("src/main/resources/fabric-particles-v1.accesswidener")
 }
 
-moduleDependencies(project, ['fabric-api-base'])
+moduleDependencies(project, [
+	'fabric-api-base',
+	'fabric-networking-api-v1'
+])
 
 testDependencies(project, [
 		':fabric-command-api-v2',

--- a/fabric-particles-v1/src/client/java/net/fabricmc/fabric/impl/client/particle/ExtendedBlockStateParticleEffectSyncClient.java
+++ b/fabric-particles-v1/src/client/java/net/fabricmc/fabric/impl/client/particle/ExtendedBlockStateParticleEffectSyncClient.java
@@ -23,6 +23,8 @@ import net.fabricmc.fabric.impl.particle.ExtendedBlockStateParticleEffectSync;
 public class ExtendedBlockStateParticleEffectSyncClient implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
+		// Register a receiver so ExtendedBlockStateParticleEffectSync#shouldEncodeFallback can detect that this client
+		// supports extended data
 		ClientConfigurationNetworking.registerGlobalReceiver(ExtendedBlockStateParticleEffectSync.DummyPayload.ID, (payload, context) -> {
 		});
 	}

--- a/fabric-particles-v1/src/client/java/net/fabricmc/fabric/impl/client/particle/ExtendedBlockStateParticleEffectSyncClient.java
+++ b/fabric-particles-v1/src/client/java/net/fabricmc/fabric/impl/client/particle/ExtendedBlockStateParticleEffectSyncClient.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.particle;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.networking.v1.ClientConfigurationNetworking;
+import net.fabricmc.fabric.impl.particle.ExtendedBlockStateParticleEffectSync;
+
+public class ExtendedBlockStateParticleEffectSyncClient implements ClientModInitializer {
+	@Override
+	public void onInitializeClient() {
+		ClientConfigurationNetworking.registerGlobalReceiver(ExtendedBlockStateParticleEffectSync.DummyPayload.ID, (payload, context) -> {
+		});
+	}
+}

--- a/fabric-particles-v1/src/client/java/net/fabricmc/fabric/mixin/client/particle/BlockDustParticleMixin.java
+++ b/fabric-particles-v1/src/client/java/net/fabricmc/fabric/mixin/client/particle/BlockDustParticleMixin.java
@@ -33,7 +33,6 @@ import net.minecraft.particle.BlockStateParticleEffect;
 import net.minecraft.util.math.BlockPos;
 
 import net.fabricmc.fabric.api.client.particle.v1.ParticleRenderEvents;
-import net.fabricmc.fabric.impl.particle.BlockStateParticleEffectExtension;
 
 // Implements ParticleRenderEvents.ALLOW_BLOCK_DUST_TINT
 @Mixin(BlockDustParticle.class)
@@ -67,7 +66,7 @@ abstract class BlockDustParticleMixin extends SpriteBillboardParticle {
 
 	@Redirect(method = "create", at = @At(value = "NEW", target = "(Lnet/minecraft/client/world/ClientWorld;DDDDDDLnet/minecraft/block/BlockState;)Lnet/minecraft/client/particle/BlockDustParticle;"))
 	private static BlockDustParticle constructBlockDustParticle(ClientWorld world, double x, double y, double z, double velocityX, double velocityY, double velocityZ, BlockState state, BlockStateParticleEffect parameters, ClientWorld world1, double x1, double y1, double z1, double velocityX1, double velocityY1, double velocityZ1) {
-		BlockPos blockPos = ((BlockStateParticleEffectExtension) parameters).getBlockPos();
+		BlockPos blockPos = parameters.getBlockPos();
 
 		if (blockPos != null) {
 			return new BlockDustParticle(world, x, y, z, velocityX, velocityY, velocityZ, state, blockPos);

--- a/fabric-particles-v1/src/client/java/net/fabricmc/fabric/mixin/client/particle/BlockDustParticleMixin.java
+++ b/fabric-particles-v1/src/client/java/net/fabricmc/fabric/mixin/client/particle/BlockDustParticleMixin.java
@@ -21,15 +21,19 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.Slice;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.client.particle.BlockDustParticle;
 import net.minecraft.client.particle.SpriteBillboardParticle;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.particle.BlockStateParticleEffect;
 import net.minecraft.util.math.BlockPos;
 
 import net.fabricmc.fabric.api.client.particle.v1.ParticleRenderEvents;
+import net.fabricmc.fabric.impl.particle.BlockStateParticleEffectExtension;
 
 // Implements ParticleRenderEvents.ALLOW_BLOCK_DUST_TINT
 @Mixin(BlockDustParticle.class)
@@ -59,5 +63,16 @@ abstract class BlockDustParticleMixin extends SpriteBillboardParticle {
 		}
 
 		return state;
+	}
+
+	@Redirect(method = "create", at = @At(value = "NEW", target = "(Lnet/minecraft/client/world/ClientWorld;DDDDDDLnet/minecraft/block/BlockState;)Lnet/minecraft/client/particle/BlockDustParticle;"))
+	private static BlockDustParticle constructBlockDustParticle(ClientWorld world, double x, double y, double z, double velocityX, double velocityY, double velocityZ, BlockState state, BlockStateParticleEffect parameters, ClientWorld world1, double x1, double y1, double z1, double velocityX1, double velocityY1, double velocityZ1) {
+		BlockPos blockPos = ((BlockStateParticleEffectExtension) parameters).getBlockPos();
+
+		if (blockPos != null) {
+			return new BlockDustParticle(world, x, y, z, velocityX, velocityY, velocityZ, state, blockPos);
+		} else {
+			return new BlockDustParticle(world, x, y, z, velocityX, velocityY, velocityZ, state);
+		}
 	}
 }

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/api/particle/v1/FabricBlockStateParticleEffect.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/api/particle/v1/FabricBlockStateParticleEffect.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.particle.v1;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.particle.BlockStateParticleEffect;
+import net.minecraft.particle.ParticleType;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.BlockView;
+
+import net.fabricmc.fabric.impl.particle.BlockStateParticleEffectFactoryImpl;
+
+/**
+ * Note: This interface is automatically implemented on {@link BlockStateParticleEffect} via Mixin and interface injection.
+ */
+public interface FabricBlockStateParticleEffect {
+	/**
+	 * Alternative for {@link BlockStateParticleEffect#BlockStateParticleEffect(ParticleType, BlockState)} that also
+	 * accepts a {@link BlockPos}. This method should be used instead of the vanilla constructor when the block state
+	 * is retrieved using a block pos, most commonly through {@link BlockView#getBlockState(BlockPos)}. This ensures
+	 * that any particles created from this effect use an accurate pos for any client-side logic.
+	 *
+	 * <p>If an instance with a non-null block pos needs to be synced to the client, the block pos will only be synced
+	 * if it is known that the client supports decoding it (has this Fabric API module installed); otherwise, the effect
+	 * will be sent as a vanilla effect and the client will produce a null block pos.
+	 *
+	 * @param type the particle type
+	 * @param blockState the block state
+	 * @param blockPos the block pos from which the block state was retrieved
+	 * @return the particle effect
+	 */
+	static BlockStateParticleEffect create(ParticleType<BlockStateParticleEffect> type, BlockState blockState, @Nullable BlockPos blockPos) {
+		return BlockStateParticleEffectFactoryImpl.create(type, blockState, blockPos);
+	}
+
+	/**
+	 * @return the block pos from which {@linkplain BlockStateParticleEffect#getBlockState() the block state} was
+	 * retrieved, or {@code null} if not applicable or this instance was synced from a remote server that does not have
+	 * this Fabric API module installed
+	 */
+	@Nullable
+	default BlockPos getBlockPos() {
+		throw new AssertionError("Implemented in Mixin");
+	}
+}

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/impl/particle/BlockStateParticleEffectExtension.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/impl/particle/BlockStateParticleEffectExtension.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.particle;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.util.math.BlockPos;
+
+public interface BlockStateParticleEffectExtension {
+	@Nullable
+	BlockPos getBlockPos();
+
+	void setBlockPos(@Nullable BlockPos pos);
+}

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/impl/particle/BlockStateParticleEffectFactoryImpl.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/impl/particle/BlockStateParticleEffectFactoryImpl.java
@@ -18,8 +18,18 @@ package net.fabricmc.fabric.impl.particle;
 
 import org.jetbrains.annotations.Nullable;
 
+import net.minecraft.block.BlockState;
+import net.minecraft.particle.BlockStateParticleEffect;
+import net.minecraft.particle.ParticleType;
 import net.minecraft.util.math.BlockPos;
 
-public interface BlockStateParticleEffectExtension {
-	void fabric_setBlockPos(@Nullable BlockPos pos);
+public final class BlockStateParticleEffectFactoryImpl {
+	private BlockStateParticleEffectFactoryImpl() {
+	}
+
+	public static BlockStateParticleEffect create(ParticleType<BlockStateParticleEffect> type, BlockState blockState, @Nullable BlockPos blockPos) {
+		BlockStateParticleEffect effect = new BlockStateParticleEffect(type, blockState);
+		((BlockStateParticleEffectExtension) effect).fabric_setBlockPos(blockPos);
+		return effect;
+	}
 }

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/impl/particle/ExtendedBlockStateParticleEffectPacketCodec.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/impl/particle/ExtendedBlockStateParticleEffectPacketCodec.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.particle;
+
+import java.util.Optional;
+
+import io.netty.buffer.ByteBuf;
+
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.codec.PacketCodecs;
+import net.minecraft.particle.BlockStateParticleEffect;
+import net.minecraft.util.math.BlockPos;
+
+public class ExtendedBlockStateParticleEffectPacketCodec implements PacketCodec<RegistryByteBuf, BlockStateParticleEffect> {
+	private static final int PACKET_MARKER = -1;
+	private static final PacketCodec<ByteBuf, Optional<BlockPos>> OPTIONAL_BLOCK_POS_PACKET_CODEC = PacketCodecs.optional(BlockPos.PACKET_CODEC);
+	private final PacketCodec<? super RegistryByteBuf, BlockStateParticleEffect> fallback;
+
+	public ExtendedBlockStateParticleEffectPacketCodec(PacketCodec<? super RegistryByteBuf, BlockStateParticleEffect> fallback) {
+		this.fallback = fallback;
+	}
+
+	@Override
+	public BlockStateParticleEffect decode(RegistryByteBuf buf) {
+		int index = buf.readerIndex();
+
+		if (buf.readVarInt() != PACKET_MARKER) {
+			// Reset index for vanilla's normal deserialization logic.
+			buf.readerIndex(index);
+			return fallback.decode(buf);
+		}
+
+		BlockStateParticleEffect value = fallback.decode(buf);
+		Optional<BlockPos> optionalPos = OPTIONAL_BLOCK_POS_PACKET_CODEC.decode(buf);
+
+		if (optionalPos.isPresent()) {
+			((BlockStateParticleEffectExtension) value).setBlockPos(optionalPos.get());
+		}
+
+		return value;
+	}
+
+	@Override
+	public void encode(RegistryByteBuf buf, BlockStateParticleEffect value) {
+		if (ExtendedBlockStateParticleEffectSync.shouldEncodeFallback(buf)) {
+			fallback.encode(buf, value);
+			return;
+		}
+
+		buf.writeVarInt(PACKET_MARKER);
+		fallback.encode(buf, value);
+		BlockPos pos = ((BlockStateParticleEffectExtension) value).getBlockPos();
+		OPTIONAL_BLOCK_POS_PACKET_CODEC.encode(buf, Optional.ofNullable(pos));
+	}
+}

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/impl/particle/ExtendedBlockStateParticleEffectPacketCodec.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/impl/particle/ExtendedBlockStateParticleEffectPacketCodec.java
@@ -16,19 +16,13 @@
 
 package net.fabricmc.fabric.impl.particle;
 
-import java.util.Optional;
-
-import io.netty.buffer.ByteBuf;
-
 import net.minecraft.network.RegistryByteBuf;
 import net.minecraft.network.codec.PacketCodec;
-import net.minecraft.network.codec.PacketCodecs;
 import net.minecraft.particle.BlockStateParticleEffect;
 import net.minecraft.util.math.BlockPos;
 
 public class ExtendedBlockStateParticleEffectPacketCodec implements PacketCodec<RegistryByteBuf, BlockStateParticleEffect> {
 	private static final int PACKET_MARKER = -1;
-	private static final PacketCodec<ByteBuf, Optional<BlockPos>> OPTIONAL_BLOCK_POS_PACKET_CODEC = PacketCodecs.optional(BlockPos.PACKET_CODEC);
 	private final PacketCodec<? super RegistryByteBuf, BlockStateParticleEffect> fallback;
 
 	public ExtendedBlockStateParticleEffectPacketCodec(PacketCodec<? super RegistryByteBuf, BlockStateParticleEffect> fallback) {
@@ -46,25 +40,22 @@ public class ExtendedBlockStateParticleEffectPacketCodec implements PacketCodec<
 		}
 
 		BlockStateParticleEffect value = fallback.decode(buf);
-		Optional<BlockPos> optionalPos = OPTIONAL_BLOCK_POS_PACKET_CODEC.decode(buf);
-
-		if (optionalPos.isPresent()) {
-			((BlockStateParticleEffectExtension) value).setBlockPos(optionalPos.get());
-		}
-
+		BlockPos pos = BlockPos.PACKET_CODEC.decode(buf);
+		((BlockStateParticleEffectExtension) value).fabric_setBlockPos(pos);
 		return value;
 	}
 
 	@Override
 	public void encode(RegistryByteBuf buf, BlockStateParticleEffect value) {
-		if (ExtendedBlockStateParticleEffectSync.shouldEncodeFallback(buf)) {
+		BlockPos pos = value.getBlockPos();
+
+		if (pos == null || ExtendedBlockStateParticleEffectSync.shouldEncodeFallback(buf)) {
 			fallback.encode(buf, value);
 			return;
 		}
 
 		buf.writeVarInt(PACKET_MARKER);
 		fallback.encode(buf, value);
-		BlockPos pos = ((BlockStateParticleEffectExtension) value).getBlockPos();
-		OPTIONAL_BLOCK_POS_PACKET_CODEC.encode(buf, Optional.ofNullable(pos));
+		BlockPos.PACKET_CODEC.encode(buf, pos);
 	}
 }

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/impl/particle/ExtendedBlockStateParticleEffectSync.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/impl/particle/ExtendedBlockStateParticleEffectSync.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.particle;
+
+import java.util.Set;
+
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
+import net.fabricmc.fabric.impl.networking.FabricRegistryByteBuf;
+
+public class ExtendedBlockStateParticleEffectSync implements ModInitializer {
+	private static final Identifier PACKET_ID = Identifier.of("fabric", "extended_block_state_particle_effect_sync");
+
+	@Override
+	public void onInitialize() {
+		PayloadTypeRegistry.configurationS2C().register(DummyPayload.ID, DummyPayload.CODEC);
+	}
+
+	public static boolean shouldEncodeFallback(RegistryByteBuf buf) {
+		Set<Identifier> channels = ((FabricRegistryByteBuf) buf).fabric_getSendableConfigurationChannels();
+
+		if (channels == null) {
+			return true;
+		}
+
+		return !channels.contains(ExtendedBlockStateParticleEffectSync.PACKET_ID);
+	}
+
+	public record DummyPayload() implements CustomPayload {
+		public static final DummyPayload INSTANCE = new DummyPayload();
+		public static final PacketCodec<PacketByteBuf, DummyPayload> CODEC = PacketCodec.unit(INSTANCE);
+		public static final CustomPayload.Id<DummyPayload> ID = new Id<>(PACKET_ID);
+
+		@Override
+		public Id<? extends CustomPayload> getId() {
+			return ID;
+		}
+	}
+}

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/BlockStateParticleEffectMixin.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/BlockStateParticleEffectMixin.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.mixin.particle;
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 
 import net.minecraft.network.RegistryByteBuf;
@@ -26,12 +27,14 @@ import net.minecraft.network.codec.PacketCodec;
 import net.minecraft.particle.BlockStateParticleEffect;
 import net.minecraft.util.math.BlockPos;
 
+import net.fabricmc.fabric.api.particle.v1.FabricBlockStateParticleEffect;
 import net.fabricmc.fabric.impl.particle.BlockStateParticleEffectExtension;
 import net.fabricmc.fabric.impl.particle.ExtendedBlockStateParticleEffectPacketCodec;
 
 @Mixin(BlockStateParticleEffect.class)
-abstract class BlockStateParticleEffectMixin implements BlockStateParticleEffectExtension {
+abstract class BlockStateParticleEffectMixin implements FabricBlockStateParticleEffect, BlockStateParticleEffectExtension {
 	@Nullable
+	@Unique
 	private BlockPos blockPos;
 
 	@Override
@@ -41,7 +44,7 @@ abstract class BlockStateParticleEffectMixin implements BlockStateParticleEffect
 	}
 
 	@Override
-	public void setBlockPos(@Nullable BlockPos pos) {
+	public void fabric_setBlockPos(@Nullable BlockPos pos) {
 		blockPos = pos;
 	}
 

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/BlockStateParticleEffectMixin.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/BlockStateParticleEffectMixin.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.particle;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.particle.BlockStateParticleEffect;
+import net.minecraft.util.math.BlockPos;
+
+import net.fabricmc.fabric.impl.particle.BlockStateParticleEffectExtension;
+import net.fabricmc.fabric.impl.particle.ExtendedBlockStateParticleEffectPacketCodec;
+
+@Mixin(BlockStateParticleEffect.class)
+abstract class BlockStateParticleEffectMixin implements BlockStateParticleEffectExtension {
+	@Nullable
+	private BlockPos blockPos;
+
+	@Override
+	@Nullable
+	public BlockPos getBlockPos() {
+		return blockPos;
+	}
+
+	@Override
+	public void setBlockPos(@Nullable BlockPos pos) {
+		blockPos = pos;
+	}
+
+	@ModifyReturnValue(method = "createPacketCodec", at = @At("RETURN"))
+	private static PacketCodec<? super RegistryByteBuf, BlockStateParticleEffect> modifyPacketCodec(PacketCodec<? super RegistryByteBuf, BlockStateParticleEffect> codec) {
+		return new ExtendedBlockStateParticleEffectPacketCodec(codec);
+	}
+}

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/BreezeEntityMixin.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/BreezeEntityMixin.java
@@ -38,7 +38,7 @@ abstract class BreezeEntityMixin extends HostileEntity {
 	@ModifyExpressionValue(method = { "addLongJumpingParticles", "addBlockParticles" }, at = @At(value = "NEW", target = "(Lnet/minecraft/particle/ParticleType;Lnet/minecraft/block/BlockState;)Lnet/minecraft/particle/BlockStateParticleEffect;"))
 	private BlockStateParticleEffect modifyBlockStateParticleEffect(BlockStateParticleEffect original) {
 		BlockPos blockPos = !getBlockStateAtPos().isAir() ? getBlockPos() : getSteppingPos();
-		((BlockStateParticleEffectExtension) original).setBlockPos(blockPos);
+		((BlockStateParticleEffectExtension) original).fabric_setBlockPos(blockPos);
 		return original;
 	}
 }

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/BreezeEntityMixin.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/BreezeEntityMixin.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.particle;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.mob.BreezeEntity;
+import net.minecraft.entity.mob.HostileEntity;
+import net.minecraft.particle.BlockStateParticleEffect;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import net.fabricmc.fabric.impl.particle.BlockStateParticleEffectExtension;
+
+@Mixin(BreezeEntity.class)
+abstract class BreezeEntityMixin extends HostileEntity {
+	private BreezeEntityMixin(EntityType<? extends HostileEntity> entityType, World world) {
+		super(entityType, world);
+	}
+
+	@ModifyExpressionValue(method = { "addLongJumpingParticles", "addBlockParticles" }, at = @At(value = "NEW", target = "(Lnet/minecraft/particle/ParticleType;Lnet/minecraft/block/BlockState;)Lnet/minecraft/particle/BlockStateParticleEffect;"))
+	private BlockStateParticleEffect modifyBlockStateParticleEffect(BlockStateParticleEffect original) {
+		BlockPos blockPos = !getBlockStateAtPos().isAir() ? getBlockPos() : getSteppingPos();
+		((BlockStateParticleEffectExtension) original).setBlockPos(blockPos);
+		return original;
+	}
+}

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/BrushItemMixin.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/BrushItemMixin.java
@@ -34,7 +34,7 @@ import net.fabricmc.fabric.impl.particle.BlockStateParticleEffectExtension;
 abstract class BrushItemMixin {
 	@ModifyExpressionValue(method = "addDustParticles", at = @At(value = "NEW", target = "(Lnet/minecraft/particle/ParticleType;Lnet/minecraft/block/BlockState;)Lnet/minecraft/particle/BlockStateParticleEffect;"))
 	private BlockStateParticleEffect modifyBlockStateParticleEffect(BlockStateParticleEffect original, World world, BlockHitResult hitResult, BlockState state, Vec3d userRotation, Arm arm) {
-		((BlockStateParticleEffectExtension) original).setBlockPos(hitResult.getBlockPos());
+		((BlockStateParticleEffectExtension) original).fabric_setBlockPos(hitResult.getBlockPos());
 		return original;
 	}
 }

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/BrushItemMixin.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/BrushItemMixin.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.particle;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.item.BrushItem;
+import net.minecraft.particle.BlockStateParticleEffect;
+import net.minecraft.util.Arm;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
+
+import net.fabricmc.fabric.impl.particle.BlockStateParticleEffectExtension;
+
+@Mixin(BrushItem.class)
+abstract class BrushItemMixin {
+	@ModifyExpressionValue(method = "addDustParticles", at = @At(value = "NEW", target = "(Lnet/minecraft/particle/ParticleType;Lnet/minecraft/block/BlockState;)Lnet/minecraft/particle/BlockStateParticleEffect;"))
+	private BlockStateParticleEffect modifyBlockStateParticleEffect(BlockStateParticleEffect original, World world, BlockHitResult hitResult, BlockState state, Vec3d userRotation, Arm arm) {
+		((BlockStateParticleEffectExtension) original).setBlockPos(hitResult.getBlockPos());
+		return original;
+	}
+}

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/EntityMixin.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/EntityMixin.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.particle;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.particle.BlockStateParticleEffect;
+import net.minecraft.util.math.BlockPos;
+
+import net.fabricmc.fabric.impl.particle.BlockStateParticleEffectExtension;
+
+@Mixin(Entity.class)
+abstract class EntityMixin {
+	@ModifyExpressionValue(method = "spawnSprintingParticles", at = @At(value = "NEW", target = "(Lnet/minecraft/particle/ParticleType;Lnet/minecraft/block/BlockState;)Lnet/minecraft/particle/BlockStateParticleEffect;"))
+	private BlockStateParticleEffect modifyBlockStateParticleEffect(BlockStateParticleEffect original, @Local(ordinal = 0) BlockPos blockPos) {
+		((BlockStateParticleEffectExtension) original).setBlockPos(blockPos);
+		return original;
+	}
+}

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/EntityMixin.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/EntityMixin.java
@@ -31,7 +31,7 @@ import net.fabricmc.fabric.impl.particle.BlockStateParticleEffectExtension;
 abstract class EntityMixin {
 	@ModifyExpressionValue(method = "spawnSprintingParticles", at = @At(value = "NEW", target = "(Lnet/minecraft/particle/ParticleType;Lnet/minecraft/block/BlockState;)Lnet/minecraft/particle/BlockStateParticleEffect;"))
 	private BlockStateParticleEffect modifyBlockStateParticleEffect(BlockStateParticleEffect original, @Local(ordinal = 0) BlockPos blockPos) {
-		((BlockStateParticleEffectExtension) original).setBlockPos(blockPos);
+		((BlockStateParticleEffectExtension) original).fabric_setBlockPos(blockPos);
 		return original;
 	}
 }

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/LivingEntityMixin.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/LivingEntityMixin.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.particle;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.particle.BlockStateParticleEffect;
+import net.minecraft.util.math.BlockPos;
+
+import net.fabricmc.fabric.impl.particle.BlockStateParticleEffectExtension;
+
+@Mixin(LivingEntity.class)
+abstract class LivingEntityMixin {
+	@ModifyExpressionValue(method = "fall", at = @At(value = "NEW", target = "(Lnet/minecraft/particle/ParticleType;Lnet/minecraft/block/BlockState;)Lnet/minecraft/particle/BlockStateParticleEffect;"))
+	private BlockStateParticleEffect modifyBlockStateParticleEffect(BlockStateParticleEffect original, double heightDifference, boolean onGround, BlockState state, BlockPos landedPosition) {
+		((BlockStateParticleEffectExtension) original).setBlockPos(landedPosition);
+		return original;
+	}
+}

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/LivingEntityMixin.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/LivingEntityMixin.java
@@ -31,7 +31,7 @@ import net.fabricmc.fabric.impl.particle.BlockStateParticleEffectExtension;
 abstract class LivingEntityMixin {
 	@ModifyExpressionValue(method = "fall", at = @At(value = "NEW", target = "(Lnet/minecraft/particle/ParticleType;Lnet/minecraft/block/BlockState;)Lnet/minecraft/particle/BlockStateParticleEffect;"))
 	private BlockStateParticleEffect modifyBlockStateParticleEffect(BlockStateParticleEffect original, double heightDifference, boolean onGround, BlockState state, BlockPos landedPosition) {
-		((BlockStateParticleEffectExtension) original).setBlockPos(landedPosition);
+		((BlockStateParticleEffectExtension) original).fabric_setBlockPos(landedPosition);
 		return original;
 	}
 }

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/ParticleUtilMixin.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/ParticleUtilMixin.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.particle;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.particle.BlockStateParticleEffect;
+import net.minecraft.particle.ParticleUtil;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.WorldAccess;
+
+import net.fabricmc.fabric.impl.particle.BlockStateParticleEffectExtension;
+
+@Mixin(ParticleUtil.class)
+abstract class ParticleUtilMixin {
+	@ModifyExpressionValue(method = "spawnSmashAttackParticles", at = @At(value = "NEW", target = "(Lnet/minecraft/particle/ParticleType;Lnet/minecraft/block/BlockState;)Lnet/minecraft/particle/BlockStateParticleEffect;"))
+	private static BlockStateParticleEffect modifyBlockStateParticleEffect(BlockStateParticleEffect original, WorldAccess world, BlockPos pos, int count) {
+		((BlockStateParticleEffectExtension) original).setBlockPos(pos);
+		return original;
+	}
+}

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/ParticleUtilMixin.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/ParticleUtilMixin.java
@@ -31,7 +31,7 @@ import net.fabricmc.fabric.impl.particle.BlockStateParticleEffectExtension;
 abstract class ParticleUtilMixin {
 	@ModifyExpressionValue(method = "spawnSmashAttackParticles", at = @At(value = "NEW", target = "(Lnet/minecraft/particle/ParticleType;Lnet/minecraft/block/BlockState;)Lnet/minecraft/particle/BlockStateParticleEffect;"))
 	private static BlockStateParticleEffect modifyBlockStateParticleEffect(BlockStateParticleEffect original, WorldAccess world, BlockPos pos, int count) {
-		((BlockStateParticleEffectExtension) original).setBlockPos(pos);
+		((BlockStateParticleEffectExtension) original).fabric_setBlockPos(pos);
 		return original;
 	}
 }

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/ServerPlayerEntityMixin.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/ServerPlayerEntityMixin.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.particle;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.particle.BlockStateParticleEffect;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.math.BlockPos;
+
+import net.fabricmc.fabric.impl.particle.BlockStateParticleEffectExtension;
+
+@Mixin(ServerPlayerEntity.class)
+abstract class ServerPlayerEntityMixin {
+	@ModifyExpressionValue(method = "fall", at = @At(value = "NEW", target = "(Lnet/minecraft/particle/ParticleType;Lnet/minecraft/block/BlockState;)Lnet/minecraft/particle/BlockStateParticleEffect;"))
+	private BlockStateParticleEffect modifyBlockStateParticleEffect(BlockStateParticleEffect original, double heightDifference, boolean onGround, BlockState state, BlockPos landedPosition) {
+		((BlockStateParticleEffectExtension) original).setBlockPos(landedPosition);
+		return original;
+	}
+}

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/ServerPlayerEntityMixin.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/ServerPlayerEntityMixin.java
@@ -31,7 +31,7 @@ import net.fabricmc.fabric.impl.particle.BlockStateParticleEffectExtension;
 abstract class ServerPlayerEntityMixin {
 	@ModifyExpressionValue(method = "fall", at = @At(value = "NEW", target = "(Lnet/minecraft/particle/ParticleType;Lnet/minecraft/block/BlockState;)Lnet/minecraft/particle/BlockStateParticleEffect;"))
 	private BlockStateParticleEffect modifyBlockStateParticleEffect(BlockStateParticleEffect original, double heightDifference, boolean onGround, BlockState state, BlockPos landedPosition) {
-		((BlockStateParticleEffectExtension) original).setBlockPos(landedPosition);
+		((BlockStateParticleEffectExtension) original).fabric_setBlockPos(landedPosition);
 		return original;
 	}
 }

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/WardenEntityMixin.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/WardenEntityMixin.java
@@ -37,7 +37,7 @@ abstract class WardenEntityMixin extends HostileEntity implements Vibrations {
 
 	@ModifyExpressionValue(method = "addDigParticles", at = @At(value = "NEW", target = "(Lnet/minecraft/particle/ParticleType;Lnet/minecraft/block/BlockState;)Lnet/minecraft/particle/BlockStateParticleEffect;"))
 	private BlockStateParticleEffect modifyBlockStateParticleEffect(BlockStateParticleEffect original) {
-		((BlockStateParticleEffectExtension) original).setBlockPos(getSteppingPos());
+		((BlockStateParticleEffectExtension) original).fabric_setBlockPos(getSteppingPos());
 		return original;
 	}
 }

--- a/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/WardenEntityMixin.java
+++ b/fabric-particles-v1/src/main/java/net/fabricmc/fabric/mixin/particle/WardenEntityMixin.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.particle;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.mob.HostileEntity;
+import net.minecraft.entity.mob.WardenEntity;
+import net.minecraft.particle.BlockStateParticleEffect;
+import net.minecraft.world.World;
+import net.minecraft.world.event.Vibrations;
+
+import net.fabricmc.fabric.impl.particle.BlockStateParticleEffectExtension;
+
+@Mixin(WardenEntity.class)
+abstract class WardenEntityMixin extends HostileEntity implements Vibrations {
+	private WardenEntityMixin(EntityType<? extends HostileEntity> entityType, World world) {
+		super(entityType, world);
+	}
+
+	@ModifyExpressionValue(method = "addDigParticles", at = @At(value = "NEW", target = "(Lnet/minecraft/particle/ParticleType;Lnet/minecraft/block/BlockState;)Lnet/minecraft/particle/BlockStateParticleEffect;"))
+	private BlockStateParticleEffect modifyBlockStateParticleEffect(BlockStateParticleEffect original) {
+		((BlockStateParticleEffectExtension) original).setBlockPos(getSteppingPos());
+		return original;
+	}
+}

--- a/fabric-particles-v1/src/main/resources/fabric-particles-v1.mixins.json
+++ b/fabric-particles-v1/src/main/resources/fabric-particles-v1.mixins.json
@@ -1,0 +1,18 @@
+{
+  "required": true,
+  "package": "net.fabricmc.fabric.mixin.particle",
+  "compatibilityLevel": "JAVA_21",
+  "mixins": [
+    "BlockStateParticleEffectMixin",
+    "BreezeEntityMixin",
+    "BrushItemMixin",
+    "EntityMixin",
+    "LivingEntityMixin",
+    "ParticleUtilMixin",
+    "ServerPlayerEntityMixin",
+    "WardenEntityMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/fabric-particles-v1/src/main/resources/fabric.mod.json
+++ b/fabric-particles-v1/src/main/resources/fabric.mod.json
@@ -16,10 +16,20 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.16.10"
+    "fabricloader": ">=0.16.10",
+    "fabric-networking-api-v1": ">=4.4.0"
+  },
+  "entrypoints": {
+    "main": [
+      "net.fabricmc.fabric.impl.particle.ExtendedBlockStateParticleEffectSync"
+    ],
+    "client": [
+      "net.fabricmc.fabric.impl.client.particle.ExtendedBlockStateParticleEffectSyncClient"
+    ]
   },
   "description": "Hooks for registering custom particles.",
   "mixins": [
+    "fabric-particles-v1.mixins.json",
     {
       "config": "fabric-particles-v1.client.mixins.json",
       "environment": "client"

--- a/fabric-particles-v1/src/main/resources/fabric.mod.json
+++ b/fabric-particles-v1/src/main/resources/fabric.mod.json
@@ -36,7 +36,10 @@
     }
   ],
   "custom": {
-    "fabric-api:module-lifecycle": "stable"
+    "fabric-api:module-lifecycle": "stable",
+    "loom:injected_interfaces": {
+      "net/minecraft/class_2388": ["net/fabricmc/fabric/api/particle/v1/FabricBlockStateParticleEffect"]
+    }
   },
   "accessWidener": "fabric-particles-v1.accesswidener"
 }

--- a/fabric-renderer-api-v1/build.gradle
+++ b/fabric-renderer-api-v1/build.gradle
@@ -8,6 +8,7 @@ testDependencies(project, [
 	':fabric-blockrenderlayer-v1',
 	':fabric-model-loading-api-v1',
 	':fabric-object-builder-api-v1',
+	':fabric-particles-v1',
 	':fabric-renderer-indigo',
 	':fabric-resource-loader-v0'
 ])

--- a/fabric-renderer-api-v1/src/client/resources/fabric.mod.json
+++ b/fabric-renderer-api-v1/src/client/resources/fabric.mod.json
@@ -20,6 +20,9 @@
     "minecraft": ">=1.21.5-beta.1",
     "fabric-api-base": "*"
   },
+  "suggests": {
+    "fabric-particles-v1": "*"
+  },
   "description": "Defines rendering extensions for dynamic/fancy block and item models.",
   "mixins": [
     "fabric-renderer-api-v1.mixins.json",


### PR DESCRIPTION
This pull request makes it so `BlockDustParticle` instances use an accurate `BlockPos` when supported. This is done by adding a `BlockPos` field to `BlockStateParticleEffect` and patching common code to set it to the correct value, when applicable. The `BlockStateParticleEffect`'s packet codec is patched to sync the field to the client if both the client and server have the Particles v1 module. The server only encodes extended data if it knows the client supports it, while decoding supports both vanilla data and extended data based on a marker. If a `BlockPos` was synced, the `BlockDustParticle` constructor that accepts a `BlockPos` is used.

The main purpose of this feature is to ensure that `FabricBlockStateModel#particleSprite(BlockRenderView, BlockPos, BlockState)` also always receives an accurate `BlockPos`. Without these patches, the `BlockPos` is sometimes off by one, which can cause the model to return an incorrect particle sprite, especially when using the `BlockPos` to retrieve block entity render data or the biome. The FRAPI test mod has such models, which can be used for testing.

### TODO

- [x] Decide how to expose the ability to create a `BlockStateParticleEffect` with a `BlockPos` to API users.
  **Resolution:** Added interface injected `FabricBlockStateParticleEffect` with `BlockPos` getter and static `create` method.