### PR TITLE
Add sound event subtitle to language generation

### DIFF
--- a/fabric-data-generation-api-v1/src/client/java/net/fabricmc/fabric/api/client/datagen/v1/builder/SoundTypeBuilder.java
+++ b/fabric-data-generation-api-v1/src/client/java/net/fabricmc/fabric/api/client/datagen/v1/builder/SoundTypeBuilder.java
@@ -43,7 +43,9 @@ import net.fabricmc.fabric.impl.datagen.client.SoundTypeBuilderImpl;
 @ApiStatus.NonExtendable
 public interface SoundTypeBuilder {
 	/**
-	 * Creates a new builder pre-filled with a subtitle translation string based on the passed event.
+	 * Creates a new builder pre-filled with a subtitle translation key string based on the passed event.
+	 *
+	 * Note: To generate a translation value, use {@link net.fabricmc.fabric.api.datagen.v1.provider.FabricLanguageProvider.TranslationBuilder#add(SoundEvent, String)}.
 	 *
 	 * @return New sound type builder
 	 */
@@ -69,9 +71,11 @@ public interface SoundTypeBuilder {
 	SoundTypeBuilder category(SoundCategory category);
 
 	/**
-	 * Sets an optional translation string to use for the sound's subtitle.
+	 * Sets an optional translation key string to use for the sound's subtitle.
 	 *
 	 * <p>The default is null (no subtitle).
+	 *
+	 * <p>Note: To generate a translation value, use {@link net.fabricmc.fabric.api.datagen.v1.provider.FabricLanguageProvider.TranslationBuilder#add(SoundEvent, String)}.
 	 */
 	SoundTypeBuilder subtitle(@Nullable String subtitle);
 

--- a/fabric-data-generation-api-v1/src/client/java/net/fabricmc/fabric/api/client/datagen/v1/builder/SoundTypeBuilder.java
+++ b/fabric-data-generation-api-v1/src/client/java/net/fabricmc/fabric/api/client/datagen/v1/builder/SoundTypeBuilder.java
@@ -45,7 +45,7 @@ public interface SoundTypeBuilder {
 	/**
 	 * Creates a new builder pre-filled with a subtitle translation key string based on the passed event.
 	 *
-	 * Note: To generate a translation value, use {@link net.fabricmc.fabric.api.datagen.v1.provider.FabricLanguageProvider.TranslationBuilder#add(SoundEvent, String)}.
+	 * <p>Note: To generate a translation value, use {@link net.fabricmc.fabric.api.datagen.v1.provider.FabricLanguageProvider.TranslationBuilder#add(SoundEvent, String)}.
 	 *
 	 * @return New sound type builder
 	 */

--- a/fabric-data-generation-api-v1/src/client/java/net/fabricmc/fabric/api/client/datagen/v1/provider/FabricSoundsProvider.java
+++ b/fabric-data-generation-api-v1/src/client/java/net/fabricmc/fabric/api/client/datagen/v1/provider/FabricSoundsProvider.java
@@ -38,7 +38,7 @@ import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
 import net.fabricmc.fabric.impl.datagen.client.SoundTypeBuilderImpl;
 
 /**
- * Extend this class and implement {@link FabricSoundsProvider#generate}.
+ * Extend this class and implement {@link FabricSoundsProvider#configure(RegistryWrapper.WrapperLookup, SoundExporter)}.
  *
  * <p>Register an instance of the class with {@link FabricDataGenerator.Pack#addProvider} in a {@link net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint}.
  *

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricLanguageProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricLanguageProvider.java
@@ -250,7 +250,7 @@ public abstract class FabricLanguageProvider implements DataProvider {
 		 * @param value The value of the entry
 		 */
 		default void add(SoundEvent sound, String value) {
-			add(sound.id().toTranslationKey("subtitles"), value);
+			add(Util.createTranslationKey("subtitles", sound.id()), value);
 		}
 
 		/**

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricLanguageProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricLanguageProvider.java
@@ -44,6 +44,7 @@ import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.registry.tag.TagKey;
+import net.minecraft.sound.SoundEvent;
 import net.minecraft.stat.StatType;
 import net.minecraft.text.TextContent;
 import net.minecraft.text.TranslatableTextContent;
@@ -238,6 +239,18 @@ public abstract class FabricLanguageProvider implements DataProvider {
 		 */
 		default void add(TagKey<?> tagKey, String value) {
 			add(tagKey.getTranslationKey(), value);
+		}
+
+		/**
+		 * Adds a subtitle translation for a {@link SoundEvent} of the form
+		 * {@code subtitles.<namespace>.<path>}. If the sound event uses a non-standard
+		 * translation key for its subtitle, use {@link #add(String, String)} instead.
+		 *
+		 * @param sound The {@link SoundEvent} to get the translation key from
+		 * @param value The value of the entry
+		 */
+		default void add(SoundEvent sound, String value) {
+			add(sound.id().toTranslationKey("subtitles"), value);
 		}
 
 		/**

--- a/fabric-data-generation-api-v1/src/testmod/generated/assets/fabric-data-gen-api-v1-testmod/lang/en_us.json
+++ b/fabric-data-generation-api-v1/src/testmod/generated/assets/fabric-data-gen-api-v1-testmod/lang/en_us.json
@@ -3,5 +3,6 @@
   "block.fabric-data-gen-api-v1-testmod.simple_block": "Simple Block",
   "entity.minecraft.allay": "Allay",
   "fabric-data-gen-api-v1-testmod.identifier_test": "Identifier Test",
-  "itemGroup.fabric-data-gen-api-v1-testmod.default": "Datagen Itemgroup"
+  "itemGroup.fabric-data-gen-api-v1-testmod.default": "Datagen Itemgroup",
+  "subtitles.fabric-data-gen-api-v1-testmod.test_sound": "Test Sound"
 }

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
@@ -26,6 +26,7 @@ import static net.fabricmc.fabric.test.datagen.DataGeneratorTestContent.SIMPLE_I
 import static net.fabricmc.fabric.test.datagen.DataGeneratorTestContent.TEST_DATAGEN_DYNAMIC_REGISTRY_KEY;
 import static net.fabricmc.fabric.test.datagen.DataGeneratorTestContent.TEST_DYNAMIC_REGISTRY_EXTRA_ITEM_KEY;
 import static net.fabricmc.fabric.test.datagen.DataGeneratorTestContent.TEST_DYNAMIC_REGISTRY_ITEM_KEY;
+import static net.fabricmc.fabric.test.datagen.DataGeneratorTestContent.TEST_SOUND;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -266,6 +267,7 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 			translationBuilder.add(Identifier.of(MOD_ID, "identifier_test"), "Identifier Test");
 			translationBuilder.add(EntityType.ALLAY, "Allay");
 			translationBuilder.add(EntityAttributes.ARMOR, "Generic Armor");
+			translationBuilder.add(TEST_SOUND, "Test Sound");
 
 			try {
 				Optional<Path> path = dataOutput.getModContainer().findPath("assets/testmod/lang/en_us.base.json");


### PR DESCRIPTION
Adds a small method to the language provider for generating sound event subtitles. This method assumes that the format of the subtitle translation key is `subtitles.<namespace>.<path>`. This is because getting the actual subtitle translation key defined by the sound entry in the mod resource pack requires access to client methods, which are not available in the main source set that the language provider is defined in.