### PR TITLE
Cleanup FluidRendererMixin

### DIFF
--- a/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/fluid/FluidRenderHandlerRegistryImpl.java
+++ b/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/fluid/FluidRenderHandlerRegistryImpl.java
@@ -18,14 +18,14 @@ package net.fabricmc.fabric.impl.client.rendering.fluid;
 
 import java.util.IdentityHashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
+import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
+import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.LeavesBlock;
-import net.minecraft.block.TranslucentBlock;
+import net.minecraft.block.TransparentBlock;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.color.world.BiomeColors;
 import net.minecraft.client.render.block.FluidRenderer;
@@ -45,7 +45,7 @@ import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandlerRegistry
 public class FluidRenderHandlerRegistryImpl implements FluidRenderHandlerRegistry {
 	private final Map<Fluid, FluidRenderHandler> handlers = new IdentityHashMap<>();
 	private final Map<Fluid, FluidRenderHandler> modHandlers = new IdentityHashMap<>();
-	private final ConcurrentMap<Block, Boolean> overlayBlocks = new ConcurrentHashMap<>();
+	private final Object2BooleanMap<Block> transparencyForOverlay = new Object2BooleanOpenHashMap<>();
 
 	{
 		handlers.put(Fluids.WATER, WaterRenderHandler.INSTANCE);
@@ -77,12 +77,12 @@ public class FluidRenderHandlerRegistryImpl implements FluidRenderHandlerRegistr
 
 	@Override
 	public void setBlockTransparency(Block block, boolean transparent) {
-		overlayBlocks.put(block, transparent);
+		transparencyForOverlay.put(block, transparent);
 	}
 
 	@Override
 	public boolean isBlockTransparent(Block block) {
-		return overlayBlocks.computeIfAbsent(block, k -> k instanceof TranslucentBlock || k instanceof LeavesBlock);
+		return transparencyForOverlay.getOrDefault(block, block instanceof TransparentBlock || block instanceof LeavesBlock);
 	}
 
 	public void onFluidRendererReload(FluidRenderer renderer, Sprite[] waterSprites, Sprite[] lavaSprites, Sprite waterOverlay) {

--- a/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/fluid/FluidRenderHandlerRegistryImpl.java
+++ b/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/fluid/FluidRenderHandlerRegistryImpl.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.LeavesBlock;
-import net.minecraft.block.TransparentBlock;
+import net.minecraft.block.TranslucentBlock;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.color.world.BiomeColors;
 import net.minecraft.client.render.block.FluidRenderer;
@@ -82,7 +82,7 @@ public class FluidRenderHandlerRegistryImpl implements FluidRenderHandlerRegistr
 
 	@Override
 	public boolean isBlockTransparent(Block block) {
-		return transparencyForOverlay.getOrDefault(block, block instanceof TransparentBlock || block instanceof LeavesBlock);
+		return transparencyForOverlay.getOrDefault(block, block instanceof TranslucentBlock || block instanceof LeavesBlock);
 	}
 
 	public void onFluidRendererReload(FluidRenderer renderer, Sprite[] waterSprites, Sprite[] lavaSprites, Sprite waterOverlay) {

--- a/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/fluid/FluidRendererMixin.java
+++ b/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/fluid/FluidRendererMixin.java
@@ -16,15 +16,19 @@
 
 package net.fabricmc.fabric.mixin.client.rendering.fluid;
 
-import org.objectweb.asm.Opcodes;
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalBooleanRef;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.block.Block;
@@ -53,16 +57,13 @@ public class FluidRendererMixin {
 	@Shadow
 	private Sprite waterOverlaySprite;
 
-	@Unique
-	private final ThreadLocal<Block> neighborBlock = new ThreadLocal<>();
-
-	@Inject(at = @At("RETURN"), method = "onResourceReload")
+	@Inject(method = "onResourceReload", at = @At("RETURN"))
 	public void onResourceReloadReturn(CallbackInfo info) {
 		FluidRenderer self = (FluidRenderer) (Object) this;
 		((FluidRenderHandlerRegistryImpl) FluidRenderHandlerRegistry.INSTANCE).onFluidRendererReload(self, waterSprites, lavaSprites, waterOverlaySprite);
 	}
 
-	@Inject(at = @At("HEAD"), method = "render", cancellable = true)
+	@Inject(method = "render", at = @At("HEAD"), cancellable = true)
 	public void onHeadRender(BlockRenderView view, BlockPos pos, VertexConsumer vertexConsumer, BlockState blockState, FluidState fluidState, CallbackInfo ci) {
 		FluidRenderHandlerInfo info = FluidRenderingImpl.getCurrentInfo();
 
@@ -76,58 +77,55 @@ public class FluidRendererMixin {
 		}
 	}
 
-	@ModifyVariable(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/block/FluidRenderer;isSameFluid(Lnet/minecraft/fluid/FluidState;Lnet/minecraft/fluid/FluidState;)Z"), method = "render", ordinal = 0)
-	public boolean modLavaCheck(boolean chk) {
-		// First boolean local is set by vanilla according to 'matches lava'
-		// but uses the negation consistent with 'matches water'
-		// for determining if overlay water sprite should be used behind glass.
+	@ModifyVariable(
+			method = "render",
+			at = @At("STORE"),
+			ordinal = 0
+	)
+	public Sprite[] modSpriteArray(Sprite[] original) {
+		FluidRenderHandlerInfo info = FluidRenderingImpl.getCurrentInfo();
+		return info.handler != null ? info.sprites : original;
+	}
 
-		// Has other uses but those are overridden by this mixin and have
-		// already happened by the time this hook is called.
+	@ModifyVariable(method = "render", at = @At("STORE"), ordinal = 0)
+	public int modTintColor(int original, BlockRenderView world, BlockPos pos, VertexConsumer vertexConsumer, BlockState blockState, FluidState fluidState) {
+		FluidRenderHandlerInfo info = FluidRenderingImpl.getCurrentInfo();
+		return info.handler != null ? info.handler.getFluidColor(world, pos, fluidState) : original;
+	}
 
-		// If this fluid has an overlay texture, set this boolean to false.
+	@Definition(id = "getFrameU", method = "Lnet/minecraft/client/texture/Sprite;getFrameU(F)F")
+	@Expression("@(?).getFrameU(0.0)")
+	@ModifyVariable(
+			method = "render",
+			at = @At(value = "MIXINEXTRAS:EXPRESSION", ordinal = 0),
+			slice = @Slice(from = @At(value = "FIELD", target = "Lnet/minecraft/client/render/block/FluidRenderer;waterOverlaySprite:Lnet/minecraft/client/texture/Sprite;"))
+	)
+	private Sprite modifyOverlaySprite(
+			Sprite sprite,
+			BlockRenderView world,
+			@Local(ordinal = 1) BlockPos neighborPos,
+			@Local(ordinal = 0) boolean isLava,
+			@Local Sprite[] sprites,
+			@Share("useOverlay") LocalBooleanRef useOverlay
+	) {
 		final FluidRenderHandlerInfo info = FluidRenderingImpl.getCurrentInfo();
-		return info.handler != null ? !info.hasOverlay : chk;
-	}
+		boolean hasOverlay = info.handler != null ? info.hasOverlay : !isLava;
 
-	@ModifyVariable(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/block/FluidRenderer;isSameFluid(Lnet/minecraft/fluid/FluidState;Lnet/minecraft/fluid/FluidState;)Z"), method = "render", ordinal = 0)
-	public Sprite[] modSpriteArray(Sprite[] chk) {
-		FluidRenderHandlerInfo info = FluidRenderingImpl.getCurrentInfo();
-		return info.handler != null ? info.sprites : chk;
-	}
+		Block neighborBlock = world.getBlockState(neighborPos).getBlock();
+		useOverlay.set(hasOverlay && FluidRenderHandlerRegistry.INSTANCE.isBlockTransparent(neighborBlock));
 
-	@ModifyVariable(at = @At(value = "CONSTANT", args = "intValue=16", ordinal = 0, shift = At.Shift.BEFORE), method = "render", ordinal = 0)
-	public int modTintColor(int chk, BlockRenderView world, BlockPos pos, VertexConsumer vertexConsumer, BlockState blockState, FluidState fluidState) {
-		FluidRenderHandlerInfo info = FluidRenderingImpl.getCurrentInfo();
-		return info.handler != null ? info.handler.getFluidColor(world, pos, fluidState) : chk;
-	}
-
-	// Redirect redirects all 'waterOverlaySprite' gets in 'render' to this method, this is correct
-	@Redirect(at = @At(value = "FIELD", opcode = Opcodes.GETFIELD, target = "Lnet/minecraft/client/render/block/FluidRenderer;waterOverlaySprite:Lnet/minecraft/client/texture/Sprite;"), method = "render")
-	public Sprite modWaterOverlaySprite(FluidRenderer self) {
-		FluidRenderHandlerInfo info = FluidRenderingImpl.getCurrentInfo();
-		return info.handler != null && info.hasOverlay ? info.overlaySprite : waterOverlaySprite;
-	}
-
-	@Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;getBlock()Lnet/minecraft/block/Block;"), method = "render")
-	public Block getOverlayBlock(BlockState state) {
-		Block block = state.getBlock();
-		neighborBlock.set(block);
-
-		// An if-statement follows, we don't want this anymore and 'null' makes
-		// its condition always false (due to instanceof)
-		return null;
-	}
-
-	@ModifyVariable(at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/block/BlockState;getBlock()Lnet/minecraft/block/Block;"), method = "render", ordinal = 0)
-	public Sprite modSideSpriteForOverlay(Sprite chk) {
-		Block block = neighborBlock.get();
-
-		if (FluidRenderHandlerRegistry.INSTANCE.isBlockTransparent(block)) {
-			FluidRenderHandlerInfo info = FluidRenderingImpl.getCurrentInfo();
-			return info.handler != null && info.hasOverlay ? info.overlaySprite : waterOverlaySprite;
+		if (useOverlay.get()) {
+			return info.handler != null ? info.overlaySprite : this.waterOverlaySprite;
+		} else {
+			return sprites[1];
 		}
+	}
 
-		return chk;
+	@Definition(id = "sprite2", local = @Local(type = Sprite.class))
+	@Definition(id = "waterOverlaySprite", field = "Lnet/minecraft/client/render/block/FluidRenderer;waterOverlaySprite:Lnet/minecraft/client/texture/Sprite;")
+	@Expression("sprite2 != this.waterOverlaySprite")
+	@ModifyExpressionValue(method = "render", at = @At("MIXINEXTRAS:EXPRESSION"))
+	private boolean modifyNonOverlayCheck(boolean original, @Share("useOverlay") LocalBooleanRef useOverlay) {
+		return !useOverlay.get();
 	}
 }

--- a/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/fluid/FluidRendererMixin.java
+++ b/fabric-rendering-fluids-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/fluid/FluidRendererMixin.java
@@ -87,21 +87,28 @@ public class FluidRendererMixin {
 		return info.handler != null ? info.sprites : original;
 	}
 
-	@ModifyVariable(method = "render", at = @At("STORE"), ordinal = 0)
+	@ModifyExpressionValue(
+			method = "render",
+			at = {
+					@At(value = "CONSTANT", args = "intValue=" + 0xffffff),
+					@At(value = "INVOKE", target = "Lnet/minecraft/client/color/world/BiomeColors;getWaterColor(Lnet/minecraft/world/BlockRenderView;Lnet/minecraft/util/math/BlockPos;)I")
+			}
+	)
 	public int modTintColor(int original, BlockRenderView world, BlockPos pos, VertexConsumer vertexConsumer, BlockState blockState, FluidState fluidState) {
 		FluidRenderHandlerInfo info = FluidRenderingImpl.getCurrentInfo();
 		return info.handler != null ? info.handler.getFluidColor(world, pos, fluidState) : original;
 	}
 
 	@Definition(id = "getFrameU", method = "Lnet/minecraft/client/texture/Sprite;getFrameU(F)F")
-	@Expression("@(?).getFrameU(0.0)")
+	@Definition(id = "sprite2", local = @Local(type = Sprite.class))
+	@Expression("@(sprite2).getFrameU(0.0)")
 	@ModifyVariable(
 			method = "render",
 			at = @At(value = "MIXINEXTRAS:EXPRESSION", ordinal = 0),
 			slice = @Slice(from = @At(value = "FIELD", target = "Lnet/minecraft/client/render/block/FluidRenderer;waterOverlaySprite:Lnet/minecraft/client/texture/Sprite;"))
 	)
 	private Sprite modifyOverlaySprite(
-			Sprite sprite,
+			Sprite sprite2,
 			BlockRenderView world,
 			@Local(ordinal = 1) BlockPos neighborPos,
 			@Local(ordinal = 0) boolean isLava,

--- a/fabric-rendering-fluids-v1/src/client/resources/fabric-rendering-fluids-v1.mixins.json
+++ b/fabric-rendering-fluids-v1/src/client/resources/fabric-rendering-fluids-v1.mixins.json
@@ -6,7 +6,12 @@
     "FluidRendererMixin"
   ],
   "injectors": {
-    "defaultRequire": 1,
-    "maxShiftBy": 5
+    "defaultRequire": 1
+  },
+  "overwrites": {
+    "requireAnnotations": true
+  },
+  "mixinextras": {
+    "minVersion": "0.5.0"
   }
 }


### PR DESCRIPTION
Also changed the type of the `transparencyForOverlay` registry map from a concurrent map to the faster `Object2BooleanOpenHashMap`, by using the thread safe `getOrDefault` method over `computeIfAbsent`.