### PR TITLE
Add events for players joining and leaving the game

### DIFF
--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -49,6 +49,30 @@ public final class ServerPlayerEvents {
 	});
 
 	/**
+	 * An event that is called when a player has joined the game.
+	 * This includes loading a singleplayer world.
+	 *
+	 * <p>This event is called on the server thread after the player has fully been loaded into the world.
+	 */
+	public static final Event<Join> JOIN = EventFactory.createArrayBacked(Join.class, callbacks -> player -> {
+		for (Join callback : callbacks) {
+			callback.onJoin(player);
+		}
+	});
+
+	/**
+	 * An event that is called when a player is leaving the game.
+	 * This includes closing a singleplayer world.
+	 *
+	 * <p>This event is called on the server thread before the player has been saved and removed from the world.
+	 */
+	public static final Event<Leave> LEAVE = EventFactory.createArrayBacked(Leave.class, callbacks -> player -> {
+		for (Leave callback : callbacks) {
+			callback.onLeave(player);
+		}
+	});
+
+	/**
 	 * An event that is called when a player takes fatal damage.
 	 *
 	 * @deprecated Use the more general {@link ServerLivingEntityEvents#ALLOW_DEATH} event instead and check for {@code instanceof ServerPlayerEntity}.
@@ -86,6 +110,26 @@ public final class ServerPlayerEvents {
 		 * @param alive whether the old player is still alive
 		 */
 		void afterRespawn(ServerPlayerEntity oldPlayer, ServerPlayerEntity newPlayer, boolean alive);
+	}
+
+	@FunctionalInterface
+	public interface Join {
+		/**
+		 * Called when a player has joined the game.
+		 *
+		 * @param player the player
+		 */
+		void onJoin(ServerPlayerEntity player);
+	}
+
+	@FunctionalInterface
+	public interface Leave {
+		/**
+		 * Called when a player is leaving the game.
+		 *
+		 * @param player the player
+		 */
+		void onLeave(ServerPlayerEntity player);
 	}
 
 	/**

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/PlayerManagerMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/PlayerManagerMixin.java
@@ -19,10 +19,13 @@ package net.fabricmc.fabric.mixin.entity.event;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.network.ClientConnection;
 import net.minecraft.server.PlayerManager;
+import net.minecraft.server.network.ConnectedClientData;
 import net.minecraft.server.network.ServerPlayerEntity;
 
 import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
@@ -32,5 +35,15 @@ abstract class PlayerManagerMixin {
 	@Inject(method = "respawnPlayer", at = @At("TAIL"))
 	private void afterRespawn(ServerPlayerEntity oldPlayer, boolean alive, Entity.RemovalReason removalReason, CallbackInfoReturnable<ServerPlayerEntity> cir) {
 		ServerPlayerEvents.AFTER_RESPAWN.invoker().afterRespawn(oldPlayer, cir.getReturnValue(), alive);
+	}
+
+	@Inject(method = "onPlayerConnect", at = @At("RETURN"))
+	private void firePlayerJoinEvent(ClientConnection connection, ServerPlayerEntity player, ConnectedClientData clientData, CallbackInfo ci) {
+		ServerPlayerEvents.JOIN.invoker().onJoin(player);
+	}
+
+	@Inject(method = "remove", at = @At("HEAD"))
+	private void firePlayerLeaveEvent(ServerPlayerEntity player, CallbackInfo ci) {
+		ServerPlayerEvents.LEAVE.invoker().onLeave(player);
 	}
 }

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -35,6 +35,7 @@ import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
@@ -223,6 +224,16 @@ public final class EntityEventTests implements ModInitializer {
 		EntityElytraEvents.ALLOW.register(entity -> {
 			return !entity.getOffHandStack().isOf(Items.TORCH);
 		});
+
+		ServerPlayerEvents.JOIN.register(player -> {
+			assertOnServerThread(player.getServer());
+			LOGGER.info("Observed player {} joining the game", player.getGameProfile().getName());
+		});
+
+		ServerPlayerEvents.LEAVE.register(player -> {
+			assertOnServerThread(player.getServer());
+			LOGGER.info("Observed player {} leaving the game", player.getGameProfile().getName());
+		});
 	}
 
 	private static void addSleepWools(PlayerEntity player) {
@@ -235,6 +246,12 @@ public final class EntityEventTests implements ModInitializer {
 		inventory.offerOrDrop(createNamedItem(Items.BLACK_WOOL, "Don't reset time"));
 		inventory.offerOrDrop(createNamedItem(Items.ORANGE_WOOL, "Don't set occupied state"));
 		inventory.offerOrDrop(createNamedItem(Items.CYAN_WOOL, "Wake up high above"));
+	}
+
+	private static void assertOnServerThread(MinecraftServer server) {
+		if (!server.isOnThread()) {
+			throw new AssertionError("Expected the game to be on the server thread, but found " + Thread.currentThread());
+		}
 	}
 
 	private static ItemStack createNamedItem(Item item, String name) {


### PR DESCRIPTION
Adds two new events in `ServerPlayerEvents` that are fired when a player joins or leaves a server or a singleplayer world.

Unlike the existing events in the networking module, these events run on the game thread alongside related vanilla code, and are intended for setting up or cleaning up player state, not networking state.