### PR TITLE
Add a conventional item tag for copper nuggets

### DIFF
--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/EnglishTagLangGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/EnglishTagLangGenerator.java
@@ -247,6 +247,7 @@ public class EnglishTagLangGenerator extends FabricLanguageProvider {
 		translationBuilder.add(ConventionalItemTags.AMETHYST_GEMS, "Amethyst Gems");
 		translationBuilder.add(ConventionalItemTags.EMERALD_GEMS, "Emerald Gems");
 		translationBuilder.add(ConventionalItemTags.PRISMARINE_GEMS, "Prismarine Gems");
+		translationBuilder.add(ConventionalItemTags.COPPER_NUGGETS, "Copper Nuggets");
 		translationBuilder.add(ConventionalItemTags.IRON_NUGGETS, "Iron Nuggets");
 		translationBuilder.add(ConventionalItemTags.GOLD_NUGGETS, "Gold Nuggets");
 		translationBuilder.add(ConventionalItemTags.REDSTONE_DUSTS, "Redstone Dusts");

--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/ItemTagGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/ItemTagGenerator.java
@@ -530,6 +530,7 @@ public final class ItemTagGenerator extends FabricTagProvider.ItemTagProvider {
 				.addOptionalTag(ConventionalItemTags.GOLD_INGOTS)
 				.addOptionalTag(ConventionalItemTags.NETHERITE_INGOTS);
 		valueLookupBuilder(ConventionalItemTags.NUGGETS)
+				.addOptionalTag(ConventionalItemTags.COPPER_NUGGETS)
 				.addOptionalTag(ConventionalItemTags.IRON_NUGGETS)
 				.addOptionalTag(ConventionalItemTags.GOLD_NUGGETS);
 		copy(ConventionalBlockTags.ORES, ConventionalItemTags.ORES);
@@ -608,6 +609,8 @@ public final class ItemTagGenerator extends FabricTagProvider.ItemTagProvider {
 		valueLookupBuilder(ConventionalItemTags.PRISMARINE_GEMS)
 				.add(Items.PRISMARINE_CRYSTALS);
 
+		valueLookupBuilder(ConventionalItemTags.COPPER_NUGGETS)
+				.add(Items.COPPER_NUGGET);
 		valueLookupBuilder(ConventionalItemTags.IRON_NUGGETS)
 				.add(Items.IRON_NUGGET);
 		valueLookupBuilder(ConventionalItemTags.GOLD_NUGGETS)

--- a/fabric-convention-tags-v2/src/generated/resources/assets/fabric-convention-tags-v2/lang/en_us.json
+++ b/fabric-convention-tags-v2/src/generated/resources/assets/fabric-convention-tags-v2/lang/en_us.json
@@ -309,6 +309,7 @@
   "tag.item.c.nether_stars": "Nether Stars",
   "tag.item.c.netherracks": "Netherracks",
   "tag.item.c.nuggets": "Nuggets",
+  "tag.item.c.nuggets.copper": "Copper Nuggets",
   "tag.item.c.nuggets.gold": "Gold Nuggets",
   "tag.item.c.nuggets.iron": "Iron Nuggets",
   "tag.item.c.obsidians": "Obsidians",

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/nuggets.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/nuggets.json
@@ -1,6 +1,10 @@
 {
   "values": [
     {
+      "id": "#c:nuggets/copper",
+      "required": false
+    },
+    {
       "id": "#c:nuggets/iron",
       "required": false
     },

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/nuggets/copper.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/nuggets/copper.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:copper_nugget"
+  ]
+}

--- a/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalItemTags.java
+++ b/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalItemTags.java
@@ -172,6 +172,7 @@ public final class ConventionalItemTags {
 	public static final TagKey<Item> PRISMARINE_GEMS = register("gems/prismarine");
 
 	// Nuggets - vanilla instances
+	public static final TagKey<Item> COPPER_NUGGETS = register("nuggets/copper");
 	public static final TagKey<Item> IRON_NUGGETS = register("nuggets/iron");
 	public static final TagKey<Item> GOLD_NUGGETS = register("nuggets/gold");
 


### PR DESCRIPTION
The Copper Age game drop added copper nuggets to Minecraft, but right now, they aren't included in a conventional item tag like iron nuggets and gold nuggets already are. This PR assigns copper nuggets to the new conventional item tag `#c:nuggets/copper`, which is also added to the existing tag `#c:nuggets`.