### PR TITLE
Add render entity callback

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/RenderEntityCallback.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/RenderEntityCallback.java
@@ -1,0 +1,25 @@
+package net.fabricmc.fabric.api.client.rendering.v1;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+import net.minecraft.entity.Entity;
+
+public interface RenderEntityCallback {
+	Event<RenderEntityCallback> EVENT = EventFactory.createArrayBacked(RenderEntityCallback.class,
+			(listeners) -> (entity) -> {
+				for (RenderEntityCallback listener : listeners) {
+					listener.render(entity);
+
+				}
+
+			});
+
+	/**
+	 * Called before rendering an entity.
+	 *
+	 * @param entity the {@link Entity} instance
+	 */
+
+	void render(Entity entity);
+}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/EntityRenderDispatcherMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/EntityRenderDispatcherMixin.java
@@ -1,0 +1,28 @@
+package net.fabricmc.fabric.mixin.client.rendering;
+
+
+import net.fabricmc.fabric.api.client.rendering.v1.RenderEntityCallback;
+
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.entity.EntityRenderDispatcher;
+
+import net.minecraft.client.render.entity.EntityRenderer;
+import net.minecraft.client.render.entity.state.EntityRenderState;
+import net.minecraft.client.util.math.MatrixStack;
+
+import net.minecraft.entity.Entity;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(EntityRenderDispatcher.class)
+public class EntityRenderDispatcherMixin {
+	@Inject(method = "render(Lnet/minecraft/entity/Entity;DDDFLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;ILnet/minecraft/client/render/entity/EntityRenderer;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/entity/EntityRenderer;getAndUpdateRenderState(Lnet/minecraft/entity/Entity;F)Lnet/minecraft/client/render/entity/state/EntityRenderState;"))
+	private <E extends Entity, S extends EntityRenderState> void RenderEntityCallback(E entity, double x, double y, double z, float tickProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, EntityRenderer<? super E, S> renderer, CallbackInfo ci) {
+		RenderEntityCallback.EVENT.invoker().render(entity);
+
+	}
+
+}

--- a/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
+++ b/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
@@ -15,6 +15,7 @@
     "DrawContextMixin",
     "EntityModelLayersAccessor",
     "EntityModelsMixin",
+    "EntityRenderDispatcherMixin",
     "EntityRenderersMixin",
     "GuiRendererMixin",
     "InGameHudMixin",

--- a/fabric-rendering-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-rendering-v1/src/testmod/resources/fabric.mod.json
@@ -25,7 +25,8 @@
       "net.fabricmc.fabric.test.rendering.client.SpecialBlockRendererTest",
       "net.fabricmc.fabric.test.rendering.client.TooltipComponentTests",
       "net.fabricmc.fabric.test.rendering.client.WorldRenderEventsTests",
-      "net.fabricmc.fabric.test.rendering.client.gui.SpecialGuiElementRendererTest"
+      "net.fabricmc.fabric.test.rendering.client.gui.SpecialGuiElementRendererTest",
+      "net.fabricmc.fabric.test.rendering.client.EntityRenderEventTest"
     ],
     "fabric-client-gametest": [
       "net.fabricmc.fabric.test.rendering.client.HudTests"

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/EntityRenderEventTest.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/EntityRenderEventTest.java
@@ -1,0 +1,21 @@
+package net.fabricmc.fabric.test.rendering.client;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.rendering.v1.RenderEntityCallback;
+import net.minecraft.entity.mob.CreeperEntity;
+import net.minecraft.text.Text;
+
+
+public class EntityRenderEventTest implements ClientModInitializer {
+	@Override
+	public void onInitializeClient() {
+
+		RenderEntityCallback.EVENT.register(((entity) -> {
+
+			if (entity instanceof CreeperEntity creeperEntity) {
+				creeperEntity.setCustomName(Text.literal("creeper, aw man."));
+			}
+
+		}));
+	}
+}


### PR DESCRIPTION
An event that is called before the entity gets rendered, containing the entity that is to be rendered. It would be useful for if you want to do anything with checking if an entity is actually being rendered, doing something with a specific entity only if its being rendered etc.