### PR TITLE
Implement item FRAPI in Indigo

### DIFF
--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/accessor/AccessBatchingRenderCommandQueue.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/accessor/AccessBatchingRenderCommandQueue.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.indigo.renderer.accessor;
+
+import java.util.List;
+
+import net.fabricmc.fabric.impl.client.indigo.renderer.render.MeshItemCommand;
+
+public interface AccessBatchingRenderCommandQueue {
+	List<MeshItemCommand> fabric_getMeshItemCommands();
+}

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/accessor/AccessRenderCommandQueue.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/accessor/AccessRenderCommandQueue.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.indigo.renderer.accessor;
+
+import java.util.List;
+
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.item.ItemRenderState;
+import net.minecraft.client.render.model.BakedQuad;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.item.ItemDisplayContext;
+
+import net.fabricmc.fabric.api.renderer.v1.mesh.MeshView;
+
+public interface AccessRenderCommandQueue {
+	void fabric_submitItem(MatrixStack matrices, ItemDisplayContext displayContext, int light, int overlay, int outlineColors, int[] tintLayers, List<BakedQuad> quads, RenderLayer renderLayer, ItemRenderState.Glint glintType, MeshView mesh);
+}

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
@@ -34,11 +34,11 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.item.ItemDisplayContext;
 import net.minecraft.util.math.MatrixUtil;
 
+import net.fabricmc.fabric.api.renderer.v1.mesh.MeshView;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.renderer.v1.render.FabricLayerRenderState;
 import net.fabricmc.fabric.api.renderer.v1.render.RenderLayerHelper;
 import net.fabricmc.fabric.impl.client.indigo.renderer.helper.ColorHelper;
-import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.MeshViewImpl;
 import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.MutableQuadViewImpl;
 import net.fabricmc.fabric.mixin.client.indigo.renderer.ItemRendererAccessor;
 
@@ -48,8 +48,6 @@ import net.fabricmc.fabric.mixin.client.indigo.renderer.ItemRendererAccessor;
 public class ItemRenderContext extends AbstractRenderContext {
 	private static final int GLINT_COUNT = ItemRenderState.Glint.values().length;
 
-	public static final ThreadLocal<ItemRenderContext> POOL = ThreadLocal.withInitial(ItemRenderContext::new);
-
 	private ItemDisplayContext displayContext;
 	private VertexConsumerProvider vertexConsumers;
 	private int light;
@@ -57,11 +55,12 @@ public class ItemRenderContext extends AbstractRenderContext {
 
 	private RenderLayer defaultLayer;
 	private ItemRenderState.Glint defaultGlint;
+	private boolean ignoreQuadGlint;
 
 	private MatrixStack.Entry specialGlintEntry;
 	private final VertexConsumer[] vertexConsumerCache = new VertexConsumer[3 * GLINT_COUNT];
 
-	public void renderItem(ItemDisplayContext displayContext, MatrixStack matrixStack, VertexConsumerProvider vertexConsumers, int light, int overlay, int[] tints, List<BakedQuad> vanillaQuads, MeshViewImpl mesh, RenderLayer layer, ItemRenderState.Glint glint) {
+	public void renderItem(ItemDisplayContext displayContext, MatrixStack matrixStack, VertexConsumerProvider vertexConsumers, int light, int overlay, int[] tints, List<BakedQuad> vanillaQuads, MeshView mesh, RenderLayer layer, ItemRenderState.Glint glint, boolean ignoreQuadGlint) {
 		this.displayContext = displayContext;
 		matrices = matrixStack.peek();
 		this.vertexConsumers = vertexConsumers;
@@ -71,6 +70,7 @@ public class ItemRenderContext extends AbstractRenderContext {
 
 		defaultLayer = layer;
 		defaultGlint = glint;
+		this.ignoreQuadGlint = ignoreQuadGlint;
 
 		bufferQuads(vanillaQuads, mesh);
 
@@ -84,7 +84,7 @@ public class ItemRenderContext extends AbstractRenderContext {
 		Arrays.fill(vertexConsumerCache, null);
 	}
 
-	private void bufferQuads(List<BakedQuad> vanillaQuads, MeshViewImpl mesh) {
+	private void bufferQuads(List<BakedQuad> vanillaQuads, MeshView mesh) {
 		QuadEmitter emitter = getEmitter();
 
 		final int vanillaQuadCount = vanillaQuads.size();
@@ -143,7 +143,7 @@ public class ItemRenderContext extends AbstractRenderContext {
 			layer = RenderLayerHelper.getEntityBlockLayer(quadRenderLayer);
 		}
 
-		if (quadGlint == null) {
+		if (ignoreQuadGlint || quadGlint == null) {
 			glint = defaultGlint;
 		} else {
 			glint = quadGlint;

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/MeshItemCommand.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/MeshItemCommand.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.indigo.renderer.render;
+
+import java.util.List;
+
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.item.ItemRenderState;
+import net.minecraft.client.render.model.BakedQuad;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.item.ItemDisplayContext;
+
+import net.fabricmc.fabric.api.renderer.v1.mesh.MeshView;
+
+public record MeshItemCommand(MatrixStack.Entry positionMatrix, ItemDisplayContext displayContext, int lightCoords, int overlayCoords, int outlineColor, int[] tintLayers, List<BakedQuad> quads, RenderLayer renderLayer, ItemRenderState.Glint glintType, MeshView mesh) {
+}

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/mixin/client/indigo/renderer/BatchingRenderCommandQueueMixin.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/mixin/client/indigo/renderer/BatchingRenderCommandQueueMixin.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.indigo.renderer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.command.BatchingRenderCommandQueue;
+import net.minecraft.client.render.command.RenderCommandQueue;
+import net.minecraft.client.render.item.ItemRenderState;
+import net.minecraft.client.render.model.BakedQuad;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.item.ItemDisplayContext;
+
+import net.fabricmc.fabric.api.renderer.v1.mesh.MeshView;
+import net.fabricmc.fabric.impl.client.indigo.renderer.accessor.AccessBatchingRenderCommandQueue;
+import net.fabricmc.fabric.impl.client.indigo.renderer.accessor.AccessRenderCommandQueue;
+import net.fabricmc.fabric.impl.client.indigo.renderer.render.MeshItemCommand;
+
+@Mixin(BatchingRenderCommandQueue.class)
+abstract class BatchingRenderCommandQueueMixin implements RenderCommandQueue, AccessRenderCommandQueue, AccessBatchingRenderCommandQueue {
+	@Shadow
+	private boolean hasCommands;
+
+	@Unique
+	private final List<MeshItemCommand> meshItemCommands = new ArrayList<>();
+
+	@Inject(method = "clear()V", at = @At("RETURN"))
+	public void clear(CallbackInfo ci) {
+		meshItemCommands.clear();
+	}
+
+	@Override
+	public void fabric_submitItem(MatrixStack matrices, ItemDisplayContext displayContext, int light, int overlay, int outlineColors, int[] tintLayers, List<BakedQuad> quads, RenderLayer renderLayer, ItemRenderState.Glint glintType, MeshView mesh) {
+		hasCommands = true;
+		meshItemCommands.add(new MeshItemCommand(matrices.peek().copy(), displayContext, light, overlay, outlineColors, tintLayers, quads, renderLayer, glintType, mesh));
+	}
+
+	@Override
+	public List<MeshItemCommand> fabric_getMeshItemCommands() {
+		return meshItemCommands;
+	}
+}

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/mixin/client/indigo/renderer/ItemCommandRendererMixin.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/mixin/client/indigo/renderer/ItemCommandRendererMixin.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.indigo.renderer;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.render.OutlineVertexConsumerProvider;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.command.BatchingRenderCommandQueue;
+import net.minecraft.client.render.command.ItemCommandRenderer;
+import net.minecraft.client.render.item.ItemRenderState;
+import net.minecraft.client.util.math.MatrixStack;
+
+import net.fabricmc.fabric.impl.client.indigo.renderer.accessor.AccessBatchingRenderCommandQueue;
+import net.fabricmc.fabric.impl.client.indigo.renderer.render.ItemRenderContext;
+import net.fabricmc.fabric.impl.client.indigo.renderer.render.MeshItemCommand;
+
+@Mixin(ItemCommandRenderer.class)
+abstract class ItemCommandRendererMixin {
+	@Shadow
+	@Final
+	private MatrixStack matrices;
+
+	@Unique
+	private final ItemRenderContext itemRenderContext = new ItemRenderContext();
+
+	@Inject(method = "render", at = @At("RETURN"))
+	private void onReturnRender(BatchingRenderCommandQueue queue, VertexConsumerProvider.Immediate vertexConsumers, OutlineVertexConsumerProvider outlineVertexConsumers, CallbackInfo ci) {
+		for (MeshItemCommand itemCommand : ((AccessBatchingRenderCommandQueue) queue).fabric_getMeshItemCommands()) {
+			matrices.push();
+			matrices.peek().copy(itemCommand.positionMatrix());
+
+			itemRenderContext.renderItem(itemCommand.displayContext(), matrices, vertexConsumers, itemCommand.lightCoords(), itemCommand.overlayCoords(), itemCommand.tintLayers(), itemCommand.quads(), itemCommand.mesh(), itemCommand.renderLayer(), itemCommand.glintType(), false);
+
+			if (itemCommand.outlineColor() != 0) {
+				outlineVertexConsumers.setColor(itemCommand.outlineColor());
+				itemRenderContext.renderItem(itemCommand.displayContext(), matrices, outlineVertexConsumers, itemCommand.lightCoords(), itemCommand.overlayCoords(), itemCommand.tintLayers(), itemCommand.quads(), itemCommand.mesh(), itemCommand.renderLayer(), ItemRenderState.Glint.NONE, true);
+			}
+
+			matrices.pop();
+		}
+	}
+}

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/mixin/client/indigo/renderer/ItemRenderStateLayerRenderStateMixin.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/mixin/client/indigo/renderer/ItemRenderStateLayerRenderStateMixin.java
@@ -16,16 +16,25 @@
 
 package net.fabricmc.fabric.mixin.client.indigo.renderer;
 
+import java.util.List;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.command.OrderedRenderCommandQueue;
 import net.minecraft.client.render.item.ItemRenderState;
+import net.minecraft.client.render.model.BakedQuad;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.item.ItemDisplayContext;
 
 import net.fabricmc.fabric.api.renderer.v1.render.FabricLayerRenderState;
 import net.fabricmc.fabric.impl.client.indigo.renderer.accessor.AccessLayerRenderState;
+import net.fabricmc.fabric.impl.client.indigo.renderer.accessor.AccessRenderCommandQueue;
 import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.MutableMeshImpl;
 
 @Mixin(value = ItemRenderState.LayerRenderState.class)
@@ -38,17 +47,15 @@ abstract class ItemRenderStateLayerRenderStateMixin implements FabricLayerRender
 		mutableMesh.clear();
 	}
 
-	/* TODO 1.21.9
-	@Redirect(method = "render", at = @At(value = "INVOKE", target = "net/minecraft/client/render/item/ItemRenderer.renderItem(Lnet/minecraft/item/ItemDisplayContext;Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;II[ILjava/util/List;Lnet/minecraft/client/render/RenderLayer;Lnet/minecraft/client/render/item/ItemRenderState$Glint;)V"))
-	private void renderItemProxy(ItemDisplayContext displayContext, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay, int[] tints, List<BakedQuad> quads, RenderLayer layer, ItemRenderState.Glint glint) {
-		if (mutableMesh.size() > 0) {
-			ItemRenderContext.POOL.get().renderItem(displayContext, matrices, vertexConsumers, light, overlay, tints, quads, mutableMesh, layer, glint);
+	@Redirect(method = "render", at = @At(value = "INVOKE", target = "net/minecraft/client/render/command/OrderedRenderCommandQueue.submitItem(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/item/ItemDisplayContext;III[ILjava/util/List;Lnet/minecraft/client/render/RenderLayer;Lnet/minecraft/client/render/item/ItemRenderState$Glint;)V"))
+	private void submitItemProxy(OrderedRenderCommandQueue commandQueue, MatrixStack matrices, ItemDisplayContext displayContext, int light, int overlay, int outlineColor, int[] tints, List<BakedQuad> quads, RenderLayer layer, ItemRenderState.Glint glint) {
+		if (mutableMesh.size() > 0 && commandQueue instanceof AccessRenderCommandQueue access) {
+			// We don't have to copy the mesh here because vanilla doesn't copy the tint array or quad list either.
+			access.fabric_submitItem(matrices, displayContext, light, overlay, outlineColor, tints, quads, layer, glint, mutableMesh);
 		} else {
-			ItemRenderer.renderItem(displayContext, matrices, vertexConsumers, light, overlay, tints, quads, layer, glint);
+			commandQueue.submitItem(matrices, displayContext, light, overlay, outlineColor, tints, quads, layer, glint);
 		}
 	}
-
-	 */
 
 	@Override
 	public MutableMeshImpl fabric_getMutableMesh() {

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/mixin/client/indigo/renderer/OrderedRenderCommandQueueImplMixin.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/mixin/client/indigo/renderer/OrderedRenderCommandQueueImplMixin.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.indigo.renderer;
+
+import java.util.List;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.command.OrderedRenderCommandQueue;
+import net.minecraft.client.render.command.OrderedRenderCommandQueueImpl;
+import net.minecraft.client.render.command.RenderCommandQueue;
+import net.minecraft.client.render.item.ItemRenderState;
+import net.minecraft.client.render.model.BakedQuad;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.item.ItemDisplayContext;
+
+import net.fabricmc.fabric.api.renderer.v1.mesh.MeshView;
+import net.fabricmc.fabric.impl.client.indigo.renderer.accessor.AccessRenderCommandQueue;
+
+@Mixin(OrderedRenderCommandQueueImpl.class)
+abstract class OrderedRenderCommandQueueImplMixin implements OrderedRenderCommandQueue, AccessRenderCommandQueue {
+	@Override
+	public void fabric_submitItem(MatrixStack matrices, ItemDisplayContext displayContext, int light, int overlay, int outlineColors, int[] tintLayers, List<BakedQuad> quads, RenderLayer renderLayer, ItemRenderState.Glint glintType, MeshView mesh) {
+		RenderCommandQueue queue = getBatchingQueue(0);
+
+		if (queue instanceof AccessRenderCommandQueue access) {
+			access.fabric_submitItem(matrices, displayContext, light, overlay, outlineColors, tintLayers, quads, renderLayer, glintType, mesh);
+		} else {
+			queue.submitItem(matrices, displayContext, light, overlay, outlineColors, tintLayers, quads, renderLayer, glintType);
+		}
+	}
+}

--- a/fabric-renderer-indigo/src/client/resources/fabric-renderer-indigo.mixins.json
+++ b/fabric-renderer-indigo/src/client/resources/fabric-renderer-indigo.mixins.json
@@ -4,13 +4,16 @@
   "compatibilityLevel": "JAVA_21",
   "plugin": "net.fabricmc.fabric.impl.client.indigo.IndigoMixinConfigPlugin",
   "client": [
+    "BatchingRenderCommandQueueMixin",
     "BlockModelRendererMixin",
     "BlockRenderManagerAccessor",
     "BlockRenderManagerMixin",
     "ChunkRendererRegionMixin",
+    "ItemCommandRendererMixin",
     "ItemRendererAccessor",
-    "ItemRenderStateMixin",
     "ItemRenderStateLayerRenderStateMixin",
+    "ItemRenderStateMixin",
+    "OrderedRenderCommandQueueImplMixin",
     "SectionBuilderMixin"
   ],
   "injectors": {


### PR DESCRIPTION
This is not as simple as any of us would like, but it's inline with vanilla. My only concern is that the `VertexConsumer` cache may not work with the outline VCP, but this can be resolved later if it's the case. This also brings up the possibility of adding a secondary custom submit API to the Rendering v1 module, as vanilla custom submits are limited to a single `RenderLayer` each, which is not sufficient/convenient in some cases.