### PR TITLE
Add copper block set registration to OxidizableBlocksRegistry

### DIFF
--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/OxidizableBlocksRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/OxidizableBlocksRegistry.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.api.registry;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.CopperBlockSet;
 
 import net.fabricmc.fabric.impl.content.registry.OxidizableBlocksRegistryImpl;
 
@@ -45,5 +46,14 @@ public final class OxidizableBlocksRegistry {
 	 */
 	public static void registerWaxableBlockPair(Block unwaxed, Block waxed) {
 		OxidizableBlocksRegistryImpl.registerWaxableBlockPair(unwaxed, waxed);
+	}
+
+	/**
+	 * Registers a {@link CopperBlockSet} and its oxidizing and waxing variants.
+	 *
+	 * @param blockSet the copper block set to register
+	 */
+	public static void registerCopperBlockSet(CopperBlockSet blockSet) {
+		OxidizableBlocksRegistryImpl.registerCopperBlockSet(blockSet);
 	}
 }

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/OxidizableBlocksRegistryImpl.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/OxidizableBlocksRegistryImpl.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.impl.content.registry;
 import java.util.Objects;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.CopperBlockSet;
 import net.minecraft.block.Oxidizable;
 import net.minecraft.item.HoneycombItem;
 
@@ -39,6 +40,12 @@ public final class OxidizableBlocksRegistryImpl {
 		Objects.requireNonNull(unwaxed, "Unwaxed block cannot be null!");
 		Objects.requireNonNull(waxed, "Waxed block cannot be null!");
 		HoneycombItem.UNWAXED_TO_WAXED_BLOCKS.get().put(unwaxed, waxed);
+	}
+
+	public static void registerCopperBlockSet(CopperBlockSet blockSet) {
+		Objects.requireNonNull(blockSet, "blockSet cannot be null!");
+		blockSet.getOxidizingMap().forEach(OxidizableBlocksRegistryImpl::registerOxidizableBlockPair);
+		blockSet.getWaxingMap().forEach(OxidizableBlocksRegistryImpl::registerWaxableBlockPair);
 	}
 
 	private static void refreshRandomTickCache(Block block) {


### PR DESCRIPTION
Adds a simple method to register all of the entries in a CopperBlockSet