### PR TITLE
Add `DrawItemStackOverlayCallback`

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/DrawItemStackOverlayCallback.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/DrawItemStackOverlayCallback.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.client.rendering.v1;
+
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.item.ItemStack;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+@FunctionalInterface
+public interface DrawItemStackOverlayCallback {
+	/**
+	 * Fires at the end of {@link DrawContext#drawStackOverlay(TextRenderer, ItemStack, int, int, String)} and allows
+	 * for drawing custom item stack decorations.
+	 *
+	 * <p>In vanilla these are: durability bar, cooldown overlay and stack count.
+	 */
+	Event<DrawItemStackOverlayCallback> EVENT = EventFactory.createArrayBacked(DrawItemStackOverlayCallback.class,
+			callbacks -> (context, textRenderer, stack, x, y) -> {
+				for (DrawItemStackOverlayCallback callback : callbacks) {
+					callback.onDrawItemStackOverlay(context, textRenderer, stack, x, y);
+				}
+			});
+
+	/**
+	 * @param context      the draw context
+	 * @param textRenderer the text renderer
+	 * @param stack        the item stack
+	 * @param x            the x-position of the item stack
+	 * @param y            the y-position of the item stack
+	 */
+	void onDrawItemStackOverlay(DrawContext context, TextRenderer textRenderer, ItemStack stack, int x, int y);
+}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/DrawContextMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/DrawContextMixin.java
@@ -37,7 +37,7 @@ abstract class DrawContextMixin {
 	public void drawStackOverlay(TextRenderer textRenderer, ItemStack stack, int x, int y, @Nullable String stackCountText, CallbackInfo callback) {
 		if (!stack.isEmpty()) {
 			DrawItemStackOverlayCallback.EVENT.invoker()
-					.onDrawItemStackOverlay(DrawContext.class.cast(this), textRenderer, stack, x, y);
+					.onDrawItemStackOverlay((DrawContext) (Object) this, textRenderer, stack, x, y);
 		}
 	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/DrawContextMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/DrawContextMixin.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.rendering;
+
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.item.ItemStack;
+
+import net.fabricmc.fabric.api.client.rendering.v1.DrawItemStackOverlayCallback;
+
+@Mixin(DrawContext.class)
+abstract class DrawContextMixin {
+	@Inject(
+			method = "drawStackOverlay(Lnet/minecraft/client/font/TextRenderer;Lnet/minecraft/item/ItemStack;IILjava/lang/String;)V",
+			at = @At("RETURN")
+	)
+	public void drawStackOverlay(TextRenderer textRenderer, ItemStack stack, int x, int y, @Nullable String stackCountText, CallbackInfo callback) {
+		if (!stack.isEmpty()) {
+			DrawItemStackOverlayCallback.EVENT.invoker()
+					.onDrawItemStackOverlay(DrawContext.class.cast(this), textRenderer, stack, x, y);
+		}
+	}
+}

--- a/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
+++ b/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
@@ -10,6 +10,7 @@
     "CapeFeatureRendererMixin",
     "ClientWorldMixin",
     "DimensionEffectsAccessor",
+    "DrawContextMixin",
     "EntityModelLayersAccessor",
     "EntityModelsMixin",
     "EntityRenderersMixin",

--- a/fabric-rendering-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-rendering-v1/src/testmod/resources/fabric.mod.json
@@ -19,6 +19,7 @@
       "net.fabricmc.fabric.test.rendering.client.FeatureRendererTest",
       "net.fabricmc.fabric.test.rendering.client.HudAndShaderTest",
       "net.fabricmc.fabric.test.rendering.client.HudTests",
+      "net.fabricmc.fabric.test.rendering.client.ItemStackOverlayTest",
       "net.fabricmc.fabric.test.rendering.client.SpecialBlockRendererTest",
       "net.fabricmc.fabric.test.rendering.client.TooltipComponentTests",
       "net.fabricmc.fabric.test.rendering.client.WorldRenderEventsTests"

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/ItemStackOverlayTest.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/ItemStackOverlayTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.rendering.client;
+
+import net.minecraft.registry.tag.ItemTags;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.math.ColorHelper;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.rendering.v1.DrawItemStackOverlayCallback;
+
+public class ItemStackOverlayTest implements ClientModInitializer {
+	@Override
+	public void onInitializeClient() {
+		DrawItemStackOverlayCallback.EVENT.register((context, textRenderer, stack, x, y) -> {
+			// renders a plus sign on all shulker boxes where the stack count would usually be
+			if (stack.isIn(ItemTags.SHULKER_BOXES)) {
+				String s = "+";
+				context.getMatrices().pushMatrix();
+				context.drawText(textRenderer,
+						s,
+						x + 19 - 2 - textRenderer.getWidth(s),
+						y + 6 + 3,
+						ColorHelper.fullAlpha(Formatting.YELLOW.getColorValue()),
+						true);
+				context.getMatrices().popMatrix();
+			}
+		});
+	}
+}


### PR DESCRIPTION
Adds an event for rendering custom item stack decorations. In vanilla those are: durability bar, cooldown overlay and stack count.

The event runs for every item stack and provides that stack as a parameter.

Regarding performance concerns it is possible to introduce a more specialized event / registry in the future for specific items.