### PR TITLE
Attachment changed event

### DIFF
--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentTarget.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentTarget.java
@@ -229,7 +229,7 @@ public interface AttachmentTarget {
 	 * @param type the attachment type
 	 * @return event associated with this target and attachment type
 	 */
-	default <A> Event<OnAttachedChanged<A>> onAttachedChanged(AttachmentType<A> type) {
+	default <A> Event<OnAttachedSet<A>> onAttachedSet(AttachmentType<A> type) {
 		throw new UnsupportedOperationException("Implemented via mixin");
 	}
 
@@ -249,14 +249,14 @@ public interface AttachmentTarget {
 	}
 
 	@FunctionalInterface
-	interface OnAttachedChanged<A> {
+	interface OnAttachedSet<A> {
 		/**
-		 * Called after the attachment changes on this target.
+		 * Called after the attachment is set on this target.
 		 *
-		 * @see AttachmentTarget#onAttachedChanged(AttachmentType)
-		 * @param oldValue attachment value on the target prior to it being changed
-		 * @param newValue attachment value on the target after it was changed
+		 * @see AttachmentTarget#onAttachedSet(AttachmentType)
+		 * @param oldValue attachment value on the target prior to it being set
+		 * @param newValue attachment value on the target after it was set
 		 */
-		void onAttachedChanged(@Nullable A oldValue, @Nullable A newValue);
+		void onAttachedSet(@Nullable A oldValue, @Nullable A newValue);
 	}
 }

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentTarget.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentTarget.java
@@ -223,6 +223,9 @@ public interface AttachmentTarget {
 
 	/**
 	 * Provides an {@link Event} that lets the listener know when the target has its {@link AttachmentType} attachment changed.
+	 * <p>
+	 * The event is called after the attachment was changed, be aware of the potential of recursion if you intend on calling {@link #setAttached} on the target.
+	 * </p>
 	 *
 	 * @param type the attachment type
 	 * @return event associated with this target and attachment type
@@ -248,6 +251,13 @@ public interface AttachmentTarget {
 
 	@FunctionalInterface
 	interface OnAttachedChanged<A> {
+		/**
+		 * Called after the attachment changes on this target.
+		 *
+		 * @see AttachmentTarget#onAttachedChanged(AttachmentType)
+		 * @param oldValue attachment value on the target prior to it being changed
+		 * @param newValue attachment value on the target after it was changed
+		 */
 		void onAttachedChanged(A oldValue, A newValue);
 	}
 }

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentTarget.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentTarget.java
@@ -223,7 +223,7 @@ public interface AttachmentTarget {
 
 	/**
 	 * Provides an {@link Event} that lets the listener know when the target has its {@link AttachmentType} attachment changed.
-	 * 
+	 *
 	 * <p>
 	 * The event is called after the attachment was changed, be aware of the potential of recursion if you intend on calling {@link #setAttached} on the target.
 	 * </p>

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentTarget.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentTarget.java
@@ -224,9 +224,7 @@ public interface AttachmentTarget {
 	/**
 	 * Provides an {@link Event} that lets the listener know when the target has its {@link AttachmentType} attachment changed.
 	 *
-	 * <p>
-	 * The event is called after the attachment was changed, be aware of the potential of recursion if you intend on calling {@link #setAttached} on the target.
-	 * </p>
+	 * <p>The event is called after the attachment was changed, be aware of the potential of recursion if you intend on calling {@link #setAttached} on the target.
 	 *
 	 * @param type the attachment type
 	 * @return event associated with this target and attachment type

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentTarget.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentTarget.java
@@ -30,6 +30,8 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkStatus;
 
+import net.fabricmc.fabric.api.event.Event;
+
 /**
  * Marks all objects on which data can be attached using {@link AttachmentType}s.
  *
@@ -220,6 +222,16 @@ public interface AttachmentTarget {
 	}
 
 	/**
+	 * Provides an {@link Event} that lets the listener know when the target has its {@link AttachmentType} attachment changed.
+	 *
+	 * @param type the attachment type
+	 * @return event associated with this target and attachment type
+	 */
+	default <A> Event<OnAttachedChanged<A>> onAttachedChanged(AttachmentType<A> type) {
+		throw new UnsupportedOperationException("Implemented via mixin");
+	}
+
+	/**
 	 * Modifies the data associated with the given {@link AttachmentType}. Functionally the same as calling {@link #getAttached(AttachmentType)},
 	 * applying the modifier, then calling {@link #setAttached(AttachmentType, Object)} with the result. The modifier
 	 * takes in the currently attached value, or {@code null} if no attachment is present.
@@ -232,5 +244,10 @@ public interface AttachmentTarget {
 	@Nullable
 	default <A> A modifyAttached(AttachmentType<A> type, UnaryOperator<A> modifier) {
 		return setAttached(type, modifier.apply(getAttached(type)));
+	}
+
+	@FunctionalInterface
+	interface OnAttachedChanged<A> {
+		void onAttachedChanged(A oldValue, A newValue);
 	}
 }

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentTarget.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentTarget.java
@@ -223,6 +223,7 @@ public interface AttachmentTarget {
 
 	/**
 	 * Provides an {@link Event} that lets the listener know when the target has its {@link AttachmentType} attachment changed.
+	 * 
 	 * <p>
 	 * The event is called after the attachment was changed, be aware of the potential of recursion if you intend on calling {@link #setAttached} on the target.
 	 * </p>

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentTarget.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentTarget.java
@@ -257,6 +257,6 @@ public interface AttachmentTarget {
 		 * @param oldValue attachment value on the target prior to it being changed
 		 * @param newValue attachment value on the target after it was changed
 		 */
-		void onAttachedChanged(A oldValue, A newValue);
+		void onAttachedChanged(@Nullable A oldValue, @Nullable A newValue);
 	}
 }

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
@@ -51,7 +51,7 @@ abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
 	@Nullable
 	private IdentityHashMap<AttachmentType<?>, AttachmentChange> fabric_syncedAttachments = null;
 	@Nullable
-	private IdentityHashMap<AttachmentType<?>, Event<OnAttachedChanged<?>>> fabric_attachedChangedListeners = null;
+	private IdentityHashMap<AttachmentType<?>, Event<OnAttachedSet<?>>> fabric_attachedChangedListeners = null;
 
 	@SuppressWarnings("unchecked")
 	@Override
@@ -89,10 +89,10 @@ abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
 		}
 
 		if (fabric_attachedChangedListeners != null) {
-			Event<OnAttachedChanged<T>> event = (Event<OnAttachedChanged<T>>) (Event<?>) fabric_attachedChangedListeners.get(type);
+			Event<OnAttachedSet<T>> event = (Event<OnAttachedSet<T>>) (Event<?>) fabric_attachedChangedListeners.get(type);
 
 			if (event != null) {
-				event.invoker().onAttachedChanged(oldValue, value);
+				event.invoker().onAttachedSet(oldValue, value);
 			}
 		}
 
@@ -105,15 +105,15 @@ abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
 	}
 
 	@Override
-	public <A> Event<OnAttachedChanged<A>> onAttachedChanged(AttachmentType<A> type) {
+	public <A> Event<OnAttachedSet<A>> onAttachedSet(AttachmentType<A> type) {
 		if (fabric_attachedChangedListeners == null) {
 			fabric_attachedChangedListeners = new IdentityHashMap<>();
 		}
 
-		return (Event<OnAttachedChanged<A>>) (Event<?>) fabric_attachedChangedListeners.computeIfAbsent(type, t -> {
-			return (Event<OnAttachedChanged<?>>) (Event<?>) EventFactory.createArrayBacked(OnAttachedChanged.class, (Function<OnAttachedChanged<A>[], OnAttachedChanged<A>>) listeners -> (oldValue, newValue) -> {
-				for (OnAttachedChanged<A> listener : listeners) {
-					listener.onAttachedChanged(oldValue, newValue);
+		return (Event<OnAttachedSet<A>>) (Event<?>) fabric_attachedChangedListeners.computeIfAbsent(type, t -> {
+			return (Event<OnAttachedSet<?>>) (Event<?>) EventFactory.createArrayBacked(OnAttachedSet.class, (Function<OnAttachedSet<A>[], OnAttachedSet<A>>) listeners -> (oldValue, newValue) -> {
+				for (OnAttachedSet<A> listener : listeners) {
+					listener.onAttachedSet(oldValue, newValue);
 				}
 			});
 		});

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
@@ -20,6 +20,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
@@ -35,6 +36,8 @@ import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
 
 import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
 import net.fabricmc.fabric.impl.attachment.AttachmentSerializingImpl;
 import net.fabricmc.fabric.impl.attachment.AttachmentTargetImpl;
 import net.fabricmc.fabric.impl.attachment.AttachmentTypeImpl;
@@ -47,6 +50,8 @@ abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
 	private IdentityHashMap<AttachmentType<?>, Object> fabric_dataAttachments = null;
 	@Nullable
 	private IdentityHashMap<AttachmentType<?>, AttachmentChange> fabric_syncedAttachments = null;
+	@Nullable
+	private IdentityHashMap<AttachmentType<?>, Event<OnAttachedChanged<?>>> fabric_attachedChangedListeners = null;
 
 	@SuppressWarnings("unchecked")
 	@Override
@@ -67,24 +72,51 @@ abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
 			this.fabric_syncChange(type, new AttachmentSyncPayloadS2C(List.of(change)));
 		}
 
+		T oldValue;
+
 		if (value == null) {
 			if (fabric_dataAttachments == null) {
-				return null;
+				oldValue = null;
 			}
 
-			return (T) fabric_dataAttachments.remove(type);
+			oldValue = (T) fabric_dataAttachments.remove(type);
 		} else {
 			if (fabric_dataAttachments == null) {
 				fabric_dataAttachments = new IdentityHashMap<>();
 			}
 
-			return (T) fabric_dataAttachments.put(type, value);
+			oldValue = (T) fabric_dataAttachments.put(type, value);
 		}
+
+		if (fabric_attachedChangedListeners != null) {
+			Event<OnAttachedChanged<T>> event = (Event<OnAttachedChanged<T>>) (Event<?>) fabric_attachedChangedListeners.get(type);
+
+			if (event != null) {
+				event.invoker().onAttachedChanged(oldValue, value);
+			}
+		}
+
+		return oldValue;
 	}
 
 	@Override
 	public boolean hasAttached(AttachmentType<?> type) {
 		return fabric_dataAttachments != null && fabric_dataAttachments.containsKey(type);
+	}
+
+	@Override
+	public <A> Event<OnAttachedChanged<A>> onAttachedChanged(AttachmentType<A> type) {
+		if (fabric_attachedChangedListeners == null) {
+			fabric_attachedChangedListeners = new IdentityHashMap<>();
+		}
+
+		return (Event<OnAttachedChanged<A>>) (Event<?>) fabric_attachedChangedListeners.computeIfAbsent(type, t -> {
+			return (Event<OnAttachedChanged<?>>) (Event<?>) EventFactory.createArrayBacked(OnAttachedChanged.class, (Function<OnAttachedChanged<A>[], OnAttachedChanged<A>>) listeners -> (oldValue, newValue) -> {
+				for (OnAttachedChanged<A> listener : listeners) {
+					listener.onAttachedChanged(oldValue, newValue);
+				}
+			});
+		});
 	}
 
 	@Override

--- a/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
+++ b/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
@@ -31,6 +31,7 @@ import net.minecraft.registry.RegistryKeys;
 import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.dynamic.Codecs;
 import net.minecraft.world.gen.GenerationStep;
 import net.minecraft.world.gen.feature.DefaultFeatureConfig;
 
@@ -87,6 +88,12 @@ public class AttachmentTestMod implements ModInitializer {
 					.initializer(() -> ItemStack.EMPTY)
 					.persistent(ItemStack.CODEC)
 					.syncWith(ItemStack.OPTIONAL_PACKET_CODEC, AttachmentSyncPredicate.all())
+	);
+	public static final AttachmentType<Integer> SYNCED_RENDER_DISTANCE = AttachmentRegistry.create(
+			Identifier.of(MOD_ID, "synced_render_distance"),
+			builder -> builder
+					.persistent(Codecs.NON_NEGATIVE_INT)
+					.syncWith(PacketCodecs.INTEGER, AttachmentSyncPredicate.targetOnly())
 	);
 
 	@Override

--- a/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
+++ b/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
@@ -121,7 +121,7 @@ public class AttachmentTestMod implements ModInitializer {
 		});
 
 		ServerEntityEvents.ENTITY_LOAD.register((entity, world) -> {
-			entity.onAttachedChanged(SYNCED_ITEM).register((oldValue, newValue) -> {
+			entity.onAttachedSet(SYNCED_ITEM).register((oldValue, newValue) -> {
 				if (newValue != null && !newValue.equals(oldValue) && newValue.isOf(Items.BRICK)) {
 					entity.damage(world, world.getDamageSources().generic(), 1);
 				}

--- a/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
+++ b/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
@@ -122,8 +122,9 @@ public class AttachmentTestMod implements ModInitializer {
 
 		ServerEntityEvents.ENTITY_LOAD.register((entity, world) -> {
 			entity.onAttachedChanged(SYNCED_ITEM).register((oldValue, newValue) -> {
-				if (newValue != null && !newValue.equals(oldValue) && newValue.isOf(Items.BRICK))
+				if (newValue != null && !newValue.equals(oldValue) && newValue.isOf(Items.BRICK)) {
 					entity.damage(world, world.getDamageSources().generic(), 1);
+				}
 			});
 		});
 	}

--- a/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
+++ b/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
@@ -40,6 +40,7 @@ import net.fabricmc.fabric.api.attachment.v1.AttachmentSyncPredicate;
 import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
 import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
 import net.fabricmc.fabric.api.biome.v1.BiomeSelectors;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityEvents;
 import net.fabricmc.fabric.api.event.player.UseBlockCallback;
 
 public class AttachmentTestMod implements ModInitializer {
@@ -110,6 +111,13 @@ public class AttachmentTestMod implements ModInitializer {
 			}
 
 			return ActionResult.PASS;
+		});
+
+		ServerEntityEvents.ENTITY_LOAD.register((entity, world) -> {
+			entity.onAttachedChanged(SYNCED_ITEM).register((oldValue, newValue) -> {
+				if (newValue != null && !newValue.equals(oldValue) && newValue.isOf(Items.BRICK))
+					entity.damage(world, world.getDamageSources().generic(), 1);
+			});
 		});
 	}
 }

--- a/fabric-data-attachment-api-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-data-attachment-api-v1/src/testmod/resources/fabric.mod.json
@@ -15,6 +15,9 @@
     "main": [
       "net.fabricmc.fabric.test.attachment.AttachmentTestMod"
     ],
+    "client": [
+      "net.fabricmc.fabric.test.attachment.client.AttachmentClientTestMod"
+    ],
     "fabric-gametest": [
       "net.fabricmc.fabric.test.attachment.gametest.AttachmentCopyTests",
       "net.fabricmc.fabric.test.attachment.gametest.BlockEntityTests"

--- a/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/AttachmentClientTestMod.java
+++ b/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/AttachmentClientTestMod.java
@@ -32,6 +32,7 @@ public class AttachmentClientTestMod implements ClientModInitializer {
 			if (entity instanceof ClientPlayerEntity) {
 				entity.onAttachedChanged(AttachmentTestMod.SYNCED_RENDER_DISTANCE).register((oldValue, newValue) -> {
 					SimpleOption<Integer> viewDistance = MinecraftClient.getInstance().options.getViewDistance();
+
 					if (viewDistance.getValue() < newValue) {
 						viewDistance.setValue(newValue);
 						MinecraftClient.getInstance().inGameHud.getChatHud().addMessage(Text.of("The server requested to up the render distance to " + newValue));

--- a/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/AttachmentClientTestMod.java
+++ b/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/AttachmentClientTestMod.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.attachment.client;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.option.SimpleOption;
+import net.minecraft.text.Text;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientEntityEvents;
+import net.fabricmc.fabric.test.attachment.AttachmentTestMod;
+
+public class AttachmentClientTestMod implements ClientModInitializer {
+	@Override
+	public void onInitializeClient() {
+		ClientEntityEvents.ENTITY_LOAD.register((entity, world) -> {
+			if (entity instanceof ClientPlayerEntity) {
+				entity.onAttachedChanged(AttachmentTestMod.SYNCED_RENDER_DISTANCE).register((oldValue, newValue) -> {
+					SimpleOption<Integer> viewDistance = MinecraftClient.getInstance().options.getViewDistance();
+					if (viewDistance.getValue() < newValue) {
+						viewDistance.setValue(newValue);
+						MinecraftClient.getInstance().inGameHud.getChatHud().addMessage(Text.of("The server requested to up the render distance to " + newValue));
+					}
+				});
+			}
+		});
+	}
+}

--- a/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/AttachmentClientTestMod.java
+++ b/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/AttachmentClientTestMod.java
@@ -30,7 +30,7 @@ public class AttachmentClientTestMod implements ClientModInitializer {
 	public void onInitializeClient() {
 		ClientEntityEvents.ENTITY_LOAD.register((entity, world) -> {
 			if (entity instanceof ClientPlayerEntity) {
-				entity.onAttachedChanged(AttachmentTestMod.SYNCED_RENDER_DISTANCE).register((oldValue, newValue) -> {
+				entity.onAttachedSet(AttachmentTestMod.SYNCED_RENDER_DISTANCE).register((oldValue, newValue) -> {
 					SimpleOption<Integer> viewDistance = MinecraftClient.getInstance().options.getViewDistance();
 
 					if (viewDistance.getValue() < newValue) {

--- a/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/gametest/SyncGametest.java
+++ b/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/gametest/SyncGametest.java
@@ -90,7 +90,7 @@ public class SyncGametest implements FabricClientGameTest {
 			};
 
 			context.runOnClient(client -> {
-				// set client simulation distance before the server sets it
+				// set client render distance before the server sets it
 				client.options.getViewDistance().setValue(5);
 			});
 

--- a/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/gametest/SyncGametest.java
+++ b/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/gametest/SyncGametest.java
@@ -135,7 +135,7 @@ public class SyncGametest implements FabricClientGameTest {
 					player.setAttached(AttachmentTestMod.SYNCED_ITEM, Items.APPLE.getDefaultStack());
 
 					// check that the client changes the render distance as requested
-					player.setAttached(AttachmentTestMod.SYNCED_RENDER_DISTANCE, 14);
+					player.setAttached(AttachmentTestMod.SYNCED_RENDER_DISTANCE, 8);
 				});
 
 				// safety
@@ -158,7 +158,7 @@ public class SyncGametest implements FabricClientGameTest {
 					assertHasNotSynced(client.player, AttachmentTestMod.SYNCED_EXCEPT_TARGET);
 					assertHasNotSynced(villager, AttachmentTestMod.SYNCED_WITH_TARGET);
 
-					if (client.options.getViewDistance().getValue() != 14) {
+					if (client.options.getViewDistance().getValue() != 8) {
 						throw new AssertionError("Client did not set render distance to server requested synced attachment.");
 					}
 				});

--- a/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/gametest/SyncGametest.java
+++ b/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/gametest/SyncGametest.java
@@ -158,7 +158,7 @@ public class SyncGametest implements FabricClientGameTest {
 					assertHasNotSynced(client.player, AttachmentTestMod.SYNCED_EXCEPT_TARGET);
 					assertHasNotSynced(villager, AttachmentTestMod.SYNCED_WITH_TARGET);
 
-					if (client.options.getViewDistance().getValue() != 13) {
+					if (client.options.getViewDistance().getValue() != 14) {
 						throw new AssertionError("Client did not set render distance to server requested synced attachment.");
 					}
 				});

--- a/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/gametest/SyncGametest.java
+++ b/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/gametest/SyncGametest.java
@@ -161,6 +161,9 @@ public class SyncGametest implements FabricClientGameTest {
 					if (client.options.getViewDistance().getValue() != 8) {
 						throw new AssertionError("Client did not set render distance to server requested synced attachment.");
 					}
+
+					// reset view distance
+					client.options.getViewDistance().setValue(12);
 				});
 
 				LOGGER.info("Setting up second phase");

--- a/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/gametest/SyncGametest.java
+++ b/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/gametest/SyncGametest.java
@@ -89,6 +89,11 @@ public class SyncGametest implements FabricClientGameTest {
 				int villagerId;
 			};
 
+			context.runOnClient(client -> {
+				// set client simulation distance before the server sets it
+				client.options.getViewDistance().setValue(5);
+			});
+
 			LOGGER.info("Setting up synced attachments before join");
 			// setup before player joins
 			serverContext.runOnServer(server -> {
@@ -128,6 +133,9 @@ public class SyncGametest implements FabricClientGameTest {
 
 					// check registry objects are synced correctly
 					player.setAttached(AttachmentTestMod.SYNCED_ITEM, Items.APPLE.getDefaultStack());
+
+					// check that the client changes the render distance as requested
+					player.setAttached(AttachmentTestMod.SYNCED_RENDER_DISTANCE, 14);
 				});
 
 				// safety
@@ -149,6 +157,10 @@ public class SyncGametest implements FabricClientGameTest {
 					assertHasNotSynced(world, AttachmentTestMod.SYNCED_WITH_ALL);
 					assertHasNotSynced(client.player, AttachmentTestMod.SYNCED_EXCEPT_TARGET);
 					assertHasNotSynced(villager, AttachmentTestMod.SYNCED_WITH_TARGET);
+
+					if (client.options.getViewDistance().getValue() != 13) {
+						throw new AssertionError("Client did not set render distance to server requested synced attachment.");
+					}
 				});
 
 				LOGGER.info("Setting up second phase");


### PR DESCRIPTION
Continuation of #4592, made as a listener(and not a modify) and set in the target itself.

Example usage: 
```java
ClientEntityEvents.ENTITY_LOAD.register((entity, world) -> {
	entity.onAttachedChanged(AttachmentTestMod.SYNCED_ITEM).register((oldValue, newValue) -> {
		MinecraftClient.getInstance().inGameHud.getChatHud().addMessage(Text.of("FYI, the attachment SYNCED_ITEM had its value changed on this entity!"));
	});
});
```