### PR TITLE
Allow for more flexible / configurable stripping behaviour.

### DIFF
--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/StrippableBlockRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/StrippableBlockRegistry.java
@@ -16,56 +16,105 @@
 
 package net.fabricmc.fabric.api.registry;
 
-import java.util.Map;
-import java.util.Objects;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
 import net.minecraft.state.property.Properties;
+import net.minecraft.state.property.Property;
+import net.minecraft.util.math.Direction;
 
-import net.fabricmc.fabric.impl.content.registry.util.ImmutableCollectionUtils;
-import net.fabricmc.fabric.mixin.content.registry.AxeItemAccessor;
+import net.fabricmc.fabric.impl.content.registry.StrippableBlockRegistryImpl;
 
 /**
  * A registry for axe stripping interactions. A vanilla example is turning logs to stripped logs.
  */
 public final class StrippableBlockRegistry {
-	private static final Logger LOGGER = LoggerFactory.getLogger(StrippableBlockRegistry.class);
-
 	private StrippableBlockRegistry() {
 	}
 
 	/**
 	 * Registers a stripping interaction.
-	 *
-	 * <p>Both blocks must have the {@link Properties#AXIS axis} property.
+	 * The resulting BlockState of stripping of input will only copy the {@link Properties#AXIS axis} property, if it's present.
 	 *
 	 * @param input    the input block that can be stripped
 	 * @param stripped the stripped result block
-	 * @throws IllegalArgumentException if the input or the output doesn't have the {@link Properties#AXIS axis} property
 	 */
 	public static void register(Block input, Block stripped) {
-		requireNonNullAndAxisProperty(input, "input block");
-		requireNonNullAndAxisProperty(stripped, "stripped block");
+		StrippingTransformer transformer;
 
-		Block old = getRegistry().put(input, stripped);
-
-		if (old != null) {
-			LOGGER.debug("Replaced old stripping mapping from {} to {} with {}", input, old, stripped);
+		if (input.getDefaultState().contains(Properties.AXIS) && stripped.getDefaultState().contains(Properties.AXIS)) {
+			transformer = StrippingTransformer.VANILLA;
+		} else {
+			transformer = StrippingTransformer.DEFAULT_STATE;
 		}
+
+		StrippableBlockRegistryImpl.register(input, stripped, transformer);
 	}
 
-	private static void requireNonNullAndAxisProperty(Block block, String name) {
-		Objects.requireNonNull(block, name + " cannot be null");
-
-		if (!block.getStateManager().getProperties().contains(Properties.AXIS)) {
-			throw new IllegalArgumentException(name + " must have the 'axis' property");
-		}
+	/**
+	 * Registers a stripping interaction.
+	 * The resulting BlockState of stripping of input will copy all present properties.
+	 *
+	 * @param input    the input block that can be stripped
+	 * @param stripped the stripped result block
+	 */
+	public static void registerCopyState(Block input, Block stripped) {
+		StrippableBlockRegistryImpl.register(input, stripped, StrippingTransformer.COPY);
 	}
 
-	private static Map<Block, Block> getRegistry() {
-		return ImmutableCollectionUtils.getAsMutableMap(AxeItemAccessor::getStrippedBlocks, AxeItemAccessor::setStrippedBlocks);
+	/**
+	 * Registers a stripping interaction.
+	 * The resulting BlockState of stripping of input will depend on provided transformer.
+	 *
+	 * @param input       the input block that can be stripped
+	 * @param stripped    the stripped result block
+	 * @param transformer the transformer used to provide the resulting block state
+	 */
+	public static void register(Block input, Block stripped, StrippingTransformer transformer) {
+		StrippableBlockRegistryImpl.register(input, stripped, transformer);
+	}
+
+	/**
+	 * Provides result of stripping interaction.
+	 *
+	 * @param blockState original block state
+	 * @return stripped block state if successful, otherwise null
+	 */
+	@Nullable
+	public static BlockState getStrippedBlockState(BlockState blockState) {
+		return StrippableBlockRegistryImpl.getStrippedBlockState(blockState);
+	}
+
+	public interface StrippingTransformer {
+		StrippingTransformer DEFAULT_STATE = (strippedBlock, originalState) -> strippedBlock.getDefaultState();
+		StrippingTransformer VANILLA = (strippedBlock, originalState) -> strippedBlock.getDefaultState().withIfExists(Properties.AXIS, originalState.get(Properties.AXIS, Direction.Axis.Y));
+		StrippingTransformer COPY = Block::getStateWithProperties;
+
+		BlockState getStrippedBlockState(Block strippedBlock, BlockState originalState);
+
+		static StrippingTransformer copyOf(Property<?>... properties) {
+			if (properties.length == 0) {
+				return DEFAULT_STATE;
+			}
+
+			if (properties.length == 1 && properties[0] == Properties.AXIS) {
+				return VANILLA;
+			}
+
+			return ((strippedBlock, originalState) -> {
+				BlockState state = strippedBlock.getDefaultState();
+
+				//noinspection rawtypes
+				for (Property property : properties) {
+					if (originalState.contains(property)) {
+						//noinspection unchecked
+						state = state.withIfExists(property, originalState.get(property));
+					}
+				}
+
+				return state;
+			});
+		}
 	}
 }

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/StrippableBlockRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/StrippableBlockRegistry.java
@@ -91,6 +91,7 @@ public final class StrippableBlockRegistry {
 		StrippingTransformer VANILLA = (strippedBlock, originalState) -> strippedBlock.getDefaultState().withIfExists(Properties.AXIS, originalState.get(Properties.AXIS, Direction.Axis.Y));
 		StrippingTransformer COPY = Block::getStateWithProperties;
 
+		@Nullable
 		BlockState getStrippedBlockState(Block strippedBlock, BlockState originalState);
 
 		static StrippingTransformer copyOf(Property<?>... properties) {

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/StrippableBlockRegistryImpl.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/StrippableBlockRegistryImpl.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.content.registry;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+
+import net.fabricmc.fabric.api.registry.StrippableBlockRegistry;
+import net.fabricmc.fabric.impl.content.registry.util.ImmutableCollectionUtils;
+import net.fabricmc.fabric.mixin.content.registry.AxeItemAccessor;
+
+public final class StrippableBlockRegistryImpl {
+	private static final Logger LOGGER = LoggerFactory.getLogger(StrippableBlockRegistryImpl.class);
+	private static final IdentityHashMap<Block, StrippableBlockRegistry.StrippingTransformer> TRANSFORMERS = new IdentityHashMap<>();
+
+	public static void register(Block input, Block stripped, StrippableBlockRegistry.StrippingTransformer transformer) {
+		Objects.requireNonNull(input, "input block cannot be null");
+		Objects.requireNonNull(stripped, "stripped block cannot be null");
+
+		Block old = getRegistry().put(input, stripped);
+		TRANSFORMERS.put(input, transformer);
+
+		if (old != null) {
+			LOGGER.debug("Replaced old stripping mapping from {} to {} with {}", input, old, stripped);
+		}
+	}
+
+	private static Map<Block, Block> getRegistry() {
+		return ImmutableCollectionUtils.getAsMutableMap(AxeItemAccessor::getStrippedBlocks, AxeItemAccessor::setStrippedBlocks);
+	}
+
+	@Nullable
+	public static BlockState getStrippedBlockState(BlockState state) {
+		Block strippedBlock = getRegistry().get(state.getBlock());
+
+		if (strippedBlock == null) {
+			return null;
+		}
+
+		return TRANSFORMERS.getOrDefault(state.getBlock(), StrippableBlockRegistry.StrippingTransformer.VANILLA).getStrippedBlockState(strippedBlock, state);
+	}
+
+	@Nullable
+	public static StrippableBlockRegistry.StrippingTransformer getTransformer(Block block) {
+		return TRANSFORMERS.get(block);
+	}
+}

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/mixin/content/registry/AxeItemMixin.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/mixin/content/registry/AxeItemMixin.java
@@ -16,10 +16,12 @@
 
 package net.fabricmc.fabric.mixin.content.registry;
 
+import java.util.function.Function;
+
+import com.llamalad7.mixinextras.sugar.Local;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -30,13 +32,14 @@ import net.fabricmc.fabric.impl.content.registry.StrippableBlockRegistryImpl;
 
 @Mixin(AxeItem.class)
 public class AxeItemMixin {
-	// Lambda in getStrippedState
-	@Inject(method = "method_34717", at = @At("HEAD"), cancellable = true)
-	private static void handleCustomStrippingBehavior(BlockState blockState, Block block, CallbackInfoReturnable<BlockState> cir) {
-		StrippableBlockRegistry.StrippingTransformer transformer = StrippableBlockRegistryImpl.getTransformer(blockState.getBlock());
+	@ModifyArg(method = "getStrippedState", at = @At(value = "INVOKE", target = "Ljava/util/Optional;map(Ljava/util/function/Function;)Ljava/util/Optional;"))
+	private Function<Block, BlockState> handleCustomStrippingBehavior(Function<Block, BlockState> mapper, @Local(argsOnly = true) BlockState state) {
+		StrippableBlockRegistry.StrippingTransformer transformer = StrippableBlockRegistryImpl.getTransformer(state.getBlock());
 
 		if (transformer != null) {
-			cir.setReturnValue(transformer.getStrippedBlockState(block, blockState));
+			return block -> transformer.getStrippedBlockState(block, state);
 		}
+
+		return mapper;
 	}
 }

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/mixin/content/registry/AxeItemMixin.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/mixin/content/registry/AxeItemMixin.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.content.registry;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.item.AxeItem;
+
+import net.fabricmc.fabric.api.registry.StrippableBlockRegistry;
+import net.fabricmc.fabric.impl.content.registry.StrippableBlockRegistryImpl;
+
+@Mixin(AxeItem.class)
+public class AxeItemMixin {
+	// Lambda in getStrippedState
+	@Inject(method = "method_34717", at = @At("HEAD"), cancellable = true)
+	private static void handleCustomStrippingBehavior(BlockState blockState, Block block, CallbackInfoReturnable<BlockState> cir) {
+		StrippableBlockRegistry.StrippingTransformer transformer = StrippableBlockRegistryImpl.getTransformer(blockState.getBlock());
+
+		if (transformer != null) {
+			cir.setReturnValue(transformer.getStrippedBlockState(block, blockState));
+		}
+	}
+}

--- a/fabric-content-registries-v0/src/main/resources/fabric-content-registries-v0.mixins.json
+++ b/fabric-content-registries-v0/src/main/resources/fabric-content-registries-v0.mixins.json
@@ -3,9 +3,10 @@
   "package": "net.fabricmc.fabric.mixin.content.registry",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
-    "AbstractBlockAccessor",
     "AbstractBlockAbstractBlockStateMixin",
+    "AbstractBlockAccessor",
     "AxeItemAccessor",
+    "AxeItemMixin",
     "BrewingRecipeRegistryBuilderMixin",
     "FarmerWorkTaskAccessor",
     "FireBlockMixin",

--- a/fabric-content-registries-v0/src/testmod/java/net/fabricmc/fabric/test/content/registry/ContentRegistryGameTest.java
+++ b/fabric-content-registries-v0/src/testmod/java/net/fabricmc/fabric/test/content/registry/ContentRegistryGameTest.java
@@ -23,9 +23,11 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.ComposterBlock;
 import net.minecraft.block.HopperBlock;
+import net.minecraft.block.StairsBlock;
 import net.minecraft.block.entity.AbstractFurnaceBlockEntity;
 import net.minecraft.block.entity.BrewingStandBlockEntity;
 import net.minecraft.block.entity.HopperBlockEntity;
+import net.minecraft.block.enums.BlockHalf;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.PotionContentsComponent;
 import net.minecraft.entity.player.PlayerEntity;
@@ -154,6 +156,12 @@ public class ContentRegistryGameTest {
 		context.useBlock(pos, player);
 		context.expectBlock(Blocks.HAY_BLOCK, pos);
 		context.assertEquals(axe.getDamage(), 1, Text.literal("axe damage"));
+		context.useBlock(pos, player);
+		context.expectBlock(Blocks.TNT, pos);
+		BlockState oakStairState = Blocks.OAK_STAIRS.getDefaultState().with(StairsBlock.WATERLOGGED, true).with(StairsBlock.HALF, BlockHalf.TOP);
+		context.setBlockState(pos, oakStairState);
+		context.useBlock(pos, player);
+		context.expectBlockState(pos, Blocks.SPRUCE_STAIRS.getStateWithProperties(oakStairState));
 		context.complete();
 	}
 

--- a/fabric-content-registries-v0/src/testmod/java/net/fabricmc/fabric/test/content/registry/ContentRegistryTest.java
+++ b/fabric-content-registries-v0/src/testmod/java/net/fabricmc/fabric/test/content/registry/ContentRegistryTest.java
@@ -94,6 +94,8 @@ public final class ContentRegistryTest implements ModInitializer {
 		//  - custom items prefixed with 'smelting fuels included by' are valid smelting fuels
 		//  - dead bush is now considered as a dangerous block like sweet berry bushes (all entities except foxes should avoid it)
 		//  - quartz pillars are strippable to hay blocks
+		//  - hay blocks are strippable to tnt
+		//  - oak stairs are strippable to spruce stairs, while preserving all block state properties
 		//  - green wool is tillable to lime wool
 		//  - copper ore, iron ore, gold ore, and diamond ore can be waxed into their deepslate variants and scraped back again
 		//  - aforementioned ores can be scraped from diamond -> gold -> iron -> copper
@@ -122,16 +124,8 @@ public final class ContentRegistryTest implements ModInitializer {
 
 		LandPathNodeTypesRegistry.register(Blocks.DEAD_BUSH, PathNodeType.DAMAGE_OTHER, PathNodeType.DANGER_OTHER);
 		StrippableBlockRegistry.register(Blocks.QUARTZ_PILLAR, Blocks.HAY_BLOCK);
-
-		// assert that StrippableBlockRegistry throws when the blocks don't have 'axis'
-		try {
-			StrippableBlockRegistry.register(Blocks.BLUE_WOOL, Blocks.OAK_LOG);
-			StrippableBlockRegistry.register(Blocks.HAY_BLOCK, Blocks.BLUE_WOOL);
-			throw new AssertionError("StrippableBlockRegistry didn't throw when blocks were missing the 'axis' property!");
-		} catch (IllegalArgumentException e) {
-			// expected behavior
-			LOGGER.info("StrippableBlockRegistry test passed!");
-		}
+		StrippableBlockRegistry.register(Blocks.HAY_BLOCK, Blocks.TNT);
+		StrippableBlockRegistry.registerCopyState(Blocks.OAK_STAIRS, Blocks.SPRUCE_STAIRS);
 
 		TillableBlockRegistry.register(Blocks.GREEN_WOOL, context -> true, HoeItem.createTillAction(Blocks.LIME_WOOL.getDefaultState()));
 


### PR DESCRIPTION
Makes stripping behaviour bit more configurable, by removing the restriction of requiring AXIS property, while also allowing to define the way stripped state should be created. 

Existing StrippableBlockRegistry#register(Block input, Block stripped) still only copies AXIS property.
A new StrippableBlockRegistry#registerCopyState(Block input, Block stripped) makes it copy all compatible properties. 
If someone needs bit more control, they can use StrippableBlockRegistry#register(Block input, Block stripped, StrippingTransformer transformer) to define how and what is copied. 