### PR TITLE
Add `ScreenMouseEvents` for handling `Screen::mouseDragged`

### DIFF
--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenMouseEvents.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenMouseEvents.java
@@ -104,9 +104,48 @@ public final class ScreenMouseEvents {
 	}
 
 	/**
-	 * An event that is checks if the mouse should be allowed to scroll in a screen.
+	 * An event that checks if the mouse should be allowed to drag in a screen.
 	 *
-	 * <p>This event tracks amount of vertical and horizontal scroll.
+	 * <p>This event tracks the amount a mouse was dragged both vertically and horizontally.
+	 *
+	 * @return the event
+	 */
+	public static Event<AllowMouseDrag> allowMouseDrag(Screen screen) {
+		Objects.requireNonNull(screen, "Screen cannot be null");
+
+		return ScreenExtensions.getExtensions(screen).fabric_getAllowMouseDragEvent();
+	}
+
+	/**
+	 * An event called after mouse dragging is processed for a screen.
+	 *
+	 * <p>This event tracks the amount a mouse was dragged both vertically and horizontally.
+	 *
+	 * @return the event
+	 */
+	public static Event<BeforeMouseDrag> beforeMouseDrag(Screen screen) {
+		Objects.requireNonNull(screen, "Screen cannot be null");
+
+		return ScreenExtensions.getExtensions(screen).fabric_getBeforeMouseDragEvent();
+	}
+
+	/**
+	 * An event called after mouse dragging is processed for a screen.
+	 *
+	 * <p>This event tracks the amount a mouse was dragged both vertically and horizontally.
+	 *
+	 * @return the event
+	 */
+	public static Event<AfterMouseDrag> afterMouseDrag(Screen screen) {
+		Objects.requireNonNull(screen, "Screen cannot be null");
+
+		return ScreenExtensions.getExtensions(screen).fabric_getAfterMouseDragEvent();
+	}
+
+	/**
+	 * An event that checks if the mouse should be allowed to scroll in a screen.
+	 *
+	 * <p>This event tracks the amount a mouse was scrolled both vertically and horizontally.
 	 *
 	 * @return the event
 	 */
@@ -117,9 +156,9 @@ public final class ScreenMouseEvents {
 	}
 
 	/**
-	 * An event that is called after mouse scrolling is processed for a screen.
+	 * An event called before mouse scrolling is processed for a screen.
 	 *
-	 * <p>This event tracks amount of vertical and horizontal scroll.
+	 * <p>This event tracks the amount a mouse was scrolled both vertically and horizontally.
 	 *
 	 * @return the event
 	 */
@@ -130,9 +169,9 @@ public final class ScreenMouseEvents {
 	}
 
 	/**
-	 * An event that is called after mouse scrolling is processed for a screen.
+	 * An event called after mouse scrolling is processed for a screen.
 	 *
-	 * <p>This event tracks amount a mouse was scrolled both vertically and horizontally.
+	 * <p>This event tracks the amount a mouse was scrolled both vertically and horizontally.
 	 *
 	 * @return the event
 	 */
@@ -148,10 +187,12 @@ public final class ScreenMouseEvents {
 	@FunctionalInterface
 	public interface AllowMouseClick {
 		/**
+		 * Checks if the mouse click should be allowed in a screen.
+		 *
+		 * @param screen the screen
 		 * @param mouseX the x position of the mouse
 		 * @param mouseY the y position of the mouse
 		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}.
-		 * @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		 */
 		boolean allowMouseClick(Screen screen, double mouseX, double mouseY, int button);
 	}
@@ -159,10 +200,12 @@ public final class ScreenMouseEvents {
 	@FunctionalInterface
 	public interface BeforeMouseClick {
 		/**
+		 * Called before a mouse click in a screen.
+		 *
+		 * @param screen the screen
 		 * @param mouseX the x position of the mouse
 		 * @param mouseY the y position of the mouse
 		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}.
-		 * @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		 */
 		void beforeMouseClick(Screen screen, double mouseX, double mouseY, int button);
 	}
@@ -170,10 +213,12 @@ public final class ScreenMouseEvents {
 	@FunctionalInterface
 	public interface AfterMouseClick {
 		/**
+		 * Called after a mouse click in a screen.
+		 *
+		 * @param screen the screen
 		 * @param mouseX the x position of the mouse
 		 * @param mouseY the y position of the mouse
 		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}.
-		 * @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		 */
 		void afterMouseClick(Screen screen, double mouseX, double mouseY, int button);
 	}
@@ -183,10 +228,10 @@ public final class ScreenMouseEvents {
 		/**
 		 * Checks if the mouse click should be allowed to release in a screen.
 		 *
+		 * @param screen the screen
 		 * @param mouseX the x position of the mouse
 		 * @param mouseY the y position of the mouse
 		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}.
-		 * @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		 */
 		boolean allowMouseRelease(Screen screen, double mouseX, double mouseY, int button);
 	}
@@ -196,10 +241,10 @@ public final class ScreenMouseEvents {
 		/**
 		 * Called before a mouse click has released in a screen.
 		 *
+		 * @param screen the screen
 		 * @param mouseX the x position of the mouse
 		 * @param mouseY the y position of the mouse
 		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}.
-		 * @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		 */
 		void beforeMouseRelease(Screen screen, double mouseX, double mouseY, int button);
 	}
@@ -209,12 +254,59 @@ public final class ScreenMouseEvents {
 		/**
 		 * Called after a mouse click has released in a screen.
 		 *
+		 * @param screen the screen
 		 * @param mouseX the x position of the mouse
 		 * @param mouseY the y position of the mouse
 		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}.
-		 * @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		 */
 		void afterMouseRelease(Screen screen, double mouseX, double mouseY, int button);
+	}
+
+	@FunctionalInterface
+	public interface AllowMouseDrag {
+		/**
+		 * Checks if the mouse should be allowed to drag in a screen by moving the cursor while a mouse button is held
+		 * down.
+		 *
+		 * @param screen the screen
+		 * @param mouseX the x position of the mouse
+		 * @param mouseY the y position of the mouse
+		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}.
+		 * @param horizontalAmount the horizontal drag amount
+		 * @param verticalAmount the vertical drag amount
+		 * @return whether the mouse should be allowed to drag
+		 */
+		boolean allowMouseDrag(Screen screen, double mouseX, double mouseY, int button, double horizontalAmount, double verticalAmount);
+	}
+
+	@FunctionalInterface
+	public interface BeforeMouseDrag {
+		/**
+		 * Called before a mouse is dragged on screen.
+		 *
+		 * @param screen the screen
+		 * @param mouseX the x position of the mouse
+		 * @param mouseY the y position of the mouse
+		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}.
+		 * @param horizontalAmount the horizontal drag amount
+		 * @param verticalAmount the vertical drag amount
+		 */
+		void beforeMouseDrag(Screen screen, double mouseX, double mouseY, int button, double horizontalAmount, double verticalAmount);
+	}
+
+	@FunctionalInterface
+	public interface AfterMouseDrag {
+		/**
+		 * Called after a mouse is dragged on screen.
+		 *
+		 * @param screen the screen
+		 * @param mouseX the x position of the mouse
+		 * @param mouseY the y position of the mouse
+		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}.
+		 * @param horizontalAmount the horizontal drag amount
+		 * @param verticalAmount the vertical drag amount
+		 */
+		void afterMouseDrag(Screen screen, double mouseX, double mouseY, int button, double horizontalAmount, double verticalAmount);
 	}
 
 	@FunctionalInterface
@@ -222,6 +314,7 @@ public final class ScreenMouseEvents {
 		/**
 		 * Checks if the mouse should be allowed to scroll in a screen.
 		 *
+		 * @param screen the screen
 		 * @param mouseX the x position of the mouse
 		 * @param mouseY the y position of the mouse
 		 * @param horizontalAmount the horizontal scroll amount
@@ -236,6 +329,7 @@ public final class ScreenMouseEvents {
 		/**
 		 * Called before a mouse has scrolled on screen.
 		 *
+		 * @param screen the screen
 		 * @param mouseX the x position of the mouse
 		 * @param mouseY the y position of the mouse
 		 * @param horizontalAmount the horizontal scroll amount
@@ -249,6 +343,7 @@ public final class ScreenMouseEvents {
 		/**
 		 * Called after a mouse has scrolled on screen.
 		 *
+		 * @param screen the screen
 		 * @param mouseX the x position of the mouse
 		 * @param mouseY the y position of the mouse
 		 * @param horizontalAmount the horizontal scroll amount

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenMouseEvents.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenMouseEvents.java
@@ -192,7 +192,8 @@ public final class ScreenMouseEvents {
 		 * @param screen the screen
 		 * @param mouseX the x position of the mouse
 		 * @param mouseY the y position of the mouse
-		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}.
+		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}
+		 * @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		 */
 		boolean allowMouseClick(Screen screen, double mouseX, double mouseY, int button);
 	}
@@ -205,7 +206,8 @@ public final class ScreenMouseEvents {
 		 * @param screen the screen
 		 * @param mouseX the x position of the mouse
 		 * @param mouseY the y position of the mouse
-		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}.
+		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}
+		 * @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		 */
 		void beforeMouseClick(Screen screen, double mouseX, double mouseY, int button);
 	}
@@ -218,7 +220,8 @@ public final class ScreenMouseEvents {
 		 * @param screen the screen
 		 * @param mouseX the x position of the mouse
 		 * @param mouseY the y position of the mouse
-		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}.
+		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}
+		 * @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		 */
 		void afterMouseClick(Screen screen, double mouseX, double mouseY, int button);
 	}
@@ -231,7 +234,8 @@ public final class ScreenMouseEvents {
 		 * @param screen the screen
 		 * @param mouseX the x position of the mouse
 		 * @param mouseY the y position of the mouse
-		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}.
+		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}
+		 * @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		 */
 		boolean allowMouseRelease(Screen screen, double mouseX, double mouseY, int button);
 	}
@@ -244,7 +248,8 @@ public final class ScreenMouseEvents {
 		 * @param screen the screen
 		 * @param mouseX the x position of the mouse
 		 * @param mouseY the y position of the mouse
-		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}.
+		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}
+		 * @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		 */
 		void beforeMouseRelease(Screen screen, double mouseX, double mouseY, int button);
 	}
@@ -257,7 +262,8 @@ public final class ScreenMouseEvents {
 		 * @param screen the screen
 		 * @param mouseX the x position of the mouse
 		 * @param mouseY the y position of the mouse
-		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}.
+		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}
+		 * @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		 */
 		void afterMouseRelease(Screen screen, double mouseX, double mouseY, int button);
 	}
@@ -271,10 +277,11 @@ public final class ScreenMouseEvents {
 		 * @param screen the screen
 		 * @param mouseX the x position of the mouse
 		 * @param mouseY the y position of the mouse
-		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}.
+		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}
 		 * @param horizontalAmount the horizontal drag amount
 		 * @param verticalAmount the vertical drag amount
 		 * @return whether the mouse should be allowed to drag
+		 * @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		 */
 		boolean allowMouseDrag(Screen screen, double mouseX, double mouseY, int button, double horizontalAmount, double verticalAmount);
 	}
@@ -287,9 +294,10 @@ public final class ScreenMouseEvents {
 		 * @param screen the screen
 		 * @param mouseX the x position of the mouse
 		 * @param mouseY the y position of the mouse
-		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}.
+		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}
 		 * @param horizontalAmount the horizontal drag amount
 		 * @param verticalAmount the vertical drag amount
+		 * @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		 */
 		void beforeMouseDrag(Screen screen, double mouseX, double mouseY, int button, double horizontalAmount, double verticalAmount);
 	}
@@ -302,9 +310,10 @@ public final class ScreenMouseEvents {
 		 * @param screen the screen
 		 * @param mouseX the x position of the mouse
 		 * @param mouseY the y position of the mouse
-		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}.
+		 * @param button the button number, which can be identified by the constants in {@link org.lwjgl.glfw.GLFW GLFW}
 		 * @param horizontalAmount the horizontal drag amount
 		 * @param verticalAmount the vertical drag amount
+		 * @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		 */
 		void afterMouseDrag(Screen screen, double mouseX, double mouseY, int button, double horizontalAmount, double verticalAmount);
 	}

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenEventFactory.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenEventFactory.java
@@ -182,6 +182,34 @@ public final class ScreenEventFactory {
 		});
 	}
 
+	public static Event<ScreenMouseEvents.AllowMouseDrag> createAllowMouseDragEvent() {
+		return EventFactory.createArrayBacked(ScreenMouseEvents.AllowMouseDrag.class, callbacks -> (screen, mouseX, mouseY, button, horizontalAmount, verticalAmount) -> {
+			for (ScreenMouseEvents.AllowMouseDrag callback : callbacks) {
+				if (!callback.allowMouseDrag(screen, mouseX, mouseY, button, horizontalAmount, verticalAmount)) {
+					return false;
+				}
+			}
+
+			return true;
+		});
+	}
+
+	public static Event<ScreenMouseEvents.BeforeMouseDrag> createBeforeMouseDragEvent() {
+		return EventFactory.createArrayBacked(ScreenMouseEvents.BeforeMouseDrag.class, callbacks -> (screen, mouseX, mouseY, button, horizontalAmount, verticalAmount) -> {
+			for (ScreenMouseEvents.BeforeMouseDrag callback : callbacks) {
+				callback.beforeMouseDrag(screen, mouseX, mouseY, button, horizontalAmount, verticalAmount);
+			}
+		});
+	}
+
+	public static Event<ScreenMouseEvents.AfterMouseDrag> createAfterMouseDragEvent() {
+		return EventFactory.createArrayBacked(ScreenMouseEvents.AfterMouseDrag.class, callbacks -> (screen, mouseX, mouseY, button, horizontalAmount, verticalAmount) -> {
+			for (ScreenMouseEvents.AfterMouseDrag callback : callbacks) {
+				callback.afterMouseDrag(screen, mouseX, mouseY, button, horizontalAmount, verticalAmount);
+			}
+		});
+	}
+
 	public static Event<ScreenMouseEvents.AllowMouseScroll> createAllowMouseScrollEvent() {
 		return EventFactory.createArrayBacked(ScreenMouseEvents.AllowMouseScroll.class, callbacks -> (screen, mouseX, mouseY, horizontalAmount, verticalAmount) -> {
 			for (ScreenMouseEvents.AllowMouseScroll callback : callbacks) {

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenExtensions.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenExtensions.java
@@ -71,6 +71,12 @@ public interface ScreenExtensions {
 
 	Event<ScreenMouseEvents.AfterMouseRelease> fabric_getAfterMouseReleaseEvent();
 
+	Event<ScreenMouseEvents.AllowMouseDrag> fabric_getAllowMouseDragEvent();
+
+	Event<ScreenMouseEvents.BeforeMouseDrag> fabric_getBeforeMouseDragEvent();
+
+	Event<ScreenMouseEvents.AfterMouseDrag> fabric_getAfterMouseDragEvent();
+
 	Event<ScreenMouseEvents.AllowMouseScroll> fabric_getAllowMouseScrollEvent();
 
 	Event<ScreenMouseEvents.BeforeMouseScroll> fabric_getBeforeMouseScrollEvent();

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/MouseMixin.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/MouseMixin.java
@@ -74,6 +74,29 @@ abstract class MouseMixin {
 		return result;
 	}
 
+	@WrapOperation(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;mouseDragged(DDIDD)Z"))
+	private boolean invokeMouseDragEvents(Screen screen, double mouseX, double mouseY, int button, double horizontalAmount, double verticalAmount, Operation<Boolean> operation) {
+		// The screen passed to events is the same as the screen the handler method is called on,
+		// regardless of whether the screen changes within the handler or event invocations.
+
+		if (screen != null) {
+			if (!ScreenMouseEvents.allowMouseDrag(screen).invoker().allowMouseDrag(screen, mouseX, mouseY, button, horizontalAmount, verticalAmount)) {
+				// Set this drag action as handled
+				return true;
+			}
+
+			ScreenMouseEvents.beforeMouseDrag(screen).invoker().beforeMouseDrag(screen, mouseX, mouseY, button, horizontalAmount, verticalAmount);
+		}
+
+		boolean result = operation.call(screen, mouseX, mouseY, button, horizontalAmount, verticalAmount);
+
+		if (screen != null) {
+			ScreenMouseEvents.afterMouseDrag(screen).invoker().afterMouseDrag(screen, mouseX, mouseY, button, horizontalAmount, verticalAmount);
+		}
+
+		return result;
+	}
+
 	@WrapOperation(method = "onMouseScroll", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;mouseScrolled(DDDD)Z"))
 	private boolean invokeMouseScrollEvents(Screen screen, double mouseX, double mouseY, double horizontalAmount, double verticalAmount, Operation<Boolean> operation) {
 		// The screen passed to events is the same as the screen the handler method is called on,

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/ScreenMixin.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/ScreenMixin.java
@@ -54,57 +54,57 @@ abstract class ScreenMixin implements ScreenExtensions {
 	protected List<Drawable> drawables;
 
 	@Unique
-	private ButtonList fabric$buttonList;
+	private ButtonList buttonList;
 	@Unique
-	private Event<ScreenEvents.Remove> fabric$removeEvent;
+	private Event<ScreenEvents.Remove> removeEvent;
 	@Unique
-	private Event<ScreenEvents.BeforeTick> fabric$beforeTickEvent;
+	private Event<ScreenEvents.BeforeTick> beforeTickEvent;
 	@Unique
-	private Event<ScreenEvents.AfterTick> fabric$afterTickEvent;
+	private Event<ScreenEvents.AfterTick> afterTickEvent;
 	@Unique
-	private Event<ScreenEvents.BeforeRender> fabric$beforeRenderEvent;
+	private Event<ScreenEvents.BeforeRender> beforeRenderEvent;
 	@Unique
-	private Event<ScreenEvents.AfterRender> fabric$afterRenderEvent;
+	private Event<ScreenEvents.AfterRender> afterRenderEvent;
 
 	// Keyboard
 	@Unique
-	private Event<ScreenKeyboardEvents.AllowKeyPress> fabric$allowKeyPressEvent;
+	private Event<ScreenKeyboardEvents.AllowKeyPress> allowKeyPressEvent;
 	@Unique
-	private Event<ScreenKeyboardEvents.BeforeKeyPress> fabric$beforeKeyPressEvent;
+	private Event<ScreenKeyboardEvents.BeforeKeyPress> beforeKeyPressEvent;
 	@Unique
-	private Event<ScreenKeyboardEvents.AfterKeyPress> fabric$afterKeyPressEvent;
+	private Event<ScreenKeyboardEvents.AfterKeyPress> afterKeyPressEvent;
 	@Unique
-	private Event<ScreenKeyboardEvents.AllowKeyRelease> fabric$allowKeyReleaseEvent;
+	private Event<ScreenKeyboardEvents.AllowKeyRelease> allowKeyReleaseEvent;
 	@Unique
-	private Event<ScreenKeyboardEvents.BeforeKeyRelease> fabric$beforeKeyReleaseEvent;
+	private Event<ScreenKeyboardEvents.BeforeKeyRelease> beforeKeyReleaseEvent;
 	@Unique
-	private Event<ScreenKeyboardEvents.AfterKeyRelease> fabric$afterKeyReleaseEvent;
+	private Event<ScreenKeyboardEvents.AfterKeyRelease> afterKeyReleaseEvent;
 
 	// Mouse
 	@Unique
-	private Event<ScreenMouseEvents.AllowMouseClick> fabric$allowMouseClickEvent;
+	private Event<ScreenMouseEvents.AllowMouseClick> allowMouseClickEvent;
 	@Unique
-	private Event<ScreenMouseEvents.BeforeMouseClick> fabric$beforeMouseClickEvent;
+	private Event<ScreenMouseEvents.BeforeMouseClick> beforeMouseClickEvent;
 	@Unique
-	private Event<ScreenMouseEvents.AfterMouseClick> fabric$afterMouseClickEvent;
+	private Event<ScreenMouseEvents.AfterMouseClick> afterMouseClickEvent;
 	@Unique
-	private Event<ScreenMouseEvents.AllowMouseRelease> fabric$allowMouseReleaseEvent;
+	private Event<ScreenMouseEvents.AllowMouseRelease> allowMouseReleaseEvent;
 	@Unique
-	private Event<ScreenMouseEvents.BeforeMouseRelease> fabric$beforeMouseReleaseEvent;
+	private Event<ScreenMouseEvents.BeforeMouseRelease> beforeMouseReleaseEvent;
 	@Unique
-	private Event<ScreenMouseEvents.AfterMouseRelease> fabric$afterMouseReleaseEvent;
+	private Event<ScreenMouseEvents.AfterMouseRelease> afterMouseReleaseEvent;
 	@Unique
-	private Event<ScreenMouseEvents.AllowMouseDrag> fabric$allowMouseDragEvent;
+	private Event<ScreenMouseEvents.AllowMouseDrag> allowMouseDragEvent;
 	@Unique
-	private Event<ScreenMouseEvents.BeforeMouseDrag> fabric$beforeMouseDragEvent;
+	private Event<ScreenMouseEvents.BeforeMouseDrag> beforeMouseDragEvent;
 	@Unique
-	private Event<ScreenMouseEvents.AfterMouseDrag> fabric$afterMouseDragEvent;
+	private Event<ScreenMouseEvents.AfterMouseDrag> afterMouseDragEvent;
 	@Unique
-	private Event<ScreenMouseEvents.AllowMouseScroll> fabric$allowMouseScrollEvent;
+	private Event<ScreenMouseEvents.AllowMouseScroll> allowMouseScrollEvent;
 	@Unique
-	private Event<ScreenMouseEvents.BeforeMouseScroll> fabric$beforeMouseScrollEvent;
+	private Event<ScreenMouseEvents.BeforeMouseScroll> beforeMouseScrollEvent;
 	@Unique
-	private Event<ScreenMouseEvents.AfterMouseScroll> fabric$afterMouseScrollEvent;
+	private Event<ScreenMouseEvents.AfterMouseScroll> afterMouseScrollEvent;
 
 	@Inject(method = "init(Lnet/minecraft/client/MinecraftClient;II)V", at = @At("HEAD"))
 	private void beforeInitScreen(MinecraftClient client, int width, int height, CallbackInfo ci) {
@@ -129,34 +129,34 @@ abstract class ScreenMixin implements ScreenExtensions {
 	@Unique
 	private void beforeInit(MinecraftClient client, int width, int height) {
 		// All elements are repopulated on the screen, so we need to reinitialize all events
-		this.fabric$buttonList = null;
-		this.fabric$removeEvent = ScreenEventFactory.createRemoveEvent();
-		this.fabric$beforeRenderEvent = ScreenEventFactory.createBeforeRenderEvent();
-		this.fabric$afterRenderEvent = ScreenEventFactory.createAfterRenderEvent();
-		this.fabric$beforeTickEvent = ScreenEventFactory.createBeforeTickEvent();
-		this.fabric$afterTickEvent = ScreenEventFactory.createAfterTickEvent();
+		this.buttonList = null;
+		this.removeEvent = ScreenEventFactory.createRemoveEvent();
+		this.beforeRenderEvent = ScreenEventFactory.createBeforeRenderEvent();
+		this.afterRenderEvent = ScreenEventFactory.createAfterRenderEvent();
+		this.beforeTickEvent = ScreenEventFactory.createBeforeTickEvent();
+		this.afterTickEvent = ScreenEventFactory.createAfterTickEvent();
 
 		// Keyboard
-		this.fabric$allowKeyPressEvent = ScreenEventFactory.createAllowKeyPressEvent();
-		this.fabric$beforeKeyPressEvent = ScreenEventFactory.createBeforeKeyPressEvent();
-		this.fabric$afterKeyPressEvent = ScreenEventFactory.createAfterKeyPressEvent();
-		this.fabric$allowKeyReleaseEvent = ScreenEventFactory.createAllowKeyReleaseEvent();
-		this.fabric$beforeKeyReleaseEvent = ScreenEventFactory.createBeforeKeyReleaseEvent();
-		this.fabric$afterKeyReleaseEvent = ScreenEventFactory.createAfterKeyReleaseEvent();
+		this.allowKeyPressEvent = ScreenEventFactory.createAllowKeyPressEvent();
+		this.beforeKeyPressEvent = ScreenEventFactory.createBeforeKeyPressEvent();
+		this.afterKeyPressEvent = ScreenEventFactory.createAfterKeyPressEvent();
+		this.allowKeyReleaseEvent = ScreenEventFactory.createAllowKeyReleaseEvent();
+		this.beforeKeyReleaseEvent = ScreenEventFactory.createBeforeKeyReleaseEvent();
+		this.afterKeyReleaseEvent = ScreenEventFactory.createAfterKeyReleaseEvent();
 
 		// Mouse
-		this.fabric$allowMouseClickEvent = ScreenEventFactory.createAllowMouseClickEvent();
-		this.fabric$beforeMouseClickEvent = ScreenEventFactory.createBeforeMouseClickEvent();
-		this.fabric$afterMouseClickEvent = ScreenEventFactory.createAfterMouseClickEvent();
-		this.fabric$allowMouseReleaseEvent = ScreenEventFactory.createAllowMouseReleaseEvent();
-		this.fabric$beforeMouseReleaseEvent = ScreenEventFactory.createBeforeMouseReleaseEvent();
-		this.fabric$afterMouseReleaseEvent = ScreenEventFactory.createAfterMouseReleaseEvent();
-		this.fabric$allowMouseDragEvent = ScreenEventFactory.createAllowMouseDragEvent();
-		this.fabric$beforeMouseDragEvent = ScreenEventFactory.createBeforeMouseDragEvent();
-		this.fabric$afterMouseDragEvent = ScreenEventFactory.createAfterMouseDragEvent();
-		this.fabric$allowMouseScrollEvent = ScreenEventFactory.createAllowMouseScrollEvent();
-		this.fabric$beforeMouseScrollEvent = ScreenEventFactory.createBeforeMouseScrollEvent();
-		this.fabric$afterMouseScrollEvent = ScreenEventFactory.createAfterMouseScrollEvent();
+		this.allowMouseClickEvent = ScreenEventFactory.createAllowMouseClickEvent();
+		this.beforeMouseClickEvent = ScreenEventFactory.createBeforeMouseClickEvent();
+		this.afterMouseClickEvent = ScreenEventFactory.createAfterMouseClickEvent();
+		this.allowMouseReleaseEvent = ScreenEventFactory.createAllowMouseReleaseEvent();
+		this.beforeMouseReleaseEvent = ScreenEventFactory.createBeforeMouseReleaseEvent();
+		this.afterMouseReleaseEvent = ScreenEventFactory.createAfterMouseReleaseEvent();
+		this.allowMouseDragEvent = ScreenEventFactory.createAllowMouseDragEvent();
+		this.beforeMouseDragEvent = ScreenEventFactory.createBeforeMouseDragEvent();
+		this.afterMouseDragEvent = ScreenEventFactory.createAfterMouseDragEvent();
+		this.allowMouseScrollEvent = ScreenEventFactory.createAllowMouseScrollEvent();
+		this.beforeMouseScrollEvent = ScreenEventFactory.createBeforeMouseScrollEvent();
+		this.afterMouseScrollEvent = ScreenEventFactory.createAfterMouseScrollEvent();
 
 		ScreenEvents.BEFORE_INIT.invoker().beforeInit(client, (Screen) (Object) this, width, height);
 	}
@@ -169,11 +169,11 @@ abstract class ScreenMixin implements ScreenExtensions {
 	@Override
 	public List<ClickableWidget> fabric_getButtons() {
 		// Lazy init to make the list access safe after Screen#init
-		if (this.fabric$buttonList == null) {
-			this.fabric$buttonList = new ButtonList(this.drawables, this.selectables, this.children);
+		if (this.buttonList == null) {
+			this.buttonList = new ButtonList(this.drawables, this.selectables, this.children);
 		}
 
-		return this.fabric$buttonList;
+		return this.buttonList;
 	}
 
 	@Unique
@@ -187,120 +187,120 @@ abstract class ScreenMixin implements ScreenExtensions {
 
 	@Override
 	public Event<ScreenEvents.Remove> fabric_getRemoveEvent() {
-		return ensureEventsAreInitialized(this.fabric$removeEvent);
+		return ensureEventsAreInitialized(this.removeEvent);
 	}
 
 	@Override
 	public Event<ScreenEvents.BeforeTick> fabric_getBeforeTickEvent() {
-		return ensureEventsAreInitialized(this.fabric$beforeTickEvent);
+		return ensureEventsAreInitialized(this.beforeTickEvent);
 	}
 
 	@Override
 	public Event<ScreenEvents.AfterTick> fabric_getAfterTickEvent() {
-		return ensureEventsAreInitialized(this.fabric$afterTickEvent);
+		return ensureEventsAreInitialized(this.afterTickEvent);
 	}
 
 	@Override
 	public Event<ScreenEvents.BeforeRender> fabric_getBeforeRenderEvent() {
-		return ensureEventsAreInitialized(this.fabric$beforeRenderEvent);
+		return ensureEventsAreInitialized(this.beforeRenderEvent);
 	}
 
 	@Override
 	public Event<ScreenEvents.AfterRender> fabric_getAfterRenderEvent() {
-		return ensureEventsAreInitialized(this.fabric$afterRenderEvent);
+		return ensureEventsAreInitialized(this.afterRenderEvent);
 	}
 
 	// Keyboard
 
 	@Override
 	public Event<ScreenKeyboardEvents.AllowKeyPress> fabric_getAllowKeyPressEvent() {
-		return ensureEventsAreInitialized(this.fabric$allowKeyPressEvent);
+		return ensureEventsAreInitialized(this.allowKeyPressEvent);
 	}
 
 	@Override
 	public Event<ScreenKeyboardEvents.BeforeKeyPress> fabric_getBeforeKeyPressEvent() {
-		return ensureEventsAreInitialized(this.fabric$beforeKeyPressEvent);
+		return ensureEventsAreInitialized(this.beforeKeyPressEvent);
 	}
 
 	@Override
 	public Event<ScreenKeyboardEvents.AfterKeyPress> fabric_getAfterKeyPressEvent() {
-		return ensureEventsAreInitialized(this.fabric$afterKeyPressEvent);
+		return ensureEventsAreInitialized(this.afterKeyPressEvent);
 	}
 
 	@Override
 	public Event<ScreenKeyboardEvents.AllowKeyRelease> fabric_getAllowKeyReleaseEvent() {
-		return ensureEventsAreInitialized(this.fabric$allowKeyReleaseEvent);
+		return ensureEventsAreInitialized(this.allowKeyReleaseEvent);
 	}
 
 	@Override
 	public Event<ScreenKeyboardEvents.BeforeKeyRelease> fabric_getBeforeKeyReleaseEvent() {
-		return ensureEventsAreInitialized(this.fabric$beforeKeyReleaseEvent);
+		return ensureEventsAreInitialized(this.beforeKeyReleaseEvent);
 	}
 
 	@Override
 	public Event<ScreenKeyboardEvents.AfterKeyRelease> fabric_getAfterKeyReleaseEvent() {
-		return ensureEventsAreInitialized(this.fabric$afterKeyReleaseEvent);
+		return ensureEventsAreInitialized(this.afterKeyReleaseEvent);
 	}
 
 	// Mouse
 
 	@Override
 	public Event<ScreenMouseEvents.AllowMouseClick> fabric_getAllowMouseClickEvent() {
-		return ensureEventsAreInitialized(this.fabric$allowMouseClickEvent);
+		return ensureEventsAreInitialized(this.allowMouseClickEvent);
 	}
 
 	@Override
 	public Event<ScreenMouseEvents.BeforeMouseClick> fabric_getBeforeMouseClickEvent() {
-		return ensureEventsAreInitialized(this.fabric$beforeMouseClickEvent);
+		return ensureEventsAreInitialized(this.beforeMouseClickEvent);
 	}
 
 	@Override
 	public Event<ScreenMouseEvents.AfterMouseClick> fabric_getAfterMouseClickEvent() {
-		return ensureEventsAreInitialized(this.fabric$afterMouseClickEvent);
+		return ensureEventsAreInitialized(this.afterMouseClickEvent);
 	}
 
 	@Override
 	public Event<ScreenMouseEvents.AllowMouseRelease> fabric_getAllowMouseReleaseEvent() {
-		return ensureEventsAreInitialized(this.fabric$allowMouseReleaseEvent);
+		return ensureEventsAreInitialized(this.allowMouseReleaseEvent);
 	}
 
 	@Override
 	public Event<ScreenMouseEvents.BeforeMouseRelease> fabric_getBeforeMouseReleaseEvent() {
-		return ensureEventsAreInitialized(this.fabric$beforeMouseReleaseEvent);
+		return ensureEventsAreInitialized(this.beforeMouseReleaseEvent);
 	}
 
 	@Override
 	public Event<ScreenMouseEvents.AfterMouseRelease> fabric_getAfterMouseReleaseEvent() {
-		return ensureEventsAreInitialized(this.fabric$afterMouseReleaseEvent);
+		return ensureEventsAreInitialized(this.afterMouseReleaseEvent);
 	}
 
 	@Override
 	public Event<ScreenMouseEvents.AllowMouseDrag> fabric_getAllowMouseDragEvent() {
-		return ensureEventsAreInitialized(this.fabric$allowMouseDragEvent);
+		return ensureEventsAreInitialized(this.allowMouseDragEvent);
 	}
 
 	@Override
 	public Event<ScreenMouseEvents.BeforeMouseDrag> fabric_getBeforeMouseDragEvent() {
-		return ensureEventsAreInitialized(this.fabric$beforeMouseDragEvent);
+		return ensureEventsAreInitialized(this.beforeMouseDragEvent);
 	}
 
 	@Override
 	public Event<ScreenMouseEvents.AfterMouseDrag> fabric_getAfterMouseDragEvent() {
-		return ensureEventsAreInitialized(this.fabric$afterMouseDragEvent);
+		return ensureEventsAreInitialized(this.afterMouseDragEvent);
 	}
 
 	@Override
 	public Event<ScreenMouseEvents.AllowMouseScroll> fabric_getAllowMouseScrollEvent() {
-		return ensureEventsAreInitialized(this.fabric$allowMouseScrollEvent);
+		return ensureEventsAreInitialized(this.allowMouseScrollEvent);
 	}
 
 	@Override
 	public Event<ScreenMouseEvents.BeforeMouseScroll> fabric_getBeforeMouseScrollEvent() {
-		return ensureEventsAreInitialized(this.fabric$beforeMouseScrollEvent);
+		return ensureEventsAreInitialized(this.beforeMouseScrollEvent);
 	}
 
 	@Override
 	public Event<ScreenMouseEvents.AfterMouseScroll> fabric_getAfterMouseScrollEvent() {
-		return ensureEventsAreInitialized(this.fabric$afterMouseScrollEvent);
+		return ensureEventsAreInitialized(this.afterMouseScrollEvent);
 	}
 }

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/ScreenMixin.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/ScreenMixin.java
@@ -54,7 +54,7 @@ abstract class ScreenMixin implements ScreenExtensions {
 	protected List<Drawable> drawables;
 
 	@Unique
-	private ButtonList buttonList;
+	private ButtonList fabricButtons;
 	@Unique
 	private Event<ScreenEvents.Remove> removeEvent;
 	@Unique
@@ -129,7 +129,7 @@ abstract class ScreenMixin implements ScreenExtensions {
 	@Unique
 	private void beforeInit(MinecraftClient client, int width, int height) {
 		// All elements are repopulated on the screen, so we need to reinitialize all events
-		this.buttonList = null;
+		this.fabricButtons = null;
 		this.removeEvent = ScreenEventFactory.createRemoveEvent();
 		this.beforeRenderEvent = ScreenEventFactory.createBeforeRenderEvent();
 		this.afterRenderEvent = ScreenEventFactory.createAfterRenderEvent();
@@ -169,11 +169,11 @@ abstract class ScreenMixin implements ScreenExtensions {
 	@Override
 	public List<ClickableWidget> fabric_getButtons() {
 		// Lazy init to make the list access safe after Screen#init
-		if (this.buttonList == null) {
-			this.buttonList = new ButtonList(this.drawables, this.selectables, this.children);
+		if (this.fabricButtons == null) {
+			this.fabricButtons = new ButtonList(this.drawables, this.selectables, this.children);
 		}
 
-		return this.buttonList;
+		return this.fabricButtons;
 	}
 
 	@Unique

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/ScreenMixin.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/ScreenMixin.java
@@ -54,51 +54,57 @@ abstract class ScreenMixin implements ScreenExtensions {
 	protected List<Drawable> drawables;
 
 	@Unique
-	private ButtonList fabricButtons;
+	private ButtonList fabric$buttonList;
 	@Unique
-	private Event<ScreenEvents.Remove> removeEvent;
+	private Event<ScreenEvents.Remove> fabric$removeEvent;
 	@Unique
-	private Event<ScreenEvents.BeforeTick> beforeTickEvent;
+	private Event<ScreenEvents.BeforeTick> fabric$beforeTickEvent;
 	@Unique
-	private Event<ScreenEvents.AfterTick> afterTickEvent;
+	private Event<ScreenEvents.AfterTick> fabric$afterTickEvent;
 	@Unique
-	private Event<ScreenEvents.BeforeRender> beforeRenderEvent;
+	private Event<ScreenEvents.BeforeRender> fabric$beforeRenderEvent;
 	@Unique
-	private Event<ScreenEvents.AfterRender> afterRenderEvent;
+	private Event<ScreenEvents.AfterRender> fabric$afterRenderEvent;
 
 	// Keyboard
 	@Unique
-	private Event<ScreenKeyboardEvents.AllowKeyPress> allowKeyPressEvent;
+	private Event<ScreenKeyboardEvents.AllowKeyPress> fabric$allowKeyPressEvent;
 	@Unique
-	private Event<ScreenKeyboardEvents.BeforeKeyPress> beforeKeyPressEvent;
+	private Event<ScreenKeyboardEvents.BeforeKeyPress> fabric$beforeKeyPressEvent;
 	@Unique
-	private Event<ScreenKeyboardEvents.AfterKeyPress> afterKeyPressEvent;
+	private Event<ScreenKeyboardEvents.AfterKeyPress> fabric$afterKeyPressEvent;
 	@Unique
-	private Event<ScreenKeyboardEvents.AllowKeyRelease> allowKeyReleaseEvent;
+	private Event<ScreenKeyboardEvents.AllowKeyRelease> fabric$allowKeyReleaseEvent;
 	@Unique
-	private Event<ScreenKeyboardEvents.BeforeKeyRelease> beforeKeyReleaseEvent;
+	private Event<ScreenKeyboardEvents.BeforeKeyRelease> fabric$beforeKeyReleaseEvent;
 	@Unique
-	private Event<ScreenKeyboardEvents.AfterKeyRelease> afterKeyReleaseEvent;
+	private Event<ScreenKeyboardEvents.AfterKeyRelease> fabric$afterKeyReleaseEvent;
 
 	// Mouse
 	@Unique
-	private Event<ScreenMouseEvents.AllowMouseClick> allowMouseClickEvent;
+	private Event<ScreenMouseEvents.AllowMouseClick> fabric$allowMouseClickEvent;
 	@Unique
-	private Event<ScreenMouseEvents.BeforeMouseClick> beforeMouseClickEvent;
+	private Event<ScreenMouseEvents.BeforeMouseClick> fabric$beforeMouseClickEvent;
 	@Unique
-	private Event<ScreenMouseEvents.AfterMouseClick> afterMouseClickEvent;
+	private Event<ScreenMouseEvents.AfterMouseClick> fabric$afterMouseClickEvent;
 	@Unique
-	private Event<ScreenMouseEvents.AllowMouseRelease> allowMouseReleaseEvent;
+	private Event<ScreenMouseEvents.AllowMouseRelease> fabric$allowMouseReleaseEvent;
 	@Unique
-	private Event<ScreenMouseEvents.BeforeMouseRelease> beforeMouseReleaseEvent;
+	private Event<ScreenMouseEvents.BeforeMouseRelease> fabric$beforeMouseReleaseEvent;
 	@Unique
-	private Event<ScreenMouseEvents.AfterMouseRelease> afterMouseReleaseEvent;
+	private Event<ScreenMouseEvents.AfterMouseRelease> fabric$afterMouseReleaseEvent;
 	@Unique
-	private Event<ScreenMouseEvents.AllowMouseScroll> allowMouseScrollEvent;
+	private Event<ScreenMouseEvents.AllowMouseDrag> fabric$allowMouseDragEvent;
 	@Unique
-	private Event<ScreenMouseEvents.BeforeMouseScroll> beforeMouseScrollEvent;
+	private Event<ScreenMouseEvents.BeforeMouseDrag> fabric$beforeMouseDragEvent;
 	@Unique
-	private Event<ScreenMouseEvents.AfterMouseScroll> afterMouseScrollEvent;
+	private Event<ScreenMouseEvents.AfterMouseDrag> fabric$afterMouseDragEvent;
+	@Unique
+	private Event<ScreenMouseEvents.AllowMouseScroll> fabric$allowMouseScrollEvent;
+	@Unique
+	private Event<ScreenMouseEvents.BeforeMouseScroll> fabric$beforeMouseScrollEvent;
+	@Unique
+	private Event<ScreenMouseEvents.AfterMouseScroll> fabric$afterMouseScrollEvent;
 
 	@Inject(method = "init(Lnet/minecraft/client/MinecraftClient;II)V", at = @At("HEAD"))
 	private void beforeInitScreen(MinecraftClient client, int width, int height, CallbackInfo ci) {
@@ -123,31 +129,34 @@ abstract class ScreenMixin implements ScreenExtensions {
 	@Unique
 	private void beforeInit(MinecraftClient client, int width, int height) {
 		// All elements are repopulated on the screen, so we need to reinitialize all events
-		this.fabricButtons = null;
-		this.removeEvent = ScreenEventFactory.createRemoveEvent();
-		this.beforeRenderEvent = ScreenEventFactory.createBeforeRenderEvent();
-		this.afterRenderEvent = ScreenEventFactory.createAfterRenderEvent();
-		this.beforeTickEvent = ScreenEventFactory.createBeforeTickEvent();
-		this.afterTickEvent = ScreenEventFactory.createAfterTickEvent();
+		this.fabric$buttonList = null;
+		this.fabric$removeEvent = ScreenEventFactory.createRemoveEvent();
+		this.fabric$beforeRenderEvent = ScreenEventFactory.createBeforeRenderEvent();
+		this.fabric$afterRenderEvent = ScreenEventFactory.createAfterRenderEvent();
+		this.fabric$beforeTickEvent = ScreenEventFactory.createBeforeTickEvent();
+		this.fabric$afterTickEvent = ScreenEventFactory.createAfterTickEvent();
 
 		// Keyboard
-		this.allowKeyPressEvent = ScreenEventFactory.createAllowKeyPressEvent();
-		this.beforeKeyPressEvent = ScreenEventFactory.createBeforeKeyPressEvent();
-		this.afterKeyPressEvent = ScreenEventFactory.createAfterKeyPressEvent();
-		this.allowKeyReleaseEvent = ScreenEventFactory.createAllowKeyReleaseEvent();
-		this.beforeKeyReleaseEvent = ScreenEventFactory.createBeforeKeyReleaseEvent();
-		this.afterKeyReleaseEvent = ScreenEventFactory.createAfterKeyReleaseEvent();
+		this.fabric$allowKeyPressEvent = ScreenEventFactory.createAllowKeyPressEvent();
+		this.fabric$beforeKeyPressEvent = ScreenEventFactory.createBeforeKeyPressEvent();
+		this.fabric$afterKeyPressEvent = ScreenEventFactory.createAfterKeyPressEvent();
+		this.fabric$allowKeyReleaseEvent = ScreenEventFactory.createAllowKeyReleaseEvent();
+		this.fabric$beforeKeyReleaseEvent = ScreenEventFactory.createBeforeKeyReleaseEvent();
+		this.fabric$afterKeyReleaseEvent = ScreenEventFactory.createAfterKeyReleaseEvent();
 
 		// Mouse
-		this.allowMouseClickEvent = ScreenEventFactory.createAllowMouseClickEvent();
-		this.beforeMouseClickEvent = ScreenEventFactory.createBeforeMouseClickEvent();
-		this.afterMouseClickEvent = ScreenEventFactory.createAfterMouseClickEvent();
-		this.allowMouseReleaseEvent = ScreenEventFactory.createAllowMouseReleaseEvent();
-		this.beforeMouseReleaseEvent = ScreenEventFactory.createBeforeMouseReleaseEvent();
-		this.afterMouseReleaseEvent = ScreenEventFactory.createAfterMouseReleaseEvent();
-		this.allowMouseScrollEvent = ScreenEventFactory.createAllowMouseScrollEvent();
-		this.beforeMouseScrollEvent = ScreenEventFactory.createBeforeMouseScrollEvent();
-		this.afterMouseScrollEvent = ScreenEventFactory.createAfterMouseScrollEvent();
+		this.fabric$allowMouseClickEvent = ScreenEventFactory.createAllowMouseClickEvent();
+		this.fabric$beforeMouseClickEvent = ScreenEventFactory.createBeforeMouseClickEvent();
+		this.fabric$afterMouseClickEvent = ScreenEventFactory.createAfterMouseClickEvent();
+		this.fabric$allowMouseReleaseEvent = ScreenEventFactory.createAllowMouseReleaseEvent();
+		this.fabric$beforeMouseReleaseEvent = ScreenEventFactory.createBeforeMouseReleaseEvent();
+		this.fabric$afterMouseReleaseEvent = ScreenEventFactory.createAfterMouseReleaseEvent();
+		this.fabric$allowMouseDragEvent = ScreenEventFactory.createAllowMouseDragEvent();
+		this.fabric$beforeMouseDragEvent = ScreenEventFactory.createBeforeMouseDragEvent();
+		this.fabric$afterMouseDragEvent = ScreenEventFactory.createAfterMouseDragEvent();
+		this.fabric$allowMouseScrollEvent = ScreenEventFactory.createAllowMouseScrollEvent();
+		this.fabric$beforeMouseScrollEvent = ScreenEventFactory.createBeforeMouseScrollEvent();
+		this.fabric$afterMouseScrollEvent = ScreenEventFactory.createAfterMouseScrollEvent();
 
 		ScreenEvents.BEFORE_INIT.invoker().beforeInit(client, (Screen) (Object) this, width, height);
 	}
@@ -160,11 +169,11 @@ abstract class ScreenMixin implements ScreenExtensions {
 	@Override
 	public List<ClickableWidget> fabric_getButtons() {
 		// Lazy init to make the list access safe after Screen#init
-		if (this.fabricButtons == null) {
-			this.fabricButtons = new ButtonList(this.drawables, this.selectables, this.children);
+		if (this.fabric$buttonList == null) {
+			this.fabric$buttonList = new ButtonList(this.drawables, this.selectables, this.children);
 		}
 
-		return this.fabricButtons;
+		return this.fabric$buttonList;
 	}
 
 	@Unique
@@ -178,105 +187,120 @@ abstract class ScreenMixin implements ScreenExtensions {
 
 	@Override
 	public Event<ScreenEvents.Remove> fabric_getRemoveEvent() {
-		return ensureEventsAreInitialized(this.removeEvent);
+		return ensureEventsAreInitialized(this.fabric$removeEvent);
 	}
 
 	@Override
 	public Event<ScreenEvents.BeforeTick> fabric_getBeforeTickEvent() {
-		return ensureEventsAreInitialized(this.beforeTickEvent);
+		return ensureEventsAreInitialized(this.fabric$beforeTickEvent);
 	}
 
 	@Override
 	public Event<ScreenEvents.AfterTick> fabric_getAfterTickEvent() {
-		return ensureEventsAreInitialized(this.afterTickEvent);
+		return ensureEventsAreInitialized(this.fabric$afterTickEvent);
 	}
 
 	@Override
 	public Event<ScreenEvents.BeforeRender> fabric_getBeforeRenderEvent() {
-		return ensureEventsAreInitialized(this.beforeRenderEvent);
+		return ensureEventsAreInitialized(this.fabric$beforeRenderEvent);
 	}
 
 	@Override
 	public Event<ScreenEvents.AfterRender> fabric_getAfterRenderEvent() {
-		return ensureEventsAreInitialized(this.afterRenderEvent);
+		return ensureEventsAreInitialized(this.fabric$afterRenderEvent);
 	}
 
 	// Keyboard
 
 	@Override
 	public Event<ScreenKeyboardEvents.AllowKeyPress> fabric_getAllowKeyPressEvent() {
-		return ensureEventsAreInitialized(this.allowKeyPressEvent);
+		return ensureEventsAreInitialized(this.fabric$allowKeyPressEvent);
 	}
 
 	@Override
 	public Event<ScreenKeyboardEvents.BeforeKeyPress> fabric_getBeforeKeyPressEvent() {
-		return ensureEventsAreInitialized(this.beforeKeyPressEvent);
+		return ensureEventsAreInitialized(this.fabric$beforeKeyPressEvent);
 	}
 
 	@Override
 	public Event<ScreenKeyboardEvents.AfterKeyPress> fabric_getAfterKeyPressEvent() {
-		return ensureEventsAreInitialized(this.afterKeyPressEvent);
+		return ensureEventsAreInitialized(this.fabric$afterKeyPressEvent);
 	}
 
 	@Override
 	public Event<ScreenKeyboardEvents.AllowKeyRelease> fabric_getAllowKeyReleaseEvent() {
-		return ensureEventsAreInitialized(this.allowKeyReleaseEvent);
+		return ensureEventsAreInitialized(this.fabric$allowKeyReleaseEvent);
 	}
 
 	@Override
 	public Event<ScreenKeyboardEvents.BeforeKeyRelease> fabric_getBeforeKeyReleaseEvent() {
-		return ensureEventsAreInitialized(this.beforeKeyReleaseEvent);
+		return ensureEventsAreInitialized(this.fabric$beforeKeyReleaseEvent);
 	}
 
 	@Override
 	public Event<ScreenKeyboardEvents.AfterKeyRelease> fabric_getAfterKeyReleaseEvent() {
-		return ensureEventsAreInitialized(this.afterKeyReleaseEvent);
+		return ensureEventsAreInitialized(this.fabric$afterKeyReleaseEvent);
 	}
 
 	// Mouse
 
 	@Override
 	public Event<ScreenMouseEvents.AllowMouseClick> fabric_getAllowMouseClickEvent() {
-		return ensureEventsAreInitialized(this.allowMouseClickEvent);
+		return ensureEventsAreInitialized(this.fabric$allowMouseClickEvent);
 	}
 
 	@Override
 	public Event<ScreenMouseEvents.BeforeMouseClick> fabric_getBeforeMouseClickEvent() {
-		return ensureEventsAreInitialized(this.beforeMouseClickEvent);
+		return ensureEventsAreInitialized(this.fabric$beforeMouseClickEvent);
 	}
 
 	@Override
 	public Event<ScreenMouseEvents.AfterMouseClick> fabric_getAfterMouseClickEvent() {
-		return ensureEventsAreInitialized(this.afterMouseClickEvent);
+		return ensureEventsAreInitialized(this.fabric$afterMouseClickEvent);
 	}
 
 	@Override
 	public Event<ScreenMouseEvents.AllowMouseRelease> fabric_getAllowMouseReleaseEvent() {
-		return ensureEventsAreInitialized(this.allowMouseReleaseEvent);
+		return ensureEventsAreInitialized(this.fabric$allowMouseReleaseEvent);
 	}
 
 	@Override
 	public Event<ScreenMouseEvents.BeforeMouseRelease> fabric_getBeforeMouseReleaseEvent() {
-		return ensureEventsAreInitialized(this.beforeMouseReleaseEvent);
+		return ensureEventsAreInitialized(this.fabric$beforeMouseReleaseEvent);
 	}
 
 	@Override
 	public Event<ScreenMouseEvents.AfterMouseRelease> fabric_getAfterMouseReleaseEvent() {
-		return ensureEventsAreInitialized(this.afterMouseReleaseEvent);
+		return ensureEventsAreInitialized(this.fabric$afterMouseReleaseEvent);
+	}
+
+	@Override
+	public Event<ScreenMouseEvents.AllowMouseDrag> fabric_getAllowMouseDragEvent() {
+		return ensureEventsAreInitialized(this.fabric$allowMouseDragEvent);
+	}
+
+	@Override
+	public Event<ScreenMouseEvents.BeforeMouseDrag> fabric_getBeforeMouseDragEvent() {
+		return ensureEventsAreInitialized(this.fabric$beforeMouseDragEvent);
+	}
+
+	@Override
+	public Event<ScreenMouseEvents.AfterMouseDrag> fabric_getAfterMouseDragEvent() {
+		return ensureEventsAreInitialized(this.fabric$afterMouseDragEvent);
 	}
 
 	@Override
 	public Event<ScreenMouseEvents.AllowMouseScroll> fabric_getAllowMouseScrollEvent() {
-		return ensureEventsAreInitialized(this.allowMouseScrollEvent);
+		return ensureEventsAreInitialized(this.fabric$allowMouseScrollEvent);
 	}
 
 	@Override
 	public Event<ScreenMouseEvents.BeforeMouseScroll> fabric_getBeforeMouseScrollEvent() {
-		return ensureEventsAreInitialized(this.beforeMouseScrollEvent);
+		return ensureEventsAreInitialized(this.fabric$beforeMouseScrollEvent);
 	}
 
 	@Override
 	public Event<ScreenMouseEvents.AfterMouseScroll> fabric_getAfterMouseScrollEvent() {
-		return ensureEventsAreInitialized(this.afterMouseScrollEvent);
+		return ensureEventsAreInitialized(this.fabric$afterMouseScrollEvent);
 	}
 }

--- a/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/ScreenMouseEventTests.java
+++ b/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/ScreenMouseEventTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.screen;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.minecraft.client.gui.screen.ingame.HopperScreen;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
+import net.fabricmc.fabric.api.client.screen.v1.ScreenMouseEvents;
+
+public class ScreenMouseEventTests implements ClientModInitializer {
+	public static final Logger LOGGER = LoggerFactory.getLogger("fabric-screen-api-v1");
+
+	@Override
+	public void onInitializeClient() {
+		ScreenEvents.AFTER_INIT.register((client, screen, scaledWidth, scaledHeight) -> {
+			if (screen instanceof HopperScreen) {
+				ScreenMouseEvents.allowMouseDrag(screen).register((screen1, mouseX, mouseY, button, horizontalAmount, verticalAmount) -> {
+					LOGGER.info("Allow Mouse Drag: Screen {}, Horizontal Amount {}, Vertical Amount {}", screen1.getClass().getSimpleName(), horizontalAmount, verticalAmount);
+					return true;
+				});
+				ScreenMouseEvents.beforeMouseDrag(screen).register((screen1, mouseX, mouseY, button, horizontalAmount, verticalAmount) -> {
+					LOGGER.info("Before Mouse Drag: Screen {}, Horizontal Amount {}, Vertical Amount {}", screen1.getClass().getSimpleName(), horizontalAmount, verticalAmount);
+				});
+				ScreenMouseEvents.afterMouseDrag(screen).register((screen1, mouseX, mouseY, button, horizontalAmount, verticalAmount) -> {
+					LOGGER.info("After Mouse Drag: Screen {}, Horizontal Amount {}, Vertical Amount {}", screen1.getClass().getSimpleName(), horizontalAmount, verticalAmount);
+				});
+			}
+		});
+	}
+}

--- a/fabric-screen-api-v1/src/testmodClient/resources/fabric.mod.json
+++ b/fabric-screen-api-v1/src/testmodClient/resources/fabric.mod.json
@@ -10,6 +10,7 @@
   },
   "entrypoints": {
     "client": [
+      "net.fabricmc.fabric.test.screen.ScreenMouseEventTests",
       "net.fabricmc.fabric.test.screen.ScreenTests"
     ]
   }


### PR DESCRIPTION
Events for handling `Screen::mouseDragged` have been missing from Fabric for a long time, there are plenty of mods this will be useful for, like Mouse Tweaks, Mouse Wheelie, Easy Shulker Boxes, etc.

So this adds three new events for handling `Screen::mouseDragged`:
- `ScreenMouseEvents$AllowMouseDrag`
- `ScreenMouseEvents$BeforeMouseDrag`
- `ScreenMouseEvents$AfterMouseDrag`

These follow the exact same style as all the other events found in `ScreenMouseEvents`.

I also included some very small cleanup duty for Javadoc in `ScreenMouseEvents`, and I've prefixed unique fields in `ScreenMixin` with `fabric$`.

This also includes a very basic test for the new events.