### PR TITLE
Fix Object[] allocations from WrapOperation

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/BipedEntityRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/BipedEntityRendererMixin.java
@@ -16,13 +16,12 @@
 
 package net.fabricmc.fabric.mixin.client.rendering;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 import net.minecraft.client.render.entity.BipedEntityRenderer;
-import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.item.ItemStack;
 
 import net.fabricmc.fabric.impl.client.rendering.ArmorRendererRegistryImpl;
@@ -33,8 +32,8 @@ import net.fabricmc.fabric.impl.client.rendering.ArmorRendererRegistryImpl;
 // only be called for items with an existing vanilla armor model.
 @Mixin(BipedEntityRenderer.class)
 abstract class BipedEntityRendererMixin {
-	@WrapOperation(method = "getEquippedStack", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/entity/feature/ArmorFeatureRenderer;hasModel(Lnet/minecraft/item/ItemStack;Lnet/minecraft/entity/EquipmentSlot;)Z"))
-	private static boolean permitArmorWithCustomRenderers(ItemStack stack, EquipmentSlot slot, Operation<Boolean> original) {
-		return original.call(stack, slot) || ArmorRendererRegistryImpl.get(stack.getItem()) != null;
+	@ModifyExpressionValue(method = "getEquippedStack", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/entity/feature/ArmorFeatureRenderer;hasModel(Lnet/minecraft/item/ItemStack;Lnet/minecraft/entity/EquipmentSlot;)Z"))
+	private static boolean permitArmorWithCustomRenderers(boolean original, @Local ItemStack stack) {
+		return original || ArmorRendererRegistryImpl.get(stack.getItem()) != null;
 	}
 }


### PR DESCRIPTION
This removes the overhead of creating a new `Object[]` every time the method is called.