### PR TITLE
Add `AfterBackground` event

### DIFF
--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenEvents.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenEvents.java
@@ -127,6 +127,17 @@ public final class ScreenEvents {
 	}
 
 	/**
+	 * An event that is called after a screen's background is rendered.
+	 *
+	 * @return the event
+	 */
+	public static Event<AfterBackground> afterBackground(Screen screen) {
+		Objects.requireNonNull(screen, "Screen cannot be null");
+
+		return ScreenExtensions.getExtensions(screen).fabric_getAfterBackgroundEvent();
+	}
+
+	/**
 	 * An event that is called after a screen is rendered.
 	 *
 	 * @return the event
@@ -177,6 +188,11 @@ public final class ScreenEvents {
 	@FunctionalInterface
 	public interface BeforeRender {
 		void beforeRender(Screen screen, DrawContext drawContext, int mouseX, int mouseY, float tickDelta);
+	}
+
+	@FunctionalInterface
+	public interface AfterBackground {
+		void afterBackground(Screen screen, DrawContext drawContext, int mouseX, int mouseY, float tickDelta);
 	}
 
 	@FunctionalInterface

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenEventFactory.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenEventFactory.java
@@ -42,6 +42,14 @@ public final class ScreenEventFactory {
 		});
 	}
 
+	public static Event<ScreenEvents.AfterBackground> createAfterBackgroundEvent() {
+		return EventFactory.createArrayBacked(ScreenEvents.AfterBackground.class, callbacks -> (screen, matrices, mouseX, mouseY, tickDelta) -> {
+			for (ScreenEvents.AfterBackground callback : callbacks) {
+				callback.afterBackground(screen, matrices, mouseX, mouseY, tickDelta);
+			}
+		});
+	}
+
 	public static Event<ScreenEvents.AfterRender> createAfterRenderEvent() {
 		return EventFactory.createArrayBacked(ScreenEvents.AfterRender.class, callbacks -> (screen, matrices, mouseX, mouseY, tickDelta) -> {
 			for (ScreenEvents.AfterRender callback : callbacks) {

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenExtensions.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenExtensions.java
@@ -41,6 +41,8 @@ public interface ScreenExtensions {
 
 	Event<ScreenEvents.BeforeRender> fabric_getBeforeRenderEvent();
 
+	Event<ScreenEvents.AfterBackground> fabric_getAfterBackgroundEvent();
+
 	Event<ScreenEvents.AfterRender> fabric_getAfterRenderEvent();
 
 	// Keyboard

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/ScreenMixin.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/ScreenMixin.java
@@ -27,6 +27,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.Drawable;
 import net.minecraft.client.gui.Element;
 import net.minecraft.client.gui.Selectable;
@@ -63,6 +64,8 @@ abstract class ScreenMixin implements ScreenExtensions {
 	private Event<ScreenEvents.AfterTick> afterTickEvent;
 	@Unique
 	private Event<ScreenEvents.BeforeRender> beforeRenderEvent;
+	@Unique
+	private Event<ScreenEvents.AfterBackground> afterBackgroundEvent;
 	@Unique
 	private Event<ScreenEvents.AfterRender> afterRenderEvent;
 
@@ -106,6 +109,11 @@ abstract class ScreenMixin implements ScreenExtensions {
 	@Unique
 	private Event<ScreenMouseEvents.AfterMouseScroll> afterMouseScrollEvent;
 
+	@Inject(method = "renderWithTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;renderBackground(Lnet/minecraft/client/gui/DrawContext;IIF)V", shift = At.Shift.AFTER))
+	public final void renderWithTooltip(DrawContext context, int mouseX, int mouseY, float deltaTicks, CallbackInfo ci) {
+		ScreenEvents.afterBackground(((Screen) (Object) this)).invoker().afterBackground((Screen) (Object) this, context, mouseX, mouseY, deltaTicks);
+	}
+
 	@Inject(method = "init(Lnet/minecraft/client/MinecraftClient;II)V", at = @At("HEAD"))
 	private void beforeInitScreen(MinecraftClient client, int width, int height, CallbackInfo ci) {
 		beforeInit(client, width, height);
@@ -132,6 +140,7 @@ abstract class ScreenMixin implements ScreenExtensions {
 		this.fabricButtons = null;
 		this.removeEvent = ScreenEventFactory.createRemoveEvent();
 		this.beforeRenderEvent = ScreenEventFactory.createBeforeRenderEvent();
+		this.afterBackgroundEvent = ScreenEventFactory.createAfterBackgroundEvent();
 		this.afterRenderEvent = ScreenEventFactory.createAfterRenderEvent();
 		this.beforeTickEvent = ScreenEventFactory.createBeforeTickEvent();
 		this.afterTickEvent = ScreenEventFactory.createAfterTickEvent();
@@ -203,6 +212,11 @@ abstract class ScreenMixin implements ScreenExtensions {
 	@Override
 	public Event<ScreenEvents.BeforeRender> fabric_getBeforeRenderEvent() {
 		return ensureEventsAreInitialized(this.beforeRenderEvent);
+	}
+
+	@Override
+	public Event<ScreenEvents.AfterBackground> fabric_getAfterBackgroundEvent() {
+		return ensureEventsAreInitialized(this.afterBackgroundEvent);
 	}
 
 	@Override

--- a/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/ScreenTests.java
+++ b/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/ScreenTests.java
@@ -18,6 +18,8 @@ package net.fabricmc.fabric.test.screen;
 
 import java.util.List;
 
+import net.minecraft.client.gui.screen.ingame.GrindstoneScreen;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,12 +80,6 @@ public final class ScreenTests implements ClientModInitializer {
 					.findAny()
 					.orElseThrow(() -> new AssertionError("Failed to find the \"Stop Sound\" button in the screen's elements"));
 
-			// Register render event to draw an icon on the screen
-			ScreenEvents.afterRender(screen).register((_screen, drawContext, mouseX, mouseY, tickDelta) -> {
-				// Render an armor icon to test
-				drawContext.drawGuiTexture(RenderPipelines.GUI_TEXTURED, ScreenTests.ARMOR_FULL_TEXTURE, (screen.width / 2) - 124, (screen.height / 4) + 96, 20, 20);
-			});
-
 			ScreenKeyboardEvents.allowKeyPress(screen).register((_screen, context) -> {
 				LOGGER.info("After Pressed, Context: {}", context);
 				return true; // Let actions continue
@@ -94,6 +90,27 @@ public final class ScreenTests implements ClientModInitializer {
 			});
 		} else if (screen instanceof CreativeInventoryScreen) {
 			Screens.getButtons(screen).add(new TestButtonWidget());
+		} else if (screen instanceof GrindstoneScreen) {
+			// Register render event to draw an icon on the screen
+			// Expected result: the icon is drawn BEHIND both the handled screen interface and the darkened background, text, items, the carried item, tooltips, etc.
+			ScreenEvents.beforeRender(screen).register((_screen, drawContext, mouseX, mouseY, tickDelta) -> {
+				// Render an armor icon to test
+				drawContext.drawGuiTexture(RenderPipelines.GUI_TEXTURED, ScreenTests.ARMOR_FULL_TEXTURE, (screen.width / 2) - 88 - 10, (screen.height / 2) - 34, 20, 20);
+			});
+
+			// Register render event to draw an icon on the screen
+			// Expected result: the icon is drawn ABOVE both the handled screen interface and the darkened background, but still BEHIND text, items, the carried item, tooltips, etc.
+			ScreenEvents.afterBackground(screen).register((_screen, drawContext, mouseX, mouseY, tickDelta) -> {
+				// Render an armor icon to test
+				drawContext.drawGuiTexture(RenderPipelines.GUI_TEXTURED, ScreenTests.ARMOR_FULL_TEXTURE, (screen.width / 2) - 88 - 10, (screen.height / 2) - 10, 20, 20);
+			});
+
+			// Register render event to draw an icon on the screen
+			// Expected result: the icon is drawn ABOVE everything, including the background, handled screen interface, text, items, the carried item, tooltips, etc.
+			ScreenEvents.afterRender(screen).register((_screen, drawContext, mouseX, mouseY, tickDelta) -> {
+				// Render an armor icon to test
+				drawContext.drawGuiTexture(RenderPipelines.GUI_TEXTURED, ScreenTests.ARMOR_FULL_TEXTURE, (screen.width / 2) - 88 - 10, (screen.height / 2) + 14, 20, 20);
+			});
 		}
 	}
 

--- a/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/ScreenTests.java
+++ b/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/ScreenTests.java
@@ -18,8 +18,6 @@ package net.fabricmc.fabric.test.screen;
 
 import java.util.List;
 
-import net.minecraft.client.gui.screen.ingame.GrindstoneScreen;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,6 +27,7 @@ import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.TitleScreen;
 import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
+import net.minecraft.client.gui.screen.ingame.GrindstoneScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.ClickableWidget;
 import net.minecraft.text.Text;


### PR DESCRIPTION
This adds a new screen render event that runs between `BeforeRender` and `AfterRender`, directly after `Screen::renderBackground` has been called. 

This is useful for drawing additional background contents before text, items, the carried item, tooltips, etc. are drawn.

Here is an example from the included test mod using all three screen render events to demonstrate the usefulness of each one individually:
<img width="1708" height="960" alt="2025-09-23_23 54 07" src="https://github.com/user-attachments/assets/06153355-f8ec-46e1-b34c-c4fc79b3a9f6" />

1. `BeforeRender`: The icon is drawn BEHIND both the handled screen interface and the darkened background, text, items, the carried item, tooltips, etc.
2. `AfterBackground`: The icon is drawn ABOVE both the handled screen interface and the darkened background, but still BEHIND text, items, the carried item, tooltips, etc.
3. `AfterRender`: The icon is drawn ABOVE everything, including the background, handled screen interface, text, items, the carried item, tooltips, etc.