### PR TITLE
Fix getRecipeIdentifier applying twice to advancement paths

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricRecipeProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricRecipeProvider.java
@@ -126,7 +126,7 @@ public abstract class FabricRecipeProvider extends RecipeGenerator.RecipeProvide
 					if (advancement != null) {
 						JsonObject advancementJson = Advancement.CODEC.encodeStart(registryOps, advancement.value()).getOrThrow(IllegalStateException::new).getAsJsonObject();
 						FabricDataGenHelper.addConditions(advancementJson, conditions);
-						list.add(DataProvider.writeToPath(writer, advancementJson, advancementsPathResolver.resolveJson(getRecipeIdentifier(advancement.id()))));
+						list.add(DataProvider.writeToPath(writer, advancementJson, advancementsPathResolver.resolveJson(advancement.id())));
 					}
 				}
 


### PR DESCRIPTION
Fixes a bug introduced in #4703.

The advancement's path is already modified by the getRecipeIdentifier call in each recipe JSON builder mixin, so this applied getRecipeIdentifier twice to a single ID (and to different parts).

For example, this getRecipeIdentifier implementation:
```java
@Override
protected Identifier getRecipeIdentifier(Identifier identifier) {
    return super.getRecipeIdentifier(identifier).withPrefixedPath("foo/");
}
```
would have resulted in an advancement being placed at `data/mod_id/advancement/foo/recipes/.../foo/the_item.json`, which is clearly wrong. With this fix, only the last "foo/" will appear.

---

Can be backported cleanly to any version with #4703 also applied. The 1.21.1 backport is already contained in #4724.