### PR TITLE
Provide a way to get existing spawn entries in `SpawnSettingsContext`

### DIFF
--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModificationContext.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModificationContext.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.api.biome.v1;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.BiPredicate;
@@ -31,6 +32,7 @@ import net.minecraft.sound.BiomeMoodSound;
 import net.minecraft.sound.MusicSound;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.util.collection.Pool;
+import net.minecraft.util.collection.Weighted;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.BiomeEffects;
 import net.minecraft.world.biome.BiomeParticleConfig;
@@ -351,6 +353,15 @@ public interface BiomeModificationContext {
 		 * @see SpawnSettings.Builder#creatureSpawnProbability(float)
 		 */
 		void setCreatureSpawnProbability(float probability);
+
+		/**
+		 * Provides a view of all spawns of the given spawn group.
+		 *
+		 * <p>Associated JSON property: <code>spawners</code>.
+		 *
+		 * @see SpawnSettings#getSpawnEntries(SpawnGroup)
+		 */
+		List<Weighted<SpawnSettings.SpawnEntry>> getSpawnEntries(SpawnGroup spawnGroup);
 
 		/**
 		 * Associated JSON property: <code>spawners</code>.

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModificationContext.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModificationContext.java
@@ -22,6 +22,7 @@ import java.util.OptionalInt;
 import java.util.function.BiPredicate;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.UnmodifiableView;
 
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.SpawnGroup;
@@ -361,7 +362,7 @@ public interface BiomeModificationContext {
 		 *
 		 * @see SpawnSettings#getSpawnEntries(SpawnGroup)
 		 */
-		List<Weighted<SpawnSettings.SpawnEntry>> getSpawnEntries(SpawnGroup spawnGroup);
+		@UnmodifiableView List<Weighted<SpawnSettings.SpawnEntry>> getSpawnEntries(SpawnGroup spawnGroup);
 
 		/**
 		 * Associated JSON property: <code>spawners</code>.

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/modification/BiomeModificationContextImpl.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/modification/BiomeModificationContextImpl.java
@@ -395,6 +395,13 @@ public class BiomeModificationContextImpl implements BiomeModificationContext {
 		}
 
 		@Override
+		public List<Weighted<SpawnSettings.SpawnEntry>> getSpawnEntries(SpawnGroup spawnGroup) {
+			Objects.requireNonNull(spawnGroup);
+
+			return Collections.unmodifiableList(fabricSpawners.get(spawnGroup));
+		}
+
+		@Override
 		public void addSpawn(SpawnGroup spawnGroup, SpawnSettings.SpawnEntry spawnEntry, int weight) {
 			Objects.requireNonNull(spawnGroup);
 			Objects.requireNonNull(spawnEntry);

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/modification/BiomeModificationContextImpl.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/modification/BiomeModificationContextImpl.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
 
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.SpawnGroup;
@@ -395,7 +396,7 @@ public class BiomeModificationContextImpl implements BiomeModificationContext {
 		}
 
 		@Override
-		public List<Weighted<SpawnSettings.SpawnEntry>> getSpawnEntries(SpawnGroup spawnGroup) {
+		public @UnmodifiableView List<Weighted<SpawnSettings.SpawnEntry>> getSpawnEntries(SpawnGroup spawnGroup) {
 			Objects.requireNonNull(spawnGroup);
 
 			return Collections.unmodifiableList(fabricSpawners.get(spawnGroup));


### PR DESCRIPTION
`SpawnSettingsContext` currently has no way to get the already registered spawn entries, particularly vanilla entries.

Personally I find this very useful information to have, as I use it in a bunch of my mods to add spawns of variant mobs depending on the presence of vanilla mobs.

Example: In the Mutant Monsters mod I add mutant zombie spawning only to biomes which in vanilla are allowed to spawn zombies at a weight relative to the vanilla counterpart.

So this PR adds a simple method for providing a view already registered spawn entries for a given spawn group.

An alternative approach would be to make a view of the entire `fabricSpawners` map accessible, although I don't think that is really necessary.