### PR TITLE
Stacktrace remapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ $RECYCLE.BIN/
 .DS_Store
 
 !/buildSrc/src/**
+!/fabric-crash-report-info-v1/src/buildTools/**

--- a/fabric-crash-report-info-v1/build.gradle
+++ b/fabric-crash-report-info-v1/build.gradle
@@ -3,3 +3,39 @@ version = getSubprojectVersion(project)
 testDependencies(project, [
 	':fabric-command-api-v2'
 ])
+
+sourceSets {
+	buildTools
+	test {
+		compileClasspath += sourceSets.buildTools.output
+		runtimeClasspath += sourceSets.buildTools.output
+	}
+}
+
+configurations {
+	buildToolsRuntimeClasspath {
+		extendsFrom configurations.mappingsFinal
+	}
+	testImplementation {
+		extendsFrom configurations.buildToolsImplementation
+	}
+}
+
+dependencies {
+	buildToolsImplementation 'net.fabricmc:mapping-io:0.7.1'
+}
+
+tasks.register('mappingsPreparation', JavaExec) {
+	def out = layout.buildDirectory.file("mappings.bin")
+
+	mainClass = 'net.fabricmc.fabric.impl.crash.build.MappingsPreparation'
+	outputs.file(out)
+	classpath = sourceSets.buildTools.runtimeClasspath
+	args(out.get().asFile.absolutePath)
+}
+
+jar {
+	from(tasks.mappingsPreparation.outputs) {
+		into 'data/fabric-crash-report-info-v1'
+	}
+}

--- a/fabric-crash-report-info-v1/src/buildTools/java/net/fabricmc/fabric/impl/crash/build/BinaryMappingsWriter.java
+++ b/fabric-crash-report-info-v1/src/buildTools/java/net/fabricmc/fabric/impl/crash/build/BinaryMappingsWriter.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.crash.build;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+
+import net.fabricmc.mappingio.tree.MappingTreeView;
+
+/*
+[byte] magic header
+[int] version
+[int] size of classes map
+[int] size of methods map
+: for each class
+[int] intermediary class id
+[int] relative offset to class name
+: for each method
+[int] intermediary method id
+[int] relative offset to method name
+-- start of name section, name offsets are relative to this
+: for every name
+[int] -- TODO could be a var int
+	if top 2 bits set (0xC0) this is a pointer to another name, as a relative offset from the start of the name section
+	if 0 end of string
+	else read the number of bytes specified and then move onto the next name segment
+ */
+public class BinaryMappingsWriter {
+	private static final int BUFFER_SIZE = 1024 * 1024 * 10; // 10 MiB should be enough
+	private static final byte[] MAGIC_HEADER = new byte[]{'B', 'T', 'N', 'Y'};
+
+	public static void write(Path out, MappingTreeView mappings) throws IOException {
+		List<Name> names = getNames(mappings);
+		NameSection nameSection = writeNameSection(names);
+
+		// Intermediary id to the offset in the name section
+		Map<Integer, Integer> classes = new TreeMap<>();
+		Map<Integer, Integer> methods = new TreeMap<>();
+
+		for (MappingTreeView.ClassMappingView classMapping : mappings.getClasses()) {
+			int classId = getIntermediaryId(classMapping);
+
+			if (classId > 0) {
+				Name className = new Name(classMapping.getName(mappings.getNamespaceId("named")));
+				int classOffset = nameSection.offsets.get(className);
+				classes.put(classId, classOffset);
+			}
+
+			for (MappingTreeView.MethodMappingView methodMapping : classMapping.getMethods()) {
+				int methodId = getIntermediaryId(methodMapping);
+
+				if (methodId > 0) {
+					Name methodName = new Name(methodMapping.getName(mappings.getNamespaceId("named")));
+					int methodOffset = nameSection.offsets.get(methodName);
+					methods.put(methodId, methodOffset);
+				}
+			}
+		}
+
+		ByteBuffer buffer = ByteBuffer.allocate(BUFFER_SIZE);
+		buffer.put(MAGIC_HEADER);
+		buffer.putInt(1); // Version 1
+		buffer.putInt(classes.size());
+		buffer.putInt(methods.size());
+		writeOffsets(classes, buffer);
+		writeOffsets(methods, buffer);
+		buffer.put(nameSection.data);
+
+		Files.write(out, getData(buffer));
+	}
+
+	private static int getIntermediaryId(MappingTreeView.ElementMappingView element) {
+		String name = element.getSrcName();
+
+		int index = name.lastIndexOf('_');
+
+		if (index < 0) {
+			// Not an intermediary name
+			return -1;
+		}
+
+		String subStr = name.substring(index + 1);
+
+		if (subStr.contains("$")) {
+			// Unmapped anonymous inner class
+			return -1;
+		}
+
+		return Integer.parseInt(subStr);
+	}
+
+	private static List<Name> getNames(MappingTreeView mappings) {
+		List<Name> names = new ArrayList<>();
+
+		int namedNs = mappings.getNamespaceId("named");
+
+		for (MappingTreeView.ClassMappingView classMapping : mappings.getClasses()) {
+			if (getIntermediaryId(classMapping) > 0) {
+				names.add(new Name(classMapping.getName(namedNs)));
+			}
+
+			for (MappingTreeView.MethodMappingView methodMapping : classMapping.getMethods()) {
+				if (getIntermediaryId(methodMapping) > 0) {
+					names.add(new Name(methodMapping.getName(namedNs)));
+				}
+			}
+		}
+
+		return names;
+	}
+
+	private static void writeOffsets(Map<Integer, Integer> map, ByteBuffer buffer) {
+		for (Map.Entry<Integer, Integer> entry : map.entrySet()) {
+			buffer.putInt(entry.getKey());
+			buffer.putInt(entry.getValue());
+		}
+	}
+
+	private static NameSection writeNameSection(List<Name> names) {
+		ByteBuffer buffer = ByteBuffer.allocate(BUFFER_SIZE);
+
+		// The offsets to the start of each full name
+		Map<Name, Integer> offsets = new HashMap<>();
+		// The offsets to start of each part of a name
+		Map<List<String>, Integer> partOffsets = new HashMap<>();
+
+		for (Name name : names) {
+			if (offsets.containsKey(name)) {
+				// Duplicate name that has already been written
+				continue;
+			}
+
+			List<String> parts = name.getReversedParts();
+
+			// We know for sure that we need to write the first part, so this becomes to offset to this name
+			int offset = buffer.position();
+			writeParts(parts, buffer, partOffsets);
+
+			offsets.put(name, offset);
+		}
+
+		return new NameSection(getData(buffer), Collections.unmodifiableMap(offsets));
+	}
+
+	private static void writeParts(List<String> parts, ByteBuffer buffer, Map<List<String>, Integer> partOffsets) {
+		if (parts.isEmpty()) {
+			// We have reached the fnd of the string, terminate with a null character
+			buffer.putInt(0);
+			return;
+		}
+
+		if (partOffsets.containsKey(parts)) {
+			int offset = partOffsets.get(parts);
+			buffer.putInt(offset | 0xC0000000); // Set the top two bits to indicate this is a pointer
+			return;
+		}
+
+		String part = parts.getFirst();
+		List<String> next = parts.subList(1, parts.size());
+
+		// As we use the top two bits to indicate a pointer, we need to ensure that the part length does not exceed the new limit
+		if (part.length() > 0x3FFFFFFF) {
+			throw new IllegalArgumentException("Part too long: " + part);
+		}
+
+		// Write the size and data of the current part
+		int offset = buffer.position();
+		buffer.putInt(part.length());
+		buffer.put(part.getBytes(StandardCharsets.UTF_8));
+
+		// Store the offset for this part, so it can be referenced later
+		partOffsets.put(parts, offset);
+
+		// Keep writing until we reach the end of the name
+		writeParts(next, buffer, partOffsets);
+	}
+
+	// Return the written data as a byte array
+	private static byte[] getData(ByteBuffer buffer) {
+		int length = buffer.position();
+		byte[] data = new byte[length];
+		buffer.rewind();
+		buffer.get(data, 0, length);
+		return data;
+	}
+
+	private record NameSection(byte[] data, Map<Name, Integer> offsets) { }
+
+	/**
+	 * A class that represents the full name of a given class.
+	 * @param raw e.g "net/example/package/MyClass$Inner"
+	 */
+	private record Name(String raw) {
+		/**
+		 * Return a reversed list of the parts of the string to write.
+		 * E.g given "net/example/package/MyClass$Inner" return "MyClass$Inner", "package", "example", "net"
+		 */
+		public List<String> getReversedParts() {
+			String[] parts = raw.split("/");
+			return Stream.of(parts)
+					.map(String::intern)
+					.toList()
+					.reversed();
+		}
+	}
+}

--- a/fabric-crash-report-info-v1/src/buildTools/java/net/fabricmc/fabric/impl/crash/build/MappingsPreparation.java
+++ b/fabric-crash-report-info-v1/src/buildTools/java/net/fabricmc/fabric/impl/crash/build/MappingsPreparation.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.crash.build;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.List;
+
+import net.fabricmc.mappingio.MappingReader;
+import net.fabricmc.mappingio.adapter.MappingDstNsReorder;
+import net.fabricmc.mappingio.adapter.MappingSourceNsSwitch;
+import net.fabricmc.mappingio.tree.MappingTree;
+import net.fabricmc.mappingio.tree.MemoryMappingTree;
+
+public class MappingsPreparation {
+	public static void main(String[] args) throws IOException {
+		if (args.length != 1) {
+			System.err.println("Usage: java MappingsPreparation <output-file>");
+			System.exit(1);
+		}
+
+		prepare(Path.of(args[0]));
+	}
+
+	public static void prepare(Path out) throws IOException {
+		MemoryMappingTree mappings = new MemoryMappingTree();
+
+		try (InputStream is = MappingsPreparation.class.getResourceAsStream("/mappings/mappings.tiny");
+				InputStreamReader reader = new InputStreamReader(is);
+				BufferedReader bufferedReader = new BufferedReader(reader)) {
+			MappingDstNsReorder dstNsReorder = new MappingDstNsReorder(mappings, List.of("named"));
+			MappingSourceNsSwitch sourceNsSwitch = new MappingSourceNsSwitch(dstNsReorder, "intermediary", true);
+			MappingReader.read(bufferedReader, sourceNsSwitch);
+		}
+
+		int namedNs = mappings.getNamespaceId("named");
+
+		for (MappingTree.ClassMapping classMapping : mappings.getClasses()) {
+			List<? extends MappingTree.MethodMapping> toRemove = classMapping.getMethods().stream()
+					.filter(methodMapping -> methodMapping.getSrcName().equals(methodMapping.getDstName(namedNs)))
+					.toList();
+
+			toRemove.forEach(methodMapping -> classMapping.removeMethod(methodMapping.getSrcName(), methodMapping.getSrcDesc()));
+		}
+
+		List<String> toRemove = mappings.getClasses().stream()
+				.filter(classMapping -> classMapping.getSrcName().equals(classMapping.getDstName(namedNs))
+						&& classMapping.getMethods().isEmpty()).map(MappingTree.ClassMapping::getSrcName).toList();
+		toRemove.forEach(mappings::removeClass);
+
+		BinaryMappingsWriter.write(out, mappings);
+	}
+}

--- a/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/impl/crash/report/info/BinaryMappingReader.java
+++ b/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/impl/crash/report/info/BinaryMappingReader.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.crash.report.info;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.jetbrains.annotations.Nullable;
+
+public class BinaryMappingReader {
+	private static final byte[] MAGIC_HEADER = new byte[]{'B', 'T', 'N', 'Y'};
+	private static final int NAME_ENTRY_SIZE = 8; // 4 bytes for id, 4 bytes for offset
+
+	private final ByteBuffer buf;
+	private final int classNameMapCount;
+	private final int classNameMapOffset;
+	private final int methodNameMapCount;
+	private final int methodNameMapOffset;
+	private final int namesOffset;
+
+	public BinaryMappingReader() throws IOException {
+		this(open());
+	}
+
+	public BinaryMappingReader(ByteBuffer buffer) throws IOException {
+		this.buf = buffer;
+
+		byte[] header = new byte[4];
+		this.buf.get(header);
+
+		if (!Arrays.equals(header, MAGIC_HEADER)) {
+			throw new IOException("Invalid header in mappings.bin");
+		}
+
+		int version = this.buf.getInt();
+
+		if (version != 1) {
+			throw new IOException("Unsupported version in mappings.bin: " + version);
+		}
+
+		this.classNameMapCount = this.buf.getInt();
+		this.methodNameMapCount = this.buf.getInt();
+		// End of header
+
+		int offset = this.buf.position();
+		this.classNameMapOffset = offset;
+		offset += this.classNameMapCount * NAME_ENTRY_SIZE;
+		this.methodNameMapOffset = offset;
+		offset += this.methodNameMapCount * NAME_ENTRY_SIZE;
+		this.namesOffset = offset;
+	}
+
+	@Nullable
+	public String getClassName(int id) {
+		int offset = getOffset(id, classNameMapOffset, classNameMapCount);
+
+		if (offset < 0) {
+			return null;
+		}
+
+		return getName(offset);
+	}
+
+	@Nullable
+	public String getMethodName(int id) {
+		int offset = getOffset(id, methodNameMapOffset, methodNameMapCount);
+
+		if (offset < 0) {
+			return null;
+		}
+
+		return getName(offset);
+	}
+
+	// Returns the offset for the given id from the class or method name map, or 0 if not found.
+	private int getOffset(int id, int baseOffset, int count) {
+		int low = 0;
+		int high = count - 1;
+
+		while (low <= high) {
+			int mid = (low + high) >>> 1;
+			int offset = baseOffset + mid * NAME_ENTRY_SIZE;
+			buf.position(offset);
+
+			int key = buf.getInt();
+
+			if (key == id) {
+				return buf.getInt();
+			} else if (key < id) {
+				low = mid + 1; // Search in the upper half
+			} else {
+				high = mid - 1; // Search in the lower half
+			}
+		}
+
+		return -1;
+	}
+
+	private String getName(int offset) {
+		List<String> parts = new ArrayList<>();
+
+		buf.position(namesOffset + offset);
+		getNextName(parts);
+
+		if (parts.isEmpty()) {
+			throw new IllegalStateException("No name parts found for offset: " + offset);
+		}
+
+		Collections.reverse(parts);
+		return String.join("/", parts);
+	}
+
+	private void getNextName(List<String> parts) {
+		int length = buf.getInt();
+
+		// String terminator
+		if (length == 0) {
+			return;
+		}
+
+		// Pointer to another name
+		if ((length & 0xC0000000) == 0xC0000000) {
+			buf.position(namesOffset + (length & 0x3FFFFFFF));
+		} else {
+			byte[] nameBytes = new byte[length];
+			buf.get(nameBytes);
+			parts.add(new String(nameBytes, StandardCharsets.UTF_8));
+		}
+
+		getNextName(parts);
+	}
+
+	private static ByteBuffer open() throws IOException {
+		try (InputStream is = BinaryMappingReader.class.getResourceAsStream("/data/fabric-crash-report-info-v1/mappings.bin")) {
+			if (is == null) {
+				throw new IOException("Could not find mappings.bin resource");
+			}
+
+			return ByteBuffer.wrap(is.readAllBytes());
+		}
+	}
+}

--- a/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/impl/crash/report/info/StackRemapper.java
+++ b/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/impl/crash/report/info/StackRemapper.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.crash.report.info;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.fabricmc.loader.api.FabricLoader;
+
+public final class StackRemapper {
+	private StackRemapper() {
+	}
+
+	public static Throwable remap(Throwable throwable) {
+		if (!shouldRemap()) {
+			return throwable;
+		}
+
+		if (isOOM(throwable)) {
+			return throwable;
+		}
+
+		// Be super careful not to throw for an unrelated reason, we cannot trust that the logger is working.
+		Logger logger = null;
+
+		try {
+			logger = LoggerFactory.getLogger(StackRemapper.class);
+			return doRemap(throwable);
+		} catch (Throwable t) {
+			try {
+				if (logger != null) {
+					logger.error("Failed to remap stack trace", t);
+				}
+			} catch (Throwable ignored) {
+				// Ignored, something is seriously wrong if we cannot log this.
+			}
+
+			return throwable;
+		}
+	}
+
+	private static Throwable doRemap(Throwable throwable) throws Throwable {
+		BinaryMappingReader mappings = new BinaryMappingReader();
+		return remapThrowable(throwable, mappings);
+	}
+
+	private static Throwable remapThrowable(Throwable throwable, BinaryMappingReader mappings) {
+		String message = throwable.getMessage();
+		Throwable cause = throwable.getCause();
+		Throwable[] suppressed = throwable.getSuppressed();
+		StackTraceElement[] elements = throwable.getStackTrace();
+
+		if (cause != null) {
+			cause = remapThrowable(cause, mappings);
+		}
+
+		Throwable remapped = new Throwable(message, cause);
+		remapped.setStackTrace(remapElements(elements, mappings));
+
+		for (Throwable sup : suppressed) {
+			remapped.addSuppressed(remapThrowable(sup, mappings));
+		}
+
+		return remapped;
+	}
+
+	private static StackTraceElement[] remapElements(StackTraceElement[] elements, BinaryMappingReader mappings) {
+		StackTraceElement[] remapped = new StackTraceElement[elements.length];
+
+		for (int i = 0; i < elements.length; i++) {
+			StackTraceElement element = elements[i];
+			String className = element.getClassName();
+			String methodName = element.getMethodName();
+			String fileName = element.getFileName();
+			int lineNumber = element.getLineNumber();
+
+			// TODO actually remap
+
+			remapped[i] = new StackTraceElement(className, methodName, fileName, lineNumber);
+		}
+
+		return remapped;
+	}
+
+	// Don't attempt to remap the stack trace if the throwable is an OutOfMemoryError.
+	// We need memory available to remap the stack trace, if there is no memory available, attempting to remap will even more of a problem.
+	private static boolean isOOM(Throwable throwable) {
+		if (throwable instanceof OutOfMemoryError) {
+			return true;
+		}
+
+		Throwable cause = throwable.getCause();
+
+		while (cause != null) {
+			if (isOOM(cause)) {
+				return true;
+			}
+
+			cause = cause.getCause();
+		}
+
+		for (Throwable suppressed : throwable.getSuppressed()) {
+			if (isOOM(suppressed)) {
+				return true;
+			}
+		}
+
+		return true;
+	}
+
+	public static boolean shouldRemap() {
+		return FabricLoader.getInstance().isDevelopmentEnvironment()
+				|| "intermediary".equals(FabricLoader.getInstance().getMappingResolver().getCurrentRuntimeNamespace());
+	}
+}

--- a/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/mixin/crash/report/info/CrashReportMixin.java
+++ b/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/mixin/crash/report/info/CrashReportMixin.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.crash.report.info;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.util.crash.CrashReport;
+
+import net.fabricmc.fabric.impl.crash.report.info.StackRemapper;
+
+@Mixin(CrashReport.class)
+public class CrashReportMixin {
+	@Shadow
+	@Final
+	@Mutable
+	private Throwable cause;
+
+	@Inject(method = "<init>", at = @At("RETURN"))
+	private void remap(String message, Throwable cause, CallbackInfo ci) {
+		this.cause = StackRemapper.remap(cause);
+	}
+}

--- a/fabric-crash-report-info-v1/src/main/resources/fabric-crash-report-info-v1.mixins.json
+++ b/fabric-crash-report-info-v1/src/main/resources/fabric-crash-report-info-v1.mixins.json
@@ -3,6 +3,7 @@
   "package": "net.fabricmc.fabric.mixin.crash.report.info",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
+    "CrashReportMixin",
     "DedicatedServerWatchdogMixin",
     "SystemDetailsMixin"
   ],

--- a/fabric-crash-report-info-v1/src/test/java/net/fabricmc/fabric/impl/crash/test/BinaryMappingsTest.java
+++ b/fabric-crash-report-info-v1/src/test/java/net/fabricmc/fabric/impl/crash/test/BinaryMappingsTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.crash.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import net.fabricmc.fabric.impl.crash.build.BinaryMappingsWriter;
+import net.fabricmc.fabric.impl.crash.build.MappingsPreparation;
+import net.fabricmc.fabric.impl.crash.report.info.BinaryMappingReader;
+import net.fabricmc.mappingio.format.tiny.Tiny2FileReader;
+import net.fabricmc.mappingio.tree.MappingTreeView;
+import net.fabricmc.mappingio.tree.MemoryMappingTree;
+
+public class BinaryMappingsTest {
+	@TempDir
+	Path tempDir;
+
+	@Test
+	void testReadWriteClassName() throws IOException {
+		Path mappingsFile = tempDir.resolve("mappings.bin");
+
+		MappingTreeView mappings = getMapping(SIMPLE_MAPPINGS);
+		BinaryMappingsWriter.write(mappingsFile, mappings);
+
+		BinaryMappingReader reader = new BinaryMappingReader(read(mappingsFile));
+
+		assertEquals("net/minecraft/Example", reader.getClassName(12));
+		assertEquals("example", reader.getMethodName(5432));
+		assertEquals("net/minecraft/util/Test", reader.getClassName(34));
+		assertEquals("test", reader.getMethodName(1));
+		assertEquals("net/minecraft/util/Test$Inner", reader.getClassName(56));
+		assertEquals("inner", reader.getMethodName(2));
+		assertEquals("net/minecraft/Test", reader.getClassName(78));
+	}
+
+	@Test
+	void testReadWriteFullMappings() throws IOException {
+		Path mappingsFile = tempDir.resolve("mappings.bin");
+		MappingsPreparation.prepare(mappingsFile);
+
+		BinaryMappingReader reader = new BinaryMappingReader(read(mappingsFile));
+
+		assertEquals("net/minecraft/block/Blocks", reader.getClassName(2246));
+		assertEquals("getBlockState", reader.getMethodName(48884));
+		assertEquals("net/minecraft/world/BlockLocating$Rectangle", reader.getClassName(5460));
+	}
+
+	private static ByteBuffer read(Path path) throws IOException {
+		return ByteBuffer.wrap(Files.readAllBytes(path));
+	}
+
+	private static MappingTreeView getMapping(String tiny) throws IOException {
+		MemoryMappingTree mappings = new MemoryMappingTree();
+		Tiny2FileReader.read(new StringReader(tiny), mappings);
+		return mappings;
+	}
+
+	private static final String SIMPLE_MAPPINGS = """
+			tiny	2	0	intermediary	named
+			c	net/minecraft/class_12	net/minecraft/Example
+			\tm	()V;	method_5432	example
+			c	net/minecraft/class_34	net/minecraft/util/Test
+			\tm	()V;	method_1	test
+			c	net/minecraft/class_56	net/minecraft/util/Test$Inner
+			\tm	()V;	method_2	inner
+			c	net/minecraft/class_78	net/minecraft/Test
+			""".stripIndent();
+}


### PR DESCRIPTION
This PR is very much **work in progress**, im opening it to get early feedback/ideas before I get too far with it, please leave any thoughts in the comments.

The goal with the PR is to improve the debugging experiance for players and modders by remapping the stacktrace from intermediary to yarn names. This has been done before by a few mods, but as far as im aware all of them download the mappings at runtime, this isnt something I want to do for many reasons.

This PR introduces a custom binary file format for storing the minimal amount of mapping data required to remap stacktraces in a compact and easily parsable format. Currently this data is 400KB when compressed in the jar, which is a bit larger than I would have liked to have, if anyone has any suggestions for improving this please let me know. There needs to be a balance between size and complexity of parsing, the current format supports random reads allowing for very fast name lookup and minimal memory usage.

The binary file is generated at FabricAPI build time and embeded in the crash reports jar. I am also not sure on the best way to hook all of the stacktraces to remap them, I currently have a mixin in `CrashReport` but I expect this will mess a lot of stacktraces such as the ones that dont actually crash the game. I ran out of time today to properly look at that side of things.