### PR TITLE
[1.21.1] Backport world attachment sync fix from #4366

### DIFF
--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/sync/AttachmentSync.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/sync/AttachmentSync.java
@@ -29,6 +29,7 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.entity.event.v1.ServerEntityWorldChangeEvents;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.api.networking.v1.ServerConfigurationConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerConfigurationNetworking;
@@ -107,6 +108,17 @@ public class AttachmentSync implements ModInitializer {
 			((AttachmentTargetImpl) player.getServerWorld()).fabric_computeInitialSyncChanges(player, changes::add);
 			// sync player's own persistent attachments that couldn't be synced earlier
 			((AttachmentTargetImpl) player).fabric_computeInitialSyncChanges(player, changes::add);
+
+			if (!changes.isEmpty()) {
+				AttachmentChange.partitionAndSendPackets(changes, player);
+			}
+		});
+
+		ServerEntityWorldChangeEvents.AFTER_PLAYER_CHANGE_WORLD.register((player, origin, destination) -> {
+			// sync new world's attachments
+			// no conflict with previous one because the client world is recreated every time
+			List<AttachmentChange> changes = new ArrayList<>();
+			((AttachmentTargetImpl) destination).fabric_computeInitialSyncChanges(player, changes::add);
 
 			if (!changes.isEmpty()) {
 				AttachmentChange.partitionAndSendPackets(changes, player);


### PR DESCRIPTION
Backports only the world attachment sync fix from #4366 to 1.21.1

Somewhat related to #4658