### PR TITLE
Use `RegistryInfoGetter` to test `TagsPopulatedResourceCondition`

### DIFF
--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/impl/resource/conditions/ResourceConditionsImpl.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/impl/resource/conditions/ResourceConditionsImpl.java
@@ -17,13 +17,8 @@
 package net.fabricmc.fabric.impl.resource.conditions;
 
 import java.util.Collection;
-import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 import com.google.gson.JsonObject;
 import com.mojang.serialization.DataResult;
@@ -34,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryEntryLookup;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryOps;
 import net.minecraft.registry.tag.TagKey;
@@ -108,42 +104,27 @@ public final class ResourceConditionsImpl implements ModInitializer {
 		return and;
 	}
 
-	/**
-	 * Stores the tags deserialized before they are bound, to use them in the tags_populated conditions.
-	 * If the resource reload fails, the thread local is not cleared and:
-	 * - the map will remain in memory until the next reload;
-	 * - any call to {@link #tagsPopulated} will check the tags from the failed reload instead of failing directly.
-	 * This is probably acceptable.
-	 */
-	public static final AtomicReference<Map<RegistryKey<?>, Set<Identifier>>> LOADED_TAGS = new AtomicReference<>();
-
-	public static void setTags(List<Registry.PendingTagLoad<?>> tags) {
-		Map<RegistryKey<?>, Set<Identifier>> tagMap = new IdentityHashMap<>();
-
-		for (Registry.PendingTagLoad<?> registryTags : tags) {
-			tagMap.put(registryTags.getKey(), registryTags.getLookup().streamTagKeys().map(TagKey::id).collect(Collectors.toSet()));
-		}
-
-		if (LOADED_TAGS.getAndSet(tagMap) != null) {
-			throw new IllegalStateException("Tags already captured, this should not happen");
-		}
-	}
-
-	// Cannot use registry because tags are not loaded to the registry at this stage yet.
-	public static boolean tagsPopulated(Identifier registryId, List<Identifier> tags) {
-		Map<RegistryKey<?>, Set<Identifier>> tagMap = LOADED_TAGS.get();
-
-		if (tagMap == null) {
+	public static boolean tagsPopulated(@Nullable RegistryOps.RegistryInfoGetter infoGetter, Identifier registryId, List<Identifier> tags) {
+		if (infoGetter == null) {
 			LOGGER.warn("Can't retrieve registry {}, failing tags_populated resource condition check", registryId);
 			return false;
 		}
 
-		Set<Identifier> tagSet = tagMap.get(RegistryKey.ofRegistry(registryId));
+		RegistryKey<? extends Registry<Object>> registryKey = RegistryKey.ofRegistry(registryId);
+		Optional<RegistryOps.RegistryInfo<Object>> optionalInfo = infoGetter.getRegistryInfo(registryKey);
 
-		if (tagSet == null) {
-			return tags.isEmpty();
+		if (optionalInfo.isPresent()) {
+			RegistryEntryLookup<Object> lookup = optionalInfo.get().entryLookup();
+
+			for (Identifier id : tags) {
+				if (lookup.getOptional(TagKey.of(registryKey, id)).isEmpty()) {
+					return false;
+				}
+			}
+
+			return true;
 		} else {
-			return tagSet.containsAll(tags);
+			return tags.isEmpty();
 		}
 	}
 
@@ -166,19 +147,20 @@ public final class ResourceConditionsImpl implements ModInitializer {
 		return set.isSubsetOf(currentFeatures);
 	}
 
-	public static boolean registryContains(@Nullable RegistryOps.RegistryInfoGetter registryInfo, Identifier registryId, List<Identifier> entries) {
-		RegistryKey<? extends Registry<Object>> registryKey = RegistryKey.ofRegistry(registryId);
-
-		if (registryInfo == null) {
+	public static boolean registryContains(@Nullable RegistryOps.RegistryInfoGetter infoGetter, Identifier registryId, List<Identifier> entries) {
+		if (infoGetter == null) {
 			LOGGER.warn("Can't retrieve registry {}, failing registry_contains resource condition check", registryId);
 			return false;
 		}
 
-		Optional<RegistryOps.RegistryInfo<Object>> wrapper = registryInfo.getRegistryInfo(registryKey);
+		RegistryKey<? extends Registry<Object>> registryKey = RegistryKey.ofRegistry(registryId);
+		Optional<RegistryOps.RegistryInfo<Object>> optionalInfo = infoGetter.getRegistryInfo(registryKey);
 
-		if (wrapper.isPresent()) {
+		if (optionalInfo.isPresent()) {
+			RegistryEntryLookup<Object> lookup = optionalInfo.get().entryLookup();
+
 			for (Identifier id : entries) {
-				if (wrapper.get().entryLookup().getOptional(RegistryKey.of(registryKey, id)).isEmpty()) {
+				if (lookup.getOptional(RegistryKey.of(registryKey, id)).isEmpty()) {
 					return false;
 				}
 			}

--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/impl/resource/conditions/conditions/TagsPopulatedResourceCondition.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/impl/resource/conditions/conditions/TagsPopulatedResourceCondition.java
@@ -58,6 +58,6 @@ public record TagsPopulatedResourceCondition(Identifier registry, List<Identifie
 
 	@Override
 	public boolean test(@Nullable RegistryOps.RegistryInfoGetter registryInfo) {
-		return ResourceConditionsImpl.tagsPopulated(this.registry(), this.tags());
+		return ResourceConditionsImpl.tagsPopulated(registryInfo, this.registry(), this.tags());
 	}
 }

--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/mixin/resource/conditions/DataPackContentsMixin.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/mixin/resource/conditions/DataPackContentsMixin.java
@@ -17,14 +17,12 @@
 package net.fabricmc.fabric.mixin.resource.conditions;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.registry.CombinedDynamicRegistries;
@@ -45,14 +43,5 @@ public class DataPackContentsMixin {
 	)
 	private static void hookReload(ResourceManager manager, CombinedDynamicRegistries<ServerDynamicRegistryType> combinedDynamicRegistries, List<Registry.PendingTagLoad<?>> pendingTagLoads, FeatureSet enabledFeatures, CommandManager.RegistrationEnvironment environment, int functionPermissionLevel, Executor prepareExecutor, Executor applyExecutor, CallbackInfoReturnable<CompletableFuture<DataPackContents>> cir) {
 		ResourceConditionsImpl.currentFeatures = enabledFeatures;
-		ResourceConditionsImpl.setTags(pendingTagLoads);
-	}
-
-	@Inject(
-			method = "applyPendingTagLoads",
-			at = @At("TAIL")
-	)
-	private void removeLoadedTags(CallbackInfo ci) {
-		Objects.requireNonNull(ResourceConditionsImpl.LOADED_TAGS.getAndSet(null), "loaded tags not reset");
 	}
 }

--- a/fabric-resource-conditions-api-v1/src/testmod/java/net/fabricmc/fabric/test/resource/conditions/DefaultResourceConditionsTest.java
+++ b/fabric-resource-conditions-api-v1/src/testmod/java/net/fabricmc/fabric/test/resource/conditions/DefaultResourceConditionsTest.java
@@ -16,11 +16,8 @@
 
 package net.fabricmc.fabric.test.resource.conditions;
 
-import java.util.stream.Collectors;
-
 import com.mojang.serialization.JsonOps;
 
-import net.minecraft.registry.DynamicRegistryManager;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
@@ -38,7 +35,6 @@ import net.minecraft.world.biome.BiomeKeys;
 import net.fabricmc.fabric.api.gametest.v1.GameTest;
 import net.fabricmc.fabric.api.resource.conditions.v1.ResourceCondition;
 import net.fabricmc.fabric.api.resource.conditions.v1.ResourceConditions;
-import net.fabricmc.fabric.impl.resource.conditions.ResourceConditionsImpl;
 
 public class DefaultResourceConditionsTest {
 	private static final String TESTMOD_ID = "fabric-resource-conditions-api-v1-testmod";
@@ -93,14 +89,6 @@ public class DefaultResourceConditionsTest {
 
 	@GameTest
 	public void tagsPopulated(TestContext context) {
-		// We need to set the tags ourselves as it is cleared outside the resource loading context.
-		ResourceConditionsImpl.LOADED_TAGS.set(
-				context.getWorld().getRegistryManager().streamAllRegistries().collect(Collectors.toMap(
-						DynamicRegistryManager.Entry::key,
-						e -> e.value().streamTags().map(t -> t.getTag().id()).collect(Collectors.toUnmodifiableSet())
-				))
-		);
-
 		// Static registry
 		ResourceCondition dirt = ResourceConditions.tagsPopulated(RegistryKeys.BLOCK, BlockTags.DIRT);
 		ResourceCondition dirtAndUnknownBlock = ResourceConditions.tagsPopulated(RegistryKeys.BLOCK, BlockTags.DIRT, TagKey.of(RegistryKeys.BLOCK, UNKNOWN_ENTRY_ID));


### PR DESCRIPTION
This should work based on how `PendingTag`s are implemented and how the `WrapperLookup` is constructed during a server resource reload. Tags retrieved through the `RegistryInfoGetter` will be present as expected, but their contents will be empty unless the registry is a reloadable registry (loot tables). Luckily this resource condition does not need to test for tag contents.

This also allows the condition to work even after the resource reload is done.