### PR TITLE
Attachment modify event

### DIFF
--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentType.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentType.java
@@ -19,6 +19,9 @@ package net.fabricmc.fabric.api.attachment.v1;
 import java.util.function.Supplier;
 
 import com.mojang.serialization.Codec;
+
+import net.fabricmc.fabric.api.event.Event;
+
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
@@ -111,4 +114,10 @@ public interface AttachmentType<A> {
 	 * when a mob is converted (e.g. zombie → drowned)
 	 */
 	boolean copyOnDeath();
+
+	Event<AttachmentModified<A>> modify();
+
+	public interface AttachmentModified<A> {
+		A onModify(A newValue, AttachmentTarget target, boolean isClient);
+	}
 }

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentType.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentType.java
@@ -19,9 +19,6 @@ package net.fabricmc.fabric.api.attachment.v1;
 import java.util.function.Supplier;
 
 import com.mojang.serialization.Codec;
-
-import net.fabricmc.fabric.api.event.Event;
-
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
@@ -36,6 +33,7 @@ import net.minecraft.world.chunk.WorldChunk;
 import net.fabricmc.fabric.api.entity.event.v1.ServerEntityWorldChangeEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
+import net.fabricmc.fabric.api.event.Event;
 
 /**
  * An attachment allows "attaching" arbitrary data to various game objects (entities, block entities, worlds and chunks at the moment).
@@ -121,7 +119,7 @@ public interface AttachmentType<A> {
 	Event<AttachmentModified<A>> modify();
 
 	@FunctionalInterface
-	public interface AttachmentModified<A> {
+	interface AttachmentModified<A> {
 		/**
 		 * Called right before the attachment is set and lets the listener change or cancel the operation.
 		 *

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentType.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentType.java
@@ -116,7 +116,7 @@ public interface AttachmentType<A> {
 	/**
 	 * An event that is called right before this type of attachment changes on a target.
 	 */
-	Event<AttachmentModified<A>> modify();
+	Event<AttachmentModified<A>> onModify();
 
 	@FunctionalInterface
 	interface AttachmentModified<A> {

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentType.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentType.java
@@ -115,9 +115,23 @@ public interface AttachmentType<A> {
 	 */
 	boolean copyOnDeath();
 
+	/**
+	 * An event that is called right before this type of attachment changes on a target.
+	 */
 	Event<AttachmentModified<A>> modify();
 
+	@FunctionalInterface
 	public interface AttachmentModified<A> {
+		/**
+		 * Called right before the attachment is set and lets the listener change or cancel the operation.
+		 *
+		 * <p>The old attachment value is available on the target with {@code getAttached}.</p>
+		 *
+		 * @param newValue new attachment that is about to be set, null if attachment is being removed
+		 * @param target target to set the value upon
+		 * @param isClient isClient from the associated world when applicable, false otherwise
+		 * @return value to set onto the target, return {@code newValue} to avoid modifying it, return null to remove the attachment.
+		 */
 		A onModify(A newValue, AttachmentTarget target, boolean isClient);
 	}
 }

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentRegistryImpl.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentRegistryImpl.java
@@ -139,13 +139,13 @@ public final class AttachmentRegistryImpl {
 					persistenceCodec,
 					packetCodec,
 					syncPredicate,
+					copyOnDeath,
 					EventFactory.createArrayBacked(AttachmentType.AttachmentModified.class, callbacks -> (newValue, target, isClient) -> {
 						for (AttachmentType.AttachmentModified<A> callback : callbacks)
 							newValue = callback.onModify(newValue, target, isClient);
-						
+
 						return newValue;
-					}),
-					copyOnDeath
+					})
 			);
 			register(id, attachment);
 			return attachment;

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentRegistryImpl.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentRegistryImpl.java
@@ -25,9 +25,6 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 import com.mojang.serialization.Codec;
-
-import net.fabricmc.fabric.api.event.EventFactory;
-
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +36,7 @@ import net.minecraft.util.Identifier;
 import net.fabricmc.fabric.api.attachment.v1.AttachmentRegistry;
 import net.fabricmc.fabric.api.attachment.v1.AttachmentSyncPredicate;
 import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
+import net.fabricmc.fabric.api.event.EventFactory;
 import net.fabricmc.fabric.impl.attachment.sync.AttachmentSync;
 
 public final class AttachmentRegistryImpl {
@@ -141,8 +139,9 @@ public final class AttachmentRegistryImpl {
 					syncPredicate,
 					copyOnDeath,
 					EventFactory.createArrayBacked(AttachmentType.AttachmentModified.class, callbacks -> (newValue, target, isClient) -> {
-						for (AttachmentType.AttachmentModified<A> callback : callbacks)
+						for (AttachmentType.AttachmentModified<A> callback : callbacks) {
 							newValue = callback.onModify(newValue, target, isClient);
+						}
 
 						return newValue;
 					})

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentRegistryImpl.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentRegistryImpl.java
@@ -25,6 +25,9 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 import com.mojang.serialization.Codec;
+
+import net.fabricmc.fabric.api.event.EventFactory;
+
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -136,6 +139,12 @@ public final class AttachmentRegistryImpl {
 					persistenceCodec,
 					packetCodec,
 					syncPredicate,
+					EventFactory.createArrayBacked(AttachmentType.AttachmentModified.class, callbacks -> (newValue, target, isClient) -> {
+						for (AttachmentType.AttachmentModified<A> callback : callbacks)
+							newValue = callback.onModify(newValue, target, isClient);
+						
+						return newValue;
+					}),
 					copyOnDeath
 			);
 			register(id, attachment);

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentTargetImpl.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentTargetImpl.java
@@ -92,6 +92,10 @@ public interface AttachmentTargetImpl extends AttachmentTarget {
 	}
 
 	default boolean fabric_shouldTryToSync() {
+		return !this.fabric_isClient();
+	}
+
+	default boolean fabric_isClient() {
 		throw new UnsupportedOperationException("Implemented via mixin");
 	}
 

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentTypeImpl.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentTypeImpl.java
@@ -36,7 +36,7 @@ public record AttachmentTypeImpl<A>(
 		@Nullable PacketCodec<? super RegistryByteBuf, A> packetCodec,
 		@Nullable AttachmentSyncPredicate syncPredicate,
 		boolean copyOnDeath,
-		Event<AttachmentModified<A>> modify
+		Event<AttachmentModified<A>> onModify
 ) implements AttachmentType<A> {
 	@Override
 	public boolean isSynced() {

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentTypeImpl.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentTypeImpl.java
@@ -27,6 +27,7 @@ import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.api.attachment.v1.AttachmentSyncPredicate;
 import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
+import net.fabricmc.fabric.api.event.Event;
 
 public record AttachmentTypeImpl<A>(
 		Identifier identifier,
@@ -34,6 +35,7 @@ public record AttachmentTypeImpl<A>(
 		@Nullable Codec<A> persistenceCodec,
 		@Nullable PacketCodec<? super RegistryByteBuf, A> packetCodec,
 		@Nullable AttachmentSyncPredicate syncPredicate,
+		Event<AttachmentModified<A>> modify,
 		boolean copyOnDeath
 ) implements AttachmentType<A> {
 	@Override

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentTypeImpl.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentTypeImpl.java
@@ -35,8 +35,8 @@ public record AttachmentTypeImpl<A>(
 		@Nullable Codec<A> persistenceCodec,
 		@Nullable PacketCodec<? super RegistryByteBuf, A> packetCodec,
 		@Nullable AttachmentSyncPredicate syncPredicate,
-		Event<AttachmentModified<A>> modify,
-		boolean copyOnDeath
+		boolean copyOnDeath,
+		Event<AttachmentModified<A>> modify
 ) implements AttachmentType<A> {
 	@Override
 	public boolean isSynced() {

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
@@ -61,6 +61,8 @@ abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
 	public <T> T setAttached(AttachmentType<T> type, @Nullable T value) {
 		this.fabric_markChanged(type);
 
+		value = type.modify().invoker().onModify(value, this, fabric_isClient());
+
 		if (this.fabric_shouldTryToSync() && type.isSynced()) {
 			AttachmentChange change = AttachmentChange.create(fabric_getSyncTargetInfo(), type, value, fabric_getDynamicRegistryManager());
 			acknowledgeSyncedEntry(type, change);

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
@@ -61,7 +61,7 @@ abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
 	public <T> T setAttached(AttachmentType<T> type, @Nullable T value) {
 		this.fabric_markChanged(type);
 
-		value = type.modify().invoker().onModify(value, this, fabric_isClient());
+		value = type.onModify().invoker().onModify(value, this, fabric_isClient());
 
 		if (this.fabric_shouldTryToSync() && type.isSynced()) {
 			AttachmentChange change = AttachmentChange.create(fabric_getSyncTargetInfo(), type, value, fabric_getDynamicRegistryManager());

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/BlockEntityMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/BlockEntityMixin.java
@@ -92,9 +92,8 @@ abstract class BlockEntityMixin implements AttachmentTargetImpl {
 	}
 
 	@Override
-	public boolean fabric_shouldTryToSync() {
-		// Persistent attachments are read at a time with no world
-		return !this.hasWorld() || !this.world.isClient();
+	public boolean fabric_isClient() {
+		return this.hasWorld() && this.world.isClient();
 	}
 
 	@Override

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/ChunkMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/ChunkMixin.java
@@ -70,6 +70,11 @@ abstract class ChunkMixin implements AttachmentTargetImpl {
 	}
 
 	@Override
+	public boolean fabric_isClient() {
+		return false;
+	}
+
+	@Override
 	public DynamicRegistryManager fabric_getDynamicRegistryManager() {
 		// Should never happen as this is only used for sync
 		throw new UnsupportedOperationException("Chunk does not have a DynamicRegistryManager.");

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/EntityMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/EntityMixin.java
@@ -87,8 +87,8 @@ abstract class EntityMixin implements AttachmentTargetImpl {
 	}
 
 	@Override
-	public boolean fabric_shouldTryToSync() {
-		return !this.getWorld().isClient();
+	public boolean fabric_isClient() {
+		return this.getWorld().isClient();
 	}
 
 	@Override

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/EntityMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/EntityMixin.java
@@ -88,7 +88,7 @@ abstract class EntityMixin implements AttachmentTargetImpl {
 
 	@Override
 	public boolean fabric_isClient() {
-		return this.getWorld().isClient();
+		return this.getWorld() != null && this.getWorld().isClient();
 	}
 
 	@Override

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WorldChunkMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WorldChunkMixin.java
@@ -81,8 +81,8 @@ abstract class WorldChunkMixin extends AttachmentTargetsMixin implements Attachm
 	}
 
 	@Override
-	public boolean fabric_shouldTryToSync() {
-		return !this.world.isClient();
+	public boolean fabric_isClient() {
+		return this.world.isClient();
 	}
 
 	@Override

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WorldChunkMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WorldChunkMixin.java
@@ -82,7 +82,7 @@ abstract class WorldChunkMixin extends AttachmentTargetsMixin implements Attachm
 
 	@Override
 	public boolean fabric_isClient() {
-		return this.world.isClient();
+		return this.world != null && this.world.isClient();
 	}
 
 	@Override

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WorldChunkMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WorldChunkMixin.java
@@ -81,6 +81,11 @@ abstract class WorldChunkMixin extends AttachmentTargetsMixin implements Attachm
 	}
 
 	@Override
+	public boolean fabric_shouldTryToSync() {
+		return !fabric_isClient();
+	}
+
+	@Override
 	public boolean fabric_isClient() {
 		return this.world != null && this.world.isClient();
 	}

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WorldMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WorldMixin.java
@@ -33,8 +33,8 @@ abstract class WorldMixin implements AttachmentTargetImpl {
 	public abstract DynamicRegistryManager getRegistryManager();
 
 	@Override
-	public boolean fabric_shouldTryToSync() {
-		return !this.isClient();
+	public boolean fabric_isClient() {
+		return this.isClient();
 	}
 
 	@Override

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WrapperProtoChunkMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WrapperProtoChunkMixin.java
@@ -86,6 +86,11 @@ abstract class WrapperProtoChunkMixin extends AttachmentTargetsMixin {
 	}
 
 	@Override
+	public boolean fabric_isClient() {
+		return ((AttachmentTargetImpl) wrapped).fabric_isClient();
+	}
+
+	@Override
 	public void fabric_computeInitialSyncChanges(ServerPlayerEntity player, Consumer<AttachmentChange> changeOutput) {
 		((AttachmentTargetImpl) wrapped).fabric_computeInitialSyncChanges(player, changeOutput);
 	}

--- a/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
+++ b/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
@@ -116,7 +116,7 @@ public class AttachmentTestMod implements ModInitializer {
 			if (!isClient) {
 				ItemStack oldValue = target.getAttached(SYNCED_ITEM);
 
-				if (oldValue != null && oldValue.isOf(Items.BAMBOO) && newValue.isOf(Items.BONE_MEAL)) {
+				if (oldValue != null && oldValue.isOf(Items.APPLE) && newValue.isOf(Items.BONE_MEAL)) {
 					return oldValue.copyWithCount(oldValue.getCount() + 1);
 				}
 			}

--- a/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
+++ b/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
@@ -111,5 +111,17 @@ public class AttachmentTestMod implements ModInitializer {
 
 			return ActionResult.PASS;
 		});
+
+		SYNCED_ITEM.modify().register((newValue, target, isClient) -> {
+			if (!isClient) {
+				ItemStack oldValue = target.getAttached(SYNCED_ITEM);
+
+				if (oldValue != null && oldValue.isOf(Items.BAMBOO) && newValue.isOf(Items.BONE_MEAL)) {
+					return oldValue.copyWithCount(oldValue.getCount() + 1);
+				}
+			}
+
+			return newValue;
+		});
 	}
 }

--- a/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
+++ b/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
@@ -87,6 +87,12 @@ public class AttachmentTestMod implements ModInitializer {
 					.persistent(ItemStack.CODEC)
 					.syncWith(ItemStack.OPTIONAL_PACKET_CODEC, AttachmentSyncPredicate.all())
 	);
+	public static final AttachmentType<Integer> SYNCED_REQUESTED_SIMULATION_DISTANCE = AttachmentRegistry.create(
+			Identifier.of(MOD_ID, "synced_requested_simulation_distance"),
+			builder -> builder
+					.persistent(Codec.INT)
+					.syncWith(PacketCodecs.INTEGER, AttachmentSyncPredicate.targetOnly())
+	);
 
 	@Override
 	public void onInitialize() {

--- a/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
+++ b/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
@@ -112,7 +112,7 @@ public class AttachmentTestMod implements ModInitializer {
 			return ActionResult.PASS;
 		});
 
-		SYNCED_ITEM.modify().register((newValue, target, isClient) -> {
+		SYNCED_ITEM.onModify().register((newValue, target, isClient) -> {
 			if (!isClient) {
 				ItemStack oldValue = target.getAttached(SYNCED_ITEM);
 

--- a/fabric-data-attachment-api-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-data-attachment-api-v1/src/testmod/resources/fabric.mod.json
@@ -15,6 +15,9 @@
     "main": [
       "net.fabricmc.fabric.test.attachment.AttachmentTestMod"
     ],
+    "client": [
+      "net.fabricmc.fabric.test.attachment.client.AttachmentClientTestMod"
+    ],
     "fabric-gametest": [
       "net.fabricmc.fabric.test.attachment.gametest.AttachmentCopyTests",
       "net.fabricmc.fabric.test.attachment.gametest.BlockEntityTests"

--- a/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/AttachmentClientTestMod.java
+++ b/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/AttachmentClientTestMod.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.attachment.client;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.test.attachment.AttachmentTestMod;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.text.Text;
+
+public class AttachmentClientTestMod implements ClientModInitializer {
+	@Override
+	public void onInitializeClient() {
+		AttachmentTestMod.SYNCED_REQUESTED_SIMULATION_DISTANCE.onModify().register((newValue, target, isClient) -> {
+			if (isClient) {
+				MinecraftClient.getInstance().inGameHud.getChatHud().addMessage(Text.of("Server requested that the simulation distance be set to " + newValue));
+				MinecraftClient.getInstance().options.getSimulationDistance().setValue(newValue);
+			}
+
+			return newValue;
+		});
+	}
+}

--- a/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/AttachmentClientTestMod.java
+++ b/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/AttachmentClientTestMod.java
@@ -16,11 +16,11 @@
 
 package net.fabricmc.fabric.test.attachment.client;
 
-import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.test.attachment.AttachmentTestMod;
-
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.text.Text;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.test.attachment.AttachmentTestMod;
 
 public class AttachmentClientTestMod implements ClientModInitializer {
 	@Override

--- a/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/gametest/SyncGametest.java
+++ b/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/gametest/SyncGametest.java
@@ -129,7 +129,7 @@ public class SyncGametest implements FabricClientGameTest {
 					// check registry objects are synced correctly
 					player.setAttached(AttachmentTestMod.SYNCED_ITEM, Items.APPLE.getDefaultStack());
 
-					// check modify event happening prior to syncing
+					// check onModify event happening prior to syncing
 					player.setAttached(AttachmentTestMod.SYNCED_ITEM, Items.BONE_MEAL.getDefaultStack());
 				});
 

--- a/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/gametest/SyncGametest.java
+++ b/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/gametest/SyncGametest.java
@@ -89,6 +89,11 @@ public class SyncGametest implements FabricClientGameTest {
 				int villagerId;
 			};
 
+			context.runOnClient(client -> {
+				// set client simulation distance before the server sets it
+				client.options.getSimulationDistance().setValue(12);
+			});
+
 			LOGGER.info("Setting up synced attachments before join");
 			// setup before player joins
 			serverContext.runOnServer(server -> {
@@ -131,6 +136,9 @@ public class SyncGametest implements FabricClientGameTest {
 
 					// check onModify event happening prior to syncing
 					player.setAttached(AttachmentTestMod.SYNCED_ITEM, Items.BONE_MEAL.getDefaultStack());
+
+					// try syncing simulation distance attachment to see if it changes the option on the client
+					player.setAttached(AttachmentTestMod.SYNCED_REQUESTED_SIMULATION_DISTANCE, 10);
 				});
 
 				// safety
@@ -155,6 +163,10 @@ public class SyncGametest implements FabricClientGameTest {
 
 					if (Objects.requireNonNull(client.player.getAttached(AttachmentTestMod.SYNCED_ITEM)).getCount() != 2) {
 						throw new AssertionError("Synced attachment %s was not incremented on the server".formatted(AttachmentTestMod.SYNCED_ITEM.identifier()));
+					}
+
+					if (client.options.getSimulationDistance().getValue() != 10) {
+						throw new AssertionError("Simulation distance was not set as requested.");
 					}
 				});
 

--- a/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/gametest/SyncGametest.java
+++ b/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/gametest/SyncGametest.java
@@ -128,6 +128,9 @@ public class SyncGametest implements FabricClientGameTest {
 
 					// check registry objects are synced correctly
 					player.setAttached(AttachmentTestMod.SYNCED_ITEM, Items.APPLE.getDefaultStack());
+
+					// check modify event happening prior to syncing
+					player.setAttached(AttachmentTestMod.SYNCED_ITEM, Items.BONE_MEAL.getDefaultStack());
 				});
 
 				// safety
@@ -149,6 +152,10 @@ public class SyncGametest implements FabricClientGameTest {
 					assertHasNotSynced(world, AttachmentTestMod.SYNCED_WITH_ALL);
 					assertHasNotSynced(client.player, AttachmentTestMod.SYNCED_EXCEPT_TARGET);
 					assertHasNotSynced(villager, AttachmentTestMod.SYNCED_WITH_TARGET);
+
+					if (Objects.requireNonNull(client.player.getAttached(AttachmentTestMod.SYNCED_ITEM)).getCount() != 2) {
+						throw new AssertionError("Synced attachment %s was not incremented on the server".formatted(AttachmentTestMod.SYNCED_ITEM.identifier()));
+					}
 				});
 
 				LOGGER.info("Setting up second phase");


### PR DESCRIPTION
Initially I needed a listener for when attachments are synced but I have now expanded it to be usable for more mods while I was here anyways. 
This PR introduces a simple event in the attachment type that both lets users get notified whenever an attachment value is modified on a target while also allowing the listener to modify the value before it is set.

As was requested by @Syst3ms I also added a parameter to signal to the listener whether the world is a client world or not when applicable.