### PR TITLE
Call AFTER_PLAYER_CHANGE_WORLD on respawn in different world

### DIFF
--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerEntityWorldChangeEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerEntityWorldChangeEvents.java
@@ -49,7 +49,10 @@ public final class ServerEntityWorldChangeEvents {
 	 * An event which is called after a player has been moved to a different world.
 	 *
 	 * <p>This is similar to {@link ServerEntityWorldChangeEvents#AFTER_ENTITY_CHANGE_WORLD} but is only called for players.
-	 * This is because the player is physically moved to the new world instead of being recreated at the destination.
+	 * This is because the player is usually physically moved to the new world instead of being recreated at the destination.
+	 *
+	 * <p>However, there is one exception to this. When the player respawns in a different world, the player is recreated at the destination. When that happens,
+	 * this event passes in the new {@link ServerPlayerEntity}. If you need the old {@link ServerPlayerEntity}, see {@link ServerPlayerEvents#AFTER_RESPAWN}
 	 *
 	 * @see ServerEntityWorldChangeEvents#AFTER_ENTITY_CHANGE_WORLD
 	 */

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/PlayerManagerMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/PlayerManagerMixin.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.mixin.entity.event;
 
+import net.fabricmc.fabric.api.entity.event.v1.ServerEntityWorldChangeEvents;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -29,8 +31,14 @@ import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
 
 @Mixin(PlayerManager.class)
 abstract class PlayerManagerMixin {
+
 	@Inject(method = "respawnPlayer", at = @At("TAIL"))
 	private void afterRespawn(ServerPlayerEntity oldPlayer, boolean alive, Entity.RemovalReason removalReason, CallbackInfoReturnable<ServerPlayerEntity> cir) {
-		ServerPlayerEvents.AFTER_RESPAWN.invoker().afterRespawn(oldPlayer, cir.getReturnValue(), alive);
+		ServerPlayerEntity newPlayer = cir.getReturnValue();
+		ServerPlayerEvents.AFTER_RESPAWN.invoker().afterRespawn(oldPlayer, newPlayer, alive);
+
+		if (oldPlayer.getServerWorld() != newPlayer.getServerWorld()) {
+			ServerEntityWorldChangeEvents.AFTER_PLAYER_CHANGE_WORLD.invoker().afterChangeWorld(newPlayer, oldPlayer.getServerWorld(), newPlayer.getServerWorld());
+		}
 	}
 }

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/PlayerManagerMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/PlayerManagerMixin.java
@@ -16,8 +16,6 @@
 
 package net.fabricmc.fabric.mixin.entity.event;
 
-import net.fabricmc.fabric.api.entity.event.v1.ServerEntityWorldChangeEvents;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -27,11 +25,11 @@ import net.minecraft.entity.Entity;
 import net.minecraft.server.PlayerManager;
 import net.minecraft.server.network.ServerPlayerEntity;
 
+import net.fabricmc.fabric.api.entity.event.v1.ServerEntityWorldChangeEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
 
 @Mixin(PlayerManager.class)
 abstract class PlayerManagerMixin {
-
 	@Inject(method = "respawnPlayer", at = @At("TAIL"))
 	private void afterRespawn(ServerPlayerEntity oldPlayer, boolean alive, Entity.RemovalReason removalReason, CallbackInfoReturnable<ServerPlayerEntity> cir) {
 		ServerPlayerEntity newPlayer = cir.getReturnValue();


### PR DESCRIPTION
Currently, the AFTER_PLAYER_CHANGE_WORLD event does not fire when a player respawns in a different world. This causes a problem for Data Attachment syncing as that API relies on this event to sync world attachments correctly.

This PR fires the event on player respawn if the world the player respawns in is different.