### PR TITLE
[Craftmine] Fix item assets being created for every block

### DIFF
--- a/fabric-data-generation-api-v1/src/client/java/net/fabricmc/fabric/impl/datagen/client/FabricItemAssetDefinitions.java
+++ b/fabric-data-generation-api-v1/src/client/java/net/fabricmc/fabric/impl/datagen/client/FabricItemAssetDefinitions.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.datagen.client;
+
+import java.util.Set;
+
+import net.minecraft.block.Block;
+
+public interface FabricItemAssetDefinitions extends FabricModelProviderDefinitions {
+	void fabric_setProcessedBlocks(Set<Block> processedBlocks);
+}

--- a/fabric-data-generation-api-v1/src/client/java/net/fabricmc/fabric/mixin/datagen/client/ModelProviderItemAssetsMixin.java
+++ b/fabric-data-generation-api-v1/src/client/java/net/fabricmc/fabric/mixin/datagen/client/ModelProviderItemAssetsMixin.java
@@ -17,47 +17,52 @@
 package net.fabricmc.fabric.mixin.datagen.client;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+import net.minecraft.block.Block;
 import net.minecraft.client.data.ModelProvider;
 import net.minecraft.client.item.ItemAsset;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
-import net.fabricmc.fabric.impl.datagen.client.FabricModelProviderDefinitions;
+import net.fabricmc.fabric.impl.datagen.client.FabricItemAssetDefinitions;
 
 @Mixin(ModelProvider.ItemAssets.class)
-public class ModelProviderItemAssetsMixin implements FabricModelProviderDefinitions {
-	@Shadow
-	@Final
-	private Map<Item, ItemAsset> itemAssets;
+public class ModelProviderItemAssetsMixin implements FabricItemAssetDefinitions {
 	@Unique
 	private FabricDataOutput fabricDataOutput;
+	@Unique
+	private Set<Block> processedBlocks;
 
 	@Override
 	public void setFabricDataOutput(FabricDataOutput fabricDataOutput) {
 		this.fabricDataOutput = fabricDataOutput;
 	}
 
+	@Override
+	public void fabric_setProcessedBlocks(Set<Block> processedBlocks) {
+		this.processedBlocks = processedBlocks;
+	}
+
 	@WrapOperation(method = "method_65470", at = @At(value = "INVOKE", target = "Ljava/util/Map;containsKey(Ljava/lang/Object;)Z", ordinal = 1, remap = false))
-	private boolean filterItemsForProcessingMod(Map<Item, ItemAsset> map, Object o, Operation<Boolean> original, @Local BlockItem blockItem) {
+	private boolean filterItemsForProcessingMod(Map<Identifier, ItemAsset> map, Object o, Operation<Boolean> original, @Local BlockItem blockItem) {
 		if (fabricDataOutput != null) {
 			// Only generate the item model if the block state json was registered
-			if (itemAssets.containsKey(blockItem)) {
+			if (!processedBlocks.contains(blockItem.getBlock())) {
 				return true;
 			}
 
@@ -67,7 +72,7 @@ public class ModelProviderItemAssetsMixin implements FabricModelProviderDefiniti
 			}
 		}
 
-		return original.call(map, blockItem);
+		return original.call(map, o);
 	}
 
 	@Redirect(method = "resolveAndValidate", at = @At(value = "INVOKE", target = "Ljava/util/stream/Stream;filter(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;", ordinal = 0, remap = false))

--- a/fabric-data-generation-api-v1/src/client/java/net/fabricmc/fabric/mixin/datagen/client/ModelProviderMixin.java
+++ b/fabric-data-generation-api-v1/src/client/java/net/fabricmc/fabric/mixin/datagen/client/ModelProviderMixin.java
@@ -35,6 +35,7 @@ import net.minecraft.data.DataWriter;
 
 import net.fabricmc.fabric.api.client.datagen.v1.provider.FabricModelProvider;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+import net.fabricmc.fabric.impl.datagen.client.FabricItemAssetDefinitions;
 import net.fabricmc.fabric.impl.datagen.client.FabricModelProviderDefinitions;
 
 @Mixin(ModelProvider.class)
@@ -75,5 +76,6 @@ public class ModelProviderMixin {
 							@Local ModelProvider.ItemAssets itemAssets) {
 		((FabricModelProviderDefinitions) blockStateSuppliers).setFabricDataOutput(fabricDataOutput);
 		((FabricModelProviderDefinitions) itemAssets).setFabricDataOutput(fabricDataOutput);
+		((FabricItemAssetDefinitions) itemAssets).fabric_setProcessedBlocks(blockStateSuppliers.blockStateSuppliers.keySet());
 	}
 }

--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.accesswidener
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.accesswidener
@@ -58,6 +58,7 @@ transitive-accessible class net/minecraft/client/data/BlockStateModelGenerator$C
 
 accessible class net/minecraft/client/data/ModelProvider$ItemAssets
 accessible class net/minecraft/client/data/ModelProvider$BlockStateSuppliers
+accessible field net/minecraft/client/data/ModelProvider$BlockStateSuppliers blockStateSuppliers Ljava/util/Map;
 
 ### Generated access wideners below
 

--- a/fabric-data-generation-api-v1/template.accesswidener
+++ b/fabric-data-generation-api-v1/template.accesswidener
@@ -53,5 +53,6 @@ transitive-accessible class net/minecraft/client/data/BlockStateModelGenerator$C
 
 accessible class net/minecraft/client/data/ModelProvider$ItemAssets
 accessible class net/minecraft/client/data/ModelProvider$BlockStateSuppliers
+accessible field net/minecraft/client/data/ModelProvider$BlockStateSuppliers blockStateSuppliers Ljava/util/Map;
 
 ### Generated access wideners below


### PR DESCRIPTION
Fixes #4570 (the broken filter) as well as the original operation call which became outdated in the Craftmine update.

I don't think it's possible to write an automated test for this. You need to have a block with an item that generates an item model but no block model, but strict validation doesn't like blocks with missing models.