### PR TITLE
Add way to get an instance of WorldRenderContext if you only have a WorldRenderer

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderContext.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/WorldRenderContext.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.api.client.rendering.v1;
 
+import com.google.common.base.Preconditions;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix4f;
 
@@ -32,11 +33,27 @@ import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.math.BlockPos;
 
+import net.fabricmc.fabric.impl.client.rendering.WorldRendererHooks;
+
 /**
  * Except as noted below, the properties exposed here match the parameters passed to
  * {@link WorldRenderer#render}.
  */
 public interface WorldRenderContext {
+	/**
+	 * Returns the {@code WorldRenderContext} for the given {@code WorldRenderer} instance, for use in cases where you
+	 * have access to the world renderer but not the world render context. World render events always pass the world
+	 * render context as a parameter, so always prefer to use that over this method.
+	 *
+	 * @param worldRenderer The world renderer
+	 * @return The world render context for the world renderer
+	 * @throws IllegalStateException If not currently rendering the world
+	 */
+	static WorldRenderContext getInstance(WorldRenderer worldRenderer) {
+		Preconditions.checkNotNull(worldRenderer, "worldRenderer");
+		return ((WorldRendererHooks) worldRenderer).fabric$getWorldRenderContext();
+	}
+
 	/**
 	 * The world renderer instance doing the rendering and invoking the event.
 	 *

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/WorldRendererHooks.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/WorldRendererHooks.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.rendering;
+
+import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
+
+public interface WorldRendererHooks {
+	WorldRenderContext fabric$getWorldRenderContext();
+}


### PR DESCRIPTION
This is especially useful if a mod wants to create their own custom render event, but could also be useful more generally in case someone wants to access stuff from this context but doesn't have direct access to that context for some reason.

Note that even in situations where you don't strictly require a `WorldRenderContext`, it can still be useful to have one as it captures local variables from inside `WorldRenderer` which are otherwise difficult to access.