### PR TITLE
Add consume for after screen mouse events

### DIFF
--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenMouseEvents.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenMouseEvents.java
@@ -176,6 +176,20 @@ public final class ScreenMouseEvents {
 		 * @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		 */
 		void afterMouseClick(Screen screen, double mouseX, double mouseY, int button);
+
+		default boolean afterMouseClick(Screen screen, double mouseX, double mouseY, int button, boolean consumed) {
+			afterMouseClick(screen, mouseX, mouseY, button);
+			return false;
+		}
+	}
+
+	@FunctionalInterface
+	public interface AfterMouseClickV2 extends AfterMouseClick {
+		@Override
+		default void afterMouseClick(Screen screen, double mouseX, double mouseY, int button) {}
+
+		@Override
+		boolean afterMouseClick(Screen screen, double mouseX, double mouseY, int button, boolean consumed);
 	}
 
 	@FunctionalInterface
@@ -215,6 +229,20 @@ public final class ScreenMouseEvents {
 		 * @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		 */
 		void afterMouseRelease(Screen screen, double mouseX, double mouseY, int button);
+
+		default boolean afterMouseRelease(Screen screen, double mouseX, double mouseY, int button, boolean consumed) {
+			afterMouseRelease(screen, mouseX, mouseY, button);
+			return false;
+		}
+	}
+
+	@FunctionalInterface
+	public interface AfterMouseReleaseV2 extends AfterMouseRelease {
+		@Override
+		default void afterMouseRelease(Screen screen, double mouseX, double mouseY, int button) {}
+
+		@Override
+		boolean afterMouseRelease(Screen screen, double mouseX, double mouseY, int button, boolean consumed);
 	}
 
 	@FunctionalInterface
@@ -255,5 +283,19 @@ public final class ScreenMouseEvents {
 		 * @param verticalAmount the vertical scroll amount
 		 */
 		void afterMouseScroll(Screen screen, double mouseX, double mouseY, double horizontalAmount, double verticalAmount);
+
+		default boolean afterMouseScroll(Screen screen, double mouseX, double mouseY, double horizontalAmount, double verticalAmount, boolean consumed) {
+			afterMouseScroll(screen, mouseX, mouseY, horizontalAmount, verticalAmount);
+			return false;
+		}
+	}
+
+	@FunctionalInterface
+	public interface AfterMouseScrollV2 extends AfterMouseScroll {
+		@Override
+		default void afterMouseScroll(Screen screen, double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {}
+
+		@Override
+		boolean afterMouseScroll(Screen screen, double mouseX, double mouseY, double horizontalAmount, double verticalAmount, boolean consumed);
 	}
 }

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenEventFactory.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenEventFactory.java
@@ -147,10 +147,12 @@ public final class ScreenEventFactory {
 	}
 
 	public static Event<ScreenMouseEvents.AfterMouseClick> createAfterMouseClickEvent() {
-		return EventFactory.createArrayBacked(ScreenMouseEvents.AfterMouseClick.class, callbacks -> (screen, mouseX, mouseY, button) -> {
+		return EventFactory.createArrayBacked(ScreenMouseEvents.AfterMouseClick.class, callbacks -> (ScreenMouseEvents.AfterMouseClickV2) (screen, mouseX, mouseY, button, consumed) -> {
+			boolean consume = false;
 			for (ScreenMouseEvents.AfterMouseClick callback : callbacks) {
-				callback.afterMouseClick(screen, mouseX, mouseY, button);
+				consume |= callback.afterMouseClick(screen, mouseX, mouseY, button, consume | consumed);
 			}
+			return consume;
 		});
 	}
 
@@ -175,10 +177,12 @@ public final class ScreenEventFactory {
 	}
 
 	public static Event<ScreenMouseEvents.AfterMouseRelease> createAfterMouseReleaseEvent() {
-		return EventFactory.createArrayBacked(ScreenMouseEvents.AfterMouseRelease.class, callbacks -> (screen, mouseX, mouseY, button) -> {
+		return EventFactory.createArrayBacked(ScreenMouseEvents.AfterMouseRelease.class, callbacks -> (ScreenMouseEvents.AfterMouseReleaseV2) (screen, mouseX, mouseY, button, consumed) -> {
+			boolean consume = false;
 			for (ScreenMouseEvents.AfterMouseRelease callback : callbacks) {
-				callback.afterMouseRelease(screen, mouseX, mouseY, button);
+				consume |= callback.afterMouseRelease(screen, mouseX, mouseY, button, consume | consumed);
 			}
+			return consume;
 		});
 	}
 
@@ -203,10 +207,12 @@ public final class ScreenEventFactory {
 	}
 
 	public static Event<ScreenMouseEvents.AfterMouseScroll> createAfterMouseScrollEvent() {
-		return EventFactory.createArrayBacked(ScreenMouseEvents.AfterMouseScroll.class, callbacks -> (screen, mouseX, mouseY, horizontalAmount, verticalAmount) -> {
+		return EventFactory.createArrayBacked(ScreenMouseEvents.AfterMouseScroll.class, callbacks -> (ScreenMouseEvents.AfterMouseScrollV2)(screen, mouseX, mouseY, horizontalAmount, verticalAmount, consumed) -> {
+			boolean consume = false;
 			for (ScreenMouseEvents.AfterMouseScroll callback : callbacks) {
-				callback.afterMouseScroll(screen, mouseX, mouseY, horizontalAmount, verticalAmount);
+				consume |= callback.afterMouseScroll(screen, mouseX, mouseY, horizontalAmount, verticalAmount, consume | consumed);
 			}
+			return consume;
 		});
 	}
 

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/MouseMixin.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/MouseMixin.java
@@ -45,7 +45,7 @@ abstract class MouseMixin {
 		boolean result = operation.call(screen, mouseX, mouseY, button);
 
 		if (screen != null) {
-			ScreenMouseEvents.afterMouseClick(screen).invoker().afterMouseClick(screen, mouseX, mouseY, button);
+			result |= ScreenMouseEvents.afterMouseClick(screen).invoker().afterMouseClick(screen, mouseX, mouseY, button, result);
 		}
 
 		return result;
@@ -68,7 +68,7 @@ abstract class MouseMixin {
 		boolean result = operation.call(screen, mouseX, mouseY, button);
 
 		if (screen != null) {
-			ScreenMouseEvents.afterMouseRelease(screen).invoker().afterMouseRelease(screen, mouseX, mouseY, button);
+			result |= ScreenMouseEvents.afterMouseRelease(screen).invoker().afterMouseRelease(screen, mouseX, mouseY, button, result);
 		}
 
 		return result;
@@ -91,7 +91,7 @@ abstract class MouseMixin {
 		boolean result = operation.call(screen, mouseX, mouseY, horizontalAmount, verticalAmount);
 
 		if (screen != null) {
-			ScreenMouseEvents.afterMouseScroll(screen).invoker().afterMouseScroll(screen, mouseX, mouseY, horizontalAmount, verticalAmount);
+			result |= ScreenMouseEvents.afterMouseScroll(screen).invoker().afterMouseScroll(screen, mouseX, mouseY, horizontalAmount, verticalAmount, result);
 		}
 
 		return result;

--- a/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/ScreenTests.java
+++ b/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/ScreenTests.java
@@ -34,6 +34,7 @@ import net.minecraft.util.Identifier;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenKeyboardEvents;
+import net.fabricmc.fabric.api.client.screen.v1.ScreenMouseEvents;
 import net.fabricmc.fabric.api.client.screen.v1.Screens;
 
 public final class ScreenTests implements ClientModInitializer {
@@ -93,6 +94,11 @@ public final class ScreenTests implements ClientModInitializer {
 			});
 		} else if (screen instanceof CreativeInventoryScreen) {
 			Screens.getButtons(screen).add(new TestButtonWidget());
+
+			ScreenMouseEvents.afterMouseRelease(screen).register((ScreenMouseEvents.AfterMouseReleaseV2) (_screen, mouseX, mouseY, button, consumed) -> {
+				LOGGER.info("After Mouse Released, X: {}, Y: {}, Button: {}, Consumed: {}", mouseX, mouseY, button, consumed);
+				return true;
+			});
 		}
 	}
 


### PR DESCRIPTION
Allow listeners to check if the click has been consumed and consume the click.

This pr is lacking in comments as I am looking for feedback at this stage. The names should be updated based on suggestions.