### PR TITLE
Flatten bundle packets

### DIFF
--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/BundlePacketMixin.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/BundlePacketMixin.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.networking;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import net.minecraft.network.packet.BundlePacket;
+import net.minecraft.network.packet.Packet;
+
+@Mixin(BundlePacket.class)
+public class BundlePacketMixin {
+	@ModifyVariable(method = "<init>", at = @At("HEAD"), argsOnly = true)
+	private static Iterable<? extends Packet<?>> flattenBundlePackets(Iterable<? extends Packet<?>> value) {
+		var packets = new ArrayList<Packet<?>>();
+		iterateBundle(value, packets);
+		return packets;
+	}
+
+	@Unique
+	private static void iterateBundle(Iterable<? extends Packet<?>> value, List<Packet<?>> result) {
+		for (Packet<?> packet : value) {
+			if (packet instanceof BundlePacket<?> bundlePacket) {
+				iterateBundle(bundlePacket.getPackets(), result);
+			} else {
+				result.add(packet);
+			}
+		}
+	}
+}

--- a/fabric-networking-api-v1/src/main/resources/fabric-networking-api-v1.mixins.json
+++ b/fabric-networking-api-v1/src/main/resources/fabric-networking-api-v1.mixins.json
@@ -3,6 +3,7 @@
   "package": "net.fabricmc.fabric.mixin.networking",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
+    "BundlePacketMixin",
     "PacketCodecDispatcherMixin",
     "ClientConnectionMixin",
     "CommandManagerMixin",

--- a/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/play/NetworkingPlayPacketTest.java
+++ b/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/play/NetworkingPlayPacketTest.java
@@ -91,7 +91,10 @@ public final class NetworkingPlayPacketTest implements ModInitializer {
 				.then(literal("bundled").executes(ctx -> {
 					BundleS2CPacket packet = new BundleS2CPacket(List.of(
 							ServerPlayNetworking.createS2CPacket(new OverlayPacket(Text.literal("bundled #1"))),
-							ServerPlayNetworking.createS2CPacket(new OverlayPacket(Text.literal("bundled #2")))
+							new BundleS2CPacket(List.of(
+									ServerPlayNetworking.createS2CPacket(new OverlayPacket(Text.literal("bundled #2"))),
+									ServerPlayNetworking.createS2CPacket(new OverlayPacket(Text.literal("bundled #3")))
+							))
 					));
 					ServerPlayNetworking.getSender(ctx.getSource().getPlayer()).sendPacket(packet);
 					return Command.SINGLE_SUCCESS;


### PR DESCRIPTION
As the title say. Simple patch that allows to bundle bundle packets safely, by flattening the result.
Example case where it is beneficial is for all methods that require you to provide single packet that then later is put in a bundle (like entity spawn packets).