### PR TITLE
1.21.9 porting fixes

### DIFF
--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/util/NbtType.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/util/NbtType.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.fabric.api.util;
 
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
 
 /**

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/util/NbtType.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/util/NbtType.java
@@ -42,13 +42,5 @@ public final class NbtType {
 	public static final int INT_ARRAY = 11;
 	public static final int LONG_ARRAY = 12;
 
-	/**
-	 * Any numeric value: byte, short, int, long, float, double.
-	 * @deprecated This constant is no longer accepted by any vanilla method,
-	 * and therefore is completely useless.
-	 */
-	@Deprecated(forRemoval = true)
-	public static final int NUMBER = 99;
-
 	private NbtType() { }
 }

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/util/NbtType.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/util/NbtType.java
@@ -24,7 +24,6 @@ import net.minecraft.nbt.NbtElement;
  *
  * <p>For the current list of types, check with {@link NbtElement}.
  *
- * @see NbtCompound#contains(String, int)
  * @see net.minecraft.nbt.NbtTypes#byId(int)
  * @deprecated Use the constants in {@link NbtElement} instead.
  */
@@ -46,9 +45,10 @@ public final class NbtType {
 
 	/**
 	 * Any numeric value: byte, short, int, long, float, double.
-	 *
-	 * @see NbtCompound#contains(String, int)
+	 * @deprecated This constant is no longer accepted by any vanilla method,
+	 * and therefore is completely useless.
 	 */
+	@Deprecated(forRemoval = true)
 	public static final int NUMBER = 99;
 
 	private NbtType() { }

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModificationContext.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModificationContext.java
@@ -356,7 +356,7 @@ public interface BiomeModificationContext {
 		 * Associated JSON property: <code>spawners</code>.
 		 *
 		 * @see SpawnSettings#getSpawnEntries(SpawnGroup)
-		 * @see SpawnSettings.Builder#spawn(SpawnGroup, SpawnSettings.SpawnEntry)
+		 * @see SpawnSettings.Builder#spawn(SpawnGroup, int, SpawnSettings.SpawnEntry)
 		 */
 		void addSpawn(SpawnGroup spawnGroup, SpawnSettings.SpawnEntry spawnEntry, int weight);
 

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModifications.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModifications.java
@@ -65,7 +65,7 @@ public final class BiomeModifications {
 	 * Convenience method to add an entity spawn to one or more biomes.
 	 *
 	 * @see BiomeSelectors
-	 * @see net.minecraft.world.biome.SpawnSettings.Builder#spawn(SpawnGroup, SpawnSettings.SpawnEntry)
+	 * @see net.minecraft.world.biome.SpawnSettings.Builder#spawn(SpawnGroup, int, SpawnSettings.SpawnEntry)
 	 */
 	public static void addSpawn(Predicate<BiomeSelectionContext> biomeSelector,
 								SpawnGroup spawnGroup, EntityType<?> entityType,

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/TestInput.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/TestInput.java
@@ -20,7 +20,7 @@ import java.util.function.Function;
 
 import org.jetbrains.annotations.ApiStatus;
 
-import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.GameOptions;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.util.InputUtil;
@@ -94,7 +94,7 @@ public interface TestInput {
 
 	/**
 	 * Starts holding down left control, or left super on macOS. Suitable for triggering
-	 * {@link Screen#hasControlDown()}. The key will be held until it is released. Does nothing if the key is already
+	 * {@link MinecraftClient#isCtrlPressed()}. The key will be held until it is released. Does nothing if the key is already
 	 * being held.
 	 *
 	 * @see #releaseControl()
@@ -102,7 +102,7 @@ public interface TestInput {
 	void holdControl();
 
 	/**
-	 * Starts holding down left shift. Suitable for triggering {@link Screen#hasShiftDown()}. The key will be held until
+	 * Starts holding down left shift. Suitable for triggering {@link MinecraftClient#isShiftPressed()}. The key will be held until
 	 * it is released. Does nothing if the key is already being held.
 	 *
 	 * @see #releaseShift()
@@ -110,7 +110,7 @@ public interface TestInput {
 	void holdShift();
 
 	/**
-	 * Starts holding down left alt. Suitable for triggering {@link Screen#hasAltDown()}. The key will be held until it
+	 * Starts holding down left alt. Suitable for triggering {@link MinecraftClient#isAltPressed()}. The key will be held until it
 	 * is released. Does nothing if the key is already being held.
 	 *
 	 * @see #releaseAlt()
@@ -170,7 +170,7 @@ public interface TestInput {
 	void releaseMouse(int button);
 
 	/**
-	 * Releases left control, or left super on macOS. Suitable for un-triggering {@link Screen#hasControlDown()}. Does
+	 * Releases left control, or left super on macOS. Suitable for un-triggering {@link MinecraftClient#isCtrlPressed()}. Does
 	 * nothing if the key is not being held.
 	 *
 	 * @see #holdControl()
@@ -178,7 +178,7 @@ public interface TestInput {
 	void releaseControl();
 
 	/**
-	 * Releases left shift. Suitable for un-triggering {@link Screen#hasShiftDown()}. Does nothing if the key is not
+	 * Releases left shift. Suitable for un-triggering {@link MinecraftClient#isShiftPressed()}. Does nothing if the key is not
 	 * being held.
 	 *
 	 * @see #holdShift()
@@ -186,7 +186,7 @@ public interface TestInput {
 	void releaseShift();
 
 	/**
-	 * Releases left alt. Suitable for un-triggering {@link Screen#hasAltDown()}. Does nothing if the key is not being
+	 * Releases left alt. Suitable for un-triggering {@link MinecraftClient#isAltPressed()}. Does nothing if the key is not being
 	 * held.
 	 *
 	 * @see #holdAlt()

--- a/fabric-data-generation-api-v1/src/client/java/net/fabricmc/fabric/api/client/datagen/v1/builder/SoundTypeBuilder.java
+++ b/fabric-data-generation-api-v1/src/client/java/net/fabricmc/fabric/api/client/datagen/v1/builder/SoundTypeBuilder.java
@@ -198,7 +198,7 @@ public interface SoundTypeBuilder {
 		 *
 		 * <p>Must be a value between {@code 0} and {@code 1} (inclusive).
 		 *
-		 * <p>The default volume is {@link EntryBuilder.DEFAULT_VOLUME} ({@code 1F}).
+		 * <p>The default volume is {@value EntryBuilder#DEFAULT_VOLUME}.
 		 *
 		 * @see net.minecraft.client.sound.SoundSystem#MIN_VOLUME
 		 * @see net.minecraft.client.sound.SoundSystem#MAX_VOLUME
@@ -210,7 +210,7 @@ public interface SoundTypeBuilder {
 		 *
 		 * <p>Must be a value between {@code 0.5} and {@code 2}.
 		 *
-		 * <p>The default pitch is {@link EntryBuilder.DEFAULT_PITCH} ({@code 1F}).
+		 * <p>The default pitch is {@link EntryBuilder#DEFAULT_PITCH} ({@code 1F}).
 		 *
 		 * @see net.minecraft.client.sound.SoundSystem#MIN_PITCH
 		 * @see net.minecraft.client.sound.SoundSystem#MAX_PITCH
@@ -220,7 +220,7 @@ public interface SoundTypeBuilder {
 		/**
 		 * Sets the attenuation block distance of the sound.
 		 *
-		 * <p>The default attenuation is {@link EntryBuilder.DEFAULT_ATTENUATION_DISTANCE} ({@code 16} blocks). Setting it to
+		 * <p>The default attenuation is {@value EntryBuilder#DEFAULT_ATTENUATION_DISTANCE} blocks. Setting it to
 		 * higher will cause the sound to be heard from greater distances.
 		 */
 		EntryBuilder attenuationDistance(int attenuationDistance);
@@ -229,7 +229,7 @@ public interface SoundTypeBuilder {
 		 * Sets the weight or "chance" that this sound has of playing when
 		 * its parent sound event is called upon.
 		 *
-		 * <p>The default weight is {@link EntryBuilder.DEFAULT_WEIGHT} ({@code 1}).
+		 * <p>The default weight is {@value EntryBuilder#DEFAULT_WEIGHT}.
 		 */
 		EntryBuilder weight(int weight);
 

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerEntityCombatEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerEntityCombatEvents.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.api.entity.event.v1;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.server.world.ServerWorld;
 
 import net.fabricmc.fabric.api.event.Event;
@@ -30,11 +31,11 @@ public final class ServerEntityCombatEvents {
 	/**
 	 * An event that is called after an entity is directly responsible for killing another entity.
 	 *
-	 * @see Entity#onKilledOther(ServerWorld, LivingEntity, net.minecraft.entity.damage.DamageSource)
+	 * @see Entity#onKilledOther(ServerWorld, LivingEntity, DamageSource)
 	 */
-	public static final Event<AfterKilledOtherEntity> AFTER_KILLED_OTHER_ENTITY = EventFactory.createArrayBacked(AfterKilledOtherEntity.class, callbacks -> (world, entity, killedEntity) -> {
+	public static final Event<AfterKilledOtherEntity> AFTER_KILLED_OTHER_ENTITY = EventFactory.createArrayBacked(AfterKilledOtherEntity.class, callbacks -> (world, entity, killedEntity, damageSource) -> {
 		for (AfterKilledOtherEntity callback : callbacks) {
-			callback.afterKilledOtherEntity(world, entity, killedEntity);
+			callback.afterKilledOtherEntity(world, entity, killedEntity, damageSource);
 		}
 	});
 
@@ -46,8 +47,9 @@ public final class ServerEntityCombatEvents {
 		 * @param world the world
 		 * @param entity the entity
 		 * @param killedEntity the entity which was killed by the {@code entity}
+		 * @param damageSource the damage source that killed the entity
 		 */
-		void afterKilledOtherEntity(ServerWorld world, Entity entity, LivingEntity killedEntity);
+		void afterKilledOtherEntity(ServerWorld world, Entity entity, LivingEntity killedEntity, DamageSource damageSource);
 	}
 
 	private ServerEntityCombatEvents() {

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerEntityCombatEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerEntityCombatEvents.java
@@ -30,7 +30,7 @@ public final class ServerEntityCombatEvents {
 	/**
 	 * An event that is called after an entity is directly responsible for killing another entity.
 	 *
-	 * @see Entity#onKilledOther(ServerWorld, LivingEntity)
+	 * @see Entity#onKilledOther(ServerWorld, LivingEntity, net.minecraft.entity.damage.DamageSource)
 	 */
 	public static final Event<AfterKilledOtherEntity> AFTER_KILLED_OTHER_ENTITY = EventFactory.createArrayBacked(AfterKilledOtherEntity.class, callbacks -> (world, entity, killedEntity) -> {
 		for (AfterKilledOtherEntity callback : callbacks) {

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -63,7 +63,7 @@ abstract class LivingEntityMixin {
 	@WrapOperation(method = "onDeath", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;onKilledOther(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/entity/damage/DamageSource;)Z"))
 	private boolean onEntityKilledOther(Entity entity, ServerWorld serverWorld, @Nullable LivingEntity attacker, DamageSource damageSource, Operation<Boolean> original) {
 		boolean result = original.call(entity, serverWorld, attacker, damageSource);
-		ServerEntityCombatEvents.AFTER_KILLED_OTHER_ENTITY.invoker().afterKilledOtherEntity(serverWorld, entity, attacker);
+		ServerEntityCombatEvents.AFTER_KILLED_OTHER_ENTITY.invoker().afterKilledOtherEntity(serverWorld, entity, attacker, damageSource);
 		return result;
 	}
 

--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/ServerPlayerEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/ServerPlayerEntityMixin.java
@@ -67,7 +67,7 @@ abstract class ServerPlayerEntityMixin extends LivingEntityMixin {
 		// If the damage source that killed the player was an entity, then fire the event.
 		if (attacker != null) {
 			attacker.onKilledOther(this.getEntityWorld(), (ServerPlayerEntity) (Object) this, source);
-			ServerEntityCombatEvents.AFTER_KILLED_OTHER_ENTITY.invoker().afterKilledOtherEntity(this.getEntityWorld(), attacker, (ServerPlayerEntity) (Object) this);
+			ServerEntityCombatEvents.AFTER_KILLED_OTHER_ENTITY.invoker().afterKilledOtherEntity(this.getEntityWorld(), attacker, (ServerPlayerEntity) (Object) this, source);
 		}
 	}
 

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/EntityEventTests.java
@@ -70,8 +70,8 @@ public final class EntityEventTests implements ModInitializer {
 		Registry.register(Registries.ITEM, TEST_BED_KEY.getValue(), new BlockItem(TEST_BED, new Item.Settings().registryKey(RegistryKey.of(RegistryKeys.ITEM, TEST_BED_KEY.getValue()))));
 		Registry.register(Registries.ITEM, DIAMOND_ELYTRA_KEY, DIAMOND_ELYTRA);
 
-		ServerEntityCombatEvents.AFTER_KILLED_OTHER_ENTITY.register((world, entity, killed) -> {
-			LOGGER.info("Entity {} Killed: {}", entity, killed);
+		ServerEntityCombatEvents.AFTER_KILLED_OTHER_ENTITY.register((world, entity, killed, damageSource) -> {
+			LOGGER.info("Entity {} Killed: {}, source {}", entity, killed, damageSource);
 		});
 
 		ServerEntityWorldChangeEvents.AFTER_PLAYER_CHANGE_WORLD.register((player, origin, destination) -> {

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/SpecialLogicAccess.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/SpecialLogicAccess.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.transfer.item;
+
+public interface SpecialLogicAccess {
+	default boolean fabric_shouldSuppressSpecialLogic() {
+		return false;
+	}
+}

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/mixin/transfer/ListInventoryMixin.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/mixin/transfer/ListInventoryMixin.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.transfer;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.inventory.ListInventory;
+
+import net.fabricmc.fabric.impl.transfer.item.SpecialLogicAccess;
+
+@Mixin(ListInventory.class)
+interface ListInventoryMixin extends ListInventory, SpecialLogicAccess {
+	@WrapOperation(method = "setStack", at = @At(value = "INVOKE", target = "Lnet/minecraft/inventory/ListInventory;markDirty()V"))
+	private void cancelMarkDirty(ListInventory instance, Operation<Void> original) {
+		if (!this.fabric_shouldSuppressSpecialLogic()) {
+			original.call(instance);
+		}
+	}
+}

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/mixin/transfer/ShelfBlockEntityMixin.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/mixin/transfer/ShelfBlockEntityMixin.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.transfer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+import net.minecraft.block.entity.ShelfBlockEntity;
+import net.minecraft.item.ItemStack;
+
+import net.fabricmc.fabric.impl.transfer.item.SpecialLogicAccess;
+import net.fabricmc.fabric.impl.transfer.item.SpecialLogicInventory;
+
+@Mixin(ShelfBlockEntity.class)
+public abstract class ShelfBlockEntityMixin implements SpecialLogicInventory, SpecialLogicAccess {
+	@Unique
+	boolean fabric_suppressSpecialLogic;
+
+	@Override
+	public void fabric_setSuppress(boolean suppress) {
+		fabric_suppressSpecialLogic = suppress;
+	}
+
+	@Override
+	public boolean fabric_shouldSuppressSpecialLogic() {
+		return fabric_suppressSpecialLogic;
+	}
+
+	@Override
+	public void fabric_onFinalCommit(int slot, ItemStack oldStack, ItemStack newStack) {
+	}
+}

--- a/fabric-transfer-api-v1/src/main/resources/fabric-transfer-api-v1.mixins.json
+++ b/fabric-transfer-api-v1/src/main/resources/fabric-transfer-api-v1.mixins.json
@@ -16,7 +16,9 @@
     "HopperBlockEntityMixin",
     "ItemMixin",
     "JukeboxBlockEntityMixin",
+    "ListInventoryMixin",
     "LockableContainerBlockEntityMixin",
+    "ShelfBlockEntityMixin",
     "SimpleInventoryMixin"
   ],
   "injectors": {

--- a/fabric-transfer-api-v1/src/testmod/java/net/fabricmc/fabric/test/transfer/gametests/VanillaStorageTests.java
+++ b/fabric-transfer-api-v1/src/testmod/java/net/fabricmc/fabric/test/transfer/gametests/VanillaStorageTests.java
@@ -30,6 +30,7 @@ import net.minecraft.block.entity.ChestBlockEntity;
 import net.minecraft.block.entity.ChiseledBookshelfBlockEntity;
 import net.minecraft.block.entity.FurnaceBlockEntity;
 import net.minecraft.block.entity.HopperBlockEntity;
+import net.minecraft.block.entity.ShelfBlockEntity;
 import net.minecraft.block.entity.ShulkerBoxBlockEntity;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
@@ -109,7 +110,8 @@ public class VanillaStorageTests {
 		World world = context.getWorld();
 
 		BlockPos pos = new BlockPos(0, 2, 0);
-		context.setBlockState(pos, block.getDefaultState());
+		// Shelf comparator output is directional
+		context.setBlockState(pos, block.getDefaultState().withIfExists(Properties.HORIZONTAL_FACING, Direction.WEST));
 		T inventory = context.getBlockEntity(pos, inventoryClass);
 		InventoryStorage storage = InventoryStorage.of(inventory, null);
 
@@ -149,6 +151,14 @@ public class VanillaStorageTests {
 	@GameTest
 	public void testChestComparator(TestContext context) {
 		testComparatorOnInventory(context, Blocks.CHEST, ItemVariant.of(Items.DIAMOND), ChestBlockEntity.class);
+	}
+
+	/**
+	 * Same as {@link #testChestComparator} but for shelves.
+	 */
+	@GameTest
+	public void testShelfComparator(TestContext context) {
+		testComparatorOnInventory(context, Blocks.OAK_SHELF, ItemVariant.of(Items.DIAMOND), ShelfBlockEntity.class);
 	}
 
 	/**


### PR DESCRIPTION
- **Breaking**: `ServerEntityCombatEvents` now passes the damage source for consistency with vanilla (change happened in 25w31a)
- Transfer API now supports shelves.
- Javadoc fixes.
- Terminally deprecates `NbtTypes#NUMBER` because it is useless since 1.21.6; the whole class is duplicative of vanilla one, but not sure what's the best approach.