### PR TITLE
[1.21.1] Add super constructor for ForwardingBakedModel

### DIFF
--- a/fabric-model-loading-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/model/loading/ModelTestModClient.java
+++ b/fabric-model-loading-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/model/loading/ModelTestModClient.java
@@ -53,7 +53,7 @@ public class ModelTestModClient implements ClientModInitializer {
 
 	static class DownQuadRemovingModel extends ForwardingBakedModel {
 		DownQuadRemovingModel(BakedModel model) {
-			wrapped = model;
+			super(model);
 		}
 
 		@Override

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/ForwardingBakedModel.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/model/ForwardingBakedModel.java
@@ -41,6 +41,13 @@ public abstract class ForwardingBakedModel implements BakedModel, WrapperBakedMo
 	/** implementations must set this somehow. */
 	protected BakedModel wrapped;
 
+	protected ForwardingBakedModel(BakedModel wrapped) {
+		this.wrapped = wrapped;
+	}
+
+	public ForwardingBakedModel() {
+	}
+
 	@Override
 	public boolean isVanillaAdapter() {
 		return wrapped.isVanillaAdapter();


### PR DESCRIPTION
I always thought ForwardingBakedModel not having a super constructor was a bit weird, this adds a super constructor while keeping api compat