### PR TITLE
Add component tooltip appender registry

### DIFF
--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ComponentTooltipAppenderRegistry.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ComponentTooltipAppenderRegistry.java
@@ -29,7 +29,6 @@ import net.fabricmc.fabric.impl.item.ComponentTooltipAppenderRegistryImpl;
  */
 @ApiStatus.NonExtendable
 public interface ComponentTooltipAppenderRegistry {
-
 	/**
 	 * Adds the specified item component type to the list of tooltip appenders to be called first. The component will
 	 * render at the top of the tooltip.

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ComponentTooltipAppenderRegistry.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ComponentTooltipAppenderRegistry.java
@@ -16,12 +16,12 @@
 
 package net.fabricmc.fabric.api.item.v1;
 
-import net.fabricmc.fabric.impl.item.ComponentTooltipAppenderRegistryImpl;
-
 import org.jetbrains.annotations.ApiStatus;
 
 import net.minecraft.component.ComponentType;
 import net.minecraft.item.tooltip.TooltipAppender;
+
+import net.fabricmc.fabric.impl.item.ComponentTooltipAppenderRegistryImpl;
 
 /**
  * A registry of {@link TooltipAppender} item components. Adding your item component to this registry will render the

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ComponentTooltipAppenderRegistry.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ComponentTooltipAppenderRegistry.java
@@ -16,12 +16,12 @@
 
 package net.fabricmc.fabric.api.item.v1;
 
+import net.fabricmc.fabric.impl.item.ComponentTooltipAppenderRegistryImpl;
+
 import org.jetbrains.annotations.ApiStatus;
 
 import net.minecraft.component.ComponentType;
 import net.minecraft.item.tooltip.TooltipAppender;
-
-import net.fabricmc.fabric.impl.item.ComponentTooltipAppenderRegistryImpl;
 
 /**
  * A registry of {@link TooltipAppender} item components. Adding your item component to this registry will render the
@@ -29,9 +29,6 @@ import net.fabricmc.fabric.impl.item.ComponentTooltipAppenderRegistryImpl;
  */
 @ApiStatus.NonExtendable
 public interface ComponentTooltipAppenderRegistry {
-	static ComponentTooltipAppenderRegistry getInstance() {
-		return ComponentTooltipAppenderRegistryImpl.INSTANCE;
-	}
 
 	/**
 	 * Adds the specified item component type to the list of tooltip appenders to be called first. The component will
@@ -39,7 +36,9 @@ public interface ComponentTooltipAppenderRegistry {
 	 *
 	 * @param componentType the component type to add
 	 */
-	void addFirst(ComponentType<? extends TooltipAppender> componentType);
+	static void addFirst(ComponentType<? extends TooltipAppender> componentType) {
+		ComponentTooltipAppenderRegistryImpl.addFirst(componentType);
+	}
 
 	/**
 	 * Adds the specified item component type to the list of tooltip appenders to be called last. The component will
@@ -47,7 +46,9 @@ public interface ComponentTooltipAppenderRegistry {
 	 *
 	 * @param componentType the component type to add
 	 */
-	void addLast(ComponentType<? extends TooltipAppender> componentType);
+	static void addLast(ComponentType<? extends TooltipAppender> componentType) {
+		ComponentTooltipAppenderRegistryImpl.addLast(componentType);
+	}
 
 	/**
 	 * Adds the specified item component type to the list of tooltip appenders so that it will render
@@ -56,7 +57,9 @@ public interface ComponentTooltipAppenderRegistry {
 	 * @param anchor the component type before which the specified component type will be rendered
 	 * @param componentType the component type to add
 	 */
-	void addBefore(ComponentType<?> anchor, ComponentType<? extends TooltipAppender> componentType);
+	static void addBefore(ComponentType<?> anchor, ComponentType<? extends TooltipAppender> componentType) {
+		ComponentTooltipAppenderRegistryImpl.addBefore(anchor, componentType);
+	}
 
 	/**
 	 * Adds the specified item component type to the list of tooltip appenders so that it will render
@@ -65,5 +68,7 @@ public interface ComponentTooltipAppenderRegistry {
 	 * @param anchor the component type after which the specified component type will be rendered
 	 * @param componentType the component type to add
 	 */
-	void addAfter(ComponentType<?> anchor, ComponentType<? extends TooltipAppender> componentType);
+	static void addAfter(ComponentType<?> anchor, ComponentType<? extends TooltipAppender> componentType) {
+		ComponentTooltipAppenderRegistryImpl.addAfter(anchor, componentType);
+	}
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ComponentTooltipAppenderRegistry.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ComponentTooltipAppenderRegistry.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.api.item.v1;
 
+import com.google.common.base.Preconditions;
 import org.jetbrains.annotations.ApiStatus;
 
 import net.minecraft.component.ComponentType;
@@ -36,6 +37,7 @@ public interface ComponentTooltipAppenderRegistry {
 	 * @param componentType the component type to add
 	 */
 	static void addFirst(ComponentType<? extends TooltipAppender> componentType) {
+		Preconditions.checkNotNull(componentType, "componentType");
 		ComponentTooltipAppenderRegistryImpl.addFirst(componentType);
 	}
 
@@ -46,6 +48,7 @@ public interface ComponentTooltipAppenderRegistry {
 	 * @param componentType the component type to add
 	 */
 	static void addLast(ComponentType<? extends TooltipAppender> componentType) {
+		Preconditions.checkNotNull(componentType, "componentType");
 		ComponentTooltipAppenderRegistryImpl.addLast(componentType);
 	}
 
@@ -57,6 +60,8 @@ public interface ComponentTooltipAppenderRegistry {
 	 * @param componentType the component type to add
 	 */
 	static void addBefore(ComponentType<?> anchor, ComponentType<? extends TooltipAppender> componentType) {
+		Preconditions.checkNotNull(anchor, "anchor");
+		Preconditions.checkNotNull(componentType, "componentType");
 		ComponentTooltipAppenderRegistryImpl.addBefore(anchor, componentType);
 	}
 
@@ -68,6 +73,8 @@ public interface ComponentTooltipAppenderRegistry {
 	 * @param componentType the component type to add
 	 */
 	static void addAfter(ComponentType<?> anchor, ComponentType<? extends TooltipAppender> componentType) {
+		Preconditions.checkNotNull(anchor, "anchor");
+		Preconditions.checkNotNull(componentType, "componentType");
 		ComponentTooltipAppenderRegistryImpl.addAfter(anchor, componentType);
 	}
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ComponentTooltipAppenderRegistry.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ComponentTooltipAppenderRegistry.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.item.v1;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import net.minecraft.component.ComponentType;
+import net.minecraft.item.tooltip.TooltipAppender;
+
+import net.fabricmc.fabric.impl.item.ComponentTooltipAppenderRegistryImpl;
+
+/**
+ * A registry of {@link TooltipAppender} item components. Adding your item component to this registry will render the
+ * item component to the tooltip of them item when it is present, in a location relative to other item components.
+ */
+@ApiStatus.NonExtendable
+public interface ComponentTooltipAppenderRegistry {
+	static ComponentTooltipAppenderRegistry getInstance() {
+		return ComponentTooltipAppenderRegistryImpl.INSTANCE;
+	}
+
+	/**
+	 * Adds the specified item component type to the list of tooltip appenders to be called first. The component will
+	 * render at the top of the tooltip.
+	 *
+	 * @param componentType the component type to add
+	 */
+	void addFirst(ComponentType<? extends TooltipAppender> componentType);
+
+	/**
+	 * Adds the specified item component type to the list of tooltip appenders to be called last. The component will
+	 * render at the bottom of the tooltip.
+	 *
+	 * @param componentType the component type to add
+	 */
+	void addLast(ComponentType<? extends TooltipAppender> componentType);
+
+	/**
+	 * Adds the specified item component type to the list of tooltip appenders so that it will render
+	 * before the tooltip appender associated with the specified anchor component type.
+	 *
+	 * @param anchor the component type before which the specified component type will be rendered
+	 * @param componentType the component type to add
+	 */
+	void addBefore(ComponentType<?> anchor, ComponentType<? extends TooltipAppender> componentType);
+
+	/**
+	 * Adds the specified item component type to the list of tooltip appenders so that it will render
+	 * after the tooltip appender associated with the specified anchor component type.
+	 *
+	 * @param anchor the component type after which the specified component type will be rendered
+	 * @param componentType the component type to add
+	 */
+	void addAfter(ComponentType<?> anchor, ComponentType<? extends TooltipAppender> componentType);
+}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/ComponentTooltipAppenderRegistryImpl.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/ComponentTooltipAppenderRegistryImpl.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.item;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import com.google.common.base.Preconditions;
+
+import net.minecraft.component.ComponentType;
+import net.minecraft.component.type.TooltipDisplayComponent;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.tooltip.TooltipAppender;
+import net.minecraft.item.tooltip.TooltipType;
+import net.minecraft.text.Text;
+
+import net.fabricmc.fabric.api.item.v1.ComponentTooltipAppenderRegistry;
+
+public final class ComponentTooltipAppenderRegistryImpl implements ComponentTooltipAppenderRegistry {
+	public static final ComponentTooltipAppenderRegistryImpl INSTANCE = new ComponentTooltipAppenderRegistryImpl();
+
+	private final List<ComponentType<? extends TooltipAppender>> first = new ArrayList<>();
+	private final List<ComponentType<? extends TooltipAppender>> last = new ArrayList<>();
+	private final Map<ComponentType<?>, List<ComponentType<? extends TooltipAppender>>> before = new HashMap<>();
+	private final Map<ComponentType<?>, List<ComponentType<? extends TooltipAppender>>> after = new HashMap<>();
+
+	@Override
+	public void addFirst(ComponentType<? extends TooltipAppender> componentType) {
+		Preconditions.checkNotNull(componentType, "componentType");
+		first.add(componentType);
+	}
+
+	@Override
+	public void addLast(ComponentType<? extends TooltipAppender> componentType) {
+		Preconditions.checkNotNull(componentType, "componentType");
+		last.add(componentType);
+	}
+
+	@Override
+	public void addBefore(ComponentType<?> anchor, ComponentType<? extends TooltipAppender> componentType) {
+		Preconditions.checkNotNull(anchor, "anchor");
+		Preconditions.checkNotNull(componentType, "componentType");
+		before.computeIfAbsent(anchor, k -> new ArrayList<>()).add(componentType);
+	}
+
+	@Override
+	public void addAfter(ComponentType<?> anchor, ComponentType<? extends TooltipAppender> componentType) {
+		Preconditions.checkNotNull(anchor, "anchor");
+		Preconditions.checkNotNull(componentType, "componentType");
+		after.computeIfAbsent(anchor, k -> new ArrayList<>()).add(componentType);
+	}
+
+	public void onFirst(
+			ItemStack stack,
+			Item.TooltipContext context,
+			TooltipDisplayComponent displayComponent,
+			Consumer<Text> textConsumer,
+			TooltipType type
+	) {
+		Set<ComponentType<?>> cycleDetector = new HashSet<>();
+
+		for (ComponentType<? extends TooltipAppender> componentType : first) {
+			appendCustomComponentTooltip(stack, componentType, context, displayComponent, textConsumer, type, cycleDetector);
+		}
+	}
+
+	public void onLast(
+			ItemStack stack,
+			Item.TooltipContext context,
+			TooltipDisplayComponent displayComponent,
+			Consumer<Text> textConsumer,
+			TooltipType type
+	) {
+		Set<ComponentType<?>> cycleDetector = new HashSet<>();
+
+		for (ComponentType<? extends TooltipAppender> componentType : last) {
+			appendCustomComponentTooltip(stack, componentType, context, displayComponent, textConsumer, type, cycleDetector);
+		}
+	}
+
+	public void onBefore(
+			ItemStack stack,
+			ComponentType<?> componentType,
+			Item.TooltipContext context,
+			TooltipDisplayComponent displayComponent,
+			Consumer<Text> textConsumer,
+			TooltipType type,
+			Set<ComponentType<?>> cycleDetector
+	) {
+		List<ComponentType<? extends TooltipAppender>> before = this.before.get(componentType);
+
+		if (before != null) {
+			for (ComponentType<? extends TooltipAppender> beforeComponentType : before) {
+				appendCustomComponentTooltip(stack, beforeComponentType, context, displayComponent, textConsumer, type, cycleDetector);
+			}
+		}
+	}
+
+	public void onAfter(
+			ItemStack stack,
+			ComponentType<?> componentType,
+			Item.TooltipContext context,
+			TooltipDisplayComponent displayComponent,
+			Consumer<Text> textConsumer,
+			TooltipType type,
+			Set<ComponentType<?>> cycleDetector
+	) {
+		List<ComponentType<? extends TooltipAppender>> after = this.after.get(componentType);
+
+		if (after != null) {
+			for (ComponentType<? extends TooltipAppender> afterComponentType : after) {
+				appendCustomComponentTooltip(stack, afterComponentType, context, displayComponent, textConsumer, type, cycleDetector);
+			}
+		}
+	}
+
+	private void appendCustomComponentTooltip(
+			ItemStack stack,
+			ComponentType<? extends TooltipAppender> componentType,
+			Item.TooltipContext context,
+			TooltipDisplayComponent displayComponent,
+			Consumer<Text> textConsumer,
+			TooltipType type,
+			Set<ComponentType<?>> cycleDetector
+	) {
+		if (!cycleDetector.add(componentType)) {
+			return;
+		}
+
+		onBefore(stack, componentType, context, displayComponent, textConsumer, type, cycleDetector);
+		stack.appendComponentTooltip(componentType, context, displayComponent, textConsumer, type);
+		onAfter(stack, componentType, context, displayComponent, textConsumer, type, cycleDetector);
+
+		cycleDetector.remove(componentType);
+	}
+}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/ComponentTooltipAppenderRegistryImpl.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/ComponentTooltipAppenderRegistryImpl.java
@@ -24,8 +24,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import com.google.common.base.Preconditions;
-
 import net.minecraft.component.ComponentType;
 import net.minecraft.component.type.TooltipDisplayComponent;
 import net.minecraft.item.Item;
@@ -41,24 +39,18 @@ public final class ComponentTooltipAppenderRegistryImpl {
 	private static final Map<ComponentType<?>, List<ComponentType<? extends TooltipAppender>>> after = new HashMap<>();
 
 	public static void addFirst(ComponentType<? extends TooltipAppender> componentType) {
-		Preconditions.checkNotNull(componentType, "componentType");
 		first.add(componentType);
 	}
 
 	public static void addLast(ComponentType<? extends TooltipAppender> componentType) {
-		Preconditions.checkNotNull(componentType, "componentType");
 		last.add(componentType);
 	}
 
 	public static void addBefore(ComponentType<?> anchor, ComponentType<? extends TooltipAppender> componentType) {
-		Preconditions.checkNotNull(anchor, "anchor");
-		Preconditions.checkNotNull(componentType, "componentType");
 		before.computeIfAbsent(anchor, k -> new ArrayList<>()).add(componentType);
 	}
 
 	public static void addAfter(ComponentType<?> anchor, ComponentType<? extends TooltipAppender> componentType) {
-		Preconditions.checkNotNull(anchor, "anchor");
-		Preconditions.checkNotNull(componentType, "componentType");
 		after.computeIfAbsent(anchor, k -> new ArrayList<>()).add(componentType);
 	}
 

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/ComponentTooltipAppenderRegistryImpl.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/ComponentTooltipAppenderRegistryImpl.java
@@ -34,43 +34,35 @@ import net.minecraft.item.tooltip.TooltipAppender;
 import net.minecraft.item.tooltip.TooltipType;
 import net.minecraft.text.Text;
 
-import net.fabricmc.fabric.api.item.v1.ComponentTooltipAppenderRegistry;
+public final class ComponentTooltipAppenderRegistryImpl {
+	private static final List<ComponentType<? extends TooltipAppender>> first = new ArrayList<>();
+	private static final List<ComponentType<? extends TooltipAppender>> last = new ArrayList<>();
+	private static final Map<ComponentType<?>, List<ComponentType<? extends TooltipAppender>>> before = new HashMap<>();
+	private static final Map<ComponentType<?>, List<ComponentType<? extends TooltipAppender>>> after = new HashMap<>();
 
-public final class ComponentTooltipAppenderRegistryImpl implements ComponentTooltipAppenderRegistry {
-	public static final ComponentTooltipAppenderRegistryImpl INSTANCE = new ComponentTooltipAppenderRegistryImpl();
-
-	private final List<ComponentType<? extends TooltipAppender>> first = new ArrayList<>();
-	private final List<ComponentType<? extends TooltipAppender>> last = new ArrayList<>();
-	private final Map<ComponentType<?>, List<ComponentType<? extends TooltipAppender>>> before = new HashMap<>();
-	private final Map<ComponentType<?>, List<ComponentType<? extends TooltipAppender>>> after = new HashMap<>();
-
-	@Override
-	public void addFirst(ComponentType<? extends TooltipAppender> componentType) {
+	public static void addFirst(ComponentType<? extends TooltipAppender> componentType) {
 		Preconditions.checkNotNull(componentType, "componentType");
 		first.add(componentType);
 	}
 
-	@Override
-	public void addLast(ComponentType<? extends TooltipAppender> componentType) {
+	public static void addLast(ComponentType<? extends TooltipAppender> componentType) {
 		Preconditions.checkNotNull(componentType, "componentType");
 		last.add(componentType);
 	}
 
-	@Override
-	public void addBefore(ComponentType<?> anchor, ComponentType<? extends TooltipAppender> componentType) {
+	public static void addBefore(ComponentType<?> anchor, ComponentType<? extends TooltipAppender> componentType) {
 		Preconditions.checkNotNull(anchor, "anchor");
 		Preconditions.checkNotNull(componentType, "componentType");
 		before.computeIfAbsent(anchor, k -> new ArrayList<>()).add(componentType);
 	}
 
-	@Override
-	public void addAfter(ComponentType<?> anchor, ComponentType<? extends TooltipAppender> componentType) {
+	public static void addAfter(ComponentType<?> anchor, ComponentType<? extends TooltipAppender> componentType) {
 		Preconditions.checkNotNull(anchor, "anchor");
 		Preconditions.checkNotNull(componentType, "componentType");
 		after.computeIfAbsent(anchor, k -> new ArrayList<>()).add(componentType);
 	}
 
-	public void onFirst(
+	public static void onFirst(
 			ItemStack stack,
 			Item.TooltipContext context,
 			TooltipDisplayComponent displayComponent,
@@ -84,7 +76,7 @@ public final class ComponentTooltipAppenderRegistryImpl implements ComponentTool
 		}
 	}
 
-	public void onLast(
+	public static void onLast(
 			ItemStack stack,
 			Item.TooltipContext context,
 			TooltipDisplayComponent displayComponent,
@@ -98,7 +90,7 @@ public final class ComponentTooltipAppenderRegistryImpl implements ComponentTool
 		}
 	}
 
-	public void onBefore(
+	public static void onBefore(
 			ItemStack stack,
 			ComponentType<?> componentType,
 			Item.TooltipContext context,
@@ -107,16 +99,16 @@ public final class ComponentTooltipAppenderRegistryImpl implements ComponentTool
 			TooltipType type,
 			Set<ComponentType<?>> cycleDetector
 	) {
-		List<ComponentType<? extends TooltipAppender>> before = this.before.get(componentType);
+		List<ComponentType<? extends TooltipAppender>> befores = before.get(componentType);
 
-		if (before != null) {
-			for (ComponentType<? extends TooltipAppender> beforeComponentType : before) {
+		if (befores != null) {
+			for (ComponentType<? extends TooltipAppender> beforeComponentType : befores) {
 				appendCustomComponentTooltip(stack, beforeComponentType, context, displayComponent, textConsumer, type, cycleDetector);
 			}
 		}
 	}
 
-	public void onAfter(
+	public static void onAfter(
 			ItemStack stack,
 			ComponentType<?> componentType,
 			Item.TooltipContext context,
@@ -125,16 +117,16 @@ public final class ComponentTooltipAppenderRegistryImpl implements ComponentTool
 			TooltipType type,
 			Set<ComponentType<?>> cycleDetector
 	) {
-		List<ComponentType<? extends TooltipAppender>> after = this.after.get(componentType);
+		List<ComponentType<? extends TooltipAppender>> afters = after.get(componentType);
 
-		if (after != null) {
-			for (ComponentType<? extends TooltipAppender> afterComponentType : after) {
+		if (afters != null) {
+			for (ComponentType<? extends TooltipAppender> afterComponentType : afters) {
 				appendCustomComponentTooltip(stack, afterComponentType, context, displayComponent, textConsumer, type, cycleDetector);
 			}
 		}
 	}
 
-	private void appendCustomComponentTooltip(
+	private static void appendCustomComponentTooltip(
 			ItemStack stack,
 			ComponentType<? extends TooltipAppender> componentType,
 			Item.TooltipContext context,

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/ComponentTooltipAppenderRegistryImpl.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/ComponentTooltipAppenderRegistryImpl.java
@@ -17,8 +17,8 @@
 package net.fabricmc.fabric.impl.item;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -35,23 +35,37 @@ import net.minecraft.text.Text;
 public final class ComponentTooltipAppenderRegistryImpl {
 	private static final List<ComponentType<? extends TooltipAppender>> first = new ArrayList<>();
 	private static final List<ComponentType<? extends TooltipAppender>> last = new ArrayList<>();
-	private static final Map<ComponentType<?>, List<ComponentType<? extends TooltipAppender>>> before = new HashMap<>();
-	private static final Map<ComponentType<?>, List<ComponentType<? extends TooltipAppender>>> after = new HashMap<>();
+	private static final Map<ComponentType<?>, List<ComponentType<? extends TooltipAppender>>> before = new IdentityHashMap<>();
+	private static final Map<ComponentType<?>, List<ComponentType<? extends TooltipAppender>>> after = new IdentityHashMap<>();
+	private static boolean hasModdedEntries = false;
 
 	public static void addFirst(ComponentType<? extends TooltipAppender> componentType) {
 		first.add(componentType);
+		onModified();
 	}
 
 	public static void addLast(ComponentType<? extends TooltipAppender> componentType) {
 		last.add(componentType);
+		onModified();
 	}
 
 	public static void addBefore(ComponentType<?> anchor, ComponentType<? extends TooltipAppender> componentType) {
 		before.computeIfAbsent(anchor, k -> new ArrayList<>()).add(componentType);
+		onModified();
 	}
 
 	public static void addAfter(ComponentType<?> anchor, ComponentType<? extends TooltipAppender> componentType) {
 		after.computeIfAbsent(anchor, k -> new ArrayList<>()).add(componentType);
+		onModified();
+	}
+
+	private static void onModified() {
+		hasModdedEntries = true;
+		VanillaTooltipAppenderOrder.load();
+	}
+
+	public static boolean hasModdedEntries() {
+		return hasModdedEntries;
 	}
 
 	public static void onFirst(

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/VanillaTooltipAppenderOrder.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/VanillaTooltipAppenderOrder.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.item;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.spongepowered.asm.service.MixinService;
+
+import net.minecraft.component.ComponentType;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.TooltipDisplayComponent;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.tooltip.TooltipType;
+
+import net.fabricmc.loader.api.FabricLoader;
+
+public final class VanillaTooltipAppenderOrder {
+	private static final List<ComponentType<?>> VANILLA_ORDER = scrapeVanillaOrder();
+
+	private VanillaTooltipAppenderOrder() {
+	}
+
+	// Find the order in which vanilla tooltip appenders are run by inspecting the bytecode of ItemStack.appendTooltip.
+	private static List<ComponentType<?>> scrapeVanillaOrder() {
+		try {
+			ClassNode itemStackNode = MixinService.getService().getBytecodeProvider().getClassNode(Type.getInternalName(ItemStack.class));
+
+			String methodName = FabricLoader.getInstance().getMappingResolver().mapMethodName(
+					"intermediary",
+					"net.minecraft.class_1799", // ItemStack
+					"method_67194", // appendTooltip
+					Type.getMethodDescriptor(
+							Type.VOID_TYPE,
+							Type.getObjectType("net/minecraft/class_1792$class_9635"), // Item.TooltipContext
+							Type.getObjectType("net/minecraft/class_10712"), // TooltipDisplayComponent
+							Type.getObjectType("net/minecraft/class_1657"), // PlayerEntity
+							Type.getObjectType("net/minecraft/class_1836"), // TooltipType
+							Type.getType(Consumer.class)
+					)
+			);
+			String methodDesc = Type.getMethodDescriptor(
+					Type.VOID_TYPE,
+					Type.getType(Item.TooltipContext.class),
+					Type.getType(TooltipDisplayComponent.class),
+					Type.getType(PlayerEntity.class),
+					Type.getType(TooltipType.class),
+					Type.getType(Consumer.class)
+			);
+
+			String appendAttributeModifiersTooltipName = FabricLoader.getInstance().getMappingResolver().mapMethodName(
+					"intermediary",
+					"net.minecraft.class_1799", // ItemStack
+					"method_57363", // appendAttributeModifiersTooltip
+					Type.getMethodDescriptor(
+							Type.VOID_TYPE,
+							Type.getType(Consumer.class),
+							Type.getObjectType("net/minecraft/class_10712"), // TooltipDisplayComponent
+							Type.getObjectType("net/minecraft/class_1657") // PlayerEntity
+					)
+			);
+			String appendAttributeModifiersTooltipDesc = Type.getMethodDescriptor(
+					Type.VOID_TYPE,
+					Type.getType(Consumer.class),
+					Type.getType(TooltipDisplayComponent.class),
+					Type.getType(PlayerEntity.class)
+			);
+
+			MethodNode appendTooltipMethod = itemStackNode.methods.stream()
+					.filter(method -> method.name.equals(methodName) && method.desc.equals(methodDesc))
+					.findAny()
+					.orElseThrow(() -> new IllegalStateException("No appendTooltip method in ItemStack"));
+
+			// Search for data component accesses within this method
+			List<ComponentType<?>> componentTypes = new ArrayList<>();
+			Set<String> alreadyAddedComponents = new HashSet<>();
+			String owner = Type.getInternalName(DataComponentTypes.class);
+			String desc = Type.getDescriptor(ComponentType.class);
+
+			for (AbstractInsnNode insn : appendTooltipMethod.instructions) {
+				if (insn instanceof FieldInsnNode fieldInsn
+						&& fieldInsn.getOpcode() == Opcodes.GETSTATIC
+						&& fieldInsn.owner.equals(owner)
+						&& fieldInsn.desc.equals(desc)
+				) {
+					String fieldName = fieldInsn.name;
+
+					if (alreadyAddedComponents.add(fieldName)) {
+						componentTypes.add((ComponentType<?>) DataComponentTypes.class.getField(fieldName).get(null));
+					}
+				} else if (insn instanceof MethodInsnNode methodInsn
+						&& methodInsn.name.equals(appendAttributeModifiersTooltipName)
+						&& methodInsn.desc.equals(appendAttributeModifiersTooltipDesc)
+						&& methodInsn.owner.equals(Type.getInternalName(ItemStack.class))
+				) {
+					// Special case: attribute modifiers are extracted into a separate method
+					componentTypes.add(DataComponentTypes.ATTRIBUTE_MODIFIERS);
+				}
+			}
+
+			if (componentTypes.isEmpty()) {
+				throw new IllegalStateException("Found no component types in appendTooltip method");
+			}
+
+			return componentTypes;
+		} catch (ReflectiveOperationException | IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public static List<ComponentType<?>> getVanillaOrder() {
+		return VANILLA_ORDER;
+	}
+}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/VanillaTooltipAppenderOrder.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/VanillaTooltipAppenderOrder.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.impl.item;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -46,6 +47,10 @@ public final class VanillaTooltipAppenderOrder {
 	private static final List<ComponentType<?>> VANILLA_ORDER = scrapeVanillaOrder();
 
 	private VanillaTooltipAppenderOrder() {
+	}
+
+	public static void load() {
+		// calling this method loads the class, eagerly populating VANILLA_ORDER
 	}
 
 	// Find the order in which vanilla tooltip appenders are run by inspecting the bytecode of ItemStack.appendTooltip.
@@ -129,7 +134,7 @@ public final class VanillaTooltipAppenderOrder {
 				throw new IllegalStateException("Found no component types in appendTooltip method");
 			}
 
-			return componentTypes;
+			return Collections.unmodifiableList(componentTypes);
 		} catch (ReflectiveOperationException | IOException e) {
 			throw new RuntimeException(e);
 		}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemStackMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemStackMixin.java
@@ -16,26 +16,44 @@
 
 package net.fabricmc.fabric.mixin.item;
 
+import java.util.HashSet;
+import java.util.List;
 import java.util.function.Consumer;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
 import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import net.minecraft.component.ComponentType;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.TooltipDisplayComponent;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.tooltip.TooltipType;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.text.Text;
 
 import net.fabricmc.fabric.api.item.v1.CustomDamageHandler;
 import net.fabricmc.fabric.api.item.v1.FabricItemStack;
+import net.fabricmc.fabric.impl.item.ComponentTooltipAppenderRegistryImpl;
 import net.fabricmc.fabric.impl.item.ItemExtensions;
+import net.fabricmc.fabric.impl.item.VanillaTooltipAppenderOrder;
 
 @Mixin(ItemStack.class)
 public abstract class ItemStackMixin implements FabricItemStack {
@@ -71,5 +89,125 @@ public abstract class ItemStackMixin implements FabricItemStack {
 		}
 
 		original.call(instance, amount, serverWorld, serverPlayerEntity, consumer);
+	}
+
+	@ModifyArg(method = "appendTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;appendComponentTooltip(Lnet/minecraft/component/ComponentType;Lnet/minecraft/item/Item$TooltipContext;Lnet/minecraft/component/type/TooltipDisplayComponent;Ljava/util/function/Consumer;Lnet/minecraft/item/tooltip/TooltipType;)V"))
+	private ComponentType<?> preAppendComponentTooltip(
+			ComponentType<?> componentType,
+			@Local(argsOnly = true) Item.TooltipContext context,
+			@Local(argsOnly = true) TooltipDisplayComponent displayComponent,
+			@Local(argsOnly = true) TooltipType type,
+			@Local(argsOnly = true) Consumer<Text> textConsumer,
+			@Share("index") LocalIntRef index
+	) {
+		preAppendTooltip(componentType, context, displayComponent, textConsumer, type, index);
+		return componentType;
+	}
+
+	@ModifyArg(method = "appendTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/component/type/TooltipDisplayComponent;shouldDisplay(Lnet/minecraft/component/ComponentType;)Z"))
+	private ComponentType<?> preShouldDisplay(
+			ComponentType<?> componentType,
+			@Local(argsOnly = true) Item.TooltipContext context,
+			@Local(argsOnly = true) TooltipDisplayComponent displayComponent,
+			@Local(argsOnly = true) TooltipType type,
+			@Local(argsOnly = true) Consumer<Text> textConsumer,
+			@Share("index") LocalIntRef index
+	) {
+		preAppendTooltip(componentType, context, displayComponent, textConsumer, type, index);
+		return componentType;
+	}
+
+	@Inject(method = "appendTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;appendAttributeModifiersTooltip(Ljava/util/function/Consumer;Lnet/minecraft/component/type/TooltipDisplayComponent;Lnet/minecraft/entity/player/PlayerEntity;)V"))
+	private void preAttributeModifiers(
+			Item.TooltipContext context,
+			TooltipDisplayComponent displayComponent,
+			@Nullable PlayerEntity player,
+			TooltipType type,
+			Consumer<Text> textConsumer,
+			CallbackInfo ci,
+			@Share("index") LocalIntRef index
+	) {
+		// Special case: attribute modifiers are extracted into a separate method
+		preAppendTooltip(DataComponentTypes.ATTRIBUTE_MODIFIERS, context, displayComponent, textConsumer, type, index);
+	}
+
+	@Inject(method = "appendTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/registry/DefaultedRegistry;getId(Ljava/lang/Object;)Lnet/minecraft/util/Identifier;"))
+	private void postTooltipsAdvanced(
+			Item.TooltipContext context,
+			TooltipDisplayComponent displayComponent,
+			@Nullable PlayerEntity player,
+			TooltipType type,
+			Consumer<Text> textConsumer,
+			CallbackInfo ci,
+			@Share("index") LocalIntRef index
+	) {
+		preAppendTooltip(null, context, displayComponent, textConsumer, type, index);
+	}
+
+	@ModifyExpressionValue(method = "appendTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/tooltip/TooltipType;isAdvanced()Z"))
+	private boolean postTooltipsNonAdvanced(
+			boolean isAdvanced,
+			Item.TooltipContext context,
+			TooltipDisplayComponent displayComponent,
+			@Nullable PlayerEntity player,
+			TooltipType type,
+			Consumer<Text> textConsumer,
+			@Share("index") LocalIntRef index
+	) {
+		if (!isAdvanced) {
+			preAppendTooltip(null, context, displayComponent, textConsumer, type, index);
+		}
+
+		return isAdvanced;
+	}
+
+	@Unique
+	private void preAppendTooltip(
+			@Nullable ComponentType<?> componentType,
+			Item.TooltipContext context,
+			TooltipDisplayComponent displayComponent,
+			Consumer<Text> textConsumer,
+			TooltipType tooltipType,
+			LocalIntRef index
+	) {
+		if (index.get() == 0) {
+			ComponentTooltipAppenderRegistryImpl.INSTANCE.onFirst((ItemStack) (Object) this, context, displayComponent, textConsumer, tooltipType);
+		}
+
+		List<ComponentType<?>> vanillaOrder = VanillaTooltipAppenderOrder.getVanillaOrder();
+
+		if (index.get() > vanillaOrder.size()) {
+			return;
+		}
+
+		// Find out which vanilla tooltip appenders we may have skipped over and run their anchored appenders first
+
+		while (true) {
+			if (index.get() > 0) {
+				ComponentType<?> prevComponentInOrder = vanillaOrder.get(index.get() - 1);
+				HashSet<ComponentType<?>> cycleDetector = new HashSet<>();
+				cycleDetector.add(prevComponentInOrder);
+				ComponentTooltipAppenderRegistryImpl.INSTANCE.onAfter((ItemStack) (Object) this, prevComponentInOrder, context, displayComponent, textConsumer, tooltipType, cycleDetector);
+			}
+
+			if (index.get() == vanillaOrder.size()) {
+				index.set(index.get() + 1);
+				break;
+			}
+
+			ComponentType<?> componentInOrder = vanillaOrder.get(index.get());
+			HashSet<ComponentType<?>> cycleDetector = new HashSet<>();
+			cycleDetector.add(componentInOrder);
+			ComponentTooltipAppenderRegistryImpl.INSTANCE.onBefore((ItemStack) (Object) this, componentInOrder, context, displayComponent, textConsumer, tooltipType, cycleDetector);
+			index.set(index.get() + 1);
+
+			if (componentInOrder == componentType) {
+				break;
+			}
+		}
+
+		if (componentType == null) {
+			ComponentTooltipAppenderRegistryImpl.INSTANCE.onLast((ItemStack) (Object) this, context, displayComponent, textConsumer, tooltipType);
+		}
 	}
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemStackMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemStackMixin.java
@@ -170,6 +170,10 @@ public abstract class ItemStackMixin implements FabricItemStack {
 			TooltipType tooltipType,
 			LocalIntRef index
 	) {
+		if (!ComponentTooltipAppenderRegistryImpl.hasModdedEntries()) {
+			return;
+		}
+
 		if (index.get() == 0) {
 			ComponentTooltipAppenderRegistryImpl.onFirst((ItemStack) (Object) this, context, displayComponent, textConsumer, tooltipType);
 		}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemStackMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemStackMixin.java
@@ -171,7 +171,7 @@ public abstract class ItemStackMixin implements FabricItemStack {
 			LocalIntRef index
 	) {
 		if (index.get() == 0) {
-			ComponentTooltipAppenderRegistryImpl.INSTANCE.onFirst((ItemStack) (Object) this, context, displayComponent, textConsumer, tooltipType);
+			ComponentTooltipAppenderRegistryImpl.onFirst((ItemStack) (Object) this, context, displayComponent, textConsumer, tooltipType);
 		}
 
 		List<ComponentType<?>> vanillaOrder = VanillaTooltipAppenderOrder.getVanillaOrder();
@@ -187,7 +187,7 @@ public abstract class ItemStackMixin implements FabricItemStack {
 				ComponentType<?> prevComponentInOrder = vanillaOrder.get(index.get() - 1);
 				HashSet<ComponentType<?>> cycleDetector = new HashSet<>();
 				cycleDetector.add(prevComponentInOrder);
-				ComponentTooltipAppenderRegistryImpl.INSTANCE.onAfter((ItemStack) (Object) this, prevComponentInOrder, context, displayComponent, textConsumer, tooltipType, cycleDetector);
+				ComponentTooltipAppenderRegistryImpl.onAfter((ItemStack) (Object) this, prevComponentInOrder, context, displayComponent, textConsumer, tooltipType, cycleDetector);
 			}
 
 			if (index.get() == vanillaOrder.size()) {
@@ -198,7 +198,7 @@ public abstract class ItemStackMixin implements FabricItemStack {
 			ComponentType<?> componentInOrder = vanillaOrder.get(index.get());
 			HashSet<ComponentType<?>> cycleDetector = new HashSet<>();
 			cycleDetector.add(componentInOrder);
-			ComponentTooltipAppenderRegistryImpl.INSTANCE.onBefore((ItemStack) (Object) this, componentInOrder, context, displayComponent, textConsumer, tooltipType, cycleDetector);
+			ComponentTooltipAppenderRegistryImpl.onBefore((ItemStack) (Object) this, componentInOrder, context, displayComponent, textConsumer, tooltipType, cycleDetector);
 			index.set(index.get() + 1);
 
 			if (componentInOrder == componentType) {
@@ -207,7 +207,7 @@ public abstract class ItemStackMixin implements FabricItemStack {
 		}
 
 		if (componentType == null) {
-			ComponentTooltipAppenderRegistryImpl.INSTANCE.onLast((ItemStack) (Object) this, context, displayComponent, textConsumer, tooltipType);
+			ComponentTooltipAppenderRegistryImpl.onLast((ItemStack) (Object) this, context, displayComponent, textConsumer, tooltipType);
 		}
 	}
 }

--- a/fabric-item-api-v1/src/test/java/net/fabricmc/fabric/test/item/unittest/ComponentTooltipAppenderRegistryTest.java
+++ b/fabric-item-api-v1/src/test/java/net/fabricmc/fabric/test/item/unittest/ComponentTooltipAppenderRegistryTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.item.unittest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import net.minecraft.Bootstrap;
+import net.minecraft.SharedConstants;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.LoreComponent;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.item.tooltip.TooltipType;
+import net.minecraft.text.Text;
+import net.minecraft.util.Unit;
+
+import net.fabricmc.fabric.impl.item.DefaultItemComponentImpl;
+import net.fabricmc.fabric.test.item.ComponentTooltipAppenderTest;
+
+public class ComponentTooltipAppenderRegistryTest {
+	@BeforeAll
+	static void beforeAll() {
+		SharedConstants.createGameVersion();
+		Bootstrap.initialize();
+
+		new ComponentTooltipAppenderTest().onInitialize();
+		DefaultItemComponentImpl.modifyItemComponents();
+	}
+
+	@Test
+	void getSwordTooltips() {
+		ItemStack stack = new ItemStack(Items.GOLDEN_SWORD);
+		stack.set(DataComponentTypes.UNBREAKABLE, Unit.INSTANCE);
+
+		assertEquals("""
+				Golden Sword
+				This Item is Happy :)
+				This Item is Happy :)
+				This Item is Happy :)
+				This Item is Happy :)
+				This Item is Happy :)
+				This Item is Happy :)
+				This Item is Happy :)
+				This Item is Happy :)
+				This Item is Happy :)
+				This Item is Happy :)
+				This Item is Happy :)
+				This Item is Happy :)
+				This Item is Happy :)
+				This Item is Happy :)
+
+				When in Main Hand:
+				+3 Attack Damage
+				-2.4 Attack Speed
+				This Item is Sadder :'(
+				Unbreakable""", getTooltip(stack));
+	}
+
+	@Test
+	void getEggTooltips() {
+		ItemStack stack = new ItemStack(Items.PIG_SPAWN_EGG);
+		stack.set(DataComponentTypes.LORE, new LoreComponent(List.of(Text.literal("Hello"))));
+
+		assertEquals("""
+				Pig Spawn Egg
+				Hello
+				This Item is the Saddest :
+				This Item is Sad :(""", getTooltip(stack));
+	}
+
+	private static String getTooltip(ItemStack stack) {
+		List<Text> tooltips = stack.getTooltip(Item.TooltipContext.DEFAULT, null, TooltipType.BASIC);
+		return tooltips.stream().map(Text::getString).collect(Collectors.joining("\n"));
+	}
+}

--- a/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/ComponentTooltipAppenderTest.java
+++ b/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/ComponentTooltipAppenderTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.item;
+
+import com.mojang.serialization.Codec;
+
+import net.minecraft.component.ComponentType;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.item.Items;
+import net.minecraft.item.tooltip.TooltipAppender;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.text.Text;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.item.v1.ComponentTooltipAppenderRegistry;
+import net.fabricmc.fabric.api.item.v1.DefaultItemComponentEvents;
+
+public class ComponentTooltipAppenderTest implements ModInitializer {
+	@Override
+	public void onInitialize() {
+		ComponentType<TestComponent> happyComponent = Registry.register(
+				Registries.DATA_COMPONENT_TYPE,
+				"fabric-item-api-v1-testmod:happy_component",
+				ComponentType.<TestComponent>builder()
+						.codec(Codec.unit(TestComponent.ONE))
+						.build()
+		);
+
+		ComponentType<TestComponent> sadComponent = Registry.register(
+				Registries.DATA_COMPONENT_TYPE,
+				"fabric-item-api-v1-testmod:sad_component",
+				ComponentType.<TestComponent>builder()
+						.codec(Codec.unit(TestComponent.TWO))
+						.build()
+		);
+
+		ComponentType<TestComponent> sadderComponent = Registry.register(
+				Registries.DATA_COMPONENT_TYPE,
+				"fabric-item-api-v1-testmod:sadder_component",
+				ComponentType.<TestComponent>builder()
+						.codec(Codec.unit(TestComponent.THREE))
+						.build()
+		);
+
+		ComponentType<TestComponent> saddestComponent = Registry.register(
+				Registries.DATA_COMPONENT_TYPE,
+				"fabric-item-api-v1-testmod:saddest_component",
+				ComponentType.<TestComponent>builder()
+						.codec(Codec.unit(TestComponent.FOUR))
+						.build()
+		);
+
+		ComponentTooltipAppenderRegistry.getInstance().addFirst(happyComponent);
+		ComponentTooltipAppenderRegistry.getInstance().addLast(sadComponent);
+		ComponentTooltipAppenderRegistry.getInstance().addBefore(DataComponentTypes.UNBREAKABLE, sadderComponent);
+		ComponentTooltipAppenderRegistry.getInstance().addAfter(DataComponentTypes.LORE, saddestComponent);
+
+		DefaultItemComponentEvents.MODIFY.register(context -> {
+			context.modify(Items.GOLDEN_SWORD, builder -> builder.add(happyComponent, TestComponent.ONE));
+			context.modify(Items.PIG_SPAWN_EGG, builder -> builder.add(sadComponent, TestComponent.TWO));
+			context.modify(Items.GOLDEN_SWORD, builder -> builder.add(sadderComponent, TestComponent.THREE));
+			context.modify(Items.PIG_SPAWN_EGG, builder -> builder.add(saddestComponent, TestComponent.FOUR));
+		});
+	}
+
+	private interface TestComponent extends TooltipAppender {
+		TestComponent ONE = (context, textConsumer, type, components) -> {
+			for (int i = 0; i < 14; i++) {
+				textConsumer.accept(Text.literal("This Item is Happy :)").styled(s -> s.withColor(0xFFFF00).withItalic(true)));
+			}
+		};
+
+		TestComponent TWO = (context, textConsumer, type, components) -> textConsumer.accept(Text.literal("This Item is Sad :("));
+
+		TestComponent THREE = (context, textConsumer, type, components) -> textConsumer.accept(Text.literal("This Item is Sadder :'("));
+
+		TestComponent FOUR = (context, textConsumer, type, components) -> textConsumer.accept(Text.literal("This Item is the Saddest :"));
+	}
+}

--- a/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/ComponentTooltipAppenderTest.java
+++ b/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/ComponentTooltipAppenderTest.java
@@ -65,10 +65,10 @@ public class ComponentTooltipAppenderTest implements ModInitializer {
 						.build()
 		);
 
-		ComponentTooltipAppenderRegistry.getInstance().addFirst(happyComponent);
-		ComponentTooltipAppenderRegistry.getInstance().addLast(sadComponent);
-		ComponentTooltipAppenderRegistry.getInstance().addBefore(DataComponentTypes.UNBREAKABLE, sadderComponent);
-		ComponentTooltipAppenderRegistry.getInstance().addAfter(DataComponentTypes.LORE, saddestComponent);
+		ComponentTooltipAppenderRegistry.addFirst(happyComponent);
+		ComponentTooltipAppenderRegistry.addLast(sadComponent);
+		ComponentTooltipAppenderRegistry.addBefore(DataComponentTypes.UNBREAKABLE, sadderComponent);
+		ComponentTooltipAppenderRegistry.addAfter(DataComponentTypes.LORE, saddestComponent);
 
 		DefaultItemComponentEvents.MODIFY.register(context -> {
 			context.modify(Items.GOLDEN_SWORD, builder -> builder.add(happyComponent, TestComponent.ONE));

--- a/fabric-item-api-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-item-api-v1/src/testmod/resources/fabric.mod.json
@@ -15,7 +15,8 @@
       "net.fabricmc.fabric.test.item.CustomModelIdTest",
       "net.fabricmc.fabric.test.item.ItemUpdateAnimationTest",
       "net.fabricmc.fabric.test.item.ArmorKnockbackResistanceTest",
-      "net.fabricmc.fabric.test.item.CustomEnchantmentEffectsTest"
+      "net.fabricmc.fabric.test.item.CustomEnchantmentEffectsTest",
+      "net.fabricmc.fabric.test.item.ComponentTooltipAppenderTest"
     ],
     "client": [
       "net.fabricmc.fabric.test.item.client.TooltipTests"


### PR DESCRIPTION
Supersedes #4567.

Adds a way to register `TooltipAppender` item components. This implementation allows modders to anchor their item components relative to any vanilla (or modded) item component, while not hardcoding the list or order of vanilla item components. It's annoying to need to scrape the vanilla order from the bytecode, but at least it should be low maintenance.