### PR TITLE
Fix FabricRecipeProvider.getRecipeIdentifier not applying to recipe advancements

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricRecipeProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricRecipeProvider.java
@@ -91,6 +91,11 @@ public abstract class FabricRecipeProvider extends RecipeGenerator.RecipeProvide
 			@Override
 			public void addRootAdvancement() {
 			}
+
+			@Override
+			public Identifier getRecipeIdentifier(Identifier recipeId) {
+				return exporter.getRecipeIdentifier(recipeId);
+			}
 		};
 	}
 
@@ -102,7 +107,7 @@ public abstract class FabricRecipeProvider extends RecipeGenerator.RecipeProvide
 			RecipeGenerator recipeGenerator = getRecipeGenerator(wrapperLookup, new RecipeExporter() {
 				@Override
 				public void accept(RegistryKey<Recipe<?>> recipeKey, Recipe<?> recipe, @Nullable AdvancementEntry advancement) {
-					Identifier identifier = getRecipeIdentifier(recipeKey.getValue());
+					Identifier identifier = recipeKey.getValue();
 
 					if (!generatedRecipes.add(identifier)) {
 						throw new IllegalStateException("Duplicate recipe " + identifier);
@@ -133,6 +138,11 @@ public abstract class FabricRecipeProvider extends RecipeGenerator.RecipeProvide
 
 				@Override
 				public void addRootAdvancement() {
+				}
+
+				@Override
+				public Identifier getRecipeIdentifier(Identifier recipeId) {
+					return FabricRecipeProvider.this.getRecipeIdentifier(recipeId);
 				}
 			});
 			recipeGenerator.generate();

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/recipe/FabricRecipeExporter.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/recipe/FabricRecipeExporter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.datagen.v1.recipe;
+
+import net.minecraft.data.recipe.RecipeExporter;
+import net.minecraft.util.Identifier;
+
+/**
+ * Injected to all {@link RecipeExporter} instances.
+ */
+public interface FabricRecipeExporter {
+	/**
+	 * Override this method to change the recipe identifier.
+	 *
+	 * <p>The default implementation returns the ID unchanged.
+	 * Fabric API implementations automatically apply the corresponding method in
+	 * {@link net.fabricmc.fabric.api.datagen.v1.provider.FabricRecipeProvider FabricRecipeProvider}.
+	 *
+	 * @see net.fabricmc.fabric.api.datagen.v1.provider.FabricRecipeProvider#getRecipeIdentifier(Identifier)
+	 */
+	default Identifier getRecipeIdentifier(Identifier recipeId) {
+		return recipeId;
+	}
+}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/AllCraftingRecipeJsonBuildersMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/AllCraftingRecipeJsonBuildersMixin.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.datagen.recipe;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import net.minecraft.data.recipe.CookingRecipeJsonBuilder;
+import net.minecraft.data.recipe.RecipeExporter;
+import net.minecraft.data.recipe.ShapedRecipeJsonBuilder;
+import net.minecraft.data.recipe.ShapelessRecipeJsonBuilder;
+import net.minecraft.data.recipe.StonecuttingRecipeJsonBuilder;
+import net.minecraft.data.recipe.TransmuteRecipeJsonBuilder;
+import net.minecraft.recipe.Recipe;
+import net.minecraft.registry.RegistryKey;
+
+@Mixin({
+		CookingRecipeJsonBuilder.class,
+		ShapedRecipeJsonBuilder.class,
+		ShapelessRecipeJsonBuilder.class,
+		StonecuttingRecipeJsonBuilder.class,
+		TransmuteRecipeJsonBuilder.class,
+})
+abstract class AllCraftingRecipeJsonBuildersMixin {
+	@ModifyVariable(method = "offerTo(Lnet/minecraft/data/recipe/RecipeExporter;Lnet/minecraft/registry/RegistryKey;)V", at = @At("HEAD"), argsOnly = true)
+	private RegistryKey<Recipe<?>> modifyRecipeKey(RegistryKey<Recipe<?>> recipeKey, RecipeExporter exporter) {
+		return RegistryKey.of(recipeKey.getRegistryRef(), exporter.getRecipeIdentifier(recipeKey.getValue()));
+	}
+}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/ComplexRecipeJsonBuilderMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/ComplexRecipeJsonBuilderMixin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.datagen.recipe;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import net.minecraft.data.recipe.ComplexRecipeJsonBuilder;
+import net.minecraft.data.recipe.RecipeExporter;
+import net.minecraft.recipe.Recipe;
+import net.minecraft.registry.RegistryKey;
+
+@Mixin(ComplexRecipeJsonBuilder.class)
+abstract class ComplexRecipeJsonBuilderMixin {
+	@ModifyVariable(method = "offerTo(Lnet/minecraft/data/recipe/RecipeExporter;Lnet/minecraft/registry/RegistryKey;)V", at = @At("HEAD"), argsOnly = true)
+	private RegistryKey<Recipe<?>> modifyRecipeKey(RegistryKey<Recipe<?>> recipeKey, RecipeExporter exporter) {
+		return RegistryKey.of(recipeKey.getRegistryRef(), exporter.getRecipeIdentifier(recipeKey.getValue()));
+	}
+}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/SmithingTransformRecipeJsonBuilderMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/SmithingTransformRecipeJsonBuilderMixin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.datagen.recipe;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import net.minecraft.data.recipe.RecipeExporter;
+import net.minecraft.data.recipe.SmithingTransformRecipeJsonBuilder;
+import net.minecraft.recipe.Recipe;
+import net.minecraft.registry.RegistryKey;
+
+@Mixin(SmithingTransformRecipeJsonBuilder.class)
+abstract class SmithingTransformRecipeJsonBuilderMixin {
+	@ModifyVariable(method = "offerTo(Lnet/minecraft/data/recipe/RecipeExporter;Lnet/minecraft/registry/RegistryKey;)V", at = @At("HEAD"), argsOnly = true)
+	private RegistryKey<Recipe<?>> modifyRecipeKey(RegistryKey<Recipe<?>> recipeKey, RecipeExporter exporter) {
+		return RegistryKey.of(recipeKey.getRegistryRef(), exporter.getRecipeIdentifier(recipeKey.getValue()));
+	}
+}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/SmithingTrimRecipeJsonBuilderMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/SmithingTrimRecipeJsonBuilderMixin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.datagen.recipe;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import net.minecraft.data.recipe.RecipeExporter;
+import net.minecraft.data.recipe.SmithingTrimRecipeJsonBuilder;
+import net.minecraft.recipe.Recipe;
+import net.minecraft.registry.RegistryKey;
+
+@Mixin(SmithingTrimRecipeJsonBuilder.class)
+abstract class SmithingTrimRecipeJsonBuilderMixin {
+	@ModifyVariable(method = "offerTo(Lnet/minecraft/data/recipe/RecipeExporter;Lnet/minecraft/registry/RegistryKey;)V", at = @At("HEAD"), argsOnly = true)
+	private RegistryKey<Recipe<?>> modifyRecipeKey(RegistryKey<Recipe<?>> recipeKey, RecipeExporter exporter) {
+		return RegistryKey.of(recipeKey.getRegistryRef(), exporter.getRecipeIdentifier(recipeKey.getValue()));
+	}
+}

--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
@@ -14,7 +14,11 @@
     "loot.BlockLootTableGeneratorAccessor",
     "loot.BlockLootTableGeneratorMixin",
     "loot.EntityLootTableGeneratorAccessor",
-    "loot.EntityLootTableGeneratorMixin"
+    "loot.EntityLootTableGeneratorMixin",
+    "recipe.AllCraftingRecipeJsonBuildersMixin",
+    "recipe.ComplexRecipeJsonBuilderMixin",
+    "recipe.SmithingTransformRecipeJsonBuilderMixin",
+    "recipe.SmithingTrimRecipeJsonBuilderMixin"
   ],
   "server": [
     "server.MainMixin"

--- a/fabric-data-generation-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric.mod.json
@@ -33,6 +33,7 @@
     "loom:injected_interfaces": {
       "net/minecraft/class_7788": ["net/fabricmc/fabric/api/datagen/v1/loot/FabricBlockLootTableGenerator"],
       "net/minecraft/class_7789": ["net/fabricmc/fabric/api/datagen/v1/loot/FabricEntityLootTableGenerator"],
+      "net/minecraft/class_8790": ["net/fabricmc/fabric/api/datagen/v1/recipe/FabricRecipeExporter"],
       "net/minecraft/class_11389": ["net/fabricmc/fabric/api/datagen/v1/provider/FabricProvidedTagBuilder"]
     }
   }

--- a/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/recipes/misc/beacon.json
+++ b/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/recipes/misc/beacon.json
@@ -14,7 +14,7 @@
     "has_the_recipe": {
       "trigger": "minecraft:recipe_unlocked",
       "conditions": {
-        "recipe": "minecraft:beacon"
+        "recipe": "fabric-data-gen-api-v1-testmod:beacon"
       }
     }
   },
@@ -26,7 +26,7 @@
   ],
   "rewards": {
     "recipes": [
-      "minecraft:beacon"
+      "fabric-data-gen-api-v1-testmod:beacon"
     ]
   }
 }

--- a/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/recipes/misc/diamond.json
+++ b/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/recipes/misc/diamond.json
@@ -19,7 +19,7 @@
     "has_the_recipe": {
       "trigger": "minecraft:recipe_unlocked",
       "conditions": {
-        "recipe": "minecraft:diamond"
+        "recipe": "fabric-data-gen-api-v1-testmod:diamond"
       }
     }
   },
@@ -31,7 +31,7 @@
   ],
   "rewards": {
     "recipes": [
-      "minecraft:diamond"
+      "fabric-data-gen-api-v1-testmod:diamond"
     ]
   }
 }

--- a/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/recipes/misc/diamond_block.json
+++ b/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/recipes/misc/diamond_block.json
@@ -14,7 +14,7 @@
     "has_the_recipe": {
       "trigger": "minecraft:recipe_unlocked",
       "conditions": {
-        "recipe": "minecraft:diamond_block"
+        "recipe": "fabric-data-gen-api-v1-testmod:diamond_block"
       }
     }
   },
@@ -26,7 +26,7 @@
   ],
   "rewards": {
     "recipes": [
-      "minecraft:diamond_block"
+      "fabric-data-gen-api-v1-testmod:diamond_block"
     ]
   }
 }

--- a/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/recipes/misc/diamond_ore.json
+++ b/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/recipes/misc/diamond_ore.json
@@ -23,7 +23,7 @@
     "has_the_recipe": {
       "trigger": "minecraft:recipe_unlocked",
       "conditions": {
-        "recipe": "minecraft:diamond_ore"
+        "recipe": "fabric-data-gen-api-v1-testmod:diamond_ore"
       }
     }
   },
@@ -35,7 +35,7 @@
   ],
   "rewards": {
     "recipes": [
-      "minecraft:diamond_ore"
+      "fabric-data-gen-api-v1-testmod:diamond_ore"
     ]
   }
 }

--- a/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/recipes/misc/emerald.json
+++ b/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/recipes/misc/emerald.json
@@ -24,7 +24,7 @@
     "has_the_recipe": {
       "trigger": "minecraft:recipe_unlocked",
       "conditions": {
-        "recipe": "minecraft:emerald"
+        "recipe": "fabric-data-gen-api-v1-testmod:emerald"
       }
     }
   },
@@ -36,7 +36,7 @@
   ],
   "rewards": {
     "recipes": [
-      "minecraft:emerald"
+      "fabric-data-gen-api-v1-testmod:emerald"
     ]
   }
 }

--- a/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/recipes/misc/gold_block.json
+++ b/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/recipes/misc/gold_block.json
@@ -24,7 +24,7 @@
     "has_the_recipe": {
       "trigger": "minecraft:recipe_unlocked",
       "conditions": {
-        "recipe": "minecraft:gold_block"
+        "recipe": "fabric-data-gen-api-v1-testmod:gold_block"
       }
     }
   },
@@ -37,7 +37,7 @@
   ],
   "rewards": {
     "recipes": [
-      "minecraft:gold_block"
+      "fabric-data-gen-api-v1-testmod:gold_block"
     ]
   }
 }

--- a/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/recipes/misc/gold_ingot.json
+++ b/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/recipes/misc/gold_ingot.json
@@ -22,7 +22,7 @@
     "has_the_recipe": {
       "trigger": "minecraft:recipe_unlocked",
       "conditions": {
-        "recipe": "minecraft:gold_ingot"
+        "recipe": "fabric-data-gen-api-v1-testmod:gold_ingot"
       }
     }
   },
@@ -34,7 +34,7 @@
   ],
   "rewards": {
     "recipes": [
-      "minecraft:gold_ingot"
+      "fabric-data-gen-api-v1-testmod:gold_ingot"
     ]
   }
 }

--- a/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/recipes/misc/torch.json
+++ b/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/recipes/misc/torch.json
@@ -14,7 +14,7 @@
     "has_the_recipe": {
       "trigger": "minecraft:recipe_unlocked",
       "conditions": {
-        "recipe": "minecraft:torch"
+        "recipe": "fabric-data-gen-api-v1-testmod:torch"
       }
     }
   },
@@ -26,7 +26,7 @@
   ],
   "rewards": {
     "recipes": [
-      "minecraft:torch"
+      "fabric-data-gen-api-v1-testmod:torch"
     ]
   }
 }


### PR DESCRIPTION
Without this fix, the recipe and its corresponding advancement may refer to different ids, making the advancement useless.

The idea is to apply the id transformation before vanilla code uses the recipe key for advancements. This sadly requires mixing into every recipe json builder separately to apply the transformer since `offerTo` is abstract.