### PR TITLE
Don't erase data attachments if missing in NBT

### DIFF
--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
@@ -124,7 +124,17 @@ abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
 	public void fabric_readAttachmentsFromNbt(NbtCompound nbt, RegistryWrapper.WrapperLookup wrapperLookup) {
 		// Note on player targets: no syncing can happen here as the networkHandler is still null
 		// Instead it is done on player join (see AttachmentSync)
-		this.fabric_dataAttachments = AttachmentSerializingImpl.deserializeAttachmentData(nbt, wrapperLookup);
+		IdentityHashMap<AttachmentType<?>, Object> fromNbt = AttachmentSerializingImpl.deserializeAttachmentData(nbt, wrapperLookup);
+
+		// If the NBT is devoid of data attachments, treat it as a no-op, rather than wiping them out.
+		// Any changes to data attachments (including removals) post-load are done independently of this
+		// code path, so we don't need to blindly overwrite it every time if Vanilla MC sends updates
+		// (i.e. block entity updates) sans data attachments. See https://github.com/FabricMC/fabric/issues/4638
+		if (fromNbt == null) {
+			return;
+		}
+
+		this.fabric_dataAttachments = fromNbt;
 
 		if (this.fabric_shouldTryToSync() && this.fabric_dataAttachments != null) {
 			this.fabric_dataAttachments.forEach((type, value) -> {


### PR DESCRIPTION
As far as I can tell, this code path is only _actually_ used for data attachments on initial load, since any changes are synced with the custom network packets. Therefore, I think it's safe to consider missing attachment data a no-op rather than an erasure of all attachments.

Fixes #4638 