### PR TITLE
Finalize 1.21.5 FRAPI port and other improvements

### DIFF
--- a/fabric-model-loading-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/model/loading/BakedModelFeatureRenderer.java
+++ b/fabric-model-loading-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/model/loading/BakedModelFeatureRenderer.java
@@ -53,7 +53,7 @@ public class BakedModelFeatureRenderer<S extends LivingEntityRenderState, M exte
 		matrices.scale(-0.75F, -0.75F, 0.75F);
 		float aboveHead = (float) (Math.sin(state.age * 0.08F)) * 0.5F + 0.5F;
 		matrices.translate(-0.5F, 0.75F + aboveHead, -0.5F);
-		FabricBlockModelRenderer.render(matrices.peek(), layer -> vertexConsumers.getBuffer(RenderLayerHelper.getEntityBlockLayer(layer)), model, 1, 1, 1, light, OverlayTexture.DEFAULT_UV, EmptyBlockRenderView.INSTANCE, BlockPos.ORIGIN, Blocks.AIR.getDefaultState());
+		FabricBlockModelRenderer.render(matrices.peek(), RenderLayerHelper.entityDelegate(vertexConsumers), model, 1, 1, 1, light, OverlayTexture.DEFAULT_UV, EmptyBlockRenderView.INSTANCE, BlockPos.ORIGIN, Blocks.AIR.getDefaultState());
 		matrices.pop();
 	}
 }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/Renderer.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/Renderer.java
@@ -146,7 +146,7 @@ public interface Renderer {
 	/**
 	 * @see FabricBlockModelPart#emitQuads(QuadEmitter, Predicate)
 	 */
-	@ApiStatus.Experimental
+	@Deprecated(forRemoval = true)
 	@ApiStatus.OverrideOnly
 	default void emitBlockModelPartQuads(BlockModelPart modelPart, QuadEmitter emitter, Predicate<@Nullable Direction> cullTest) {
 		VanillaBlockModelPartEncoder.emitQuads(modelPart, emitter, cullTest);

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/MutableQuadView.java
@@ -29,6 +29,7 @@ import net.minecraft.util.math.Direction;
 import net.fabricmc.fabric.api.renderer.v1.Renderer;
 import net.fabricmc.fabric.api.renderer.v1.material.MaterialFinder;
 import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
+import net.fabricmc.fabric.impl.renderer.QuadSpriteBaker;
 
 /**
  * A mutable {@link QuadView} instance. The base interface for
@@ -41,46 +42,47 @@ import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
  */
 public interface MutableQuadView extends QuadView {
 	/**
-	 * Causes texture to appear with no rotation.
+	 * When enabled, causes texture to appear with no rotation. This is the default and does not have to be specified
+	 * explicitly. Can be overridden by other rotation flags.
 	 * Pass in bakeFlags parameter to {@link #spriteBake(Sprite, int)}.
 	 */
 	int BAKE_ROTATE_NONE = 0;
 
 	/**
-	 * Causes texture to appear rotated 90 deg. clockwise relative to nominal face.
+	 * When enabled, causes texture to appear rotated 90 degrees clockwise.
 	 * Pass in bakeFlags parameter to {@link #spriteBake(Sprite, int)}.
 	 */
 	int BAKE_ROTATE_90 = 1;
 
 	/**
-	 * Causes texture to appear rotated 180 deg. relative to nominal face.
+	 * When enabled, causes texture to appear rotated 180 degrees.
 	 * Pass in bakeFlags parameter to {@link #spriteBake(Sprite, int)}.
 	 */
 	int BAKE_ROTATE_180 = 2;
 
 	/**
-	 * Causes texture to appear rotated 270 deg. clockwise relative to nominal face.
+	 * When enabled, causes texture to appear rotated 270 degrees clockwise.
 	 * Pass in bakeFlags parameter to {@link #spriteBake(Sprite, int)}.
 	 */
 	int BAKE_ROTATE_270 = 3;
 
 	/**
-	 * When enabled, texture coordinate are assigned based on vertex position.
-	 * Any existing UV coordinates will be replaced.
+	 * When enabled, texture coordinates are assigned based on vertex positions and the
+	 * {@linkplain #nominalFace() nominal face}.
+	 * Any existing UV coordinates will be replaced and the {@link #BAKE_NORMALIZED} flag will be ignored.
 	 * Pass in bakeFlags parameter to {@link #spriteBake(Sprite, int)}.
 	 *
-	 * <p>UV lock always derives texture coordinates based on nominal face, even
-	 * when the quad is not co-planar with that face, and the result is
-	 * the same as if the quad were projected onto the nominal face, which
-	 * is usually the desired result.
+	 * <p>UV lock derives texture coordinates based on {@linkplain #nominalFace() nominal face} by projecting the quad
+	 * onto it, even when the quad is not co-planar with it. This flag is ignored if the normal face is {@code null}.
 	 */
 	int BAKE_LOCK_UV = 4;
 
 	/**
-	 * When set, U texture coordinates for the given sprite are
+	 * When enabled, U texture coordinates for the given sprite are
 	 * flipped as part of baking. Can be useful for some randomization
 	 * and texture mapping scenarios. Results are different from what
-	 * can be obtained via rotation and both can be applied.
+	 * can be obtained via rotation and both can be applied. Any
+	 * rotation is applied before this flag.
 	 * Pass in bakeFlags parameter to {@link #spriteBake(Sprite, int)}.
 	 */
 	int BAKE_FLIP_U = 8;
@@ -168,7 +170,10 @@ public interface MutableQuadView extends QuadView {
 	 * Can handle UV locking, rotation, interpolation, etc. Control this behavior
 	 * by passing additive combinations of the BAKE_ flags defined in this interface.
 	 */
-	MutableQuadView spriteBake(Sprite sprite, int bakeFlags);
+	default MutableQuadView spriteBake(Sprite sprite, int bakeFlags) {
+		QuadSpriteBaker.bakeSprite(this, sprite, bakeFlags);
+		return this;
+	}
 
 	/**
 	 * Accept vanilla lightmap values.  Input values will override lightmap values

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/mesh/QuadEmitter.java
@@ -78,7 +78,10 @@ public interface QuadEmitter extends MutableQuadView {
 	}
 
 	@Override
-	QuadEmitter spriteBake(Sprite sprite, int bakeFlags);
+	default QuadEmitter spriteBake(Sprite sprite, int bakeFlags) {
+		MutableQuadView.super.spriteBake(sprite, bakeFlags);
+		return this;
+	}
 
 	default QuadEmitter uvUnitSquare() {
 		uv(0, 0, 0);

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/FabricBlockModelPart.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/FabricBlockModelPart.java
@@ -18,7 +18,6 @@ package net.fabricmc.fabric.api.renderer.v1.model;
 
 import java.util.function.Predicate;
 
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.BlockState;
@@ -32,15 +31,15 @@ import net.fabricmc.fabric.api.renderer.v1.Renderer;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 
 /**
- * Note: This interface is automatically implemented on all block model parts via Mixin and interface injection.
+ * Note: This interface is automatically implemented on {@link BlockModelPart} via Mixin and interface injection.
  */
-@ApiStatus.Experimental
 public interface FabricBlockModelPart {
 	/**
 	 * Produces this model part's geometry. <b>This method must be called instead of
-	 * {@link BlockModelPart#getQuads(Direction)}; the vanilla method should be considered deprecated as it may not
-	 * produce accurate results.</b> However, it is acceptable for a custom model part to only implement the vanilla
-	 * method as the default implementation of this method will delegate to the vanilla method.
+	 * {@link BlockModelPart#getQuads(Direction)} and {@link BlockModelPart#useAmbientOcclusion()}; the vanilla methods
+	 * should be considered deprecated as they may not produce accurate results.</b> However, it is acceptable for a
+	 * custom model part to only implement the vanilla methods as the default implementation of this method will
+	 * delegate to the vanilla methods.
 	 *
 	 * <p>This method mainly exists for convenience when interacting with parts implemented and produced by vanilla
 	 * code. Custom models should generally override

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/FabricBlockStateModel.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/FabricBlockStateModel.java
@@ -41,7 +41,7 @@ import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
  *
  * <p>Implementors should have a look at {@link ModelHelper} as it contains many useful functions.
  *
- * <p>Note: This interface is automatically implemented on all block state models via Mixin and interface injection.
+ * <p>Note: This interface is automatically implemented on {@link BlockStateModel} via Mixin and interface injection.
  */
 public interface FabricBlockStateModel {
 	/**

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/MeshBakedGeometry.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/MeshBakedGeometry.java
@@ -18,21 +18,24 @@ package net.fabricmc.fabric.api.renderer.v1.model;
 
 import java.util.List;
 
-import org.jetbrains.annotations.ApiStatus;
-
 import net.minecraft.client.render.model.BakedGeometry;
 import net.minecraft.client.render.model.BakedQuad;
+import net.minecraft.client.render.model.Baker;
+import net.minecraft.client.render.model.Geometry;
+import net.minecraft.client.render.model.ModelBakeSettings;
+import net.minecraft.client.render.model.ModelTextures;
+import net.minecraft.client.render.model.SimpleModel;
 
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
 
 /**
- * A special {@link BakedGeometry} which hides a {@link Mesh} instead of using {@link BakedQuad}s. Instances of this
- * class always return empty lists from inherited methods.
+ * A special {@link BakedGeometry} which hides a {@link Mesh} instead of using {@link BakedQuad}s. Useful for custom
+ * implementations of {@link Geometry#bake(ModelTextures, Baker, ModelBakeSettings, SimpleModel)} that want to return a
+ * mesh. Instances of this class always return empty lists from inherited methods.
  *
  * <p>Any code that interacts with {@link BakedGeometry} should first check {@code instanceof MeshBakedGeometry} and use
  * {@link #getMesh()} if {@code true} or the vanilla methods otherwise.
  */
-@ApiStatus.Experimental
 public final class MeshBakedGeometry extends BakedGeometry {
 	private final Mesh mesh;
 

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/ModelBakeSettingsHelper.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/ModelBakeSettingsHelper.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.renderer.v1.model;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import org.joml.Matrix3f;
+import org.joml.Matrix4f;
+import org.joml.Matrix4fc;
+import org.joml.Vector3f;
+import org.joml.Vector4f;
+
+import net.minecraft.client.render.model.Geometry;
+import net.minecraft.client.render.model.ModelBakeSettings;
+import net.minecraft.client.render.model.ModelRotation;
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.util.math.AffineTransformation;
+import net.minecraft.util.math.AffineTransformations;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.MatrixUtil;
+
+import net.fabricmc.fabric.api.renderer.v1.mesh.QuadTransform;
+
+/**
+ * Utilities to make it easier to work with {@link ModelBakeSettings}.
+ */
+public final class ModelBakeSettingsHelper {
+	private static final Direction[] DIRECTIONS = Direction.values();
+
+	private ModelBakeSettingsHelper() {
+	}
+
+	/**
+	 * Creates a new {@link ModelBakeSettings} using the given transformation and enables UV lock if specified. Works
+	 * exactly like {@link ModelRotation}, but allows an arbitrary transformation. Instances should be retained and
+	 * reused, especially if UV lock is enabled, to avoid redoing costly computations.
+	 */
+	public static ModelBakeSettings of(AffineTransformation transformation, boolean uvLock) {
+		Matrix4fc matrix = transformation.getMatrix();
+
+		if (MatrixUtil.isIdentity(matrix)) {
+			return ModelRotation.X0_Y0;
+		}
+
+		if (!uvLock) {
+			return new ModelBakeSettings() {
+				@Override
+				public AffineTransformation getRotation() {
+					return transformation;
+				}
+			};
+		}
+
+		Map<Direction, Matrix4fc> faceTransformations = new EnumMap<>(Direction.class);
+		Map<Direction, Matrix4fc> inverseFaceTransformations = new EnumMap<>(Direction.class);
+
+		for (Direction face : DIRECTIONS) {
+			Matrix4fc faceTransformation = AffineTransformations.getTransformed(transformation, face).getMatrix();
+			faceTransformations.put(face, faceTransformation);
+			inverseFaceTransformations.put(face, faceTransformation.invert(new Matrix4f()));
+		}
+
+		return new ModelBakeSettings() {
+			@Override
+			public AffineTransformation getRotation() {
+				return transformation;
+			}
+
+			@Override
+			public Matrix4fc forward(Direction face) {
+				return faceTransformations.get(face);
+			}
+
+			@Override
+			public Matrix4fc reverse(Direction face) {
+				return inverseFaceTransformations.get(face);
+			}
+		};
+	}
+
+	/**
+	 * Creates a new {@link ModelBakeSettings} that is the product of the two given settings. Settings are represented
+	 * by matrices, so this method follows the rules of matrix multiplication, namely that applying the resulting
+	 * settings is (mostly) equivalent to applying the right settings and then the left settings. The only exception
+	 * during standard application is cull face transformation, as the result must be clamped. Thus, applying a single
+	 * premultiplied transformation generally yields better results than multiple applications.
+	 */
+	public static ModelBakeSettings multiply(ModelBakeSettings left, ModelBakeSettings right) {
+		// Assumes face transformations are identity if main transformation is identity
+		if (MatrixUtil.isIdentity(left.getRotation().getMatrix())) {
+			return right;
+		} else if (MatrixUtil.isIdentity(right.getRotation().getMatrix())) {
+			return left;
+		}
+
+		AffineTransformation transformation = left.getRotation().multiply(right.getRotation());
+
+		boolean leftHasFaceTransformations = false;
+		boolean rightHasFaceTransformations = false;
+
+		// Assumes inverse face transformations are exactly inverse of regular face transformations
+		for (Direction face : DIRECTIONS) {
+			if (!leftHasFaceTransformations && !MatrixUtil.isIdentity(left.forward(face))) {
+				leftHasFaceTransformations = true;
+			}
+
+			if (!rightHasFaceTransformations && !MatrixUtil.isIdentity(right.forward(face))) {
+				rightHasFaceTransformations = true;
+			}
+		}
+
+		if (leftHasFaceTransformations & rightHasFaceTransformations) {
+			Map<Direction, Matrix4fc> faceTransformations = new EnumMap<>(Direction.class);
+			Map<Direction, Matrix4fc> inverseFaceTransformations = new EnumMap<>(Direction.class);
+
+			for (Direction face : DIRECTIONS) {
+				faceTransformations.put(face, left.forward(face).mul(right.forward(face), new Matrix4f()));
+				inverseFaceTransformations.put(face, right.reverse(face).mul(left.reverse(face), new Matrix4f()));
+			}
+
+			return new ModelBakeSettings() {
+				@Override
+				public AffineTransformation getRotation() {
+					return transformation;
+				}
+
+				@Override
+				public Matrix4fc forward(Direction face) {
+					return faceTransformations.get(face);
+				}
+
+				@Override
+				public Matrix4fc reverse(Direction face) {
+					return inverseFaceTransformations.get(face);
+				}
+			};
+		}
+
+		ModelBakeSettings faceTransformDelegate = leftHasFaceTransformations ? left : right;
+
+		return new ModelBakeSettings() {
+			@Override
+			public AffineTransformation getRotation() {
+				return transformation;
+			}
+
+			@Override
+			public Matrix4fc forward(Direction face) {
+				return faceTransformDelegate.forward(face);
+			}
+
+			@Override
+			public Matrix4fc reverse(Direction face) {
+				return faceTransformDelegate.reverse(face);
+			}
+		};
+	}
+
+	/**
+	 * Creates a new {@link QuadTransform} that applies the given transformation. The sprite finder is used to look up
+	 * the current sprite to correctly apply UV lock, if present in the transformation.
+	 *
+	 * <p>This method is most useful when creating custom implementations of {@link Geometry}, which receive a
+	 * {@link ModelBakeSettings}.
+	 */
+	public static QuadTransform asQuadTransform(ModelBakeSettings settings, SpriteFinder spriteFinder) {
+		Matrix4fc matrix = settings.getRotation().getMatrix();
+
+		// Assumes face transformations are identity if main transformation is identity
+		if (MatrixUtil.isIdentity(matrix)) {
+			return q -> true;
+		}
+
+		Matrix3f normalMatrix = matrix.normal(new Matrix3f());
+
+		Vector4f vec4 = new Vector4f();
+		Vector3f vec3 = new Vector3f();
+
+		return quad -> {
+			Direction lightFace = quad.lightFace();
+			Matrix4fc reverseMatrix = settings.reverse(lightFace);
+
+			if (!MatrixUtil.isIdentity(reverseMatrix)) {
+				Sprite sprite = spriteFinder.find(quad);
+
+				for (int vertexIndex = 0; vertexIndex < 4; vertexIndex++) {
+					float frameU = sprite.getFrameFromU(quad.u(vertexIndex));
+					float frameV = sprite.getFrameFromV(quad.v(vertexIndex));
+					vec3.set(frameU - 0.5f, frameV - 0.5f, 0.0f);
+					reverseMatrix.transformPosition(vec3);
+					frameU = vec3.x + 0.5f;
+					frameV = vec3.y + 0.5f;
+					quad.uv(vertexIndex, sprite.getFrameU(frameU), sprite.getFrameV(frameV));
+				}
+			}
+
+			for (int vertexIndex = 0; vertexIndex < 4; vertexIndex++) {
+				vec4.set(quad.x(vertexIndex) - 0.5f, quad.y(vertexIndex) - 0.5f, quad.z(vertexIndex) - 0.5f, 1.0f);
+				vec4.mul(matrix);
+				quad.pos(vertexIndex, vec4.x + 0.5f, vec4.y + 0.5f, vec4.z + 0.5f);
+
+				if (quad.hasNormal(vertexIndex)) {
+					quad.copyNormal(vertexIndex, vec3);
+					vec3.mul(normalMatrix);
+					vec3.normalize();
+					quad.normal(vertexIndex, vec3);
+				}
+			}
+
+			Direction cullFace = quad.cullFace();
+
+			if (cullFace != null) {
+				quad.cullFace(Direction.transform(matrix, cullFace));
+			}
+
+			return true;
+		};
+	}
+}

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/ModelHelper.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/ModelHelper.java
@@ -71,7 +71,7 @@ public final class ModelHelper {
 	 * <p>Retrieves sprites from the block texture atlas via {@link SpriteFinder}.
 	 */
 	public static List<BakedQuad>[] toQuadLists(Mesh mesh) {
-		SpriteFinder finder = SpriteFinder.get(MinecraftClient.getInstance().getBakedModelManager().getAtlas(SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE));
+		SpriteFinder finder = MinecraftClient.getInstance().getBakedModelManager().getAtlas(SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE).spriteFinder();
 
 		@SuppressWarnings("unchecked")
 		final ImmutableList.Builder<BakedQuad>[] builders = new ImmutableList.Builder[7];
@@ -80,12 +80,10 @@ public final class ModelHelper {
 			builders[i] = ImmutableList.builder();
 		}
 
-		if (mesh != null) {
-			mesh.forEach(q -> {
-				Direction cullFace = q.cullFace();
-				builders[cullFace == null ? NULL_FACE_ID : cullFace.getIndex()].add(q.toBakedQuad(finder.find(q)));
-			});
-		}
+		mesh.forEach(q -> {
+			Direction cullFace = q.cullFace();
+			builders[cullFace == null ? NULL_FACE_ID : cullFace.getIndex()].add(q.toBakedQuad(finder.find(q)));
+		});
 
 		@SuppressWarnings("unchecked")
 		List<BakedQuad>[] result = new List[7];

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/SpriteFinder.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/SpriteFinder.java
@@ -16,35 +16,42 @@
 
 package net.fabricmc.fabric.api.renderer.v1.model;
 
+import java.util.function.Predicate;
+
 import org.jetbrains.annotations.ApiStatus;
 
+import net.minecraft.block.BlockState;
+import net.minecraft.client.render.model.ErrorCollectingSpriteGetter;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.texture.SpriteAtlasTexture;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.world.BlockRenderView;
 
-import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
 import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
+import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadView;
-import net.fabricmc.fabric.impl.renderer.SpriteFinderImpl;
+import net.fabricmc.fabric.api.renderer.v1.sprite.FabricAtlasPreparation;
+import net.fabricmc.fabric.api.renderer.v1.sprite.FabricErrorCollectingSpriteGetter;
+import net.fabricmc.fabric.api.renderer.v1.sprite.FabricSpriteAtlasTexture;
+import net.fabricmc.fabric.api.renderer.v1.sprite.FabricStitchResult;
 
 /**
- * Indexes a texture atlas to allow fast lookup of Sprites from
- * baked vertex coordinates.  Main use is for {@link Mesh}-based models
- * to generate vanilla quads on demand without tracking and retaining
- * the sprites that were baked into the mesh. In other words, this class
- * supplies the sprite parameter for {@link QuadView#toBakedQuad(Sprite)}.
+ * Indexes a texture atlas to allow fast lookup of {@link Sprite}s from baked texture coordinates.
+ *
+ * <p>Example use cases include interpolating the textures of a submodel's quads in
+ * {@link FabricBlockStateModel#emitQuads(QuadEmitter, BlockRenderView, BlockPos, BlockState, Random, Predicate)} or
+ * finding the sprite for use in {@link QuadView#toBakedQuad(Sprite)}.
+ *
+ * <p>A sprite finder can be retrieved from various vanilla objects. Always use
+ * {@link FabricErrorCollectingSpriteGetter#spriteFinder(Identifier)}, {@link FabricStitchResult#spriteFinder()}, or
+ * {@link FabricAtlasPreparation#spriteFinder()} whenever an applicable instance is available. For example, model
+ * baking is supplied with a {@link ErrorCollectingSpriteGetter}, so it should be used to retrieve the sprite finder.
+ * In most other cases, it is safe to use {@link FabricSpriteAtlasTexture#spriteFinder()}.
  */
 @ApiStatus.NonExtendable
 public interface SpriteFinder {
-	/**
-	 * Retrieves or creates the finder for the given atlas.
-	 * Instances should not be retained as fields, or they must be
-	 * refreshed whenever there is a resource reload or other event
-	 * that causes atlas textures to be re-stitched.
-	 */
-	static SpriteFinder get(SpriteAtlasTexture atlas) {
-		return SpriteFinderImpl.get(atlas);
-	}
-
 	/**
 	 * Finds the atlas sprite containing the vertex centroid of the quad.
 	 * Vertex centroid is essentially the mean u,v coordinate - the intent being
@@ -68,6 +75,14 @@ public interface SpriteFinder {
 	 * faster if you already have the centroid or another appropriate value.
 	 */
 	Sprite find(float u, float v);
+
+	/**
+	 * @deprecated Use {@link FabricSpriteAtlasTexture#spriteFinder()} instead.
+	 */
+	@Deprecated
+	static SpriteFinder get(SpriteAtlasTexture atlas) {
+		return atlas.spriteFinder();
+	}
 
 	/**
 	 * @deprecated Use {@link #find(QuadView)} instead.

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/FabricBlockModelRenderer.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/FabricBlockModelRenderer.java
@@ -36,7 +36,7 @@ import net.fabricmc.fabric.api.renderer.v1.Renderer;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 
 /**
- * Note: This interface is automatically implemented on all block model renderers via Mixin and interface injection.
+ * Note: This interface is automatically implemented on {@link BlockModelRenderer} via Mixin and interface injection.
  */
 public interface FabricBlockModelRenderer {
 	/**

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/FabricBlockRenderManager.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/FabricBlockRenderManager.java
@@ -33,7 +33,7 @@ import net.fabricmc.fabric.api.renderer.v1.Renderer;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 
 /**
- * Note: This interface is automatically implemented on all block render managers via Mixin and interface injection.
+ * Note: This interface is automatically implemented on {@link BlockRenderManager} via Mixin and interface injection.
  */
 public interface FabricBlockRenderManager {
 	/**

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/FabricLayerRenderState.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/FabricLayerRenderState.java
@@ -25,7 +25,8 @@ import net.fabricmc.fabric.api.renderer.v1.Renderer;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 
 /**
- * Note: This interface is automatically implemented on all layer render states via Mixin and interface injection.
+ * Note: This interface is automatically implemented on {@link ItemRenderState.LayerRenderState} via Mixin and interface
+ * injection.
  */
 public interface FabricLayerRenderState {
 	/**

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/RenderLayerHelper.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/RenderLayerHelper.java
@@ -20,6 +20,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.RenderLayers;
 import net.minecraft.client.render.TexturedRenderLayers;
+import net.minecraft.client.render.VertexConsumerProvider;
 
 public final class RenderLayerHelper {
 	private RenderLayerHelper() {
@@ -39,5 +40,21 @@ public final class RenderLayerHelper {
 	 */
 	public static RenderLayer getEntityBlockLayer(RenderLayer chunkRenderLayer) {
 		return chunkRenderLayer == RenderLayer.getTranslucent() ? TexturedRenderLayers.getItemEntityTranslucentCull() : TexturedRenderLayers.getEntityCutout();
+	}
+
+	/**
+	 * Wraps the given provider, converting {@linkplain RenderLayer#getBlockLayers() block layers} to render layers
+	 * using {@link #getMovingBlockLayer(RenderLayer)}.
+	 */
+	public static VertexConsumerProvider movingDelegate(VertexConsumerProvider vertexConsumers) {
+		return chunkRenderLayer -> vertexConsumers.getBuffer(RenderLayerHelper.getMovingBlockLayer(chunkRenderLayer));
+	}
+
+	/**
+	 * Wraps the given provider, converting {@linkplain RenderLayer#getBlockLayers() block layers} to render layers
+	 * using {@link #getEntityBlockLayer(RenderLayer)}.
+	 */
+	public static VertexConsumerProvider entityDelegate(VertexConsumerProvider vertexConsumers) {
+		return chunkRenderLayer -> vertexConsumers.getBuffer(RenderLayerHelper.getEntityBlockLayer(chunkRenderLayer));
 	}
 }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/sprite/FabricAtlasPreparation.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/sprite/FabricAtlasPreparation.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.renderer.v1.sprite;
+
+import net.minecraft.client.render.model.SpriteAtlasManager;
+
+import net.fabricmc.fabric.api.renderer.v1.model.SpriteFinder;
+
+/**
+ * Note: This interface is automatically implemented on {@link SpriteAtlasManager.AtlasPreparation} via Mixin and interface injection.
+ */
+public interface FabricAtlasPreparation {
+	/**
+	 * {@return the sprite finder for this atlas preparation}
+	 */
+	default SpriteFinder spriteFinder() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/sprite/FabricErrorCollectingSpriteGetter.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/sprite/FabricErrorCollectingSpriteGetter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.renderer.v1.sprite;
+
+import net.minecraft.client.render.model.ErrorCollectingSpriteGetter;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.api.renderer.v1.model.SpriteFinder;
+
+/**
+ * Note: This interface is automatically implemented on {@link ErrorCollectingSpriteGetter} via Mixin and interface injection.
+ */
+public interface FabricErrorCollectingSpriteGetter {
+	/**
+	 * {@return the sprite finder for the given atlas ID}
+	 */
+	default SpriteFinder spriteFinder(Identifier atlasId) {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/sprite/FabricSpriteAtlasTexture.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/sprite/FabricSpriteAtlasTexture.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.renderer.v1.sprite;
+
+import net.minecraft.client.texture.SpriteAtlasTexture;
+import net.minecraft.client.texture.SpriteLoader;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.api.renderer.v1.model.SpriteFinder;
+
+/**
+ * Note: This interface is automatically implemented on {@link SpriteAtlasTexture} via Mixin and interface injection.
+ */
+public interface FabricSpriteAtlasTexture {
+	/**
+	 * Retrieves the sprite finder for this atlas. The returned instance is only valid until the next call to
+	 * {@link SpriteAtlasTexture#upload(SpriteLoader.StitchResult)}, and thus should not be persisted across resource
+	 * reloads.
+	 *
+	 * <p><b>This method should not be used during a resource reload</b> as this atlas will only be populated with new
+	 * sprites towards the end of the resource reload. In this case, use
+	 * {@link FabricErrorCollectingSpriteGetter#spriteFinder(Identifier)}, {@link FabricStitchResult#spriteFinder()},
+	 * or {@link FabricAtlasPreparation#spriteFinder()} instead.
+	 *
+	 * @return the sprite finder for this atlas
+	 */
+	default SpriteFinder spriteFinder() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/sprite/FabricStitchResult.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/sprite/FabricStitchResult.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.renderer.v1.sprite;
+
+import net.minecraft.client.texture.SpriteLoader;
+
+import net.fabricmc.fabric.api.renderer.v1.model.SpriteFinder;
+
+/**
+ * Note: This interface is automatically implemented on {@link SpriteLoader.StitchResult} via Mixin and interface injection.
+ */
+public interface FabricStitchResult {
+	/**
+	 * {@return the sprite finder for this stitch result}
+	 */
+	default SpriteFinder spriteFinder() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/impl/renderer/QuadSpriteBaker.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/impl/renderer/QuadSpriteBaker.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.impl.client.indigo.renderer.helper;
+package net.fabricmc.fabric.impl.renderer;
 
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.util.math.Direction;
@@ -23,11 +23,10 @@ import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
 
 /**
  * Handles most texture-baking use cases for model loaders and model libraries
- * via {@link #bakeSprite(MutableQuadView, Sprite, int)}. Also used by the API
- * itself to implement automatic block-breaking models for enhanced models.
+ * via {@link #bakeSprite(MutableQuadView, Sprite, int)}.
  */
-public final class TextureHelper {
-	private TextureHelper() { }
+public final class QuadSpriteBaker {
+	private QuadSpriteBaker() { }
 
 	private static final float NORMALIZER = 1f / 16f;
 
@@ -101,11 +100,11 @@ public final class TextureHelper {
 	private static final VertexModifier[] UVLOCKERS = new VertexModifier[6];
 
 	static {
-		UVLOCKERS[Direction.EAST.getIndex()] = (q, i) -> q.uv(i, 1 - q.z(i), 1 - q.y(i));
-		UVLOCKERS[Direction.WEST.getIndex()] = (q, i) -> q.uv(i, q.z(i), 1 - q.y(i));
-		UVLOCKERS[Direction.NORTH.getIndex()] = (q, i) -> q.uv(i, 1 - q.x(i), 1 - q.y(i));
-		UVLOCKERS[Direction.SOUTH.getIndex()] = (q, i) -> q.uv(i, q.x(i), 1 - q.y(i));
 		UVLOCKERS[Direction.DOWN.getIndex()] = (q, i) -> q.uv(i, q.x(i), 1 - q.z(i));
 		UVLOCKERS[Direction.UP.getIndex()] = (q, i) -> q.uv(i, q.x(i), q.z(i));
+		UVLOCKERS[Direction.NORTH.getIndex()] = (q, i) -> q.uv(i, 1 - q.x(i), 1 - q.y(i));
+		UVLOCKERS[Direction.SOUTH.getIndex()] = (q, i) -> q.uv(i, q.x(i), 1 - q.y(i));
+		UVLOCKERS[Direction.WEST.getIndex()] = (q, i) -> q.uv(i, q.z(i), 1 - q.y(i));
+		UVLOCKERS[Direction.EAST.getIndex()] = (q, i) -> q.uv(i, 1 - q.z(i), 1 - q.y(i));
 	}
 }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/impl/renderer/StitchResultExtension.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/impl/renderer/StitchResultExtension.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.renderer;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.fabricmc.fabric.api.renderer.v1.model.SpriteFinder;
+
+public interface StitchResultExtension {
+	@Nullable
+	SpriteFinder fabric_spriteFinderNullable();
+}

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/block/render/FallingBlockEntityRendererMixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/block/render/FallingBlockEntityRendererMixin.java
@@ -57,7 +57,7 @@ abstract class FallingBlockEntityRendererMixin extends EntityRenderer<FallingBlo
 
 			BlockStateModel model = blockRenderManager.getModel(blockState);
 			long seed = blockState.getRenderingSeed(renderState.fallingBlockPos);
-			blockRenderManager.getModelRenderer().render(renderState, model, blockState, renderState.currentPos, matrixStack, layer -> vertexConsumers.getBuffer(RenderLayerHelper.getMovingBlockLayer(layer)), false, seed, OverlayTexture.DEFAULT_UV);
+			blockRenderManager.getModelRenderer().render(renderState, model, blockState, renderState.currentPos, matrixStack, RenderLayerHelper.movingDelegate(vertexConsumers), false, seed, OverlayTexture.DEFAULT_UV);
 
 			matrixStack.pop();
 			super.render(renderState, matrixStack, vertexConsumers, light);

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/block/render/PistonBlockEntityRendererMixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/block/render/PistonBlockEntityRendererMixin.java
@@ -40,6 +40,6 @@ abstract class PistonBlockEntityRendererMixin {
 	// Support multi-render layer models.
 	@Overwrite
 	private void renderModel(BlockPos pos, BlockState state, MatrixStack matrices, VertexConsumerProvider vertexConsumers, World world, boolean cull, int overlay) {
-		manager.getModelRenderer().render(world, manager.getModel(state), state, pos, matrices, layer -> vertexConsumers.getBuffer(RenderLayerHelper.getMovingBlockLayer(layer)), cull, state.getRenderingSeed(pos), overlay);
+		manager.getModelRenderer().render(world, manager.getModel(state), state, pos, matrices, RenderLayerHelper.movingDelegate(vertexConsumers), cull, state.getRenderingSeed(pos), overlay);
 	}
 }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/block/render/SnowGolemPumpkinFeatureRendererMixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/block/render/SnowGolemPumpkinFeatureRendererMixin.java
@@ -52,7 +52,7 @@ abstract class SnowGolemPumpkinFeatureRendererMixin {
 			FabricBlockModelRenderer.render(entry, layer -> vertexConsumer, model, 1, 1, 1, light, overlay, EmptyBlockRenderView.INSTANCE, BlockPos.ORIGIN, blockState);
 		} else {
 			// Support multi-render layer models, fix tinted quads being rendered completely black, and provide the BlockState as context.
-			FabricBlockModelRenderer.render(entry, layer -> vertexConsumers.getBuffer(RenderLayerHelper.getEntityBlockLayer(layer)), model, 1, 1, 1, light, overlay, EmptyBlockRenderView.INSTANCE, BlockPos.ORIGIN, blockState);
+			FabricBlockModelRenderer.render(entry, RenderLayerHelper.entityDelegate(vertexConsumers), model, 1, 1, 1, light, overlay, EmptyBlockRenderView.INSTANCE, BlockPos.ORIGIN, blockState);
 		}
 	}
 }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/item/BasicItemModelMixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/item/BasicItemModelMixin.java
@@ -29,7 +29,6 @@ import net.minecraft.client.render.item.model.BasicItemModel;
 import net.minecraft.client.render.item.model.ItemModel;
 
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
-import net.fabricmc.fabric.api.renderer.v1.render.FabricLayerRenderState;
 import net.fabricmc.fabric.impl.renderer.BasicItemModelExtension;
 
 @Mixin(BasicItemModel.class)
@@ -41,7 +40,7 @@ abstract class BasicItemModelMixin implements ItemModel, BasicItemModelExtension
 	@Inject(method = "update", at = @At("RETURN"))
 	private void onReturnUpdate(CallbackInfo ci, @Local ItemRenderState.LayerRenderState layer) {
 		if (mesh != null) {
-			mesh.outputTo(((FabricLayerRenderState) layer).emitter());
+			mesh.outputTo(layer.emitter());
 		}
 	}
 

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/sprite/BakedModelManager1Mixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/sprite/BakedModelManager1Mixin.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.renderer.client.sprite;
+
+import java.util.Map;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.client.render.model.ErrorCollectingSpriteGetter;
+import net.minecraft.client.render.model.SpriteAtlasManager;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.api.renderer.v1.model.SpriteFinder;
+
+@Mixin(targets = "net/minecraft/client/render/model/BakedModelManager$1")
+abstract class BakedModelManager1Mixin implements ErrorCollectingSpriteGetter {
+	@Shadow
+	@Final
+	Map<Identifier, SpriteAtlasManager.AtlasPreparation> field_55477;
+
+	@Override
+	public SpriteFinder spriteFinder(Identifier atlasId) {
+		return field_55477.get(atlasId).spriteFinder();
+	}
+}

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/sprite/ErrorCollectingSpriteGetterMixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/sprite/ErrorCollectingSpriteGetterMixin.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.renderer.client.sprite;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import net.minecraft.client.render.model.ErrorCollectingSpriteGetter;
+
+import net.fabricmc.fabric.api.renderer.v1.sprite.FabricErrorCollectingSpriteGetter;
+
+@Mixin(ErrorCollectingSpriteGetter.class)
+interface ErrorCollectingSpriteGetterMixin extends FabricErrorCollectingSpriteGetter {
+}

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/sprite/SpriteAtlasManagerAtlasPreparationMixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/sprite/SpriteAtlasManagerAtlasPreparationMixin.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.renderer.client.sprite;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.client.render.model.SpriteAtlasManager;
+import net.minecraft.client.texture.SpriteLoader;
+
+import net.fabricmc.fabric.api.renderer.v1.model.SpriteFinder;
+import net.fabricmc.fabric.api.renderer.v1.sprite.FabricAtlasPreparation;
+
+@Mixin(SpriteAtlasManager.AtlasPreparation.class)
+abstract class SpriteAtlasManagerAtlasPreparationMixin implements FabricAtlasPreparation {
+	@Shadow
+	@Final
+	private SpriteLoader.StitchResult stitchResult;
+
+	@Override
+	public SpriteFinder spriteFinder() {
+		return stitchResult.spriteFinder();
+	}
+}

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/sprite/SpriteAtlasTextureMixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/sprite/SpriteAtlasTextureMixin.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.renderer.client.sprite;
+
+import java.util.Map;
+
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.client.texture.SpriteAtlasTexture;
+import net.minecraft.client.texture.SpriteLoader;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.api.renderer.v1.model.SpriteFinder;
+import net.fabricmc.fabric.api.renderer.v1.sprite.FabricSpriteAtlasTexture;
+import net.fabricmc.fabric.impl.renderer.SpriteFinderImpl;
+import net.fabricmc.fabric.impl.renderer.StitchResultExtension;
+
+@Mixin(SpriteAtlasTexture.class)
+abstract class SpriteAtlasTextureMixin implements FabricSpriteAtlasTexture {
+	@Shadow
+	@Final
+	private Map<Identifier, Sprite> sprites;
+	@Shadow
+	@Final
+	@Nullable
+	private Sprite missingSprite;
+
+	@Unique
+	@Nullable
+	private volatile SpriteFinder spriteFinder;
+
+	@Inject(at = @At("RETURN"), method = "upload")
+	private void uploadHook(SpriteLoader.StitchResult stitchResult, CallbackInfo ci) {
+		// Clear this atlas' old finder. If the finder was already initialized in the stitch result, reuse it for this
+		// atlas.
+		spriteFinder = ((StitchResultExtension) (Object) stitchResult).fabric_spriteFinderNullable();
+	}
+
+	@Override
+	public SpriteFinder spriteFinder() {
+		SpriteFinder result = spriteFinder;
+
+		if (result == null) {
+			synchronized (this) {
+				result = spriteFinder;
+
+				if (result == null) {
+					if (missingSprite == null) {
+						throw new IllegalStateException("Tried to create sprite finder, but atlas is not initialized");
+					}
+
+					spriteFinder = result = new SpriteFinderImpl(sprites, missingSprite);
+				}
+			}
+		}
+
+		return result;
+	}
+}

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/sprite/SpriteLoaderStitchResultMixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/sprite/SpriteLoaderStitchResultMixin.java
@@ -14,46 +14,57 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.mixin.renderer.client;
+package net.fabricmc.fabric.mixin.renderer.client.sprite;
 
 import java.util.Map;
 
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.Unique;
 
 import net.minecraft.client.texture.Sprite;
-import net.minecraft.client.texture.SpriteAtlasTexture;
 import net.minecraft.client.texture.SpriteLoader;
 import net.minecraft.util.Identifier;
 
+import net.fabricmc.fabric.api.renderer.v1.model.SpriteFinder;
+import net.fabricmc.fabric.api.renderer.v1.sprite.FabricStitchResult;
 import net.fabricmc.fabric.impl.renderer.SpriteFinderImpl;
+import net.fabricmc.fabric.impl.renderer.StitchResultExtension;
 
-@Mixin(SpriteAtlasTexture.class)
-public class SpriteAtlasTextureMixin implements SpriteFinderImpl.SpriteFinderAccess {
-	@Final
+@Mixin(SpriteLoader.StitchResult.class)
+abstract class SpriteLoaderStitchResultMixin implements FabricStitchResult, StitchResultExtension {
 	@Shadow
-	private Map<Identifier, Sprite> sprites;
+	@Final
+	private Sprite missing;
+	@Shadow
+	@Final
+	private Map<Identifier, Sprite> regions;
 
-	private SpriteFinderImpl fabric_spriteFinder = null;
-
-	@Inject(at = @At("RETURN"), method = "upload")
-	private void uploadHook(SpriteLoader.StitchResult arg, CallbackInfo ci) {
-		fabric_spriteFinder = null;
-	}
+	@Unique
+	@Nullable
+	private volatile SpriteFinder spriteFinder;
 
 	@Override
-	public SpriteFinderImpl fabric_spriteFinder() {
-		SpriteFinderImpl result = fabric_spriteFinder;
+	public SpriteFinder spriteFinder() {
+		SpriteFinder result = spriteFinder;
 
 		if (result == null) {
-			result = new SpriteFinderImpl(sprites, (SpriteAtlasTexture) (Object) this);
-			fabric_spriteFinder = result;
+			synchronized (this) {
+				result = spriteFinder;
+
+				if (result == null) {
+					spriteFinder = result = new SpriteFinderImpl(regions, missing);
+				}
+			}
 		}
 
 		return result;
+	}
+
+	@Nullable
+	public SpriteFinder fabric_spriteFinderNullable() {
+		return spriteFinder;
 	}
 }

--- a/fabric-renderer-api-v1/src/client/resources/fabric-renderer-api-v1.mixins.json
+++ b/fabric-renderer-api-v1/src/client/resources/fabric-renderer-api-v1.mixins.json
@@ -3,7 +3,6 @@
   "package": "net.fabricmc.fabric.mixin.renderer",
   "compatibilityLevel": "JAVA_21",
   "client": [
-    "client.SpriteAtlasTextureMixin",
     "client.block.model.BlockModelPartMixin",
     "client.block.model.BlockStateModelMixin",
     "client.block.model.GeometryBakedModelMixin",
@@ -24,7 +23,12 @@
     "client.block.render.SnowGolemPumpkinFeatureRendererMixin",
     "client.item.BasicItemModelMixin",
     "client.item.BasicItemModelUnbakedMixin",
-    "client.item.ItemRenderStateLayerRenderStateMixin"
+    "client.item.ItemRenderStateLayerRenderStateMixin",
+    "client.sprite.BakedModelManager1Mixin",
+    "client.sprite.ErrorCollectingSpriteGetterMixin",
+    "client.sprite.SpriteAtlasManagerAtlasPreparationMixin",
+    "client.sprite.SpriteAtlasTextureMixin",
+    "client.sprite.SpriteLoaderStitchResultMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/fabric-renderer-api-v1/src/client/resources/fabric.mod.json
+++ b/fabric-renderer-api-v1/src/client/resources/fabric.mod.json
@@ -37,7 +37,11 @@
       "net/minecraft/class_1087": ["net/fabricmc/fabric/api/renderer/v1/model/FabricBlockStateModel"],
       "net/minecraft/class_778": ["net/fabricmc/fabric/api/renderer/v1/render/FabricBlockModelRenderer"],
       "net/minecraft/class_776": ["net/fabricmc/fabric/api/renderer/v1/render/FabricBlockRenderManager"],
-      "net/minecraft/class_10444\u0024class_10446": ["net/fabricmc/fabric/api/renderer/v1/render/FabricLayerRenderState"]
+      "net/minecraft/class_10444\u0024class_10446": ["net/fabricmc/fabric/api/renderer/v1/render/FabricLayerRenderState"],
+      "net/minecraft/class_4724\u0024class_7774": ["net/fabricmc/fabric/api/renderer/v1/sprite/FabricAtlasPreparation"],
+      "net/minecraft/class_9826": ["net/fabricmc/fabric/api/renderer/v1/sprite/FabricErrorCollectingSpriteGetter"],
+      "net/minecraft/class_1059": ["net/fabricmc/fabric/api/renderer/v1/sprite/FabricSpriteAtlasTexture"],
+      "net/minecraft/class_7766\u0024class_7767": ["net/fabricmc/fabric/api/renderer/v1/sprite/FabricStitchResult"]
     }
   }
 }

--- a/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/OctagonalColumnBlock.java
+++ b/fabric-renderer-api-v1/src/testmod/java/net/fabricmc/fabric/test/renderer/OctagonalColumnBlock.java
@@ -18,10 +18,11 @@ package net.fabricmc.fabric.test.renderer;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.PillarBlock;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
 
-public class OctagonalColumnBlock extends Block {
+public class OctagonalColumnBlock extends PillarBlock {
 	public static final BooleanProperty VANILLA_SHADE_MODE = BooleanProperty.of("vanilla_shade_mode");
 
 	public OctagonalColumnBlock(Settings settings) {
@@ -31,6 +32,7 @@ public class OctagonalColumnBlock extends Block {
 
 	@Override
 	protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
+		super.appendProperties(builder);
 		builder.add(VANILLA_SHADE_MODE);
 	}
 }

--- a/fabric-renderer-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/renderer/client/FrameGeometry.java
+++ b/fabric-renderer-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/renderer/client/FrameGeometry.java
@@ -23,6 +23,7 @@ import net.minecraft.client.render.model.ModelBakeSettings;
 import net.minecraft.client.render.model.ModelTextures;
 import net.minecraft.client.render.model.SimpleModel;
 import net.minecraft.client.texture.Sprite;
+import net.minecraft.client.texture.SpriteAtlasTexture;
 import net.minecraft.util.math.Direction;
 
 import net.fabricmc.fabric.api.renderer.v1.Renderer;
@@ -32,12 +33,14 @@ import net.fabricmc.fabric.api.renderer.v1.mesh.MutableMesh;
 import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.renderer.v1.model.MeshBakedGeometry;
+import net.fabricmc.fabric.api.renderer.v1.model.ModelBakeSettingsHelper;
 
 public record FrameGeometry(boolean emissive) implements Geometry {
 	@Override
 	public BakedGeometry bake(ModelTextures textures, Baker baker, ModelBakeSettings settings, SimpleModel model) {
 		MutableMesh builder = Renderer.get().mutableMesh();
 		QuadEmitter emitter = builder.emitter();
+		emitter.pushTransform(ModelBakeSettingsHelper.asQuadTransform(settings, baker.getSpriteGetter().spriteFinder(SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE)));
 
 		MaterialFinder finder = Renderer.get().materialFinder();
 		RenderMaterial material = finder.emissive(emissive).find();

--- a/fabric-renderer-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/renderer/client/OctagonalColumnGeometry.java
+++ b/fabric-renderer-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/renderer/client/OctagonalColumnGeometry.java
@@ -23,6 +23,7 @@ import net.minecraft.client.render.model.ModelBakeSettings;
 import net.minecraft.client.render.model.ModelTextures;
 import net.minecraft.client.render.model.SimpleModel;
 import net.minecraft.client.texture.Sprite;
+import net.minecraft.client.texture.SpriteAtlasTexture;
 import net.minecraft.util.math.Direction;
 
 import net.fabricmc.fabric.api.renderer.v1.Renderer;
@@ -34,6 +35,7 @@ import net.fabricmc.fabric.api.renderer.v1.mesh.MutableMesh;
 import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.renderer.v1.model.MeshBakedGeometry;
+import net.fabricmc.fabric.api.renderer.v1.model.ModelBakeSettingsHelper;
 
 public record OctagonalColumnGeometry(ShadeMode shadeMode) implements Geometry {
 	// (B - A) is the side length of a regular octagon that fits in a unit square.
@@ -45,6 +47,7 @@ public record OctagonalColumnGeometry(ShadeMode shadeMode) implements Geometry {
 	public BakedGeometry bake(ModelTextures textures, Baker baker, ModelBakeSettings settings, SimpleModel model) {
 		MutableMesh builder = Renderer.get().mutableMesh();
 		QuadEmitter emitter = builder.emitter();
+		emitter.pushTransform(ModelBakeSettingsHelper.asQuadTransform(settings, baker.getSpriteGetter().spriteFinder(SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE)));
 
 		MaterialFinder finder = Renderer.get().materialFinder();
 		RenderMaterial glintMaterial = finder.glintMode(GlintMode.STANDARD).shadeMode(shadeMode).find();

--- a/fabric-renderer-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/renderer/client/PillarGeometry.java
+++ b/fabric-renderer-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/renderer/client/PillarGeometry.java
@@ -23,6 +23,7 @@ import net.minecraft.client.render.model.ModelBakeSettings;
 import net.minecraft.client.render.model.ModelTextures;
 import net.minecraft.client.render.model.SimpleModel;
 import net.minecraft.client.texture.Sprite;
+import net.minecraft.client.texture.SpriteAtlasTexture;
 import net.minecraft.util.math.Direction;
 
 import net.fabricmc.fabric.api.renderer.v1.Renderer;
@@ -30,12 +31,14 @@ import net.fabricmc.fabric.api.renderer.v1.mesh.MutableMesh;
 import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.renderer.v1.model.MeshBakedGeometry;
+import net.fabricmc.fabric.api.renderer.v1.model.ModelBakeSettingsHelper;
 
 public record PillarGeometry() implements Geometry {
 	@Override
 	public BakedGeometry bake(ModelTextures textures, Baker baker, ModelBakeSettings settings, SimpleModel model) {
 		MutableMesh builder = Renderer.get().mutableMesh();
 		QuadEmitter emitter = builder.emitter();
+		emitter.pushTransform(ModelBakeSettingsHelper.asQuadTransform(settings, baker.getSpriteGetter().spriteFinder(SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE)));
 
 		Sprite sprite = baker.getSpriteGetter().get(textures.get("pillar"), model);
 

--- a/fabric-renderer-api-v1/src/testmodClient/resources/assets/fabric-renderer-api-v1-testmod/blockstates/octagonal_column.json
+++ b/fabric-renderer-api-v1/src/testmodClient/resources/assets/fabric-renderer-api-v1-testmod/blockstates/octagonal_column.json
@@ -1,6 +1,28 @@
 {
   "variants": {
-    "vanilla_shade_mode=false": { "model": "fabric-renderer-api-v1-testmod:octagonal_column_enhanced" },
-    "vanilla_shade_mode=true": { "model": "fabric-renderer-api-v1-testmod:octagonal_column_vanilla" }
+    "axis=x,vanilla_shade_mode=false": {
+      "model": "fabric-renderer-api-v1-testmod:octagonal_column_enhanced",
+      "x": 90,
+      "y": 90
+    },
+    "axis=x,vanilla_shade_mode=true": {
+      "model": "fabric-renderer-api-v1-testmod:octagonal_column_vanilla",
+      "x": 90,
+      "y": 90
+    },
+    "axis=y,vanilla_shade_mode=false": {
+      "model": "fabric-renderer-api-v1-testmod:octagonal_column_enhanced"
+    },
+    "axis=y,vanilla_shade_mode=true": {
+      "model": "fabric-renderer-api-v1-testmod:octagonal_column_vanilla"
+    },
+    "axis=z,vanilla_shade_mode=false": {
+      "model": "fabric-renderer-api-v1-testmod:octagonal_column_enhanced",
+      "x": 90
+    },
+    "axis=z,vanilla_shade_mode=true": {
+      "model": "fabric-renderer-api-v1-testmod:octagonal_column_vanilla",
+      "x": 90
+    }
   }
 }

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/IndigoRenderer.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/IndigoRenderer.java
@@ -108,7 +108,7 @@ public class IndigoRenderer implements Renderer {
 			float red = (tint >> 16 & 255) / 255.0F;
 			float green = (tint >> 8 & 255) / 255.0F;
 			float blue = (tint & 255) / 255.0F;
-			FabricBlockModelRenderer.render(matrices.peek(), layer -> vertexConsumers.getBuffer(RenderLayerHelper.getEntityBlockLayer(layer)), model, red, green, blue, light, overlay, blockView, pos, state);
+			FabricBlockModelRenderer.render(matrices.peek(), RenderLayerHelper.entityDelegate(vertexConsumers), model, red, green, blue, light, overlay, blockView, pos, state);
 			((BlockRenderManagerAccessor) renderManager).getBlockEntityModelsGetter().get().render(state.getBlock(), ItemDisplayContext.NONE, matrices, vertexConsumers, light, overlay);
 		}
 	}

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/aocalc/AoFace.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/aocalc/AoFace.java
@@ -127,8 +127,9 @@ enum AoFace {
 
 	final Direction[] neighbors;
 	/**
-	 * Vanilla models with cubic quads have vertices in a certain order, which allows
-	 * us to map them using a lookup.
+	 * Cubic quads have a vertex in each corner, which allows us to skip computing
+	 * weights and map values to vertices directly. Note that vanilla assumes a
+	 * certain vertex order, but we detect it and offset the map accordingly.
 	 */
 	final int[] vertexMap;
 

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/aocalc/AoFaceData.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/aocalc/AoFaceData.java
@@ -54,31 +54,37 @@ class AoFaceData {
 		this.s3 = (l3 >>> 16) & 0xFFFF;
 	}
 
-	int weigtedBlockLight(float[] w) {
+	int weightedBlockLight(float[] w) {
 		return (int) (b0 * w[0] + b1 * w[1] + b2 * w[2] + b3 * w[3]) & 0xFF;
 	}
 
-	int weigtedSkyLight(float[] w) {
+	int weightedSkyLight(float[] w) {
 		return (int) (s0 * w[0] + s1 * w[1] + s2 * w[2] + s3 * w[3]) & 0xFF;
 	}
 
 	int weightedCombinedLight(float[] w) {
-		return weigtedSkyLight(w) << 16 | weigtedBlockLight(w);
+		return weightedSkyLight(w) << 16 | weightedBlockLight(w);
 	}
 
-	float weigtedAo(float[] w) {
+	float weightedAo(float[] w) {
 		return a0 * w[0] + a1 * w[1] + a2 * w[2] + a3 * w[3];
 	}
 
-	void toArray(float[] aOut, int[] bOut, int[] vertexMap) {
-		aOut[vertexMap[0]] = a0;
-		aOut[vertexMap[1]] = a1;
-		aOut[vertexMap[2]] = a2;
-		aOut[vertexMap[3]] = a3;
-		bOut[vertexMap[0]] = s0 << 16 | b0;
-		bOut[vertexMap[1]] = s1 << 16 | b1;
-		bOut[vertexMap[2]] = s2 << 16 | b2;
-		bOut[vertexMap[3]] = s3 << 16 | b3;
+	void toArrays(float[] aoOut, int[] lightOut, int[] vertexMap, int vertexOffset) {
+		int i0 = vertexMap[vertexOffset];
+		int i1 = vertexMap[(vertexOffset + 1) % 4];
+		int i2 = vertexMap[(vertexOffset + 2) % 4];
+		int i3 = vertexMap[(vertexOffset + 3) % 4];
+
+		aoOut[i0] = a0;
+		aoOut[i1] = a1;
+		aoOut[i2] = a2;
+		aoOut[i3] = a3;
+
+		lightOut[i0] = s0 << 16 | b0;
+		lightOut[i1] = s1 << 16 | b1;
+		lightOut[i2] = s2 << 16 | b2;
+		lightOut[i3] = s3 << 16 | b3;
 	}
 
 	static AoFaceData weightedMean(AoFaceData in0, float w0, AoFaceData in1, float w1, AoFaceData out) {

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
@@ -32,7 +32,6 @@ import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.client.render.LightmapTextureManager;
 import net.minecraft.client.render.model.BakedQuad;
-import net.minecraft.client.texture.Sprite;
 import net.minecraft.util.math.Direction;
 
 import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
@@ -42,7 +41,6 @@ import net.fabricmc.fabric.api.renderer.v1.mesh.QuadView;
 import net.fabricmc.fabric.impl.client.indigo.renderer.IndigoRenderer;
 import net.fabricmc.fabric.impl.client.indigo.renderer.helper.ColorHelper;
 import net.fabricmc.fabric.impl.client.indigo.renderer.helper.NormalHelper;
-import net.fabricmc.fabric.impl.client.indigo.renderer.helper.TextureHelper;
 import net.fabricmc.fabric.impl.client.indigo.renderer.material.RenderMaterialImpl;
 
 /**
@@ -118,12 +116,6 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 		final int i = baseIndex + vertexIndex * VERTEX_STRIDE + VERTEX_U;
 		data[i] = Float.floatToRawIntBits(u);
 		data[i + 1] = Float.floatToRawIntBits(v);
-		return this;
-	}
-
-	@Override
-	public final MutableQuadViewImpl spriteBake(Sprite sprite, int bakeFlags) {
-		TextureHelper.bakeSprite(this, sprite, bakeFlags);
 		return this;
 	}
 

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
@@ -89,8 +89,8 @@ public class ItemRenderContext extends AbstractRenderContext {
 
 		final int vanillaQuadCount = vanillaQuads.size();
 
-		for (int j = 0; j < vanillaQuadCount; j++) {
-			final BakedQuad q = vanillaQuads.get(j);
+		for (int i = 0; i < vanillaQuadCount; i++) {
+			final BakedQuad q = vanillaQuads.get(i);
 			emitter.fromVanilla(q, IndigoRenderer.STANDARD_MATERIAL, null);
 			emitter.emit();
 		}

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/mixin/client/indigo/renderer/BlockRenderManagerMixin.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/mixin/client/indigo/renderer/BlockRenderManagerMixin.java
@@ -54,6 +54,6 @@ abstract class BlockRenderManagerMixin {
 
 	@Redirect(method = "renderBlockAsEntity(Lnet/minecraft/block/BlockState;Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;II)V", at = @At(value = "INVOKE", target = "net/minecraft/client/render/block/BlockModelRenderer.render(Lnet/minecraft/client/util/math/MatrixStack$Entry;Lnet/minecraft/client/render/VertexConsumer;Lnet/minecraft/client/render/model/BlockStateModel;FFFII)V"))
 	private void renderProxy(MatrixStack.Entry entry, VertexConsumer vertexConsumer, BlockStateModel model, float red, float green, float blue, int light, int overlay, BlockState state, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light1, int overlay1) {
-		FabricBlockModelRenderer.render(entry, layer -> vertexConsumers.getBuffer(RenderLayerHelper.getEntityBlockLayer(layer)), model, red, green, blue, light, overlay, EmptyBlockRenderView.INSTANCE, BlockPos.ORIGIN, state);
+		FabricBlockModelRenderer.render(entry, RenderLayerHelper.entityDelegate(vertexConsumers), model, red, green, blue, light, overlay, EmptyBlockRenderView.INSTANCE, BlockPos.ORIGIN, state);
 	}
 }


### PR DESCRIPTION
- Allow retrieving `SpriteFinder`s from `ErrorCollectingSpriteGetter`, `SpriteLoader.StitchResult`, and `SpriteAtlasManager.AtlasPreparation`
- Add injected interfaces to allow retrieving `SpriteFinder`s directly
- Ensure lazily initialization of sprite finders is completely thread safe
- Provide a default implementation for `MutableQuadView/QuadEmitter.spriteBake`
- Add `ModelBakeSettingsHelper`, which has methods for creating `ModelBakeSettings` from an arbitrary matrix, multiplying two `ModelBakeSettings`, and converting a `ModelBakeSettings` into a `QuadTransform`
- Make fast smooth lighting computation for cubic quads aligned to their light face work correctly regardless of vertex order
- Remove `ApitStatus.Experimental` annotations
- Deprecate `Renderer.emitBlockModelPartQuads` for removal
- Fix `GeometryBakedModel.emitQuads` not applying instance AO boolean when using `MeshBakedGeometry`
- Add `RenderLayerHelper.movingDelegate/entityDelegate` helpers and use them where appropriate