### PR TITLE
[1.21.5] Fix item assets being created for every block

### DIFF
--- a/fabric-data-generation-api-v1/src/client/java/net/fabricmc/fabric/impl/datagen/client/FabricItemAssetDefinitions.java
+++ b/fabric-data-generation-api-v1/src/client/java/net/fabricmc/fabric/impl/datagen/client/FabricItemAssetDefinitions.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.datagen.client;
+
+import java.util.Set;
+
+import net.minecraft.block.Block;
+
+public interface FabricItemAssetDefinitions extends FabricModelProviderDefinitions {
+	void fabric_setProcessedBlocks(Set<Block> processedBlocks);
+}

--- a/fabric-data-generation-api-v1/src/client/java/net/fabricmc/fabric/mixin/datagen/client/ModelProviderMixin.java
+++ b/fabric-data-generation-api-v1/src/client/java/net/fabricmc/fabric/mixin/datagen/client/ModelProviderMixin.java
@@ -35,6 +35,7 @@ import net.minecraft.data.DataWriter;
 
 import net.fabricmc.fabric.api.client.datagen.v1.provider.FabricModelProvider;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+import net.fabricmc.fabric.impl.datagen.client.FabricItemAssetDefinitions;
 import net.fabricmc.fabric.impl.datagen.client.FabricModelProviderDefinitions;
 
 @Mixin(ModelProvider.class)
@@ -75,5 +76,6 @@ public class ModelProviderMixin {
 							@Local ModelProvider.ItemAssets itemAssets) {
 		((FabricModelProviderDefinitions) blockStateSuppliers).setFabricDataOutput(fabricDataOutput);
 		((FabricModelProviderDefinitions) itemAssets).setFabricDataOutput(fabricDataOutput);
+		((FabricItemAssetDefinitions) itemAssets).fabric_setProcessedBlocks(blockStateSuppliers.blockStateSuppliers.keySet());
 	}
 }

--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.accesswidener
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.accesswidener
@@ -58,6 +58,7 @@ transitive-accessible class net/minecraft/client/data/BlockStateModelGenerator$C
 
 accessible class net/minecraft/client/data/ModelProvider$ItemAssets
 accessible class net/minecraft/client/data/ModelProvider$BlockStateSuppliers
+accessible field net/minecraft/client/data/ModelProvider$BlockStateSuppliers blockStateSuppliers Ljava/util/Map;
 
 ### Generated access wideners below
 

--- a/fabric-data-generation-api-v1/template.accesswidener
+++ b/fabric-data-generation-api-v1/template.accesswidener
@@ -53,5 +53,6 @@ transitive-accessible class net/minecraft/client/data/BlockStateModelGenerator$C
 
 accessible class net/minecraft/client/data/ModelProvider$ItemAssets
 accessible class net/minecraft/client/data/ModelProvider$BlockStateSuppliers
+accessible field net/minecraft/client/data/ModelProvider$BlockStateSuppliers blockStateSuppliers Ljava/util/Map;
 
 ### Generated access wideners below


### PR DESCRIPTION
Fixes #4570. The original operation call is also changed to be actually identical to the original to prevent any issues in future updates (see Craftmine).

I don't think it's possible to write an automated test for this without adding new source sets. You need to have a block with an item that generates an item model but no block model, but strict validation doesn't like blocks with missing models.