### PR TITLE
PreparableModelLoadingPlugin.DataLoader gets passed a ResourceReloader.Store

### DIFF
--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/PreparableModelLoadingPlugin.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/PreparableModelLoadingPlugin.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.UnmodifiableView;
 
 import net.minecraft.resource.ResourceManager;
+import net.minecraft.resource.ResourceReloader;
 
 import net.fabricmc.fabric.impl.client.model.loading.ModelLoadingPluginManager;
 
@@ -70,10 +71,10 @@ public interface PreparableModelLoadingPlugin<T> {
 		 * {@link CompletableFuture#supplyAsync(Supplier, Executor)} to compute the data.
 		 * The completable future should be scheduled to run using the passed executor.
 		 *
-		 * @param resourceManager The resource manager that can be used to retrieve resources.
+		 * @param resourceReloaderStore The {@link ResourceReloader.Store} instance. Use {@link ResourceReloader.Store#getResourceManager()} to retrieve resources.
 		 * @param executor The executor that <b>must</b> be used to schedule any completable future.
 		 */
-		CompletableFuture<T> load(ResourceManager resourceManager, Executor executor);
+		CompletableFuture<T> load(ResourceReloader.Store resourceReloaderStore, Executor executor);
 	}
 
 	/**

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/ModelLoadingPluginManager.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/ModelLoadingPluginManager.java
@@ -25,7 +25,7 @@ import java.util.concurrent.Executor;
 
 import org.jetbrains.annotations.UnmodifiableView;
 
-import net.minecraft.resource.ResourceManager;
+import net.minecraft.resource.ResourceReloader;
 import net.minecraft.util.Util;
 
 import net.fabricmc.fabric.api.client.model.loading.v1.ModelLoadingPlugin;
@@ -53,7 +53,7 @@ public final class ModelLoadingPluginManager {
 		PREPARABLE_PLUGINS.add(new HolderImpl<>(loader, plugin));
 	}
 
-	public static CompletableFuture<List<ModelLoadingPlugin>> preparePlugins(ResourceManager resourceManager, Executor executor) {
+	public static CompletableFuture<List<ModelLoadingPlugin>> preparePlugins(ResourceReloader.Store resourceReloaderStore, Executor executor) {
 		List<CompletableFuture<ModelLoadingPlugin>> futures = new ArrayList<>();
 
 		for (ModelLoadingPlugin plugin : PLUGINS) {
@@ -61,14 +61,14 @@ public final class ModelLoadingPluginManager {
 		}
 
 		for (HolderImpl<?> holder : PREPARABLE_PLUGINS) {
-			futures.add(preparePlugin(holder, resourceManager, executor));
+			futures.add(preparePlugin(holder, resourceReloaderStore, executor));
 		}
 
 		return Util.combineSafe(futures);
 	}
 
-	private static <T> CompletableFuture<ModelLoadingPlugin> preparePlugin(HolderImpl<T> holder, ResourceManager resourceManager, Executor executor) {
-		CompletableFuture<T> dataFuture = holder.loader.load(resourceManager, executor);
+	private static <T> CompletableFuture<ModelLoadingPlugin> preparePlugin(HolderImpl<T> holder, ResourceReloader.Store resourceReloaderStore, Executor executor) {
+		CompletableFuture<T> dataFuture = holder.loader.load(resourceReloaderStore, executor);
 		return dataFuture.thenApply(data -> pluginContext -> holder.plugin.initialize(data, pluginContext));
 	}
 

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/model/loading/BakedModelManagerMixin.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/model/loading/BakedModelManagerMixin.java
@@ -70,7 +70,7 @@ abstract class BakedModelManagerMixin implements FabricBakedModelManager {
 
 	@Inject(method = "reload", at = @At("HEAD"))
 	private void onHeadReload(ResourceReloader.Store sharedState, Executor prepareExecutor, ResourceReloader.Synchronizer synchronizer, Executor applyExecutor, CallbackInfoReturnable<CompletableFuture<Void>> cir) {
-		eventDispatcherFuture = ModelLoadingPluginManager.preparePlugins(sharedState.getResourceManager(), prepareExecutor).thenApplyAsync(ModelLoadingEventDispatcher::new, prepareExecutor);
+		eventDispatcherFuture = ModelLoadingPluginManager.preparePlugins(sharedState, prepareExecutor).thenApplyAsync(ModelLoadingEventDispatcher::new, prepareExecutor);
 	}
 
 	@ModifyReturnValue(method = "reload", at = @At("RETURN"))

--- a/fabric-model-loading-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/model/loading/PreparablePluginTest.java
+++ b/fabric-model-loading-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/model/loading/PreparablePluginTest.java
@@ -32,9 +32,10 @@ import org.slf4j.Logger;
 import net.minecraft.client.render.model.BakedModelManager;
 import net.minecraft.client.render.model.UnbakedModel;
 import net.minecraft.client.render.model.json.JsonUnbakedModel;
+import net.minecraft.client.texture.AtlasManager;
 import net.minecraft.resource.Resource;
 import net.minecraft.resource.ResourceFinder;
-import net.minecraft.resource.ResourceManager;
+import net.minecraft.resource.ResourceReloader;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.Util;
 
@@ -70,8 +71,10 @@ public class PreparablePluginTest implements ClientModInitializer {
 	/**
 	 * Adaptation of the {@link BakedModelManager} method.
 	 */
-	private static CompletableFuture<Map<Identifier, JsonUnbakedModel>> loadModelReplacements(ResourceManager resourceManager, Executor executor) {
-		return CompletableFuture.supplyAsync(() -> MODEL_REPLACEMENTS_FINDER.findResources(resourceManager), executor).thenCompose(models2 -> {
+	private static CompletableFuture<Map<Identifier, JsonUnbakedModel>> loadModelReplacements(ResourceReloader.Store resourceReloaderStore, Executor executor) {
+		Objects.requireNonNull(resourceReloaderStore.getOrThrow(AtlasManager.stitchKey));
+
+		return CompletableFuture.supplyAsync(() -> MODEL_REPLACEMENTS_FINDER.findResources(resourceReloaderStore.getResourceManager()), executor).thenCompose(models2 -> {
 			ArrayList<CompletableFuture<Pair<Identifier, JsonUnbakedModel>>> list = new ArrayList<>(models2.size());
 
 			for (Map.Entry<Identifier, Resource> entry : models2.entrySet()) {


### PR DESCRIPTION
This is a breaking change, to pass ResourceReloader.Store to PreparableModelLoadingPlugin.DataLoader, the resource manager can easily be aquired using `getResourceManager()`.