### PR TITLE
[1.21.1] Fix FabricRecipeProvider.getRecipeIdentifier not applying to recipe advancements

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricRecipeProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricRecipeProvider.java
@@ -82,6 +82,11 @@ public abstract class FabricRecipeProvider extends RecipeProvider {
 			public Advancement.Builder getAdvancementBuilder() {
 				return exporter.getAdvancementBuilder();
 			}
+
+			@Override
+			public Identifier getRecipeIdentifier(Identifier recipeId) {
+				return exporter.getRecipeIdentifier(recipeId);
+			}
 		};
 	}
 
@@ -92,10 +97,8 @@ public abstract class FabricRecipeProvider extends RecipeProvider {
 		generate(new RecipeExporter() {
 			@Override
 			public void accept(Identifier recipeId, Recipe<?> recipe, @Nullable AdvancementEntry advancement) {
-				Identifier identifier = getRecipeIdentifier(recipeId);
-
-				if (!generatedRecipes.add(identifier)) {
-					throw new IllegalStateException("Duplicate recipe " + identifier);
+				if (!generatedRecipes.add(recipeId)) {
+					throw new IllegalStateException("Duplicate recipe " + recipeId);
 				}
 
 				RegistryOps<JsonElement> registryOps = wrapperLookup.getOps(JsonOps.INSTANCE);
@@ -103,7 +106,7 @@ public abstract class FabricRecipeProvider extends RecipeProvider {
 				ResourceCondition[] conditions = FabricDataGenHelper.consumeConditions(recipe);
 				FabricDataGenHelper.addConditions(recipeJson, conditions);
 
-				list.add(DataProvider.writeToPath(writer, recipeJson, recipesPathResolver.resolveJson(identifier)));
+				list.add(DataProvider.writeToPath(writer, recipeJson, recipesPathResolver.resolveJson(recipeId)));
 
 				if (advancement != null) {
 					JsonObject advancementJson = Advancement.CODEC.encodeStart(registryOps, advancement.value()).getOrThrow(IllegalStateException::new).getAsJsonObject();
@@ -116,6 +119,11 @@ public abstract class FabricRecipeProvider extends RecipeProvider {
 			public Advancement.Builder getAdvancementBuilder() {
 				//noinspection removal
 				return Advancement.Builder.createUntelemetered().parent(CraftingRecipeJsonBuilder.ROOT);
+			}
+
+			@Override
+			public Identifier getRecipeIdentifier(Identifier recipeId) {
+				return FabricRecipeProvider.this.getRecipeIdentifier(recipeId);
 			}
 		});
 		return CompletableFuture.allOf(list.toArray(CompletableFuture[]::new));

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricRecipeProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricRecipeProvider.java
@@ -111,7 +111,7 @@ public abstract class FabricRecipeProvider extends RecipeProvider {
 				if (advancement != null) {
 					JsonObject advancementJson = Advancement.CODEC.encodeStart(registryOps, advancement.value()).getOrThrow(IllegalStateException::new).getAsJsonObject();
 					FabricDataGenHelper.addConditions(advancementJson, conditions);
-					list.add(DataProvider.writeToPath(writer, advancementJson, advancementsPathResolver.resolveJson(getRecipeIdentifier(advancement.id()))));
+					list.add(DataProvider.writeToPath(writer, advancementJson, advancementsPathResolver.resolveJson(advancement.id())));
 				}
 			}
 

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/recipe/FabricRecipeExporter.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/recipe/FabricRecipeExporter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.datagen.v1.recipe;
+
+import net.minecraft.data.server.recipe.RecipeExporter;
+import net.minecraft.util.Identifier;
+
+/**
+ * Injected to all {@link RecipeExporter} instances.
+ */
+public interface FabricRecipeExporter {
+	/**
+	 * Override this method to change the recipe identifier.
+	 *
+	 * <p>The default implementation returns the ID unchanged.
+	 * Fabric API implementations automatically apply the corresponding method in
+	 * {@link net.fabricmc.fabric.api.datagen.v1.provider.FabricRecipeProvider FabricRecipeProvider}.
+	 *
+	 * @see net.fabricmc.fabric.api.datagen.v1.provider.FabricRecipeProvider#getRecipeIdentifier(Identifier)
+	 */
+	default Identifier getRecipeIdentifier(Identifier recipeId) {
+		return recipeId;
+	}
+}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/AllCraftingRecipeJsonBuildersMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/AllCraftingRecipeJsonBuildersMixin.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.datagen.recipe;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import net.minecraft.data.server.recipe.CookingRecipeJsonBuilder;
+import net.minecraft.data.server.recipe.RecipeExporter;
+import net.minecraft.data.server.recipe.ShapedRecipeJsonBuilder;
+import net.minecraft.data.server.recipe.ShapelessRecipeJsonBuilder;
+import net.minecraft.data.server.recipe.StonecuttingRecipeJsonBuilder;
+import net.minecraft.util.Identifier;
+
+@Mixin({
+		CookingRecipeJsonBuilder.class,
+		ShapedRecipeJsonBuilder.class,
+		ShapelessRecipeJsonBuilder.class,
+		StonecuttingRecipeJsonBuilder.class,
+})
+abstract class AllCraftingRecipeJsonBuildersMixin {
+	@ModifyVariable(method = "offerTo(Lnet/minecraft/data/server/recipe/RecipeExporter;Lnet/minecraft/util/Identifier;)V", at = @At("HEAD"), argsOnly = true)
+	private Identifier modifyRecipeId(Identifier recipeId, RecipeExporter exporter) {
+		return exporter.getRecipeIdentifier(recipeId);
+	}
+}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/ComplexRecipeJsonBuilderMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/ComplexRecipeJsonBuilderMixin.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.datagen.recipe;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import net.minecraft.data.server.recipe.ComplexRecipeJsonBuilder;
+import net.minecraft.data.server.recipe.RecipeExporter;
+import net.minecraft.util.Identifier;
+
+@Mixin(ComplexRecipeJsonBuilder.class)
+abstract class ComplexRecipeJsonBuilderMixin {
+	@ModifyVariable(method = "offerTo(Lnet/minecraft/data/server/recipe/RecipeExporter;Lnet/minecraft/util/Identifier;)V", at = @At("HEAD"), argsOnly = true)
+	private Identifier modifyRecipeId(Identifier recipeId, RecipeExporter exporter) {
+		return exporter.getRecipeIdentifier(recipeId);
+	}
+}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/SmithingTransformRecipeJsonBuilderMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/SmithingTransformRecipeJsonBuilderMixin.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.datagen.recipe;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import net.minecraft.data.server.recipe.RecipeExporter;
+import net.minecraft.data.server.recipe.SmithingTransformRecipeJsonBuilder;
+import net.minecraft.util.Identifier;
+
+@Mixin(SmithingTransformRecipeJsonBuilder.class)
+abstract class SmithingTransformRecipeJsonBuilderMixin {
+	@ModifyVariable(method = "offerTo(Lnet/minecraft/data/server/recipe/RecipeExporter;Lnet/minecraft/util/Identifier;)V", at = @At("HEAD"), argsOnly = true)
+	private Identifier modifyRecipeId(Identifier recipeId, RecipeExporter exporter) {
+		return exporter.getRecipeIdentifier(recipeId);
+	}
+}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/SmithingTrimRecipeJsonBuilderMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/SmithingTrimRecipeJsonBuilderMixin.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.datagen.recipe;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import net.minecraft.data.server.recipe.RecipeExporter;
+import net.minecraft.data.server.recipe.SmithingTrimRecipeJsonBuilder;
+import net.minecraft.util.Identifier;
+
+@Mixin(SmithingTrimRecipeJsonBuilder.class)
+abstract class SmithingTrimRecipeJsonBuilderMixin {
+	@ModifyVariable(method = "offerTo", at = @At("HEAD"), argsOnly = true)
+	private Identifier modifyRecipeId(Identifier recipeId, RecipeExporter exporter) {
+		return exporter.getRecipeIdentifier(recipeId);
+	}
+}

--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
@@ -8,7 +8,11 @@
     "TagBuilderMixin",
     "TagProviderMixin",
     "loot.BlockLootTableGeneratorAccessor",
-    "loot.BlockLootTableGeneratorMixin"
+    "loot.BlockLootTableGeneratorMixin",
+    "recipe.AllCraftingRecipeJsonBuildersMixin",
+    "recipe.ComplexRecipeJsonBuilderMixin",
+    "recipe.SmithingTransformRecipeJsonBuilderMixin",
+    "recipe.SmithingTrimRecipeJsonBuilderMixin"
   ],
   "server": [
     "server.MainMixin"

--- a/fabric-data-generation-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric.mod.json
@@ -30,7 +30,8 @@
   "custom": {
     "fabric-api:module-lifecycle": "stable",
     "loom:injected_interfaces": {
-      "net/minecraft/class_7788": ["net/fabricmc/fabric/api/datagen/v1/loot/FabricBlockLootTableGenerator"]
+      "net/minecraft/class_7788": ["net/fabricmc/fabric/api/datagen/v1/loot/FabricBlockLootTableGenerator"],
+      "net/minecraft/class_8790": ["net/fabricmc/fabric/api/datagen/v1/recipe/FabricRecipeExporter"]
     }
   }
 }


### PR DESCRIPTION
Backport of #4703 and #4725.