### PR TITLE
Update mod to Minecraft snapshot 25w20a

### DIFF
--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPlayNetworkHandlerMixin.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPlayNetworkHandlerMixin.java
@@ -23,7 +23,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
@@ -72,10 +71,10 @@ abstract class ClientPlayNetworkHandlerMixin {
 		ClientCommandInternals.addCommands((CommandDispatcher) commandDispatcher, (FabricClientCommandSource) commandSource);
 	}
 
-	@Inject(method = "sendCommand", at = @At("HEAD"), cancellable = true)
-	private void onSendCommand(String command, CallbackInfoReturnable<Boolean> cir) {
+	@Inject(method = "method_71927", at = @At("HEAD"), cancellable = true)
+	private void onSendCommand(String command, boolean closePreviousScreen, CallbackInfo info) {
 		if (ClientCommandInternals.executeCommand(command)) {
-			cir.setReturnValue(true);
+			info.cancel();
 		}
 	}
 

--- a/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/mixin/event/interaction/client/ClientPlayerInteractionManagerMixin.java
+++ b/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/mixin/event/interaction/client/ClientPlayerInteractionManagerMixin.java
@@ -129,7 +129,7 @@ public abstract class ClientPlayerInteractionManagerMixin {
 
 	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayNetworkHandler;sendPacket(Lnet/minecraft/network/packet/Packet;)V", ordinal = 0), method = "attackEntity", cancellable = true)
 	public void attackEntity(PlayerEntity player, Entity entity, CallbackInfo info) {
-		ActionResult result = AttackEntityCallback.EVENT.invoker().interact(player, player.getEntityWorld(), Hand.MAIN_HAND /* TODO */, entity, null);
+		ActionResult result = AttackEntityCallback.EVENT.invoker().interact(player, player.getWorld(), Hand.MAIN_HAND /* TODO */, entity, null);
 
 		if (result != ActionResult.PASS) {
 			if (result == ActionResult.SUCCESS) {

--- a/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/mixin/event/interaction/client/MinecraftClientMixin.java
+++ b/fabric-events-interaction-v0/src/client/java/net/fabricmc/fabric/mixin/event/interaction/client/MinecraftClientMixin.java
@@ -75,7 +75,7 @@ public abstract class MinecraftClientMixin {
 			cancellable = true
 	)
 	private void injectUseEntityCallback(CallbackInfo ci, @Local Hand hand, @Local EntityHitResult hitResult, @Local Entity entity) {
-		ActionResult result = UseEntityCallback.EVENT.invoker().interact(player, player.getEntityWorld(), hand, entity, hitResult);
+		ActionResult result = UseEntityCallback.EVENT.invoker().interact(player, player.getWorld(), hand, entity, hitResult);
 
 		if (result != ActionResult.PASS) {
 			if (result.isAccepted()) {

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/ServerPlayNetworkHandlerInteractEntityHandlerMixin.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/ServerPlayNetworkHandlerInteractEntityHandlerMixin.java
@@ -48,7 +48,7 @@ public abstract class ServerPlayNetworkHandlerInteractEntityHandlerMixin impleme
 	@Inject(method = "interactAt(Lnet/minecraft/util/Hand;Lnet/minecraft/util/math/Vec3d;)V", at = @At(value = "HEAD"), cancellable = true)
 	public void onPlayerInteractEntity(Hand hand, Vec3d hitPosition, CallbackInfo info) {
 		PlayerEntity player = field_28963.player;
-		World world = player.getEntityWorld();
+		World world = player.getWorld();
 
 		EntityHitResult hitResult = new EntityHitResult(field_28962, hitPosition.add(field_28962.getX(), field_28962.getY(), field_28962.getZ()));
 		ActionResult result = UseEntityCallback.EVENT.invoker().interact(player, world, hand, field_28962, hitResult);
@@ -61,7 +61,7 @@ public abstract class ServerPlayNetworkHandlerInteractEntityHandlerMixin impleme
 	@Inject(method = "interact(Lnet/minecraft/util/Hand;)V", at = @At(value = "HEAD"), cancellable = true)
 	public void onPlayerInteractEntity(Hand hand, CallbackInfo info) {
 		PlayerEntity player = field_28963.player;
-		World world = player.getEntityWorld();
+		World world = player.getWorld();
 
 		ActionResult result = UseEntityCallback.EVENT.invoker().interact(player, world, hand, field_28962, null);
 

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/ServerPlayerEntityMixin.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/ServerPlayerEntityMixin.java
@@ -33,7 +33,7 @@ public class ServerPlayerEntityMixin {
 	@Inject(method = "attack", at = @At("HEAD"), cancellable = true)
 	public void onPlayerInteractEntity(Entity target, CallbackInfo info) {
 		ServerPlayerEntity player = (ServerPlayerEntity) (Object) this;
-		ActionResult result = AttackEntityCallback.EVENT.invoker().interact(player, player.getEntityWorld(), Hand.MAIN_HAND, target, null);
+		ActionResult result = AttackEntityCallback.EVENT.invoker().interact(player, player.getWorld(), Hand.MAIN_HAND, target, null);
 
 		if (result != ActionResult.PASS) {
 			info.cancel();

--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/FabricGameTestRunner.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/impl/gametest/FabricGameTestRunner.java
@@ -60,7 +60,7 @@ public final class FabricGameTestRunner {
 		boolean verify = Boolean.getBoolean(GameTestSystemProperties.VERIFY);
 		MinecraftServer.startServer((thread) -> {
 			TestServer testServer = TestServer.create(thread, session, resourcePackManager, filter, verify);
-			TestManager.INSTANCE.method_71664();
+			TestManager.INSTANCE.startTicking();
 			return testServer;
 		});
 	}

--- a/fabric-recipe-api-v1/src/testmod/resources/data/fabric-recipe-api-v1-testmod/recipe/test_customingredients_sync.json
+++ b/fabric-recipe-api-v1/src/testmod/resources/data/fabric-recipe-api-v1-testmod/recipe/test_customingredients_sync.json
@@ -3,9 +3,7 @@
   "ingredients": [
     {
       "fabric:type": "fabric:components",
-      "base": {
-        "item": "minecraft:diamond_pickaxe"
-      },
+      "base": "minecraft:diamond_pickaxe",
       "components": {
         "minecraft:damage": 0
       },

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/mixin/client/indigo/renderer/ItemRendererAccessor.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/mixin/client/indigo/renderer/ItemRendererAccessor.java
@@ -27,7 +27,7 @@ import net.minecraft.client.util.math.MatrixStack;
 
 @Mixin(ItemRenderer.class)
 public interface ItemRendererAccessor {
-	@Invoker("method_71138")
+	@Invoker("getSpecialItemGlintConsumer")
 	static VertexConsumer fabric_getDynamicDisplayGlintConsumer(VertexConsumerProvider provider, RenderLayer layer, MatrixStack.Entry entry) {
 		throw new AssertionError();
 	}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
@@ -20,6 +20,7 @@ import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import org.joml.Matrix4f;
+import org.joml.Vector4f;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -38,7 +39,6 @@ import net.minecraft.client.render.DefaultFramebufferSet;
 import net.minecraft.client.render.FrameGraphBuilder;
 import net.minecraft.client.render.FramePass;
 import net.minecraft.client.render.Frustum;
-import net.minecraft.client.render.GameRenderer;
 import net.minecraft.client.render.RenderTickCounter;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.WorldRenderer;
@@ -68,8 +68,8 @@ public abstract class WorldRendererMixin {
 	@Unique private final WorldRenderContextImpl context = new WorldRenderContextImpl();
 
 	@Inject(method = "render", at = @At("HEAD"))
-	private void beforeRender(ObjectAllocator objectAllocator, RenderTickCounter tickCounter, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, Matrix4f positionMatrix, Matrix4f projectionMatrix, CallbackInfo ci) {
-		context.prepare((WorldRenderer) (Object) this, tickCounter, renderBlockOutline, camera, gameRenderer, positionMatrix, projectionMatrix, bufferBuilders.getEntityVertexConsumers(), MinecraftClient.isFabulousGraphicsOrBetter(), world);
+	private void beforeRender(ObjectAllocator objectAllocator, RenderTickCounter tickCounter, boolean renderBlockOutline, Camera camera, Matrix4f positionMatrix, Matrix4f projectionMatrix, GpuBufferSlice slice, Vector4f skyColor, boolean thinFog, CallbackInfo ci) {
+		context.prepare((WorldRenderer) (Object) this, tickCounter, renderBlockOutline, camera, this.client.gameRenderer, positionMatrix, projectionMatrix, bufferBuilders.getEntityVertexConsumers(), MinecraftClient.isFabulousGraphicsOrBetter(), world);
 		WorldRenderEvents.START.invoker().onStart(context);
 	}
 

--- a/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.accesswidener
+++ b/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.accesswidener
@@ -347,6 +347,7 @@ transitive-accessible field net/minecraft/client/gl/RenderPipelines TRANSFORMS_P
 transitive-accessible field net/minecraft/client/gl/RenderPipelines TRANSFORMS_PROJECTION_FOG_LIGHTING_SNIPPET Lcom/mojang/blaze3d/pipeline/RenderPipeline$Snippet;
 transitive-accessible field net/minecraft/client/gl/RenderPipelines TERRAIN_SNIPPET Lcom/mojang/blaze3d/pipeline/RenderPipeline$Snippet;
 transitive-accessible field net/minecraft/client/gl/RenderPipelines ENTITY_SNIPPET Lcom/mojang/blaze3d/pipeline/RenderPipeline$Snippet;
+transitive-accessible field net/minecraft/client/gl/RenderPipelines field_60794 Lcom/mojang/blaze3d/pipeline/RenderPipeline$Snippet;
 transitive-accessible field net/minecraft/client/gl/RenderPipelines RENDERTYPE_BEACON_BEAM_SNIPPET Lcom/mojang/blaze3d/pipeline/RenderPipeline$Snippet;
 transitive-accessible field net/minecraft/client/gl/RenderPipelines TEXT_SNIPPET Lcom/mojang/blaze3d/pipeline/RenderPipeline$Snippet;
 transitive-accessible field net/minecraft/client/gl/RenderPipelines RENDERTYPE_END_PORTAL_SNIPPET Lcom/mojang/blaze3d/pipeline/RenderPipeline$Snippet;

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2560M
 org.gradle.parallel=true
 
 version=0.124.0
-minecraft_version=25w19a
+minecraft_version=25w20a
 yarn_version=+build.1
 loader_version=0.16.13
 installer_version=1.0.1


### PR DESCRIPTION
This pull request ports Fabric API to [Minecraft snapshot 25w20a](https://www.minecraft.net/en-us/article/minecraft-snapshot-25w20a).

Item tooltips seemingly do not show when running with Fabric API's test mods. However, they do show when using only Fabric API. Is this behavior expected?