### PR TITLE
Call all remaining listeners when ALLOW_CHAT event is cancled

### DIFF
--- a/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/api/client/message/v1/ClientReceiveMessageEvents.java
+++ b/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/api/client/message/v1/ClientReceiveMessageEvents.java
@@ -36,40 +36,21 @@ public final class ClientReceiveMessageEvents {
 	private ClientReceiveMessageEvents() {
 	}
 
-	public static final Event<ChatV2> CHAT_V2 = EventFactory.createArrayBacked(ChatV2.class, listeners -> (text, message, signedMessage, sender, params, receptionTimestamp) -> {
-		boolean allow = true;
-		for (ChatV2 listener : listeners) {
-			allow &= listener.onReceiveChatMessage(text, message, signedMessage, sender, params, receptionTimestamp);
-		}
-
-		return allow;
-	});
-
-	public static final Event<GameV2> GAME_V2 = EventFactory.createArrayBacked(GameV2.class, listeners -> (text, message, overlay) -> {
-		boolean allow = true;
-		for (GameV2 listener : listeners) {
-			allow &= listener.onReceiveGameMessage(text, message, overlay);
-		}
-
-		return allow;
-	});
-
 	/**
 	 * An event triggered when the client receives a chat message,
 	 * which is any message sent by a player. Mods can use this to block the message.
 	 *
 	 * <p>If a listener returned {@code false}, the message will not be displayed,
-	 * the remaining listeners will not be called (if any), and
+	 * the remaining listeners will be called (if any), and
 	 * {@link #CHAT_CANCELED} will be triggered instead of {@link #CHAT}.
 	 */
 	public static final Event<AllowChat> ALLOW_CHAT = EventFactory.createArrayBacked(AllowChat.class, listeners -> (message, signedMessage, sender, params, receptionTimestamp) -> {
+		boolean allow = true;
 		for (AllowChat listener : listeners) {
-			if (!listener.allowReceiveChatMessage(message, signedMessage, sender, params, receptionTimestamp)) {
-				return false;
-			}
+			allow &= listener.allowReceiveChatMessage(message, signedMessage, sender, params, receptionTimestamp);
 		}
 
-		return true;
+		return allow;
 	});
 
 	/**
@@ -78,7 +59,7 @@ public final class ClientReceiveMessageEvents {
 	 * Mods can use this to block the message or toggle overlay.
 	 *
 	 * <p>If a listener returned {@code false}, the message will not be displayed,
-	 * the remaining listeners will not be called (if any), and
+	 * the remaining listeners will be called (if any), and
 	 * {@link #GAME_CANCELED} will be triggered instead of {@link #MODIFY_GAME}.
 	 *
 	 * <p>Overlay is whether the message will be displayed in the action bar.
@@ -86,13 +67,12 @@ public final class ClientReceiveMessageEvents {
 	 * {@link net.minecraft.client.network.ClientPlayerEntity#sendMessage(Text, boolean) ClientPlayerEntity.sendMessage(message, overlay)}.
 	 */
 	public static final Event<AllowGame> ALLOW_GAME = EventFactory.createArrayBacked(AllowGame.class, listeners -> (message, overlay) -> {
+		boolean allow = true;
 		for (AllowGame listener : listeners) {
-			if (!listener.allowReceiveGameMessage(message, overlay)) {
-				return false;
-			}
+			allow &= listener.allowReceiveGameMessage(message, overlay);
 		}
 
-		return true;
+		return allow;
 	});
 
 	/**
@@ -162,16 +142,6 @@ public final class ClientReceiveMessageEvents {
 			listener.onReceiveGameMessageCanceled(message, overlay);
 		}
 	});
-
-	@FunctionalInterface
-	public interface ChatV2 {
-		boolean onReceiveChatMessage(Text text, String message, @Nullable SignedMessage signedMessage, @Nullable GameProfile sender, MessageType.Parameters params, Instant receptionTimestamp);
-	}
-
-	@FunctionalInterface
-	public interface GameV2 {
-		boolean onReceiveGameMessage(Text text, String message, boolean overlay);
-	}
 
 	@FunctionalInterface
 	public interface AllowChat {

--- a/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/api/client/message/v1/ClientReceiveMessageEvents.java
+++ b/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/api/client/message/v1/ClientReceiveMessageEvents.java
@@ -36,6 +36,24 @@ public final class ClientReceiveMessageEvents {
 	private ClientReceiveMessageEvents() {
 	}
 
+	public static final Event<ChatV2> CHAT_V2 = EventFactory.createArrayBacked(ChatV2.class, listeners -> (text, message, signedMessage, sender, params, receptionTimestamp) -> {
+		boolean allow = true;
+		for (ChatV2 listener : listeners) {
+			allow &= listener.onReceiveChatMessage(text, message, signedMessage, sender, params, receptionTimestamp);
+		}
+
+		return allow;
+	});
+
+	public static final Event<GameV2> GAME_V2 = EventFactory.createArrayBacked(GameV2.class, listeners -> (text, message, overlay) -> {
+		boolean allow = true;
+		for (GameV2 listener : listeners) {
+			allow &= listener.onReceiveGameMessage(text, message, overlay);
+		}
+
+		return allow;
+	});
+
 	/**
 	 * An event triggered when the client receives a chat message,
 	 * which is any message sent by a player. Mods can use this to block the message.
@@ -144,6 +162,16 @@ public final class ClientReceiveMessageEvents {
 			listener.onReceiveGameMessageCanceled(message, overlay);
 		}
 	});
+
+	@FunctionalInterface
+	public interface ChatV2 {
+		boolean onReceiveChatMessage(Text text, String message, @Nullable SignedMessage signedMessage, @Nullable GameProfile sender, MessageType.Parameters params, Instant receptionTimestamp);
+	}
+
+	@FunctionalInterface
+	public interface GameV2 {
+		boolean onReceiveGameMessage(Text text, String message, boolean overlay);
+	}
 
 	@FunctionalInterface
 	public interface AllowChat {

--- a/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/api/client/message/v1/ClientReceiveMessageEvents.java
+++ b/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/api/client/message/v1/ClientReceiveMessageEvents.java
@@ -46,6 +46,7 @@ public final class ClientReceiveMessageEvents {
 	 */
 	public static final Event<AllowChat> ALLOW_CHAT = EventFactory.createArrayBacked(AllowChat.class, listeners -> (message, signedMessage, sender, params, receptionTimestamp) -> {
 		boolean allow = true;
+
 		for (AllowChat listener : listeners) {
 			allow &= listener.allowReceiveChatMessage(message, signedMessage, sender, params, receptionTimestamp);
 		}
@@ -68,6 +69,7 @@ public final class ClientReceiveMessageEvents {
 	 */
 	public static final Event<AllowGame> ALLOW_GAME = EventFactory.createArrayBacked(AllowGame.class, listeners -> (message, overlay) -> {
 		boolean allow = true;
+
 		for (AllowGame listener : listeners) {
 			allow &= listener.allowReceiveGameMessage(message, overlay);
 		}

--- a/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/message/MessageHandlerMixin.java
+++ b/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/message/MessageHandlerMixin.java
@@ -59,7 +59,7 @@ public abstract class MessageHandlerMixin {
 
 	@Unique
 	private void fabric_onChatMessage(Text message, @Nullable SignedMessage signedMessage, @Nullable GameProfile sender, MessageType.Parameters params, Instant receptionTimestamp, CallbackInfoReturnable<Boolean> cir) {
-		if (ClientReceiveMessageEvents.ALLOW_CHAT.invoker().allowReceiveChatMessage(message, signedMessage, sender, params, receptionTimestamp)) {
+		if (ClientReceiveMessageEvents.CHAT_V2.invoker().onReceiveChatMessage(message, message.getString(), signedMessage, sender, params, receptionTimestamp) && ClientReceiveMessageEvents.ALLOW_CHAT.invoker().allowReceiveChatMessage(message, signedMessage, sender, params, receptionTimestamp)) {
 			ClientReceiveMessageEvents.CHAT.invoker().onReceiveChatMessage(message, signedMessage, sender, params, receptionTimestamp);
 		} else {
 			ClientReceiveMessageEvents.CHAT_CANCELED.invoker().onReceiveChatMessageCanceled(message, signedMessage, sender, params, receptionTimestamp);
@@ -69,7 +69,7 @@ public abstract class MessageHandlerMixin {
 
 	@Inject(method = "onGameMessage", at = @At("HEAD"), cancellable = true)
 	private void fabric_allowGameMessage(Text _message, boolean overlay, CallbackInfo ci, @Local(argsOnly = true) LocalRef<Text> message) {
-		if (ClientReceiveMessageEvents.ALLOW_GAME.invoker().allowReceiveGameMessage(message.get(), overlay)) {
+		if (ClientReceiveMessageEvents.GAME_V2.invoker().onReceiveGameMessage(message.get(), message.get().getString(), overlay) && ClientReceiveMessageEvents.ALLOW_GAME.invoker().allowReceiveGameMessage(message.get(), overlay)) {
 			message.set(ClientReceiveMessageEvents.MODIFY_GAME.invoker().modifyReceivedGameMessage(message.get(), overlay));
 			ClientReceiveMessageEvents.GAME.invoker().onReceiveGameMessage(message.get(), overlay);
 		} else {

--- a/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/message/MessageHandlerMixin.java
+++ b/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/message/MessageHandlerMixin.java
@@ -59,7 +59,7 @@ public abstract class MessageHandlerMixin {
 
 	@Unique
 	private void fabric_onChatMessage(Text message, @Nullable SignedMessage signedMessage, @Nullable GameProfile sender, MessageType.Parameters params, Instant receptionTimestamp, CallbackInfoReturnable<Boolean> cir) {
-		if (ClientReceiveMessageEvents.CHAT_V2.invoker().onReceiveChatMessage(message, message.getString(), signedMessage, sender, params, receptionTimestamp) && ClientReceiveMessageEvents.ALLOW_CHAT.invoker().allowReceiveChatMessage(message, signedMessage, sender, params, receptionTimestamp)) {
+		if (ClientReceiveMessageEvents.ALLOW_CHAT.invoker().allowReceiveChatMessage(message, signedMessage, sender, params, receptionTimestamp)) {
 			ClientReceiveMessageEvents.CHAT.invoker().onReceiveChatMessage(message, signedMessage, sender, params, receptionTimestamp);
 		} else {
 			ClientReceiveMessageEvents.CHAT_CANCELED.invoker().onReceiveChatMessageCanceled(message, signedMessage, sender, params, receptionTimestamp);
@@ -69,7 +69,7 @@ public abstract class MessageHandlerMixin {
 
 	@Inject(method = "onGameMessage", at = @At("HEAD"), cancellable = true)
 	private void fabric_allowGameMessage(Text _message, boolean overlay, CallbackInfo ci, @Local(argsOnly = true) LocalRef<Text> message) {
-		if (ClientReceiveMessageEvents.GAME_V2.invoker().onReceiveGameMessage(message.get(), message.get().getString(), overlay) && ClientReceiveMessageEvents.ALLOW_GAME.invoker().allowReceiveGameMessage(message.get(), overlay)) {
+		if (ClientReceiveMessageEvents.ALLOW_GAME.invoker().allowReceiveGameMessage(message.get(), overlay)) {
 			message.set(ClientReceiveMessageEvents.MODIFY_GAME.invoker().modifyReceivedGameMessage(message.get(), overlay));
 			ClientReceiveMessageEvents.GAME.invoker().onReceiveGameMessage(message.get(), overlay);
 		} else {


### PR DESCRIPTION
Allow listeners to listen to all received messages and optionally cancel. Previously, this required listening to two or three events (ALLOW and CANCELED) and often messages are processed twice. This pr also adds a string parameter, eliminating excessive usage of `text.getString()`. No breaking changes.

This pr is lacking in comments as I am looking for feedback at this stage. The names should be updated based on suggestions.

Fixes #3133.
See previous discussion [here](https://discord.com/channels/507304429255393322/566276937035546624/1241410968173416468).