### PR TITLE
ArmorRenderer: Add option to disable default head item rendering

### DIFF
--- a/fabric-rendering-v1/build.gradle
+++ b/fabric-rendering-v1/build.gradle
@@ -7,5 +7,6 @@ moduleDependencies(project, [
 
 testDependencies(project, [
 	':fabric-client-gametest-api-v1',
+	':fabric-item-api-v1',
 	':fabric-object-builder-api-v1'
 ])

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/ArmorRenderer.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/ArmorRenderer.java
@@ -84,8 +84,8 @@ public interface ArmorRenderer {
 
 	/**
 	 * Checks whether an item stack equipped on the head should also be
-	 * rendered as an item. By default, vanilla renders most items equipped on the head
-	 * using their models (or special item renderers), but this is often unwanted for custom equipment.
+	 * rendered as an item. By default, vanilla renders most items with their models (or special item renderers)
+	 * around or on top of the entity's head, but this is often unwanted for custom equipment.
 	 *
 	 * <p>This method only applies to items registered with this renderer.
 	 *

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/ArmorRenderer.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/ArmorRenderer.java
@@ -84,10 +84,14 @@ public interface ArmorRenderer {
 
 	/**
 	 * Checks whether an item stack equipped on the head should also be
-	 * rendered as an item when it's rendered using this renderer.
+	 * rendered as an item. By default, vanilla renders most items equipped on the head
+	 * using their models (or special item renderers), but this is often unwanted for custom equipment.
 	 *
-	 * <p>Note that the item won't be rendered by vanilla code if it has an armor model defined
+	 * <p>This method only applies to items registered with this renderer.
+	 *
+	 * <p>Note that the item will never be rendered by vanilla code if it has an armor model defined
 	 * by the {@link net.minecraft.component.DataComponentTypes#EQUIPPABLE minecraft:equippable} component.
+	 * This method cannot be used to overwrite that check to re-enable also rendering the item model.
 	 * See {@link net.minecraft.client.render.entity.feature.ArmorFeatureRenderer#hasModel(ItemStack, EquipmentSlot)}.
 	 *
 	 * @param entity the equipping entity

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/ArmorRenderer.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/ArmorRenderer.java
@@ -27,6 +27,7 @@ import net.minecraft.client.render.entity.state.BipedEntityRenderState;
 import net.minecraft.client.render.item.ItemRenderer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemConvertible;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
@@ -80,4 +81,20 @@ public interface ArmorRenderer {
 	 * @param contextModel		     the model provided by {@link FeatureRenderer#getContextModel()}
 	 */
 	void render(MatrixStack matrices, VertexConsumerProvider vertexConsumers, ItemStack stack, BipedEntityRenderState bipedEntityRenderState, EquipmentSlot slot, int light, BipedEntityModel<BipedEntityRenderState> contextModel);
+
+	/**
+	 * Checks whether an item stack equipped on the head should also be
+	 * rendered as an item when it's rendered using this renderer.
+	 *
+	 * <p>Note that the item won't be rendered by vanilla code if it has an armor model defined
+	 * by the {@link net.minecraft.component.DataComponentTypes#EQUIPPABLE minecraft:equippable} component.
+	 * See {@link net.minecraft.client.render.entity.feature.ArmorFeatureRenderer#hasModel(ItemStack, EquipmentSlot)}.
+	 *
+	 * @param entity the equipping entity
+	 * @param stack  the item stack equipped on the head
+	 * @return {@code true} if the head item should be rendered, {@code false} otherwise
+	 */
+	default boolean shouldRenderDefaultHeadItem(LivingEntity entity, ItemStack stack) {
+		return true;
+	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/BipedEntityRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/BipedEntityRendererMixin.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.rendering;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.client.render.entity.BipedEntityRenderer;
+import net.minecraft.item.ItemStack;
+
+import net.fabricmc.fabric.impl.client.rendering.ArmorRendererRegistryImpl;
+
+@Mixin(BipedEntityRenderer.class)
+abstract class BipedEntityRendererMixin {
+	@ModifyExpressionValue(method = "getEquippedStack", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/entity/feature/ArmorFeatureRenderer;hasModel(Lnet/minecraft/item/ItemStack;Lnet/minecraft/entity/EquipmentSlot;)Z"))
+	private static boolean permitArmorWithCustomRenderers(boolean hasModel, @Local ItemStack stack) {
+		return hasModel || ArmorRendererRegistryImpl.get(stack.getItem()) != null;
+	}
+}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/BipedEntityRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/BipedEntityRendererMixin.java
@@ -16,12 +16,13 @@
 
 package net.fabricmc.fabric.mixin.client.rendering;
 
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
-import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 import net.minecraft.client.render.entity.BipedEntityRenderer;
+import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.item.ItemStack;
 
 import net.fabricmc.fabric.impl.client.rendering.ArmorRendererRegistryImpl;
@@ -32,8 +33,8 @@ import net.fabricmc.fabric.impl.client.rendering.ArmorRendererRegistryImpl;
 // only be called for items with an existing vanilla armor model.
 @Mixin(BipedEntityRenderer.class)
 abstract class BipedEntityRendererMixin {
-	@ModifyExpressionValue(method = "getEquippedStack", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/entity/feature/ArmorFeatureRenderer;hasModel(Lnet/minecraft/item/ItemStack;Lnet/minecraft/entity/EquipmentSlot;)Z"))
-	private static boolean permitArmorWithCustomRenderers(boolean hasModel, @Local ItemStack stack) {
-		return hasModel || ArmorRendererRegistryImpl.get(stack.getItem()) != null;
+	@WrapOperation(method = "getEquippedStack", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/entity/feature/ArmorFeatureRenderer;hasModel(Lnet/minecraft/item/ItemStack;Lnet/minecraft/entity/EquipmentSlot;)Z"))
+	private static boolean permitArmorWithCustomRenderers(ItemStack stack, EquipmentSlot slot, Operation<Boolean> original) {
+		return original.call(stack, slot) || ArmorRendererRegistryImpl.get(stack.getItem()) != null;
 	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/BipedEntityRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/BipedEntityRendererMixin.java
@@ -26,6 +26,10 @@ import net.minecraft.item.ItemStack;
 
 import net.fabricmc.fabric.impl.client.rendering.ArmorRendererRegistryImpl;
 
+// Allows items with armor renderers to be passed to the armor feature in the first place.
+// Vanilla only stores the items with armor models in the entity's render state,
+// but we want to store any item with an armor renderer. Otherwise, armor renderers would
+// only be called for items with an existing vanilla armor model.
 @Mixin(BipedEntityRenderer.class)
 abstract class BipedEntityRendererMixin {
 	@ModifyExpressionValue(method = "getEquippedStack", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/entity/feature/ArmorFeatureRenderer;hasModel(Lnet/minecraft/item/ItemStack;Lnet/minecraft/entity/EquipmentSlot;)Z"))

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/LivingEntityRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/LivingEntityRendererMixin.java
@@ -16,12 +16,14 @@
 
 package net.fabricmc.fabric.mixin.client.rendering;
 
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 import net.minecraft.client.render.entity.LivingEntityRenderer;
+import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
 
@@ -30,13 +32,13 @@ import net.fabricmc.fabric.impl.client.rendering.ArmorRendererRegistryImpl;
 
 @Mixin(LivingEntityRenderer.class)
 abstract class LivingEntityRendererMixin {
-	@ModifyExpressionValue(
+	@WrapOperation(
 			method = "updateRenderState(Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/client/render/entity/state/LivingEntityRenderState;F)V",
 			at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/entity/feature/ArmorFeatureRenderer;hasModel(Lnet/minecraft/item/ItemStack;Lnet/minecraft/entity/EquipmentSlot;)Z")
 	)
-	private boolean toggleDefaultHeadItem(boolean skip, @Local(argsOnly = true) LivingEntity entity, @Local ItemStack headStack) {
+	private boolean toggleDefaultHeadItem(ItemStack headStack, EquipmentSlot slot, Operation<Boolean> original, @Local(argsOnly = true) LivingEntity entity) {
 		// Return value: true if the item isn't rendered
-		if (skip) return true;
+		if (original.call(headStack, slot)) return true;
 		ArmorRenderer renderer = ArmorRendererRegistryImpl.get(headStack.getItem());
 		return renderer != null && !renderer.shouldRenderDefaultHeadItem(entity, headStack);
 	}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/LivingEntityRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/LivingEntityRendererMixin.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.rendering;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.client.render.entity.LivingEntityRenderer;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+
+import net.fabricmc.fabric.api.client.rendering.v1.ArmorRenderer;
+import net.fabricmc.fabric.impl.client.rendering.ArmorRendererRegistryImpl;
+
+@Mixin(LivingEntityRenderer.class)
+abstract class LivingEntityRendererMixin {
+	@ModifyExpressionValue(
+			method = "updateRenderState(Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/client/render/entity/state/LivingEntityRenderState;F)V",
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/entity/feature/ArmorFeatureRenderer;hasModel(Lnet/minecraft/item/ItemStack;Lnet/minecraft/entity/EquipmentSlot;)Z")
+	)
+	private boolean toggleDefaultHeadItem(boolean skip, @Local(argsOnly = true) LivingEntity entity, @Local ItemStack headStack) {
+		// Return value: true if the item isn't rendered
+		if (skip) return true;
+		ArmorRenderer renderer = ArmorRendererRegistryImpl.get(headStack.getItem());
+		return renderer != null && !renderer.shouldRenderDefaultHeadItem(entity, headStack);
+	}
+}

--- a/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
+++ b/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
@@ -5,6 +5,7 @@
   "client": [
     "ArmorFeatureRendererMixin",
     "AtlasSourceManagerAccessor",
+    "BipedEntityRendererMixin",
     "BlockColorsMixin",
     "BlockEntityRendererFactoriesMixin",
     "CapeFeatureRendererMixin",

--- a/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
+++ b/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
@@ -16,6 +16,7 @@
     "EntityRenderersMixin",
     "InGameHudMixin",
     "LivingEntityRendererAccessor",
+    "LivingEntityRendererMixin",
     "RenderLayersMixin",
     "SpecialModelTypesMixin",
     "TooltipComponentMixin",

--- a/fabric-rendering-v1/src/testmod/java/net/fabricmc/fabric/test/rendering/ArmorRenderingTestsInit.java
+++ b/fabric-rendering-v1/src/testmod/java/net/fabricmc/fabric/test/rendering/ArmorRenderingTestsInit.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.rendering;
+
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.EquippableComponent;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.item.Items;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.item.v1.DefaultItemComponentEvents;
+
+public final class ArmorRenderingTestsInit implements ModInitializer {
+	@Override
+	public void onInitialize() {
+		DefaultItemComponentEvents.MODIFY.register(context -> context.modify(Items.DIAMOND_SWORD, builder -> {
+			EquippableComponent component = EquippableComponent.builder(EquipmentSlot.HEAD).build();
+			builder.add(DataComponentTypes.EQUIPPABLE, component);
+		}));
+	}
+}

--- a/fabric-rendering-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-rendering-v1/src/testmod/resources/fabric.mod.json
@@ -7,6 +7,7 @@
   "license": "Apache-2.0",
   "entrypoints": {
     "main": [
+      "net.fabricmc.fabric.test.rendering.ArmorRenderingTestsInit",
       "net.fabricmc.fabric.test.rendering.CustomAtlasSourcesTestInit",
       "net.fabricmc.fabric.test.rendering.CustomColorResolverTestInit",
       "net.fabricmc.fabric.test.rendering.TooltipComponentTestInit"

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/ArmorRenderingTests.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/ArmorRenderingTests.java
@@ -17,10 +17,14 @@
 package net.fabricmc.fabric.test.rendering.client;
 
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.entity.model.BipedEntityModel;
 import net.minecraft.client.render.entity.model.EntityModelLayers;
 import net.minecraft.client.render.entity.state.BipedEntityRenderState;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.util.Identifier;
 
@@ -32,20 +36,31 @@ public class ArmorRenderingTests implements ClientModInitializer {
 	private final Identifier texture = Identifier.ofVanilla("textures/block/dirt.png");
 
 	// Renders a biped model with dirt texture, replacing diamond helmet and diamond chest plate rendering
+	// Also makes diamond sword a valid helmet and renders them as dirt helmets. Their default head item rendering is disabled.
 	@Override
 	public void onInitializeClient() {
-		ArmorRenderer.register((matrices, vertexConsumers, stack, renderState, slot, light, model) -> {
-			if (armorModel == null) {
-				armorModel = new BipedEntityModel<>(MinecraftClient.getInstance().getLoadedEntityModels().getModelPart(EntityModelLayers.PLAYER_OUTER_ARMOR));
+		ArmorRenderer armorRenderer = new ArmorRenderer() {
+			@Override
+			public void render(MatrixStack matrices, VertexConsumerProvider vertexConsumers, ItemStack stack, BipedEntityRenderState renderState, EquipmentSlot slot, int light, BipedEntityModel<BipedEntityRenderState> contextModel) {
+				if (armorModel == null) {
+					armorModel = new BipedEntityModel<>(MinecraftClient.getInstance().getLoadedEntityModels().getModelPart(EntityModelLayers.PLAYER_OUTER_ARMOR));
+				}
+
+				armorModel.setAngles(renderState);
+				armorModel.setVisible(false);
+				armorModel.body.visible = slot == EquipmentSlot.CHEST;
+				armorModel.leftArm.visible = slot == EquipmentSlot.CHEST;
+				armorModel.rightArm.visible = slot == EquipmentSlot.CHEST;
+				armorModel.head.visible = slot == EquipmentSlot.HEAD;
+				ArmorRenderer.renderPart(matrices, vertexConsumers, light, stack, armorModel, texture);
 			}
 
-			armorModel.setAngles(renderState);
-			armorModel.setVisible(false);
-			armorModel.body.visible = slot == EquipmentSlot.CHEST;
-			armorModel.leftArm.visible = slot == EquipmentSlot.CHEST;
-			armorModel.rightArm.visible = slot == EquipmentSlot.CHEST;
-			armorModel.head.visible = slot == EquipmentSlot.HEAD;
-			ArmorRenderer.renderPart(matrices, vertexConsumers, light, stack, armorModel, texture);
-		}, Items.DIAMOND_HELMET, Items.DIAMOND_CHESTPLATE);
+			@Override
+			public boolean shouldRenderDefaultHeadItem(LivingEntity entity, ItemStack stack) {
+				return !stack.isOf(Items.DIAMOND_SWORD);
+			}
+		};
+
+		ArmorRenderer.register(armorRenderer, Items.DIAMOND_HELMET, Items.DIAMOND_CHESTPLATE, Items.DIAMOND_SWORD);
 	}
 }


### PR DESCRIPTION
Adds a new method to `ArmorRenderer`, `shouldRenderDefaultHeadItem`, that can disable the default vanilla behaviour of rendering an item as its model when it doesn't have an armor asset id defined. Most custom armor doesn't need the extra item model, so it's useful to have an API to turn it off.

Also contains a fix for armor renderers not applying at all when the item doesn't have an armor model defined in the `equippable` component.