### PR TITLE
Improve debug entry sorting.

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/DebugOptionsComparator.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/DebugOptionsComparator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.rendering;
+
+import java.util.Comparator;
+
+import net.minecraft.util.Identifier;
+
+// Same logic from CategoryComparator in keybindings
+public class DebugOptionsComparator implements Comparator<Identifier> {
+	public static final DebugOptionsComparator INSTANCE = new DebugOptionsComparator();
+
+	@Override
+	public int compare(Identifier o1, Identifier o2) {
+		boolean o1Vanilla = o1.getNamespace().equals(Identifier.DEFAULT_NAMESPACE);
+		boolean o2Vanilla = o2.getNamespace().equals(Identifier.DEFAULT_NAMESPACE);
+
+		// If both are from vanilla, don't reorder them. Assumes sort is stable.
+		if (o1Vanilla && o2Vanilla) {
+			return 0;
+		}
+
+		// If exactly one is from vanilla, sort the one from vanilla first.
+		if (o1Vanilla) {
+			return -1;
+		} else if (o2Vanilla) {
+			return 1;
+		}
+
+		// If neither is from vanilla, sort alphabetically by namespace and then path.
+		int c = o1.getNamespace().compareTo(o2.getNamespace());
+
+		if (c != 0) {
+			return c;
+		}
+
+		return o1.getPath().compareTo(o2.getPath());
+	}
+}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/DebugOptionsComparator.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/DebugOptionsComparator.java
@@ -20,28 +20,23 @@ import java.util.Comparator;
 
 import net.minecraft.util.Identifier;
 
-// Same logic from CategoryComparator in keybindings
 public class DebugOptionsComparator implements Comparator<Identifier> {
 	public static final DebugOptionsComparator INSTANCE = new DebugOptionsComparator();
 
 	@Override
 	public int compare(Identifier o1, Identifier o2) {
-		boolean o1Vanilla = o1.getNamespace().equals(Identifier.DEFAULT_NAMESPACE);
-		boolean o2Vanilla = o2.getNamespace().equals(Identifier.DEFAULT_NAMESPACE);
+		// Sort 'minecraft' namespace first, then alphabetically by namespace, then path.
+		boolean o1IsMinecraft = Identifier.DEFAULT_NAMESPACE.equals(o1.getNamespace());
+		boolean o2IsMinecraft = Identifier.DEFAULT_NAMESPACE.equals(o2.getNamespace());
 
-		// If both are from vanilla, don't reorder them. Assumes sort is stable.
-		if (o1Vanilla && o2Vanilla) {
-			return 0;
+		if (o1IsMinecraft && !o2IsMinecraft) {
+			return -1;
 		}
 
-		// If exactly one is from vanilla, sort the one from vanilla first.
-		if (o1Vanilla) {
-			return -1;
-		} else if (o2Vanilla) {
+		if (!o1IsMinecraft && o2IsMinecraft) {
 			return 1;
 		}
 
-		// If neither is from vanilla, sort alphabetically by namespace and then path.
 		int c = o1.getNamespace().compareTo(o2.getNamespace());
 
 		if (c != 0) {

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/DebugOptionsScreenListWidgetMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/DebugOptionsScreenListWidgetMixin.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.rendering;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.impl.client.rendering.DebugOptionsComparator;
+
+@Mixin(targets = "net/minecraft/client/gui/screen/DebugOptionsScreen$OptionsListWidget")
+public class DebugOptionsScreenListWidgetMixin {
+	@Redirect(method = "method_72822", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Identifier;compareTo(Lnet/minecraft/util/Identifier;)I"))
+	private static int sort(Identifier o1, Identifier o2) {
+		return DebugOptionsComparator.INSTANCE.compare(o1, o2);
+	}
+}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/DebugOptionsScreenListWidgetMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/DebugOptionsScreenListWidgetMixin.java
@@ -16,10 +16,16 @@
 
 package net.fabricmc.fabric.mixin.client.rendering;
 
+import java.util.Map;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+import net.minecraft.client.gui.hud.debug.DebugHudEntry;
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.impl.client.rendering.DebugOptionsComparator;
@@ -29,5 +35,12 @@ public class DebugOptionsScreenListWidgetMixin {
 	@Redirect(method = "method_72822", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Identifier;compareTo(Lnet/minecraft/util/Identifier;)I"))
 	private static int sort(Identifier o1, Identifier o2) {
 		return DebugOptionsComparator.INSTANCE.compare(o1, o2);
+	}
+
+	@WrapOperation(method = "fillEntries", at = @At(value = "INVOKE", target = "Ljava/lang/String;contains(Ljava/lang/CharSequence;)Z"))
+	private boolean searchPath(String instance, CharSequence searchStrings, Operation<Boolean> original, @Local Map.Entry<Identifier, DebugHudEntry> entry) {
+		final String namespace = entry.getKey().getNamespace();
+		return original.call(instance, searchStrings)
+				|| (!Identifier.DEFAULT_NAMESPACE.equals(namespace) && namespace.contains(searchStrings));
 	}
 }

--- a/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
+++ b/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
@@ -11,6 +11,7 @@
     "CapeFeatureRendererMixin",
     "ClientWorldMixin",
     "DebugOptionsScreenEntryMixin",
+    "DebugOptionsScreenListWidgetMixin",
     "DimensionEffectsAccessor",
     "DrawAccessor",
     "DrawContextMixin",

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/DebugOptionsTests.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/DebugOptionsTests.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.test.rendering.client;
 
 import net.minecraft.client.gui.hud.debug.DebugHudEntries;
+import net.minecraft.client.gui.hud.debug.DebugHudEntry;
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.api.ClientModInitializer;
@@ -27,5 +28,13 @@ public class DebugOptionsTests implements ClientModInitializer {
 		DebugHudEntries.register(Identifier.of("fabric-rendering", "example"), (lines, world, clientChunk, chunk) -> {
 			lines.addLine("Very important debug information");
 		});
+
+		DebugHudEntry nope = (lines, world, clientChunk, chunk) -> {
+		};
+
+		// Test sorting
+		DebugHudEntries.register(Identifier.of("fabric-rendering", "a"), nope);
+		DebugHudEntries.register(Identifier.of("fabric-rendering", "b"), nope);
+		DebugHudEntries.register(Identifier.of("fabric-rendering", "z"), nope);
 	}
 }


### PR DESCRIPTION
Closes https://github.com/FabricMC/fabric/issues/4910 

Sorts the entries by namespace and then path (`minecraft` ns being first)
Allows to search by namespace (other than `minecraft`)

<img width="3680" height="2318" alt="Screenshot 2025-10-07 at 21 01 11" src="https://github.com/user-attachments/assets/f1e94adb-cb00-4a8b-861a-d7215a9b733d" />

