### PR TITLE
Data Attachments: Don't mark changed & sync if old value is the same as new value

### DIFF
--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
@@ -68,14 +68,6 @@ abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
 	@Override
 	@Nullable
 	public <T> T setAttached(AttachmentType<T> type, @Nullable T value) {
-		this.fabric_markChanged(type);
-
-		if (this.fabric_shouldTryToSync() && type.isSynced()) {
-			AttachmentChange change = AttachmentChange.create(fabric_getSyncTargetInfo(), type, value, fabric_getDynamicRegistryManager());
-			acknowledgeSyncedEntry(type, change);
-			this.fabric_syncChange(type, new AttachmentSyncPayloadS2C(List.of(change)));
-		}
-
 		T oldValue;
 
 		if (value == null) {
@@ -93,6 +85,16 @@ abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
 
 			if (event != null) {
 				event.invoker().onAttachedSet(oldValue, value);
+			}
+		}
+
+		if (oldValue != value) {
+			this.fabric_markChanged(type);
+
+			if (this.fabric_shouldTryToSync() && type.isSynced()) {
+				AttachmentChange change = AttachmentChange.create(fabric_getSyncTargetInfo(), type, value, fabric_getDynamicRegistryManager());
+				acknowledgeSyncedEntry(type, change);
+				this.fabric_syncChange(type, new AttachmentSyncPayloadS2C(List.of(change)));
 			}
 		}
 

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.mixin.attachment;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -88,7 +89,7 @@ abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
 			}
 		}
 
-		if (oldValue != value) {
+		if (!Objects.equals(oldValue, value)) {
 			this.fabric_markChanged(type);
 
 			if (this.fabric_shouldTryToSync() && type.isSynced()) {


### PR DESCRIPTION
Gives more flexibility to API consumers as they won't have to add this check themselves. In cases where attachments are constantly updated with the same value, should reduce disk time usage and network bandwidth usage