### PR TITLE
Fix Resource Loader's FMJ not declaring dependency on Fabric API Base

### DIFF
--- a/fabric-resource-loader-v0/src/main/resources/fabric.mod.json
+++ b/fabric-resource-loader-v0/src/main/resources/fabric.mod.json
@@ -16,7 +16,8 @@
     "FabricMC"
   ],
   "depends": {
-    "fabricloader": ">=0.16.13"
+    "fabricloader": ">=0.16.13",
+    "fabric-api-base": "*"
   },
   "description": "Asset and data resource loading.",
   "mixins": [


### PR DESCRIPTION
The module's build.gradle declares this dependency and the module itself uses classes from Base, so its FMJ should also declare this dependency.