### PR TITLE
Fix Datagen API's FMJ and build.gradle dependencies

### DIFF
--- a/fabric-data-generation-api-v1/build.gradle
+++ b/fabric-data-generation-api-v1/build.gradle
@@ -1,17 +1,15 @@
 version = getSubprojectVersion(project)
 
 moduleDependencies(project, [
-	'fabric-api-base',
 	'fabric-convention-tags-v2',
+	'fabric-recipe-api-v1',
 	'fabric-registry-sync-v0',
-	'fabric-networking-api-v1',
 	'fabric-resource-conditions-api-v1',
-	'fabric-item-group-api-v1',
 	'fabric-tag-api-v1',
-	'fabric-recipe-api-v1'
 ])
 
 testDependencies(project, [
+	':fabric-item-group-api-v1',
     ':fabric-object-builder-api-v1'
 ])
 

--- a/fabric-data-generation-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric.mod.json
@@ -17,6 +17,10 @@
   ],
   "depends": {
     "fabricloader": ">=0.16.13",
+    "fabric-convention-tags-v2": "*",
+    "fabric-recipe-api-v1": "*",
+    "fabric-registry-sync-v0": "*",
+    "fabric-resource-conditions-api-v1": "*",
     "fabric-tag-api-v1": "*"
   },
   "description": "Allows for automatic data generation.",


### PR DESCRIPTION
Fix #4823. `fabric-networking-api-v1` was declared as a module dependency but was not used by either the module or testmod, strangely enough.