### PR TITLE
Ensure item groups with the same namespace appear together

### DIFF
--- a/fabric-item-group-api-v1/src/client/java/net/fabricmc/fabric/mixin/itemgroup/client/CreativeInventoryScreenMixin.java
+++ b/fabric-item-group-api-v1/src/client/java/net/fabricmc/fabric/mixin/itemgroup/client/CreativeInventoryScreenMixin.java
@@ -176,11 +176,7 @@ public abstract class CreativeInventoryScreenMixin extends HandledScreen<Creativ
 				.filter(itemGroup -> getPage(itemGroup) == page)
 				// Thanks to isXander for the sorting
 				.sorted(Comparator.comparing(ItemGroup::getRow).thenComparingInt(ItemGroup::getColumn))
-				.sorted((a, b) -> {
-					if (a.isSpecial() && !b.isSpecial()) return 1;
-					if (!a.isSpecial() && b.isSpecial()) return -1;
-					return 0;
-				})
+				.sorted((a, b) -> Boolean.compare(a.isSpecial(), b.isSpecial()))
 				.toList();
 	}
 

--- a/fabric-item-group-api-v1/src/main/java/net/fabricmc/fabric/mixin/itemgroup/ItemGroupsMixin.java
+++ b/fabric-item-group-api-v1/src/main/java/net/fabricmc/fabric/mixin/itemgroup/ItemGroupsMixin.java
@@ -46,6 +46,7 @@ import net.minecraft.item.ItemGroups;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.impl.itemgroup.FabricItemGroupImpl;
 
@@ -77,7 +78,7 @@ public class ItemGroupsMixin {
 				return -displayCompare;
 			} else {
 				// Ensure a deterministic order
-				return e1.registryKey().getValue().compareTo(e2.registryKey().getValue());
+				return compareNamespaceFirst(e1.registryKey().getValue(), e2.registryKey().getValue());
 			}
 		};
 		final List<RegistryEntry.Reference<ItemGroup>> sortedItemGroups = Registries.ITEM_GROUP.streamEntries()
@@ -119,5 +120,18 @@ public class ItemGroupsMixin {
 				throw new IllegalArgumentException("Duplicate position: (%s) for item groups %s vs %s".formatted(position, displayName, existingName));
 			}
 		}
+	}
+
+	// Identifier#compareTo checks the path first, but we want to check the namespace first so that groups added by the
+	// same mod appear next to each other.
+	@Unique
+	private static int compareNamespaceFirst(Identifier a, Identifier b) {
+		int c = a.getNamespace().compareTo(b.getNamespace());
+
+		if (c != 0) {
+			return c;
+		}
+
+		return a.getPath().compareTo(b.getPath());
 	}
 }


### PR DESCRIPTION
Replace the `Identifier.compareTo` call with a new method that works the same way, but checks the namespace before the path.