### PR TITLE
Add mob conversion to AttachmentRegistry.Builder.copyOnDeath() javadoc

### DIFF
--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentRegistry.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/api/attachment/v1/AttachmentRegistry.java
@@ -127,7 +127,7 @@ public final class AttachmentRegistry {
 		Builder<A> persistent(Codec<A> codec);
 
 		/**
-		 * Declares that when a player dies and respawns, the attachments of this type should remain.
+		 * Declares that when a player dies and respawns or when a mob is converted (e.g. zombie → drowned), the attachments of this type should remain.
 		 *
 		 * @return the builder
 		 */


### PR DESCRIPTION
Brings it up to sync with the `AttachmentType.copyOnDeath()` javadoc.