### PR TITLE
[1.21.6] Fix removed hud elements still rendering when replaced

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/hud/HudLayer.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/hud/HudLayer.java
@@ -27,15 +27,17 @@ public interface HudLayer {
 
 	HudElement element(HudElement vanillaElement);
 
+	boolean isRemoved();
+
 	static HudLayer ofVanilla(Identifier id) {
-		return of(id, Function.identity());
+		return of(id, Function.identity(), false);
 	}
 
 	static HudLayer ofElement(Identifier id, HudElement element) {
-		return of(id, $ -> element);
+		return of(id, $ -> element, false);
 	}
 
-	static HudLayer of(Identifier id, Function<HudElement, HudElement> operator) {
+	static HudLayer of(Identifier id, Function<HudElement, HudElement> operator, boolean isRemoved) {
 		return new HudLayer() {
 			@Override
 			public Identifier id() {
@@ -45,6 +47,11 @@ public interface HudLayer {
 			@Override
 			public HudElement element(HudElement vanillaElement) {
 				return operator.apply(vanillaElement);
+			}
+
+			@Override
+			public boolean isRemoved() {
+				return isRemoved;
 			}
 		};
 	}


### PR DESCRIPTION
From Discord:
> Crendgrim: Hm, I just came up with a potential issue with the HUD API. Let's say I have a mod that draws a glint on armour pieces if they are enchanted. So I replace the armour renderer, call the original renderer, and then put the glint on top. (Another example might be appleskin for saturation). But another mod (onebar, in the example that made me think about this) calls "removeElement" on the armour (/food) bar. Depending on mod load order, the behaviour will be different: either it will be fully gone, or the glint (drawn on top of the no-op) remains. I'm not sure if there is an easy fix, or if this is worth fixing in the first place..

> modmuss: Humm, if im reading this right I think the expected behaviour would be for nothing to render as the removeElement should take over.

> Crendgrim: If that was the reason, then my vote would be for a flag to enforce the no-op. At least to me, that seems like the more intuitive behaviour.

This PR implements the fix suggested by @Crendgrim.