### PR TITLE
Prevent Guaranteed Resource Reload on first resource refresh

### DIFF
--- a/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/GameOptionsMixin.java
+++ b/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/GameOptionsMixin.java
@@ -25,6 +25,9 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.fabricmc.fabric.impl.resource.loader.FabricResourcePackProfile;
 import org.slf4j.Logger;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -131,5 +134,11 @@ public class GameOptionsMixin {
 		}
 
 		this.resourcePacks = new ArrayList<>(resourcePacks);
+	}
+
+	@ModifyExpressionValue(method = "refreshResourcePacks", at = @At(value = "INVOKE", target = "Lnet/minecraft/resource/ResourcePackProfile;isPinned()Z"))
+	private boolean excludeInternalResourcePacksFromRefreshCheck(boolean original, @Local ResourcePackProfile resourcePackProfile) {
+		// Treat Fabric hidden resource packs as pinned during the check for changed resource packs so that they won't count as changed when refreshing resource packs
+		return original || ((FabricResourcePackProfile)resourcePackProfile).fabric_isHidden();
 	}
 }

--- a/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/GameOptionsMixin.java
+++ b/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/GameOptionsMixin.java
@@ -25,8 +25,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
-import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import org.slf4j.Logger;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -136,9 +136,9 @@ public class GameOptionsMixin {
 		this.resourcePacks = new ArrayList<>(resourcePacks);
 	}
 
-	@ModifyExpressionValue(method = "refreshResourcePacks", at = @At(value = "INVOKE", target = "Lnet/minecraft/resource/ResourcePackProfile;isPinned()Z"))
-	private boolean excludeInternalResourcePacksFromRefreshCheck(boolean original, @Local ResourcePackProfile resourcePackProfile) {
+	@WrapOperation(method = "refreshResourcePacks", at = @At(value = "INVOKE", target = "Lnet/minecraft/resource/ResourcePackProfile;isPinned()Z"))
+	private boolean excludeInternalResourcePacksFromRefreshCheck(ResourcePackProfile instance, Operation<Boolean> original) {
 		// Treat Fabric hidden resource packs as pinned during the check for changed resource packs so that they won't count as changed when refreshing resource packs
-		return original || ((FabricResourcePackProfile) resourcePackProfile).fabric_isHidden();
+		return original.call(instance) || ((FabricResourcePackProfile) instance).fabric_isHidden();
 	}
 }

--- a/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/GameOptionsMixin.java
+++ b/fabric-resource-loader-v0/src/client/java/net/fabricmc/fabric/mixin/resource/loader/client/GameOptionsMixin.java
@@ -27,7 +27,6 @@ import java.util.Set;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.sugar.Local;
-import net.fabricmc.fabric.impl.resource.loader.FabricResourcePackProfile;
 import org.slf4j.Logger;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -45,6 +44,7 @@ import net.minecraft.nbt.NbtString;
 import net.minecraft.resource.ResourcePack;
 import net.minecraft.resource.ResourcePackProfile;
 
+import net.fabricmc.fabric.impl.resource.loader.FabricResourcePackProfile;
 import net.fabricmc.fabric.impl.resource.loader.ModNioResourcePack;
 import net.fabricmc.fabric.impl.resource.loader.ModResourcePackCreator;
 import net.fabricmc.loader.api.FabricLoader;
@@ -139,6 +139,6 @@ public class GameOptionsMixin {
 	@ModifyExpressionValue(method = "refreshResourcePacks", at = @At(value = "INVOKE", target = "Lnet/minecraft/resource/ResourcePackProfile;isPinned()Z"))
 	private boolean excludeInternalResourcePacksFromRefreshCheck(boolean original, @Local ResourcePackProfile resourcePackProfile) {
 		// Treat Fabric hidden resource packs as pinned during the check for changed resource packs so that they won't count as changed when refreshing resource packs
-		return original || ((FabricResourcePackProfile)resourcePackProfile).fabric_isHidden();
+		return original || ((FabricResourcePackProfile) resourcePackProfile).fabric_isHidden();
 	}
 }


### PR DESCRIPTION
Injects into `GameOptions.refreshResourcePacks` and prevents mod resource packs from being included in the check that decides if resource packs have changed. Fabric prevents them from being saved to and subsequently loaded from the `options.txt` file which will then **always** cause the first resource reload check to trigger a resource reload regardless of whether or not any packs have actually changed.