### PR TITLE
Fix Bug in LootTableEvents.MODIFY_DROPS causing inline loot tables to always throw (Breaking Change)

### DIFF
--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/api/loot/v3/LootTableEvents.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/api/loot/v3/LootTableEvents.java
@@ -106,9 +106,9 @@ public final class LootTableEvents {
 	 * and don't wish to add a custom loot function to every table.
 	 * <br/>Note: if the table was requested to separate drops into stacks of a given size, the resulting drops from this event will be separated.
 	 */
-	public static final Event<ModifyDrops> MODIFY_DROPS = EventFactory.createArrayBacked(ModifyDrops.class, listeners -> (key, context, drops) -> {
+	public static final Event<ModifyDrops> MODIFY_DROPS = EventFactory.createArrayBacked(ModifyDrops.class, listeners -> (entry, context, drops) -> {
 		for (ModifyDrops listener : listeners) {
-			listener.modifyLootTableDrops(key, context, drops);
+			listener.modifyLootTableDrops(entry, context, drops);
 		}
 	});
 
@@ -155,10 +155,10 @@ public final class LootTableEvents {
 	public interface ModifyDrops {
 		/**
 		 * Called after a loot table is finished generating drops to modify drops.
-		 * @param entry the loot table's registry entry
+		 * @param entry the loot table's registry entry. This will be a {@link RegistryEntry.Reference} if the lootTable is registered, and {@link RegistryEntry.Direct} if it is not, and should not be
 		 * @param context the loot context for the current drops
 		 * @param drops the list of drops from the loot table to modify
 		 */
-		void modifyLootTableDrops(RegistryEntry.Reference<LootTable> entry, LootContext context, List<ItemStack> drops);
+		void modifyLootTableDrops(RegistryEntry<LootTable> entry, LootContext context, List<ItemStack> drops);
 	}
 }

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/api/loot/v3/LootTableEvents.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/api/loot/v3/LootTableEvents.java
@@ -155,7 +155,7 @@ public final class LootTableEvents {
 	public interface ModifyDrops {
 		/**
 		 * Called after a loot table is finished generating drops to modify drops.
-		 * @param entry the loot table's registry entry. This will be a {@link RegistryEntry.Reference} if the lootTable is registered, and {@link RegistryEntry.Direct} if it is not, and should not be
+		 * @param entry the loot table's registry entry. This will be a {@link RegistryEntry.Reference} if the lootTable is registered, or {@link RegistryEntry.Direct} if the table is inline
 		 * @param context the loot context for the current drops
 		 * @param drops the list of drops from the loot table to modify
 		 */

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/api/loot/v3/LootTableEvents.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/api/loot/v3/LootTableEvents.java
@@ -155,7 +155,7 @@ public final class LootTableEvents {
 	public interface ModifyDrops {
 		/**
 		 * Called after a loot table is finished generating drops to modify drops.
-		 * @param entry the loot table's registry entry. This will be a {@link RegistryEntry.Reference} if the lootTable is registered, or {@link RegistryEntry.Direct} if the table is inline
+		 * @param entry the loot table's registry entry. This will be a {@link RegistryEntry.Reference} if the lootTable is registered, or a {@link RegistryEntry.Direct} if the table is inline
 		 * @param context the loot context for the current drops
 		 * @param drops the list of drops from the loot table to modify
 		 */

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/FabricLootTable.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/FabricLootTable.java
@@ -20,5 +20,5 @@ import net.minecraft.loot.LootTable;
 import net.minecraft.registry.entry.RegistryEntry;
 
 public interface FabricLootTable {
-	void fabric$setRegistryEntry(RegistryEntry.Reference<LootTable> key);
+	void fabric$setRegistryEntry(RegistryEntry<LootTable> key);
 }

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootUtil.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootUtil.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.impl.loot;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 import net.minecraft.loot.LootTable;
 import net.minecraft.registry.RegistryKeys;
@@ -53,7 +54,7 @@ public final class LootUtil {
 		return LootTableSource.DATA_PACK;
 	}
 
-	public static RegistryEntry.Reference<LootTable> getEntry(ServerWorld world, LootTable table) {
+	public static RegistryEntry<LootTable> getEntryOrDirect(ServerWorld world, LootTable table) {
 		RegistryWrapper.WrapperLookup wrapperLookup = world
 				.getServer()
 				.getReloadableRegistries()
@@ -67,8 +68,7 @@ public final class LootUtil {
 				.streamEntries()
 				.filter(it -> it.value().equals(table))
 				.findFirst()
-				.orElseThrow(
-						() -> new IllegalStateException("LootTable appears to be unregistered, but has been asked to generate loot")
-				);
+				.map(Function.<RegistryEntry<LootTable>>identity())
+				.orElseGet(() -> RegistryEntry.of(table));
 	}
 }

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/mixin/loot/LootTableMixin.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/mixin/loot/LootTableMixin.java
@@ -42,12 +42,12 @@ class LootTableMixin implements FabricLootTable {
 	 */
 	@Unique
 	@Nullable
-	RegistryEntry.Reference<LootTable> entry = null;
+	RegistryEntry<LootTable> entry = null;
 
 	@WrapMethod(method = "generateUnprocessedLoot(Lnet/minecraft/loot/context/LootContext;Ljava/util/function/Consumer;)V")
 	private void fabric$modifyDrops(LootContext context, Consumer<ItemStack> lootConsumer, Operation<Void> original) {
 		if (entry == null) {
-			this.entry = LootUtil.getEntry(context.getWorld(), (LootTable) (Object) this);
+			this.entry = LootUtil.getEntryOrDirect(context.getWorld(), (LootTable) (Object) this);
 		}
 
 		List<ItemStack> list = new ObjectArrayList<>();
@@ -61,7 +61,7 @@ class LootTableMixin implements FabricLootTable {
 	}
 
 	@Override
-	public void fabric$setRegistryEntry(RegistryEntry.Reference<LootTable> key) {
+	public void fabric$setRegistryEntry(RegistryEntry<LootTable> key) {
 		this.entry = key;
 	}
 }

--- a/fabric-loot-api-v3/src/testmod/java/net/fabricmc/fabric/test/loot/LootTest.java
+++ b/fabric-loot-api-v3/src/testmod/java/net/fabricmc/fabric/test/loot/LootTest.java
@@ -16,10 +16,15 @@
 
 package net.fabricmc.fabric.test.loot;
 
+import java.lang.ref.WeakReference;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.ParseResults;
 import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.apache.commons.lang3.mutable.MutableObject;
 
 import net.minecraft.block.Blocks;
 import net.minecraft.enchantment.Enchantment;
@@ -43,6 +48,9 @@ import net.minecraft.recipe.input.SingleStackRecipeInput;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.text.Text;
 
@@ -167,12 +175,50 @@ public class LootTest implements ModInitializer {
 			try {
 				recGuard.setTrue();
 
-				if (entry.registryKey().toString().contains("red")) { // all red blocks drop double
+				if (entry.getKey().map(it -> it.toString().contains("red")).orElse(false)) { // all red blocks drop double
 					entry.value().generateLoot(context, drops::add);
 				}
 			} finally {
 				recGuard.setFalse();
 			}
 		});
+		var recGuard2 = new MutableBoolean(false);
+		Function<MinecraftServer, Runnable> actionGetter = createActionCache("loot spawn 0 0 0 loot {\"pools\":[{\"entries\":[], \"rolls\":1.0}]}");
+		// test inline LootPools
+		LootTableEvents.MODIFY_DROPS.register((entry, context, drops) -> {
+			if (recGuard2.isTrue()) {
+				return;
+			}
+
+			try {
+				recGuard2.setTrue();
+				actionGetter.apply(context.getWorld().getServer()).run();
+			} finally {
+				recGuard2.setFalse();
+			}
+		});
+	}
+
+	@SuppressWarnings("SameParameterValue")
+	private Function<MinecraftServer, Runnable> createActionCache(String command) {
+		MutableObject<WeakReference<MinecraftServer>> stashedServer = new MutableObject<>();
+		MutableObject<Runnable> runnable = new MutableObject<>();
+		return server -> {
+			if (runnable.getValue() != null && stashedServer.getValue() != null && stashedServer.getValue().refersTo(server)) {
+				return runnable.getValue();
+			}
+
+			stashedServer.setValue(new WeakReference<>(server));
+			CommandManager manager = server.getCommandManager();
+			CommandDispatcher<ServerCommandSource> dispatcher = manager.getDispatcher();
+			ParseResults<ServerCommandSource> parseResults = dispatcher.parse(command, server.getCommandSource());
+
+			if (parseResults.getReader().canRead()) {
+				throw new IllegalStateException("Failed to Parse Command: " + parseResults);
+			}
+
+			runnable.setValue(() -> manager.execute(parseResults, command));
+			return runnable.getValue();
+		};
 	}
 }

--- a/fabric-loot-api-v3/src/testmod/java/net/fabricmc/fabric/test/loot/LootTest.java
+++ b/fabric-loot-api-v3/src/testmod/java/net/fabricmc/fabric/test/loot/LootTest.java
@@ -199,7 +199,6 @@ public class LootTest implements ModInitializer {
 		});
 	}
 
-	@SuppressWarnings("SameParameterValue")
 	private Function<MinecraftServer, Runnable> createActionCache(String command) {
 		MutableObject<WeakReference<MinecraftServer>> stashedServer = new MutableObject<>();
 		MutableObject<Runnable> runnable = new MutableObject<>();


### PR DESCRIPTION
Fixes #4681 by passing Direct entries when the table is unregistered and adds inline table tests to the tested