### PR TITLE
Add refreshCommandCompletions method to fcapi

### DIFF
--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/api/client/command/v2/ClientCommandManager.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/api/client/command/v2/ClientCommandManager.java
@@ -22,6 +22,10 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import org.jetbrains.annotations.Nullable;
 
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.network.packet.s2c.play.CommandTreeS2CPacket;
+
 import net.fabricmc.fabric.impl.command.client.ClientCommandInternals;
 
 /**
@@ -73,6 +77,29 @@ public final class ClientCommandManager {
 	 */
 	public static @Nullable CommandDispatcher<FabricClientCommandSource> getActiveDispatcher() {
 		return ClientCommandInternals.getActiveDispatcher();
+	}
+
+	/**
+	 * Refresh the command completions. This is helpful when a condition as defined using {@link LiteralArgumentBuilder#requires}
+	 * changes for a client command. The method uses the last received {@code minecraft:commands}
+	 * packet and calls its handler. This triggers the client command's condition to be reevaluated.
+	 *
+	 * <p>Will not do anything when not connected to a server (dedicated or integrated).</p>
+	 */
+	public static void refreshCommandCompletions() {
+		ClientPlayNetworkHandler networkHandler = MinecraftClient.getInstance().getNetworkHandler();
+
+		if (networkHandler == null) {
+			return;
+		}
+
+		CommandTreeS2CPacket lastReceivedCommandsPacket = ClientCommandInternals.getLastReceivedCommandsPacket();
+
+		if (lastReceivedCommandsPacket == null) {
+			return;
+		}
+
+		networkHandler.onCommandTree(lastReceivedCommandsPacket);
 	}
 
 	/**

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/api/client/command/v2/ClientCommandManager.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/api/client/command/v2/ClientCommandManager.java
@@ -84,19 +84,20 @@ public final class ClientCommandManager {
 	 * changes for a client command. The method uses the last received {@code minecraft:commands}
 	 * packet and calls its handler. This triggers the client command's condition to be reevaluated.
 	 *
-	 * <p>Will not do anything when not connected to a server (dedicated or integrated).</p>
+	 * @throws IllegalStateException if not connected to a server (dedicated or integrated) or no
+	 * {@code minecraft:commands} packet has been received yet
 	 */
 	public static void refreshCommandCompletions() {
 		ClientPlayNetworkHandler networkHandler = MinecraftClient.getInstance().getNetworkHandler();
 
 		if (networkHandler == null) {
-			return;
+			throw new IllegalStateException("Not connected to a server (dedicated or integrated)!");
 		}
 
-		CommandTreeS2CPacket lastReceivedCommandsPacket = ClientCommandInternals.getLastReceivedCommandsPacket();
+		CommandTreeS2CPacket lastReceivedCommandsPacket = ((ClientCommandInternals.LastReceivedCommandsPacketAccessor) networkHandler).fabric_api$getLastReceivedCommandsPacket();
 
 		if (lastReceivedCommandsPacket == null) {
-			return;
+			throw new IllegalStateException("Not yet received a 'minecraft:commands' packet!");
 		}
 
 		networkHandler.onCommandTree(lastReceivedCommandsPacket);

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/impl/command/client/ClientCommandInternals.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/impl/command/client/ClientCommandInternals.java
@@ -54,7 +54,6 @@ public final class ClientCommandInternals {
 	private static final String API_COMMAND_NAME = "fabric-command-api-v2:client";
 	private static final String SHORT_API_COMMAND_NAME = "fcc";
 	private static @Nullable CommandDispatcher<FabricClientCommandSource> activeDispatcher;
-	private static @Nullable CommandTreeS2CPacket lastReceivedCommandsPacket = null;
 
 	public static void setActiveDispatcher(@Nullable CommandDispatcher<FabricClientCommandSource> dispatcher) {
 		ClientCommandInternals.activeDispatcher = dispatcher;
@@ -62,14 +61,6 @@ public final class ClientCommandInternals {
 
 	public static @Nullable CommandDispatcher<FabricClientCommandSource> getActiveDispatcher() {
 		return activeDispatcher;
-	}
-
-	public static void setLastReceivedCommandsPacket(@Nullable CommandTreeS2CPacket commandsPacket) {
-		lastReceivedCommandsPacket = commandsPacket;
-	}
-
-	public static @Nullable CommandTreeS2CPacket getLastReceivedCommandsPacket() {
-		return lastReceivedCommandsPacket;
 	}
 
 	/**
@@ -233,5 +224,9 @@ public final class ClientCommandInternals {
 				copyChildren(child, result, source, originalToCopy);
 			}
 		}
+	}
+
+	public interface LastReceivedCommandsPacketAccessor {
+		@Nullable CommandTreeS2CPacket fabric_api$getLastReceivedCommandsPacket();
 	}
 }

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/impl/command/client/ClientCommandInternals.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/impl/command/client/ClientCommandInternals.java
@@ -41,6 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.network.packet.s2c.play.CommandTreeS2CPacket;
 import net.minecraft.text.Text;
 import net.minecraft.text.Texts;
 import net.minecraft.util.profiler.Profilers;
@@ -53,6 +54,7 @@ public final class ClientCommandInternals {
 	private static final String API_COMMAND_NAME = "fabric-command-api-v2:client";
 	private static final String SHORT_API_COMMAND_NAME = "fcc";
 	private static @Nullable CommandDispatcher<FabricClientCommandSource> activeDispatcher;
+	private static @Nullable CommandTreeS2CPacket lastReceivedCommandsPacket = null;
 
 	public static void setActiveDispatcher(@Nullable CommandDispatcher<FabricClientCommandSource> dispatcher) {
 		ClientCommandInternals.activeDispatcher = dispatcher;
@@ -60,6 +62,14 @@ public final class ClientCommandInternals {
 
 	public static @Nullable CommandDispatcher<FabricClientCommandSource> getActiveDispatcher() {
 		return activeDispatcher;
+	}
+
+	public static void setLastReceivedCommandsPacket(@Nullable CommandTreeS2CPacket commandsPacket) {
+		lastReceivedCommandsPacket = commandsPacket;
+	}
+
+	public static @Nullable CommandTreeS2CPacket getLastReceivedCommandsPacket() {
+		return lastReceivedCommandsPacket;
 	}
 
 	/**

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPlayNetworkHandlerMixin.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPlayNetworkHandlerMixin.java
@@ -17,9 +17,11 @@
 package net.fabricmc.fabric.mixin.command.client;
 
 import com.mojang.brigadier.CommandDispatcher;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -39,7 +41,7 @@ import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.fabricmc.fabric.impl.command.client.ClientCommandInternals;
 
 @Mixin(ClientPlayNetworkHandler.class)
-abstract class ClientPlayNetworkHandlerMixin {
+abstract class ClientPlayNetworkHandlerMixin implements ClientCommandInternals.LastReceivedCommandsPacketAccessor {
 	@Shadow
 	private CommandDispatcher<CommandSource> commandDispatcher;
 
@@ -54,6 +56,9 @@ abstract class ClientPlayNetworkHandlerMixin {
 	@Final
 	@Shadow
 	private DynamicRegistryManager.Immutable combinedDynamicRegistries;
+
+	@Unique
+	private @Nullable CommandTreeS2CPacket lastReceivedCommandsPacket = null;
 
 	@Inject(method = "onGameJoin", at = @At("RETURN"))
 	private void onGameJoin(GameJoinS2CPacket packet, CallbackInfo info) {
@@ -72,9 +77,9 @@ abstract class ClientPlayNetworkHandlerMixin {
 		ClientCommandInternals.addCommands((CommandDispatcher) commandDispatcher, (FabricClientCommandSource) commandSource);
 	}
 
-	@Inject(method = "onCommandTree", at = @At("HEAD"))
+	@Inject(method = "onCommandTree", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/NetworkThreadUtils;forceMainThread(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/listener/PacketListener;Lnet/minecraft/network/PacketApplyBatcher;)V", shift = At.Shift.AFTER))
 	private void setLastReceivedCommandsPacket(CommandTreeS2CPacket packet, CallbackInfo ci) {
-		ClientCommandInternals.setLastReceivedCommandsPacket(packet);
+		this.lastReceivedCommandsPacket = packet;
 	}
 
 	@Inject(method = "runClickEventCommand", at = @At("HEAD"), cancellable = true)
@@ -89,5 +94,10 @@ abstract class ClientPlayNetworkHandlerMixin {
 		if (ClientCommandInternals.executeCommand(command)) {
 			info.cancel();
 		}
+	}
+
+	@Override
+	public @Nullable CommandTreeS2CPacket fabric_api$getLastReceivedCommandsPacket() {
+		return this.lastReceivedCommandsPacket;
 	}
 }

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPlayNetworkHandlerMixin.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPlayNetworkHandlerMixin.java
@@ -72,6 +72,11 @@ abstract class ClientPlayNetworkHandlerMixin {
 		ClientCommandInternals.addCommands((CommandDispatcher) commandDispatcher, (FabricClientCommandSource) commandSource);
 	}
 
+	@Inject(method = "onCommandTree", at = @At("HEAD"))
+	private void setLastReceivedCommandsPacket(CommandTreeS2CPacket packet, CallbackInfo ci) {
+		ClientCommandInternals.setLastReceivedCommandsPacket(packet);
+	}
+
 	@Inject(method = "runClickEventCommand", at = @At("HEAD"), cancellable = true)
 	private void onSendCommand(String command, Screen screen, CallbackInfo info) {
 		if (ClientCommandInternals.executeCommand(command)) {

--- a/fabric-command-api-v2/src/testmodClient/java/net/fabricmc/fabric/test/command/client/ClientCommandTest.java
+++ b/fabric-command-api-v2/src/testmodClient/java/net/fabricmc/fabric/test/command/client/ClientCommandTest.java
@@ -93,11 +93,27 @@ public final class ClientCommandTest implements ClientModInitializer {
 					})
 			));
 
-			// Command with condition that changes
-			dispatcher.register(ClientCommandManager.literal("test_client_command_with_condition_change").requires(source -> commandFlag).executes(context -> Command.SINGLE_SUCCESS));
+			// Command with condition that can be toggled
+			String commandWithCondition = "test_client_command_with_condition_toggle";
+			// The user should check whether the command is suggested iff the condition evaluates to true
+			// Initially, the command should not be suggested, as the command flag is initially false
+			dispatcher.register(ClientCommandManager.literal(commandWithCondition).requires(source -> commandFlag).executes(context -> {
+				context.getSource().sendFeedback(Text.literal("Expected: true, is: " + commandFlag));
+				return Command.SINGLE_SUCCESS;
+			}));
+			// After this command is first executed, the above command should now be suggested
+			// After this command is executed a second time, the above command should now not be suggested again, etc.
 			dispatcher.register(ClientCommandManager.literal("test_client_command_that_toggles_condition").executes(context -> {
 				commandFlag = !commandFlag;
 				ClientCommandManager.refreshCommandCompletions();
+				context.getSource().sendFeedback(Text.literal("Toggled command flag to " + commandFlag));
+
+				if (commandFlag) {
+					context.getSource().sendFeedback(Text.literal("The command " + commandWithCondition + " should now be suggested"));
+				} else {
+					context.getSource().sendFeedback(Text.literal("The command " + commandWithCondition + " should now not be suggested"));
+				}
+
 				return Command.SINGLE_SUCCESS;
 			}));
 

--- a/fabric-command-api-v2/src/testmodClient/java/net/fabricmc/fabric/test/command/client/ClientCommandTest.java
+++ b/fabric-command-api-v2/src/testmodClient/java/net/fabricmc/fabric/test/command/client/ClientCommandTest.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.test.command.client;
 
+import com.mojang.brigadier.Command;
 import com.mojang.brigadier.arguments.DoubleArgumentType;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
@@ -41,6 +42,7 @@ public final class ClientCommandTest implements ClientModInitializer {
 	private static final DynamicCommandExceptionType IS_NULL = new DynamicCommandExceptionType(x -> Text.literal("The " + x + " is null"));
 	private static final SimpleCommandExceptionType UNEXECUTABLE_EXECUTED = new SimpleCommandExceptionType(Text.literal("Executed an unexecutable command!"));
 
+	private boolean commandFlag = false;
 	private boolean wasTested = false;
 
 	@Override
@@ -90,6 +92,14 @@ public final class ClientCommandTest implements ClientModInitializer {
 						return 0;
 					})
 			));
+
+			// Command with condition that changes
+			dispatcher.register(ClientCommandManager.literal("test_client_command_with_condition_change").requires(source -> commandFlag).executes(context -> Command.SINGLE_SUCCESS));
+			dispatcher.register(ClientCommandManager.literal("test_client_command_that_toggles_condition").executes(context -> {
+				commandFlag = !commandFlag;
+				ClientCommandManager.refreshCommandCompletions();
+				return Command.SINGLE_SUCCESS;
+			}));
 
 			// Tests
 


### PR DESCRIPTION
On servers, when a change happens to a condition for a command (most commonly permission changes), the server will call `CommandManager.sendCommandTree` to inform the client. However, no such method exists for when clients want to do the same for client commands. In my case, I wanted to hide a command behind a feature flag that can be toggled by the user. Now when the flag is toggled, there is no way to inform the user, and the command will seem to be unavailable until the user re-joins the world or server. This PR adds a method to the Fabric Command API that will mimic the server calling `CommandManager.sendCommandTree` on the client by simply calling the handler for the `minecraft:commands` packet. To call this method, the last sent `minecraft:commands` packet is cached.