### PR TITLE
Add loot game tests for all existing event callbacks in the tests

### DIFF
--- a/fabric-loot-api-v3/src/testmod/java/net/fabricmc/fabric/test/loot/LootGameTest.java
+++ b/fabric-loot-api-v3/src/testmod/java/net/fabricmc/fabric/test/loot/LootGameTest.java
@@ -16,6 +16,16 @@
 
 package net.fabricmc.fabric.test.loot;
 
+import net.minecraft.block.Blocks;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.enchantment.Enchantments;
+import net.minecraft.entity.EntityType;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.loot.context.LootContextParameters;
+import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.test.TestContext;
 import net.minecraft.text.Text;
@@ -24,6 +34,70 @@ import net.fabricmc.fabric.api.gametest.v1.GameTest;
 
 public final class LootGameTest {
 	static int inlineLootTablesSeen = 0;
+
+	@GameTest
+	public void testReplace(TestContext context) {
+		// Black wool should drop an iron ingot
+		LootTableDrops drops = LootTableDrops.block(context, Blocks.BLACK_WOOL).drop();
+		drops.assertEquals(new ItemStack(Items.IRON_INGOT));
+		context.complete();
+	}
+
+	@GameTest
+	public void testAddingPools(TestContext context) {
+		// White wool should drop a white wool and a gold ingot
+		LootTableDrops drops = LootTableDrops.block(context, Blocks.WHITE_WOOL).drop();
+		drops.assertContains(new ItemStack(Items.WHITE_WOOL));
+		ItemStack goldIngot = new ItemStack(Items.GOLD_INGOT);
+		goldIngot.set(DataComponentTypes.CUSTOM_NAME, Text.literal("Gold from White Wool"));
+		drops.assertContains(goldIngot);
+		context.complete();
+	}
+
+	@GameTest
+	public void testModifyingPools(TestContext context) {
+		// Yellow wool should drop either yellow wool or emeralds.
+		// Let's generate the drops with specific seeds to check.
+		LootTableDrops emeraldDrops = LootTableDrops.block(context, Blocks.YELLOW_WOOL).seed(1).drop();
+		emeraldDrops.assertEquals(new ItemStack(Items.EMERALD));
+		LootTableDrops woolDrops = LootTableDrops.block(context, Blocks.YELLOW_WOOL).seed(490234).drop();
+		woolDrops.assertEquals(new ItemStack(Items.YELLOW_WOOL));
+		context.complete();
+	}
+
+	@GameTest
+	public void testRegistryAccess(TestContext context) {
+		// Salmons should drop an enchanted fishing rod.
+		ItemStack expected = new ItemStack(Items.FISHING_ROD);
+		RegistryEntry<Enchantment> lure = context.getWorld()
+				.getRegistryManager()
+				.getEntryOrThrow(Enchantments.LURE);
+		EnchantmentHelper.apply(expected, builder -> builder.set(lure, 1));
+
+		LootTableDrops drops = LootTableDrops.entity(context, EntityType.SALMON).drop();
+		drops.assertContains(expected);
+		context.complete();
+	}
+
+	@GameTest
+	public void testModifyDropsSmelting(TestContext context) {
+		// Mining smeltable blocks using a diamond pickaxe should smelt the drops,
+		// so copper ore should drop a copper ingot.
+		ItemStack tool = new ItemStack(Items.DIAMOND_PICKAXE);
+		LootTableDrops drops = LootTableDrops.block(context, Blocks.COPPER_ORE)
+				.set(LootContextParameters.TOOL, tool)
+				.drop();
+		drops.assertEquals(new ItemStack(Items.COPPER_INGOT));
+		context.complete();
+	}
+
+	@GameTest
+	public void testModifyDropsDoubling(TestContext context) {
+		// Red banners should drop two red banners
+		LootTableDrops drops = LootTableDrops.block(context, Blocks.RED_BANNER).drop();
+		drops.assertTotalCount(2);
+		context.complete();
+	}
 
 	@GameTest
 	public void testInlineTableModifyDrops(TestContext context) {

--- a/fabric-loot-api-v3/src/testmod/java/net/fabricmc/fabric/test/loot/LootTableDrops.java
+++ b/fabric-loot-api-v3/src/testmod/java/net/fabricmc/fabric/test/loot/LootTableDrops.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.loot;
+
+import java.util.List;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.item.ItemStack;
+import net.minecraft.loot.LootTable;
+import net.minecraft.loot.context.LootContextParameters;
+import net.minecraft.loot.context.LootContextTypes;
+import net.minecraft.loot.context.LootWorldContext;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.test.TestContext;
+import net.minecraft.text.Text;
+import net.minecraft.util.context.ContextParameter;
+import net.minecraft.util.context.ContextType;
+import net.minecraft.util.math.Vec3d;
+
+/**
+ * A utility class that can easily generate and check loot table drops.
+ */
+public final class LootTableDrops {
+	private final TestContext context;
+	private final Text name;
+	private final List<ItemStack> stacks;
+
+	private LootTableDrops(TestContext context, Text name, List<ItemStack> stacks) {
+		this.context = context;
+		this.name = name;
+		this.stacks = stacks;
+	}
+
+	/**
+	 * Asserts that the drop list only contains a single expected stack.
+	 */
+	public void assertEquals(ItemStack expected) {
+		assertEquals(List.of(expected));
+	}
+
+	/**
+	 * Asserts that the drop list matches an expected list.
+	 */
+	public void assertEquals(List<ItemStack> expected) {
+		Text message = Text.stringifiedTranslatable("test.error.value_not_equal", name, expected, stacks);
+		context.assertTrue(ItemStack.stacksEqual(expected, stacks), message);
+	}
+
+	/**
+	 * Asserts that the drop list contains an expected stack.
+	 */
+	public void assertContains(ItemStack expected) {
+		for (ItemStack stack : stacks) {
+			if (ItemStack.areEqual(expected, stack)) {
+				// Found a match
+				return;
+			}
+		}
+
+		throw context.createError(Text.literal("Expected ").append(name).append(" to contain " + expected + ", but found " + stacks));
+	}
+
+	/**
+	 * Asserts that the total drop count matches an expected value.
+	 */
+	public void assertTotalCount(int expected) {
+		int actual = stacks.stream().mapToInt(ItemStack::getCount).sum();
+		context.assertEquals(expected, actual, Text.literal("total drop count"));
+	}
+
+	/**
+	 * Drops a block loot table.
+	 */
+	public static Builder block(TestContext context, Block block) {
+		Text name = Text.empty().append(block.getName()).append(" drops");
+		return new Builder(context, name, LootContextTypes.BLOCK, block.getLootTableKey().orElseThrow())
+				.set(LootContextParameters.BLOCK_STATE, block.getDefaultState())
+				.set(LootContextParameters.ORIGIN, Vec3d.ZERO)
+				.set(LootContextParameters.TOOL, ItemStack.EMPTY);
+	}
+
+	/**
+	 * Drops an entity loot table.
+	 */
+	public static Builder entity(TestContext context, EntityType<?> type) {
+		Text name = Text.empty().append(type.getName()).append(" drops");
+		Entity contextEntity = context.spawnEntity(type, Vec3d.ZERO);
+		return new Builder(context, name, LootContextTypes.ENTITY, type.getLootTableKey().orElseThrow())
+				.set(LootContextParameters.THIS_ENTITY, contextEntity)
+				.set(LootContextParameters.ORIGIN, Vec3d.ZERO)
+				.set(LootContextParameters.DAMAGE_SOURCE, context.getWorld().getDamageSources().generic());
+	}
+
+	public static final class Builder {
+		private final TestContext testContext;
+		private final Text name;
+		private final LootWorldContext.Builder contextBuilder;
+		private final ContextType contextType;
+		private final RegistryKey<LootTable> tableKey;
+		private long seed;
+
+		private Builder(TestContext testContext, Text name, ContextType contextType, RegistryKey<LootTable> tableKey) {
+			this.testContext = testContext;
+			this.name = name;
+			this.contextBuilder = new LootWorldContext.Builder(testContext.getWorld());
+			this.contextType = contextType;
+			this.tableKey = tableKey;
+		}
+
+		/**
+		 * Sets a loot context parameter.
+		 */
+		public <T> Builder set(ContextParameter<T> parameter, T value) {
+			contextBuilder.add(parameter, value);
+			return this;
+		}
+
+		/**
+		 * Sets the loot table seed. This is only needed for tables with random drops.
+		 */
+		public Builder seed(long seed) {
+			this.seed = seed;
+			return this;
+		}
+
+		/**
+		 * Runs the drops.
+		 */
+		public LootTableDrops drop() {
+			LootWorldContext context = contextBuilder.build(contextType);
+			LootTable lootTable = testContext.getWorld().getServer().getReloadableRegistries().getLootTable(tableKey);
+			List<ItemStack> stacks = lootTable.generateLoot(context, seed);
+			return new LootTableDrops(testContext, name, stacks);
+		}
+	}
+}


### PR DESCRIPTION
This set of game tests checks all the modifications to the tables done in `LootTest`.