### PR TITLE
Make utility methods of EnchantmentHelper and Enchantment public.

### DIFF
--- a/fabric-transitive-access-wideners-v1/build.gradle
+++ b/fabric-transitive-access-wideners-v1/build.gradle
@@ -236,6 +236,8 @@ def generateEnchantmentMethods(List<String> lines, FileSystem fs) {
 			}
 		}
 	}
+	lines.add("transitive-accessible class net/minecraft/enchantment/EnchantmentHelper\$Consumer")
+	lines.add("transitive-accessible class net/minecraft/enchantment/EnchantmentHelper\$ContextAwareConsumer")
 }
 
 ClassNode loadClass(Path path) {

--- a/fabric-transitive-access-wideners-v1/build.gradle
+++ b/fabric-transitive-access-wideners-v1/build.gradle
@@ -236,8 +236,8 @@ def generateEnchantmentMethods(List<String> lines, FileSystem fs) {
 			}
 		}
 	}
-	lines.add("transitive-accessible class net/minecraft/enchantment/EnchantmentHelper\$Consumer")
-	lines.add("transitive-accessible class net/minecraft/enchantment/EnchantmentHelper\$ContextAwareConsumer")
+	lines.add('transitive-accessible class net/minecraft/enchantment/EnchantmentHelper$Consumer')
+	lines.add('transitive-accessible class net/minecraft/enchantment/EnchantmentHelper$ContextAwareConsumer')
 }
 
 ClassNode loadClass(Path path) {

--- a/fabric-transitive-access-wideners-v1/build.gradle
+++ b/fabric-transitive-access-wideners-v1/build.gradle
@@ -41,6 +41,8 @@ tasks.register('generateAccessWidener') {
 			lines.add("")
 			generateCreatorEntityTrackedDataMethods(lines, fs)
 			lines.add("")
+			generateEnchantmentMethods(lines, fs)
+			lines.add("")
 		}
 
 		Path clientJar = loom.namedMinecraftProvider.parentMinecraftProvider.clientOnlyJar.path
@@ -221,6 +223,19 @@ def generateCreatorEntityTrackedDataMethods(List<String> lines, FileSystem fs) {
 	generateTrackedDataFields("net/minecraft/entity/decoration/DisplayEntity\$BlockDisplayEntity", lines, fs)
 	generateTrackedDataFields("net/minecraft/entity/decoration/DisplayEntity\$TextDisplayEntity", lines, fs)
 	generateTrackedDataFields("net/minecraft/entity/decoration/InteractionEntity", lines, fs, "shouldRespond")
+}
+
+def generateEnchantmentMethods(List<String> lines, FileSystem fs) {
+	lines.add("# Private methods of Enchantment and EnchantmentHelper")
+
+	for (def node : [ loadClass(fs.getPath("net/minecraft/enchantment/EnchantmentHelper.class")), loadClass(fs.getPath("net/minecraft/enchantment/Enchantment.class")) ]) {
+		for (def method : node.methods) {
+			// All private inner methods of EnchantmentHelper
+			if ((method.access & Opcodes.ACC_PRIVATE) != 0 && !method.name.startsWith("method_")) {
+				lines.add("transitive-accessible method $node.name $method.name $method.desc")
+			}
+		}
+	}
 }
 
 ClassNode loadClass(Path path) {

--- a/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.accesswidener
+++ b/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.accesswidener
@@ -298,6 +298,20 @@ transitive-accessible method net/minecraft/entity/decoration/InteractionEntity g
 transitive-accessible method net/minecraft/entity/decoration/InteractionEntity setResponse (Z)V
 transitive-accessible method net/minecraft/entity/decoration/InteractionEntity shouldRespond ()Z
 
+# Private methods of Enchantment and EnchantmentHelper
+transitive-accessible method net/minecraft/enchantment/EnchantmentHelper getEnchantmentsComponentType (Lnet/minecraft/item/ItemStack;)Lnet/minecraft/component/ComponentType;
+transitive-accessible method net/minecraft/enchantment/EnchantmentHelper forEachEnchantment (Lnet/minecraft/item/ItemStack;Lnet/minecraft/enchantment/EnchantmentHelper$Consumer;)V
+transitive-accessible method net/minecraft/enchantment/EnchantmentHelper forEachEnchantment (Lnet/minecraft/item/ItemStack;Lnet/minecraft/entity/EquipmentSlot;Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/enchantment/EnchantmentHelper$ContextAwareConsumer;)V
+transitive-accessible method net/minecraft/enchantment/EnchantmentHelper forEachEnchantment (Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/enchantment/EnchantmentHelper$ContextAwareConsumer;)V
+transitive-accessible method net/minecraft/enchantment/Enchantment modifyValue (Lnet/minecraft/component/ComponentType;Lnet/minecraft/server/world/ServerWorld;ILnet/minecraft/item/ItemStack;Lorg/apache/commons/lang3/mutable/MutableFloat;)V
+transitive-accessible method net/minecraft/enchantment/Enchantment modifyValue (Lnet/minecraft/component/ComponentType;Lnet/minecraft/server/world/ServerWorld;ILnet/minecraft/item/ItemStack;Lnet/minecraft/entity/Entity;Lorg/apache/commons/lang3/mutable/MutableFloat;)V
+transitive-accessible method net/minecraft/enchantment/Enchantment modifyValue (Lnet/minecraft/component/ComponentType;Lnet/minecraft/server/world/ServerWorld;ILnet/minecraft/item/ItemStack;Lnet/minecraft/entity/Entity;Lnet/minecraft/entity/damage/DamageSource;Lorg/apache/commons/lang3/mutable/MutableFloat;)V
+transitive-accessible method net/minecraft/enchantment/Enchantment createEnchantedItemLootContext (Lnet/minecraft/server/world/ServerWorld;ILnet/minecraft/item/ItemStack;)Lnet/minecraft/loot/context/LootContext;
+transitive-accessible method net/minecraft/enchantment/Enchantment createEnchantedLocationLootContext (Lnet/minecraft/server/world/ServerWorld;ILnet/minecraft/entity/Entity;Z)Lnet/minecraft/loot/context/LootContext;
+transitive-accessible method net/minecraft/enchantment/Enchantment createEnchantedEntityLootContext (Lnet/minecraft/server/world/ServerWorld;ILnet/minecraft/entity/Entity;Lnet/minecraft/util/math/Vec3d;)Lnet/minecraft/loot/context/LootContext;
+transitive-accessible method net/minecraft/enchantment/Enchantment createHitBlockLootContext (Lnet/minecraft/server/world/ServerWorld;ILnet/minecraft/entity/Entity;Lnet/minecraft/util/math/Vec3d;Lnet/minecraft/block/BlockState;)Lnet/minecraft/loot/context/LootContext;
+transitive-accessible method net/minecraft/enchantment/Enchantment applyEffects (Ljava/util/List;Lnet/minecraft/loot/context/LootContext;Ljava/util/function/Consumer;)V
+
 # Protected static fields of RenderPhase
 transitive-accessible field net/minecraft/client/render/RenderPhase MIPMAP_BLOCK_ATLAS_TEXTURE Lnet/minecraft/client/render/RenderPhase$Texture;
 transitive-accessible field net/minecraft/client/render/RenderPhase BLOCK_ATLAS_TEXTURE Lnet/minecraft/client/render/RenderPhase$Texture;

--- a/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.accesswidener
+++ b/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.accesswidener
@@ -311,6 +311,8 @@ transitive-accessible method net/minecraft/enchantment/Enchantment createEnchant
 transitive-accessible method net/minecraft/enchantment/Enchantment createEnchantedEntityLootContext (Lnet/minecraft/server/world/ServerWorld;ILnet/minecraft/entity/Entity;Lnet/minecraft/util/math/Vec3d;)Lnet/minecraft/loot/context/LootContext;
 transitive-accessible method net/minecraft/enchantment/Enchantment createHitBlockLootContext (Lnet/minecraft/server/world/ServerWorld;ILnet/minecraft/entity/Entity;Lnet/minecraft/util/math/Vec3d;Lnet/minecraft/block/BlockState;)Lnet/minecraft/loot/context/LootContext;
 transitive-accessible method net/minecraft/enchantment/Enchantment applyEffects (Ljava/util/List;Lnet/minecraft/loot/context/LootContext;Ljava/util/function/Consumer;)V
+transitive-accessible class net/minecraft/enchantment/EnchantmentHelper$Consumer
+transitive-accessible class net/minecraft/enchantment/EnchantmentHelper$ContextAwareConsumer
 
 # Protected static fields of RenderPhase
 transitive-accessible field net/minecraft/client/render/RenderPhase MIPMAP_BLOCK_ATLAS_TEXTURE Lnet/minecraft/client/render/RenderPhase$Texture;


### PR DESCRIPTION
EnchantmentHelper and Enchantment both have few methods that are useful for mods adding enchantments (and used by Mojang in their specialized methods), but are private, requiring devs to duplicate them otherwise.