### PR TITLE
[1.21.6] fix(data-attachment): don't call ".remove" on null dataAttachments map

### DIFF
--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
@@ -76,11 +76,7 @@ abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
 		T oldValue;
 
 		if (value == null) {
-			if (fabric_dataAttachments == null) {
-				oldValue = null;
-			}
-
-			oldValue = (T) fabric_dataAttachments.remove(type);
+			oldValue = fabric_dataAttachments == null ? null : (T) fabric_dataAttachments.remove(type);
 		} else {
 			if (fabric_dataAttachments == null) {
 				fabric_dataAttachments = new IdentityHashMap<>();


### PR DESCRIPTION
See #4624 
See #4625 