### PR TITLE
Make inline loot table test a game test

### DIFF
--- a/fabric-loot-api-v3/src/testmod/java/net/fabricmc/fabric/test/loot/LootGameTest.java
+++ b/fabric-loot-api-v3/src/testmod/java/net/fabricmc/fabric/test/loot/LootGameTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.loot;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.test.TestContext;
+import net.minecraft.text.Text;
+
+import net.fabricmc.fabric.api.gametest.v1.GameTest;
+
+public final class LootGameTest {
+	static int inlineLootTablesSeen = 0;
+
+	@GameTest
+	public void testInlineTableModifyDrops(TestContext context) {
+		int seenAtStart = inlineLootTablesSeen;
+		MinecraftServer server = context.getWorld().getServer();
+		server.getCommandManager().executeWithPrefix(server.getCommandSource(), "loot spawn 0 0 0 loot {\"pools\":[{\"entries\":[], \"rolls\":1.0}]}");
+		int seenAtEnd = inlineLootTablesSeen;
+
+		context.assertTrue(seenAtStart < seenAtEnd, Text.literal("inline loot table should've been processed by MODIFY_DROPS"));
+		context.complete();
+	}
+}

--- a/fabric-loot-api-v3/src/testmod/java/net/fabricmc/fabric/test/loot/LootTest.java
+++ b/fabric-loot-api-v3/src/testmod/java/net/fabricmc/fabric/test/loot/LootTest.java
@@ -16,15 +16,11 @@
 
 package net.fabricmc.fabric.test.loot;
 
-import java.lang.ref.WeakReference;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
 
-import com.mojang.brigadier.CommandDispatcher;
-import com.mojang.brigadier.ParseResults;
 import org.apache.commons.lang3.mutable.MutableBoolean;
-import org.apache.commons.lang3.mutable.MutableObject;
 
 import net.minecraft.block.Blocks;
 import net.minecraft.enchantment.Enchantment;
@@ -35,6 +31,7 @@ import net.minecraft.item.Items;
 import net.minecraft.loot.LootPool;
 import net.minecraft.loot.LootTable;
 import net.minecraft.loot.condition.SurvivesExplosionLootCondition;
+import net.minecraft.loot.context.LootContext;
 import net.minecraft.loot.context.LootContextParameters;
 import net.minecraft.loot.entry.ItemEntry;
 import net.minecraft.loot.function.SetEnchantmentsLootFunction;
@@ -48,9 +45,6 @@ import net.minecraft.recipe.input.SingleStackRecipeInput;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.registry.entry.RegistryEntry;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.command.CommandManager;
-import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.text.Text;
 
@@ -166,58 +160,37 @@ public class LootTest implements ModInitializer {
 						.orElse(drop);
 			});
 		});
-		var recGuard = new MutableBoolean(false);
-		LootTableEvents.MODIFY_DROPS.register((entry, context, drops) -> {
-			if (recGuard.isTrue()) {
-				return; // prevent infinite recursion
+		LootTableEvents.MODIFY_DROPS.register(new ModifyDropsWithRecGuard((entry, context, drops) -> {
+			if (entry.getKey().map(it -> it.toString().contains("red")).orElse(false)) { // all red blocks drop double
+				entry.value().generateLoot(context, drops::add);
 			}
-
-			try {
-				recGuard.setTrue();
-
-				if (entry.getKey().map(it -> it.toString().contains("red")).orElse(false)) { // all red blocks drop double
-					entry.value().generateLoot(context, drops::add);
-				}
-			} finally {
-				recGuard.setFalse();
-			}
-		});
-		var recGuard2 = new MutableBoolean(false);
-		Function<MinecraftServer, Runnable> actionGetter = createActionCache("loot spawn 0 0 0 loot {\"pools\":[{\"entries\":[], \"rolls\":1.0}]}");
+		}));
 		// test inline LootPools
 		LootTableEvents.MODIFY_DROPS.register((entry, context, drops) -> {
-			if (recGuard2.isTrue()) {
-				return;
-			}
-
-			try {
-				recGuard2.setTrue();
-				actionGetter.apply(context.getWorld().getServer()).run();
-			} finally {
-				recGuard2.setFalse();
+			if (entry.getKey().isEmpty()) {
+				LootGameTest.inlineLootTablesSeen++;
 			}
 		});
 	}
 
-	private Function<MinecraftServer, Runnable> createActionCache(String command) {
-		MutableObject<WeakReference<MinecraftServer>> stashedServer = new MutableObject<>();
-		MutableObject<Runnable> runnable = new MutableObject<>();
-		return server -> {
-			if (runnable.getValue() != null && stashedServer.getValue() != null && stashedServer.getValue().refersTo(server)) {
-				return runnable.getValue();
+	private static final class ModifyDropsWithRecGuard implements LootTableEvents.ModifyDrops {
+		private final LootTableEvents.ModifyDrops inner;
+		private final MutableBoolean recGuard = new MutableBoolean(false);
+
+		ModifyDropsWithRecGuard(LootTableEvents.ModifyDrops inner) {
+			this.inner = inner;
+		}
+
+		@Override
+		public void modifyLootTableDrops(RegistryEntry<LootTable> entry, LootContext context, List<ItemStack> drops) {
+			if (recGuard.isTrue()) return;
+
+			try {
+				recGuard.setTrue();
+				inner.modifyLootTableDrops(entry, context, drops);
+			} finally {
+				recGuard.setFalse();
 			}
-
-			stashedServer.setValue(new WeakReference<>(server));
-			CommandManager manager = server.getCommandManager();
-			CommandDispatcher<ServerCommandSource> dispatcher = manager.getDispatcher();
-			ParseResults<ServerCommandSource> parseResults = dispatcher.parse(command, server.getCommandSource());
-
-			if (parseResults.getReader().canRead()) {
-				throw new IllegalStateException("Failed to Parse Command: " + parseResults);
-			}
-
-			runnable.setValue(() -> manager.execute(parseResults, command));
-			return runnable.getValue();
-		};
+		}
 	}
 }

--- a/fabric-loot-api-v3/src/testmod/java/net/fabricmc/fabric/test/loot/LootTest.java
+++ b/fabric-loot-api-v3/src/testmod/java/net/fabricmc/fabric/test/loot/LootTest.java
@@ -20,8 +20,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.apache.commons.lang3.mutable.MutableBoolean;
-
 import net.minecraft.block.Blocks;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.Enchantments;
@@ -175,7 +173,7 @@ public class LootTest implements ModInitializer {
 
 	private static final class ModifyDropsWithRecGuard implements LootTableEvents.ModifyDrops {
 		private final LootTableEvents.ModifyDrops inner;
-		private final MutableBoolean recGuard = new MutableBoolean(false);
+		private boolean running = false;
 
 		ModifyDropsWithRecGuard(LootTableEvents.ModifyDrops inner) {
 			this.inner = inner;
@@ -183,13 +181,13 @@ public class LootTest implements ModInitializer {
 
 		@Override
 		public void modifyLootTableDrops(RegistryEntry<LootTable> entry, LootContext context, List<ItemStack> drops) {
-			if (recGuard.isTrue()) return;
+			if (running) return;
 
 			try {
-				recGuard.setTrue();
+				running = true;
 				inner.modifyLootTableDrops(entry, context, drops);
 			} finally {
-				recGuard.setFalse();
+				running = false;
 			}
 		}
 	}

--- a/fabric-loot-api-v3/src/testmod/resources/fabric.mod.json
+++ b/fabric-loot-api-v3/src/testmod/resources/fabric.mod.json
@@ -11,6 +11,9 @@
   "entrypoints": {
     "main": [
       "net.fabricmc.fabric.test.loot.LootTest"
+    ],
+    "fabric-gametest": [
+      "net.fabricmc.fabric.test.loot.LootGameTest"
     ]
   }
 }


### PR DESCRIPTION
This also fixes its recursion and log spam.

In the process, I also cleaned up the other recursion guard to use a more readable class instead of a MutableBoolean guard, but that can be reverted if it's unwanted.