### PR TITLE
Sort `KeyBinding.Category`s

### DIFF
--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingHelper.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/api/client/keybinding/v1/KeyBindingHelper.java
@@ -28,8 +28,8 @@ import net.fabricmc.fabric.mixin.client.keybinding.KeyBindingAccessor;
  * Helper for registering {@link KeyBinding}s.
  *
  * <pre>{@code
- * KeyBinding left = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.example.left", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_P, "key.category.example"));
- * KeyBinding right = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.example.right", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_U, "key.category.example"));
+ * KeyBinding left = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.example.left", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_P, KeyBinding.Category.MISC));
+ * KeyBinding right = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.example.right", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_U, KeyBinding.Category.MISC));
  * }</pre>
  *
  * @see KeyBinding

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/impl/client/keybinding/CategoryComparator.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/impl/client/keybinding/CategoryComparator.java
@@ -30,7 +30,7 @@ public class CategoryComparator implements Comparator<KeyBinding.Category> {
 		boolean o2Vanilla = o2.id().getNamespace().equals(Identifier.DEFAULT_NAMESPACE);
 
 		// If both are from vanilla, don't reorder them. Assumes sort is stable.
-		if (o1Vanilla & o2Vanilla) {
+		if (o1Vanilla && o2Vanilla) {
 			return 0;
 		}
 

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/impl/client/keybinding/CategoryComparator.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/impl/client/keybinding/CategoryComparator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.keybinding;
+
+import java.util.Comparator;
+
+import net.minecraft.client.option.KeyBinding;
+import net.minecraft.util.Identifier;
+
+public class CategoryComparator implements Comparator<KeyBinding.Category> {
+	public static final CategoryComparator INSTANCE = new CategoryComparator();
+
+	@Override
+	public int compare(KeyBinding.Category o1, KeyBinding.Category o2) {
+		boolean o1Vanilla = o1.id().getNamespace().equals(Identifier.DEFAULT_NAMESPACE);
+		boolean o2Vanilla = o2.id().getNamespace().equals(Identifier.DEFAULT_NAMESPACE);
+
+		// If both are from vanilla, don't reorder them. Assumes sort is stable.
+		if (o1Vanilla & o2Vanilla) {
+			return 0;
+		}
+
+		// If exactly one is from vanilla, sort the one from vanilla first.
+		if (o1Vanilla) {
+			return -1;
+		} else if (o2Vanilla) {
+			return 1;
+		}
+
+		// If neither is from vanilla, sort alphabetically by namespace and then path.
+		int c = o1.id().getNamespace().compareTo(o2.id().getNamespace());
+
+		if (c != 0) {
+			return c;
+		}
+
+		return o1.id().getPath().compareTo(o2.id().getPath());
+	}
+}

--- a/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/keybinding/KeyBindingCategoryMixin.java
+++ b/fabric-key-binding-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/keybinding/KeyBindingCategoryMixin.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.keybinding;
+
+import java.util.List;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.client.option.KeyBinding;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.impl.client.keybinding.CategoryComparator;
+
+@Mixin(KeyBinding.Category.class)
+abstract class KeyBindingCategoryMixin {
+	@Shadow
+	@Final
+	static List<KeyBinding.Category> field_62925;
+
+	@Inject(method = "method_74698", at = @At("RETURN"))
+	private static void onReturnRegister(Identifier id, CallbackInfoReturnable<KeyBinding.Category> cir) {
+		field_62925.sort(CategoryComparator.INSTANCE);
+	}
+}

--- a/fabric-key-binding-api-v1/src/client/resources/fabric-key-binding-api-v1.mixins.json
+++ b/fabric-key-binding-api-v1/src/client/resources/fabric-key-binding-api-v1.mixins.json
@@ -3,8 +3,9 @@
   "package": "net.fabricmc.fabric.mixin.client.keybinding",
   "compatibilityLevel": "JAVA_21",
   "client": [
+    "GameOptionsMixin",
     "KeyBindingAccessor",
-    "GameOptionsMixin"
+    "KeyBindingCategoryMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/KeyBindingsTest.java
+++ b/fabric-key-binding-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/client/keybinding/KeyBindingsTest.java
@@ -22,6 +22,7 @@ import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.option.StickyKeyBinding;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
@@ -30,10 +31,14 @@ import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 public class KeyBindingsTest implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
-		KeyBinding binding1 = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.test_keybinding_1", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_P, KeyBinding.Category.MISC));
-		KeyBinding binding2 = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.test_keybinding_2", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_U, KeyBinding.Category.MISC));
-		KeyBinding stickyBinding = KeyBindingHelper.registerKeyBinding(new StickyKeyBinding("key.fabric-key-binding-api-v1-testmod.test_keybinding_sticky", GLFW.GLFW_KEY_R, KeyBinding.Category.MISC, () -> true, false));
-		KeyBinding duplicateBinding = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.test_keybinding_duplicate", GLFW.GLFW_KEY_RIGHT_SHIFT, KeyBinding.Category.MISC));
+		// Register 2 before 1, but in-game 1 should appear before 2 due to sorting. Both should appear after all vanilla categories.
+		KeyBinding.Category category2 = KeyBinding.Category.method_74698(Identifier.of("fabric-key-binding-api-v1-testmod", "test_category_2"));
+		KeyBinding.Category category1 = KeyBinding.Category.method_74698(Identifier.of("fabric-key-binding-api-v1-testmod", "test_category_1"));
+
+		KeyBinding binding1 = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.test_keybinding_1", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_P, category1));
+		KeyBinding binding2 = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.test_keybinding_2", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_U, category1));
+		KeyBinding stickyBinding = KeyBindingHelper.registerKeyBinding(new StickyKeyBinding("key.fabric-key-binding-api-v1-testmod.test_keybinding_sticky", GLFW.GLFW_KEY_R, category2, () -> true, false));
+		KeyBinding duplicateBinding = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabric-key-binding-api-v1-testmod.test_keybinding_duplicate", GLFW.GLFW_KEY_RIGHT_SHIFT, category2));
 
 		ClientTickEvents.END_CLIENT_TICK.register(client -> {
 			if (client.player == null) return;

--- a/fabric-key-binding-api-v1/src/testmodClient/resources/assets/fabric-keybindings-v1-testmod/lang/en_us.json
+++ b/fabric-key-binding-api-v1/src/testmodClient/resources/assets/fabric-keybindings-v1-testmod/lang/en_us.json
@@ -1,6 +1,6 @@
 {
-  "key.category.first.test": "First Test Category",
-  "key.category.second.test": "Second Test Category",
+  "key.category.fabric-key-binding-api-v1-testmod.test_category_1": "First Test Category",
+  "key.category.fabric-key-binding-api-v1-testmod.test_category_2": "Second Test Category",
   "key.fabric-key-binding-api-v1-testmod.test_keybinding_1": "Test 1",
   "key.fabric-key-binding-api-v1-testmod.test_keybinding_2": "Test 2",
   "key.fabric-key-binding-api-v1-testmod.test_keybinding_duplicate": "Duplicate Test",


### PR DESCRIPTION
Sort `KeyBinding.Category`s such that all vanilla categories are always displayed first and in the same order as in vanilla and such that modded categories are displayed last and are sorted by namespace and then path. Also fix some javadoc and tests.