### PR TITLE
Fix dedicated server failing to spin up in tests

### DIFF
--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/util/DedicatedServerImplUtil.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/util/DedicatedServerImplUtil.java
@@ -94,5 +94,16 @@ public final class DedicatedServerImplUtil {
 		} catch (IOException e) {
 			LOGGER.error("Failed to write server properties", e);
 		}
+
+		Properties eulaProperties = new Properties();
+		eulaProperties.put("eula", "true");
+
+		try {
+			try (BufferedWriter writer = Files.newBufferedWriter(Path.of("eula.txt"))) {
+				eulaProperties.store(writer, null);
+			}
+		} catch (IOException e) {
+			LOGGER.error("Failed to write eula properties", e);
+		}
 	}
 }


### PR DESCRIPTION
It was timing out since the dedicated server didn't start due to no eula.