### PR TITLE
Add FabricItem#getCreatorNamespace

### DIFF
--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
@@ -127,7 +127,7 @@ public interface FabricItem {
 	}
 
 	/**
-	 * Gets the namespace of the mod that created this item.
+	 * Gets the namespace of the mod or datapack that created this item.
 	 *
 	 * <p>This can be used if, for example, a library mod registers a generic item that other mods can create new
 	 * variants for, allowing those mods to take credit for those variants if a player wishes to know what mod they
@@ -138,6 +138,9 @@ public interface FabricItem {
 	 *
 	 * <p>Defaults to the namespace of the item's own registry entry, except in the cases of potions or enchanted books,
 	 * in which it uses the namespace of the potion contents or single enchantment applied.</p>
+	 *
+	 * <p>Note that while it is recommended that this reflect a namespace and/or mod ID, it can technically be any
+	 * arbitrary string.</p>
 	 *
 	 * @param stack the current stack
 	 * @return the namespace of the mod that created the item

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
@@ -153,7 +153,7 @@ public interface FabricItem {
 			if (potion.isPresent()) entry = potion.get();
 		} else if (stack.isOf(Items.ENCHANTED_BOOK) && stack.contains(DataComponentTypes.STORED_ENCHANTMENTS)) {
 			Set<RegistryEntry<Enchantment>> enchantments = stack.get(DataComponentTypes.STORED_ENCHANTMENTS).getEnchantments();
-			if (enchantments.size() == 1) entry = enchantments.stream().findFirst().get();
+			if (enchantments.size() == 1) entry = enchantments.iterator().next();
 		}
 
 		return entry.getKey().orElseThrow().getValue().getNamespace();

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
@@ -16,10 +16,17 @@
 
 package net.fabricmc.fabric.api.item.v1;
 
+import java.util.Optional;
+import java.util.Set;
+
+import net.minecraft.component.DataComponentTypes;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.item.PotionItem;
+import net.minecraft.potion.Potion;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.Hand;
 import net.minecraft.util.Identifier;
@@ -128,13 +135,24 @@ public interface FabricItem {
 	 * <p>Should be used instead of querying the item ID namespace to determine what mod an item is from when displaying
 	 * to the player.</p>
 	 *
-	 * <p>Defaults to the namespace of the item's own registry entry.</p>
+	 * <p>Defaults to the namespace of the item's own registry entry, except in the cases of potions or enchanted books,
+	 * in which it uses the namespace of the potion contents or single enchantment applied.</p>
 	 *
 	 * @param stack the current stack
 	 * @return the namespace of the mod that created the item
 	 */
 	default String getCreatorNamespace(ItemStack stack) {
-		return stack.getRegistryEntry().getKey().orElseThrow().getValue().getNamespace();
+		RegistryEntry<?> entry = stack.getRegistryEntry();
+
+		if (this instanceof PotionItem && stack.contains(DataComponentTypes.POTION_CONTENTS)) {
+			Optional<RegistryEntry<Potion>> potion = stack.get(DataComponentTypes.POTION_CONTENTS).potion();
+			if (potion.isPresent()) entry = potion.get();
+		} else if (stack.isOf(Items.ENCHANTED_BOOK) && stack.contains(DataComponentTypes.STORED_ENCHANTMENTS)) {
+			Set<RegistryEntry<Enchantment>> enchantments = stack.get(DataComponentTypes.STORED_ENCHANTMENTS).getEnchantments();
+			if (enchantments.size() == 1) entry = enchantments.stream().findFirst().get();
+		}
+
+		return entry.getKey().orElseThrow().getValue().getNamespace();
 	}
 
 	/**

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
@@ -26,6 +26,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.item.PotionItem;
+import net.minecraft.item.TippedArrowItem;
 import net.minecraft.potion.Potion;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.Hand;
@@ -144,7 +145,7 @@ public interface FabricItem {
 	default String getCreatorNamespace(ItemStack stack) {
 		RegistryEntry<?> entry = stack.getRegistryEntry();
 
-		if (this instanceof PotionItem && stack.contains(DataComponentTypes.POTION_CONTENTS)) {
+		if ((this instanceof PotionItem || this instanceof TippedArrowItem) && stack.contains(DataComponentTypes.POTION_CONTENTS)) {
 			Optional<RegistryEntry<Potion>> potion = stack.get(DataComponentTypes.POTION_CONTENTS).potion();
 			if (potion.isPresent()) entry = potion.get();
 		} else if (stack.isOf(Items.ENCHANTED_BOOK) && stack.contains(DataComponentTypes.STORED_ENCHANTMENTS)) {

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
@@ -119,6 +119,25 @@ public interface FabricItem {
 	}
 
 	/**
+	 * Gets the namespace of the mod that created this item.
+	 *
+	 * <p>This can be used if, for example, a library mod registers a generic item that other mods can create new
+	 * variants for, allowing those mods to take credit for those variants if a player wishes to know what mod they
+	 * come from.</p>
+	 *
+	 * <p>Should be used instead of querying the item ID namespace to determine what mod an item is from when displaying
+	 * to the player.</p>
+	 *
+	 * <p>Defaults to the namespace of the item's own registry entry.</p>
+	 *
+	 * @param stack the current stack
+	 * @return the namespace of the mod that created the item
+	 */
+	default String getCreatorNamespace(ItemStack stack) {
+		return stack.getRegistryEntry().getKey().orElseThrow().getValue().getNamespace();
+	}
+
+	/**
 	 * Fabric-provided extensions for {@link Item.Settings}.
 	 * This interface is automatically implemented on all item settings via Mixin and interface injection.
 	 */

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItemStack.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItemStack.java
@@ -72,7 +72,8 @@ public interface FabricItemStack {
 	 * <p>Should be used instead of querying the item ID namespace to determine what mod an item is from when displaying
 	 * to the player.</p>
 	 *
-	 * <p>Defaults to the namespace of the item's own registry entry.</p>
+	 * <p>Defaults to the namespace of the item's own registry entry, except in the cases of potions or enchanted books,
+	 * in which it uses the namespace of the potion contents or single enchantment applied.</p>
 	 *
 	 * @return the namespace of the mod that created the item
 	 */

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItemStack.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItemStack.java
@@ -63,7 +63,7 @@ public interface FabricItemStack {
 	}
 
 	/**
-	 * Gets the namespace of the mod that created this item.
+	 * Gets the namespace of the mod or datapack that created this item.
 	 *
 	 * <p>This can be used if, for example, a library mod registers a generic item that other mods can create new
 	 * variants for, allowing those mods to take credit for those variants if a player wishes to know what mod they
@@ -74,6 +74,9 @@ public interface FabricItemStack {
 	 *
 	 * <p>Defaults to the namespace of the item's own registry entry, except in the cases of potions or enchanted books,
 	 * in which it uses the namespace of the potion contents or single enchantment applied.</p>
+	 *
+	 * <p>Note that while it is recommended that this reflect a namespace and/or mod ID, it can technically be any
+	 * arbitrary string.</p>
 	 *
 	 * @return the namespace of the mod that created the item
 	 */

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItemStack.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItemStack.java
@@ -61,4 +61,22 @@ public interface FabricItemStack {
 		);
 		return result.orElseGet(() -> ((ItemStack) this).getItem().canBeEnchantedWith((ItemStack) this, enchantment, context));
 	}
+
+	/**
+	 * Gets the namespace of the mod that created this item.
+	 *
+	 * <p>This can be used if, for example, a library mod registers a generic item that other mods can create new
+	 * variants for, allowing those mods to take credit for those variants if a player wishes to know what mod they
+	 * come from.</p>
+	 *
+	 * <p>Should be used instead of querying the item ID namespace to determine what mod an item is from when displaying
+	 * to the player.</p>
+	 *
+	 * <p>Defaults to the namespace of the item's own registry entry.</p>
+	 *
+	 * @return the namespace of the mod that created the item
+	 */
+	default String getCreatorNamespace() {
+		return ((ItemStack) this).getItem().getCreatorNamespace((ItemStack) this);
+	}
 }

--- a/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/CreatorNamespaceTest.java
+++ b/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/CreatorNamespaceTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.item;
+
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+
+import net.minecraft.component.ComponentType;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.codec.PacketCodecs;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.api.ModInitializer;
+
+public class CreatorNamespaceTest implements ModInitializer {
+	public static final Codec<String> NAMESPACE_CODEC = Codec.STRING.validate((string) -> {
+		if (Identifier.isNamespaceValid(string)) return DataResult.success(string);
+		else {
+			return DataResult.error(() -> "Non [a-z0-9_.-] character in namespace "+string);
+		}
+	});
+	public static final ComponentType<String> MOD_NAMESPACE = registerComponent("mod_namespace", (builder) -> builder.codec(NAMESPACE_CODEC).packetCodec(PacketCodecs.STRING));
+	public static final Item NAMESPACE_TEST_ITEM = registerItem("namespace_test", TestItem::new);
+
+	@Override
+	public void onInitialize() {
+	}
+
+	public static Item registerItem(String id, Function<Item.Settings, Item> factory) {
+		RegistryKey<Item> key = RegistryKey.of(RegistryKeys.ITEM, id(id));
+
+		Item item = factory.apply(new Item.Settings().registryKey(key));
+		return Registry.register(Registries.ITEM, key, item);
+	}
+
+	private static <T> ComponentType<T> registerComponent(String id, UnaryOperator<ComponentType.Builder<T>> builderOperator) {
+		return Registry.register(Registries.DATA_COMPONENT_TYPE, id(id), builderOperator.apply(ComponentType.builder()).build());
+	}
+
+	public static Identifier id(String path) {
+		return Identifier.of("fabric-item-api-v1-testmod", path);
+	}
+
+	public static class TestItem extends Item {
+		public TestItem(Settings settings) {
+			super(settings);
+		}
+
+		@Override
+		public String getCreatorNamespace(ItemStack stack) {
+			return stack.getOrDefault(MOD_NAMESPACE, super.getCreatorNamespace(stack));
+		}
+	}
+}

--- a/fabric-item-api-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-item-api-v1/src/testmod/resources/fabric.mod.json
@@ -16,7 +16,8 @@
       "net.fabricmc.fabric.test.item.ItemUpdateAnimationTest",
       "net.fabricmc.fabric.test.item.ArmorKnockbackResistanceTest",
       "net.fabricmc.fabric.test.item.CustomEnchantmentEffectsTest",
-      "net.fabricmc.fabric.test.item.ComponentTooltipAppenderTest"
+      "net.fabricmc.fabric.test.item.ComponentTooltipAppenderTest",
+      "net.fabricmc.fabric.test.item.CreatorNamespaceTest"
     ],
     "client": [
       "net.fabricmc.fabric.test.item.client.TooltipTests"

--- a/fabric-item-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/item/client/TooltipTests.java
+++ b/fabric-item-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/item/client/TooltipTests.java
@@ -16,18 +16,29 @@
 
 package net.fabricmc.fabric.test.item.client;
 
+import java.util.Optional;
+
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
 
 public class TooltipTests implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
-		// Adds a tooltip to all items so testing can be verified easily.
+		// Adds a tooltip to all items with the name of the mod they come from.
 		ItemTooltipCallback.EVENT.register((stack, context, type, lines) -> {
-			lines.add(Text.literal("Fancy Tooltips").formatted(Formatting.LIGHT_PURPLE));
+			String modName = stack.getCreatorNamespace();
+			Optional<ModContainer> modContainer = FabricLoader.getInstance().getModContainer(modName);
+
+			if (modContainer.isPresent()) {
+				modName = modContainer.get().getMetadata().getName();
+			}
+
+			lines.add(Text.literal(modName).formatted(Formatting.BLUE, Formatting.ITALIC));
 		});
 	}
 }


### PR DESCRIPTION
Requested on Discord, adds `FabricItem#getCreatorNamespace(ItemStack stack)`, as well as `FabricItemStack#getCreatorNamespace()`, for a stack-aware method of getting the namespace of the mod that added an item.

This could be useful for things like Patchouli guidebooks, where Patchouli can add a single `patchouli:guide_book` item which other mods can then use to make their own variants of. Patchouli can then use this method to say that the guide book item's creator namespace is that of the mod that guidebook comes from, instead of Patchouli itself - which can then be reflected in things like recipe viewers, item filters, etc. It can also be useful for things like Polymer, which use vanilla's item IDs for creation of new items on the server-side.

Its default implementation is to just return the namespace of the item's own ID, as you would expect - except in the cases of Potions or Enchanted Books, in which case it returns the namespace of the potion contents (if it's a registered potion type) or enchantment (if only one enchantment is present).

For modders, use of the method will be recommended instead of checking the item's ID namespace when determining what mod added an item as far as a player is concerned.

To show off its functionality, the testmod now adds the name of the mod an item comes from in tooltips. Also included is a testmod item which uses the method to change the namespace based on a component, showing off its stack aware functionality.