### PR TITLE
Add support for Fabric gamerule types in MSMP.

### DIFF
--- a/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/api/gamerule/v1/rule/DoubleRule.java
+++ b/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/api/gamerule/v1/rule/DoubleRule.java
@@ -130,6 +130,10 @@ public final class DoubleRule extends GameRules.Rule<DoubleRule> implements Vali
 	}
 
 	public void set(double value, @Nullable MinecraftServer server) {
+		if (!this.inBounds(value)) {
+			throw new IllegalArgumentException(String.format("Could not set value to %s. Was out of bounds %s - %s", value, this.minimumValue, this.maximumValue));
+		}
+
 		this.value = value;
 		this.changed(server);
 	}

--- a/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/api/gamerule/v1/rule/DoubleRule.java
+++ b/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/api/gamerule/v1/rule/DoubleRule.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.api.gamerule.v1.rule;
 
 import com.mojang.brigadier.context.CommandContext;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -126,6 +127,11 @@ public final class DoubleRule extends GameRules.Rule<DoubleRule> implements Vali
 
 	public double get() {
 		return this.value;
+	}
+
+	public void set(double value, @Nullable MinecraftServer server) {
+		this.value = value;
+		this.changed(server);
 	}
 
 	private boolean inBounds(double value) {

--- a/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/api/gamerule/v1/rule/EnumRule.java
+++ b/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/api/gamerule/v1/rule/EnumRule.java
@@ -155,4 +155,15 @@ public final class EnumRule<E extends Enum<E>> extends GameRules.Rule<EnumRule<E
 		this.value = value;
 		this.changed(server);
 	}
+
+	public void set(String value, @Nullable MinecraftServer server) throws IllegalArgumentException {
+		for (E constant : getEnumClass().getEnumConstants()) {
+			if (constant.name().equalsIgnoreCase(value)) {
+				this.set(constant, server);
+				return;
+			}
+		}
+
+		throw new IllegalArgumentException("Tried to set an unsupported value: " + value);
+	}
 }

--- a/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/impl/gamerule/rpc/FabricGameRuleType.java
+++ b/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/impl/gamerule/rpc/FabricGameRuleType.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.gamerule.rpc;
+
+import net.minecraft.util.StringIdentifiable;
+
+/**
+ * Extensions to {@link net.minecraft.server.dedicated.management.dispatch.GameRuleRpcDispatcher.GameRuleType}.
+ */
+public enum FabricGameRuleType implements StringIdentifiable {
+	DOUBLE("fabric:double"),
+	ENUM("fabric:enum");
+
+	private final String name;
+
+	FabricGameRuleType(final String name) {
+		this.name = name;
+	}
+
+	public String asString() {
+		return this.name;
+	}
+}

--- a/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/impl/gamerule/rpc/FabricGameRuleType.java
+++ b/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/impl/gamerule/rpc/FabricGameRuleType.java
@@ -31,6 +31,7 @@ public enum FabricGameRuleType implements StringIdentifiable {
 		this.name = name;
 	}
 
+	@Override
 	public String asString() {
 		return this.name;
 	}

--- a/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/impl/gamerule/rpc/FabricTypedRule.java
+++ b/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/impl/gamerule/rpc/FabricTypedRule.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.gamerule.rpc;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.server.dedicated.management.dispatch.GameRuleRpcDispatcher;
+
+public interface FabricTypedRule {
+	@Nullable
+	FabricGameRuleType getFabricType();
+
+	void setFabricType(FabricGameRuleType type);
+
+	static GameRuleRpcDispatcher.TypedRule create(String name, String value, FabricGameRuleType type) {
+		GameRuleRpcDispatcher.TypedRule typedRule = new GameRuleRpcDispatcher.TypedRule(name, value, GameRuleRpcDispatcher.GameRuleType.INT);
+		((FabricTypedRule) (Object) typedRule).setFabricType(type);
+		return typedRule;
+	}
+}

--- a/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/impl/gamerule/rpc/FabricTypedRule.java
+++ b/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/impl/gamerule/rpc/FabricTypedRule.java
@@ -27,7 +27,7 @@ public interface FabricTypedRule {
 	void setFabricType(FabricGameRuleType type);
 
 	static GameRuleRpcDispatcher.TypedRule create(String name, String value, FabricGameRuleType type) {
-		GameRuleRpcDispatcher.TypedRule typedRule = new GameRuleRpcDispatcher.TypedRule(name, value, GameRuleRpcDispatcher.GameRuleType.INT);
+		GameRuleRpcDispatcher.TypedRule typedRule = new GameRuleRpcDispatcher.TypedRule(name, value, null);
 		((FabricTypedRule) (Object) typedRule).setFabricType(type);
 		return typedRule;
 	}

--- a/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/mixin/gamerule/GameRuleManagementHandlerImplMixin.java
+++ b/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/mixin/gamerule/GameRuleManagementHandlerImplMixin.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.gamerule;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.server.dedicated.MinecraftDedicatedServer;
+import net.minecraft.server.dedicated.management.ManagementLogger;
+import net.minecraft.server.dedicated.management.RpcException;
+import net.minecraft.server.dedicated.management.dispatch.GameRuleRpcDispatcher;
+import net.minecraft.server.dedicated.management.handler.GameRuleManagementHandlerImpl;
+import net.minecraft.server.dedicated.management.network.ManagementConnectionId;
+import net.minecraft.world.GameRules;
+
+import net.fabricmc.fabric.api.gamerule.v1.rule.DoubleRule;
+import net.fabricmc.fabric.api.gamerule.v1.rule.EnumRule;
+import net.fabricmc.fabric.impl.gamerule.rpc.FabricGameRuleType;
+import net.fabricmc.fabric.impl.gamerule.rpc.FabricTypedRule;
+
+@Mixin(GameRuleManagementHandlerImpl.class)
+public abstract class GameRuleManagementHandlerImplMixin {
+	@Shadow
+	@Final
+	private MinecraftDedicatedServer server;
+
+	@Shadow
+	public abstract GameRuleRpcDispatcher.TypedRule toTypedRule(String name, GameRules.Rule<?> gameRule);
+
+	@Shadow
+	@Final
+	private ManagementLogger logger;
+
+	@Inject(method = "updateRule", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/world/GameRules$Rule;serialize()Ljava/lang/String;"), cancellable = true)
+	private void updateRule(GameRuleRpcDispatcher.UntypedRule untypedRule, ManagementConnectionId remote, CallbackInfoReturnable<GameRuleRpcDispatcher.TypedRule> cir, @Local GameRules.Rule<?> rule, @Local String from) {
+		if (rule instanceof DoubleRule doubleRule) {
+			doubleRule.set(Double.parseDouble(untypedRule.value()), server);
+			cir.setReturnValue(doUpdate(untypedRule, remote, rule, from));
+		} else if (rule instanceof EnumRule<?> enumRule) {
+			try {
+				enumRule.set(untypedRule.value(), server);
+			} catch (IllegalArgumentException e) {
+				throw new RpcException(e.getMessage());
+			}
+
+			cir.setReturnValue(doUpdate(untypedRule, remote, rule, from));
+		}
+	}
+
+	@Inject(method = "toTypedRule", at = @At("HEAD"), cancellable = true)
+	public void toTypedRule(String name, GameRules.Rule<?> rule, CallbackInfoReturnable<GameRuleRpcDispatcher.TypedRule> cir) {
+		if (rule instanceof DoubleRule) {
+			cir.setReturnValue(FabricTypedRule.create(name, rule.serialize(), FabricGameRuleType.DOUBLE));
+		} else if (rule instanceof EnumRule<?>) {
+			cir.setReturnValue(FabricTypedRule.create(name, rule.serialize(), FabricGameRuleType.ENUM));
+		}
+	}
+
+	@Unique
+	private GameRuleRpcDispatcher.TypedRule doUpdate(GameRuleRpcDispatcher.UntypedRule untypedRule, ManagementConnectionId remote, GameRules.Rule<?> rule, String from) {
+		// 3 lines copied from vanilla:
+		GameRuleRpcDispatcher.TypedRule typedRule = this.toTypedRule(untypedRule.key(), rule);
+		this.logger.logAction(remote, "Game rule '{}' updated from '{}' to '{}'", typedRule.key(), from, typedRule.value());
+		this.server.onGameRuleUpdated(untypedRule.key(), rule);
+		return typedRule;
+	}
+}

--- a/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/mixin/gamerule/GameRuleManagementHandlerImplMixin.java
+++ b/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/mixin/gamerule/GameRuleManagementHandlerImplMixin.java
@@ -16,6 +16,9 @@
 
 package net.fabricmc.fabric.mixin.gamerule;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Cancellable;
 import com.llamalad7.mixinextras.sugar.Local;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -51,8 +54,11 @@ public abstract class GameRuleManagementHandlerImplMixin {
 	@Final
 	private ManagementLogger logger;
 
-	@Inject(method = "updateRule", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/world/GameRules$Rule;serialize()Ljava/lang/String;"), cancellable = true)
-	private void updateRule(GameRuleRpcDispatcher.UntypedRule untypedRule, ManagementConnectionId remote, CallbackInfoReturnable<GameRuleRpcDispatcher.TypedRule> cir, @Local GameRules.Rule<?> rule, @Local String from) {
+	@WrapOperation(method = "updateRule", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/GameRules$Rule;serialize()Ljava/lang/String;"))
+	private String updateRule(GameRules.Rule<?> rule, Operation<String> original, @Cancellable CallbackInfoReturnable<GameRuleRpcDispatcher.TypedRule> cir,
+								@Local(argsOnly = true) GameRuleRpcDispatcher.UntypedRule untypedRule, @Local(argsOnly = true) ManagementConnectionId remote) {
+		final String from = original.call(rule);
+
 		try {
 			if (rule instanceof DoubleRule doubleRule) {
 				doubleRule.set(Double.parseDouble(untypedRule.value()), server);
@@ -64,6 +70,8 @@ public abstract class GameRuleManagementHandlerImplMixin {
 		} catch (IllegalArgumentException e) {
 			throw new RpcException(e.getMessage());
 		}
+
+		return from;
 	}
 
 	@Inject(method = "toTypedRule", at = @At("HEAD"), cancellable = true)

--- a/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/mixin/gamerule/GameRuleManagementHandlerImplMixin.java
+++ b/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/mixin/gamerule/GameRuleManagementHandlerImplMixin.java
@@ -53,17 +53,16 @@ public abstract class GameRuleManagementHandlerImplMixin {
 
 	@Inject(method = "updateRule", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/world/GameRules$Rule;serialize()Ljava/lang/String;"), cancellable = true)
 	private void updateRule(GameRuleRpcDispatcher.UntypedRule untypedRule, ManagementConnectionId remote, CallbackInfoReturnable<GameRuleRpcDispatcher.TypedRule> cir, @Local GameRules.Rule<?> rule, @Local String from) {
-		if (rule instanceof DoubleRule doubleRule) {
-			doubleRule.set(Double.parseDouble(untypedRule.value()), server);
-			cir.setReturnValue(doUpdate(untypedRule, remote, rule, from));
-		} else if (rule instanceof EnumRule<?> enumRule) {
-			try {
+		try {
+			if (rule instanceof DoubleRule doubleRule) {
+				doubleRule.set(Double.parseDouble(untypedRule.value()), server);
+				cir.setReturnValue(doUpdate(untypedRule, remote, rule, from));
+			} else if (rule instanceof EnumRule<?> enumRule) {
 				enumRule.set(untypedRule.value(), server);
-			} catch (IllegalArgumentException e) {
-				throw new RpcException(e.getMessage());
+				cir.setReturnValue(doUpdate(untypedRule, remote, rule, from));
 			}
-
-			cir.setReturnValue(doUpdate(untypedRule, remote, rule, from));
+		} catch (IllegalArgumentException e) {
+			throw new RpcException(e.getMessage());
 		}
 	}
 

--- a/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/mixin/gamerule/GameRuleRpcDispatcherTypedRuleMixin.java
+++ b/fabric-game-rule-api-v1/src/main/java/net/fabricmc/fabric/mixin/gamerule/GameRuleRpcDispatcherTypedRuleMixin.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.gamerule;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+import com.mojang.datafixers.util.Either;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+
+import net.minecraft.server.dedicated.management.dispatch.GameRuleRpcDispatcher;
+import net.minecraft.util.StringIdentifiable;
+
+import net.fabricmc.fabric.impl.gamerule.rpc.FabricGameRuleType;
+import net.fabricmc.fabric.impl.gamerule.rpc.FabricTypedRule;
+
+@Mixin(GameRuleRpcDispatcher.TypedRule.class)
+public class GameRuleRpcDispatcherTypedRuleMixin implements FabricTypedRule {
+	@Shadow
+	@Final
+	public static MapCodec<GameRuleRpcDispatcher.TypedRule> CODEC;
+
+	static {
+		MapCodec<GameRuleRpcDispatcher.TypedRule> fabricTypedCodec = RecordCodecBuilder.mapCodec((instance) ->
+				instance.group(
+						Codec.STRING.fieldOf("key").forGetter(GameRuleRpcDispatcher.TypedRule::key),
+						Codec.STRING.fieldOf("value").forGetter(GameRuleRpcDispatcher.TypedRule::value),
+						StringIdentifiable.createCodec(FabricGameRuleType::values).fieldOf("type")
+								.forGetter(typedRule -> ((FabricTypedRule) (Object) typedRule).getFabricType())
+				).apply(instance, FabricTypedRule::create));
+
+		CODEC = Codec.mapEither(fabricTypedCodec, CODEC).xmap(
+				either -> either.map(Function.identity(), Function.identity()),
+				typedRule -> ((FabricTypedRule) (Object) typedRule).getFabricType() == null ? Either.right(typedRule) : Either.left(typedRule));
+	}
+
+	@Nullable
+	@Unique
+	private FabricGameRuleType fabricGameRuleType = null;
+
+	@Override
+	public @Nullable FabricGameRuleType getFabricType() {
+		return fabricGameRuleType;
+	}
+
+	@Override
+	public void setFabricType(FabricGameRuleType type) {
+		this.fabricGameRuleType = Objects.requireNonNull(type);
+	}
+}

--- a/fabric-game-rule-api-v1/src/main/resources/fabric-game-rule-api-v1.mixins.json
+++ b/fabric-game-rule-api-v1/src/main/resources/fabric-game-rule-api-v1.mixins.json
@@ -16,8 +16,5 @@
   },
   "overwrites": {
     "requireAnnotations": true
-  },
-  "mixinextras": {
-    "minVersion": "0.5.0"
   }
 }

--- a/fabric-game-rule-api-v1/src/main/resources/fabric-game-rule-api-v1.mixins.json
+++ b/fabric-game-rule-api-v1/src/main/resources/fabric-game-rule-api-v1.mixins.json
@@ -3,10 +3,12 @@
   "package": "net.fabricmc.fabric.mixin.gamerule",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
-    "GameRulesBooleanRuleAccessor",
     "GameRuleCommandAccessor",
     "GameRuleCommandVisitorMixin",
+    "GameRuleManagementHandlerImplMixin",
+    "GameRuleRpcDispatcherTypedRuleMixin",
     "GameRulesAccessor",
+    "GameRulesBooleanRuleAccessor",
     "GameRulesKeyMixin"
   ],
   "injectors": {
@@ -14,5 +16,8 @@
   },
   "overwrites": {
     "requireAnnotations": true
+  },
+  "mixinextras": {
+    "minVersion": "0.5.0"
   }
 }

--- a/fabric-game-rule-api-v1/src/test/java/net/fabricmc/fabric/test/gamerule/GameRuleManagementHandlerImplTest.java
+++ b/fabric-game-rule-api-v1/src/test/java/net/fabricmc/fabric/test/gamerule/GameRuleManagementHandlerImplTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.gamerule;
+
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import com.google.gson.JsonElement;
+import com.mojang.serialization.JsonOps;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import net.minecraft.resource.featuretoggle.FeatureSet;
+import net.minecraft.server.dedicated.MinecraftDedicatedServer;
+import net.minecraft.server.dedicated.management.ManagementLogger;
+import net.minecraft.server.dedicated.management.dispatch.GameRuleRpcDispatcher;
+import net.minecraft.server.dedicated.management.handler.GameRuleManagementHandler;
+import net.minecraft.server.dedicated.management.handler.GameRuleManagementHandlerImpl;
+import net.minecraft.server.dedicated.management.network.ManagementConnectionId;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.GameRules;
+
+import net.fabricmc.fabric.api.gamerule.v1.rule.DoubleRule;
+import net.fabricmc.fabric.api.gamerule.v1.rule.EnumRule;
+
+public class GameRuleManagementHandlerImplTest {
+	static {
+		new GameRulesTestMod().onInitialize();
+	}
+
+	private static final ManagementConnectionId CONNECTION_ID = new ManagementConnectionId(-1);
+	private static final ManagementLogger MANAGEMENT_LOGGER = new ManagementLogger();
+	private static final GameRules GAME_RULES = new GameRules(FeatureSet.empty());
+
+	@Test
+	void testUpdateDouble() {
+		MinecraftDedicatedServer server = mock(MinecraftDedicatedServer.class);
+		when(server.getGameRules()).thenReturn(GAME_RULES);
+		GameRuleManagementHandler handler = new GameRuleManagementHandlerTestImpl(server, MANAGEMENT_LOGGER);
+
+		GameRuleRpcDispatcher.TypedRule result = handler.updateRule(new GameRuleRpcDispatcher.UntypedRule("oneToTenDouble", "5.5"), CONNECTION_ID);
+
+		assertEquals("""
+				{"key":"oneToTenDouble","value":"5.5","type":"fabric:double"}
+				""", result);
+
+		verify(server).onGameRuleUpdated(
+				eq("oneToTenDouble"),
+				argThat(rule -> rule instanceof DoubleRule doubleRule && doubleRule.get() == 5.5D));
+	}
+
+	@Test
+	void testUpdateEnum() {
+		MinecraftDedicatedServer server = mock(MinecraftDedicatedServer.class);
+		when(server.getGameRules()).thenReturn(GAME_RULES);
+		GameRuleManagementHandler handler = new GameRuleManagementHandlerTestImpl(server, MANAGEMENT_LOGGER);
+
+		GameRuleRpcDispatcher.TypedRule result = handler.updateRule(new GameRuleRpcDispatcher.UntypedRule("cardinalDirection", "north"), CONNECTION_ID);
+
+		assertEquals("""
+				{"key":"cardinalDirection","value":"NORTH","type":"fabric:enum"}
+				""", result);
+
+		verify(server).onGameRuleUpdated(
+				eq("cardinalDirection"),
+				argThat(rule -> rule instanceof EnumRule<?> enumRule && enumRule.get() == Direction.NORTH)
+		);
+	}
+
+	@Test
+	void testUpdateVanillaBoolean() {
+		MinecraftDedicatedServer server = mock(MinecraftDedicatedServer.class);
+		when(server.getGameRules()).thenReturn(GAME_RULES);
+		GameRuleManagementHandler handler = new GameRuleManagementHandlerTestImpl(server, MANAGEMENT_LOGGER);
+
+		GameRuleRpcDispatcher.TypedRule result = handler.updateRule(new GameRuleRpcDispatcher.UntypedRule("doFireTick", "false"), CONNECTION_ID);
+
+		assertEquals("""
+				{"key":"doFireTick","value":"false","type":"boolean"}
+				""", result);
+
+		verify(server).onGameRuleUpdated(
+				eq("doFireTick"),
+				argThat(rule -> rule instanceof GameRules.BooleanRule booleanRule && !booleanRule.get()));
+	}
+
+	@Test
+	void testUpdateVanillaInt() {
+		MinecraftDedicatedServer server = mock(MinecraftDedicatedServer.class);
+		when(server.getGameRules()).thenReturn(GAME_RULES);
+		GameRuleManagementHandler handler = new GameRuleManagementHandlerTestImpl(server, MANAGEMENT_LOGGER);
+
+		GameRuleRpcDispatcher.TypedRule result = handler.updateRule(new GameRuleRpcDispatcher.UntypedRule("randomTickSpeed", "123"), CONNECTION_ID);
+
+		assertEquals("""
+				{"key":"randomTickSpeed","value":"123","type":"integer"}
+				""", result);
+
+		verify(server).onGameRuleUpdated(
+				eq("randomTickSpeed"),
+				argThat(rule -> rule instanceof GameRules.IntRule intRule && intRule.get() == 123));
+	}
+
+	private static void assertEquals(@Language("JSON") String expected, GameRuleRpcDispatcher.TypedRule rule) {
+		JsonElement jsonElement = GameRuleRpcDispatcher.TypedRule.CODEC.codec().encodeStart(JsonOps.INSTANCE, rule).getOrThrow();
+		Assertions.assertEquals(expected.trim(), jsonElement.toString());
+	}
+
+	private static final class GameRuleManagementHandlerTestImpl extends GameRuleManagementHandlerImpl {
+		private GameRuleManagementHandlerTestImpl(MinecraftDedicatedServer server, ManagementLogger logger) {
+			super(server, logger);
+		}
+
+		@Override
+		public Stream<Map.Entry<GameRules.Key<?>, GameRules.Type<?>>> getRules() {
+			return GameRules.streamAllRules(FeatureSet.empty());
+		}
+	}
+}


### PR DESCRIPTION
Closes #4866

Encodes as a new type of `fabric:double` or `fabric:enum`

```json
{"key":"oneToTenDouble","value":"5.5","type":"fabric:double"}
```
```json
{"key":"cardinalDirection","value":"NORTH","type":"fabric:enum"}
```