### PR TITLE
Improve access to resource reloaders profiling.

### DIFF
--- a/fabric-resource-loader-v1/README.md
+++ b/fabric-resource-loader-v1/README.md
@@ -1,0 +1,8 @@
+# Fabric Resource Loader v1
+
+## System Properties
+
+| Property                                                  | Type    | Default | Description                                                                     |
+|:----------------------------------------------------------|:--------|:--------|:--------------------------------------------------------------------------------|
+| `fabric.resource_loader.debug.profile_resource_reloaders` | boolean | `false` | Profiles and prints to the console the profiling results of resource reloaders. |
+| `fabric.resource_loader.debug.reloaders_order`            | boolean | `false` | Prints to console the application order of resource reloaders.                  |

--- a/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/impl/resource/v1/FabricResourceReloader.java
+++ b/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/impl/resource/v1/FabricResourceReloader.java
@@ -24,4 +24,12 @@ public interface FabricResourceReloader extends ResourceReloader {
 	 * {@return the unique identifier of this Vanilla resource reloader}
 	 */
 	Identifier fabric$getId();
+
+	@Override
+	default String getName() {
+		// Give a more descriptive name to Vanilla resource reloaders
+		// as in production their intermediary class names are not meaningful
+		// when profiling.
+		return this.fabric$getId() + " (" + this.getClass().getSimpleName() + ")";
+	}
 }

--- a/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/impl/resource/v1/ResourceLoaderImpl.java
+++ b/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/impl/resource/v1/ResourceLoaderImpl.java
@@ -53,6 +53,7 @@ public final class ResourceLoaderImpl implements ResourceLoader {
 
 	private static final boolean DEBUG_RELOADERS_IDENTITY = TriState.fromSystemProperty("fabric.resource_loader.debug.reloaders_identity")
 			.orElse(FabricLoader.getInstance().isDevelopmentEnvironment());
+	public static final boolean DEBUG_PROFILE_RESOURCE_RELOADERS = Boolean.getBoolean("fabric.resource_loader.debug.profile_resource_reloaders");
 	private static final boolean DEBUG_RELOADERS_ORDER = Boolean.getBoolean("fabric.resource_loader.debug.reloaders_order");
 
 	public static ResourceLoaderImpl get(ResourceType type) {

--- a/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/mixin/resource/v1/SimpleResourceReloadMixin.java
+++ b/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/mixin/resource/v1/SimpleResourceReloadMixin.java
@@ -22,6 +22,7 @@ import com.llamalad7.mixinextras.sugar.Local;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.resource.ResourceReloader;
@@ -60,5 +61,14 @@ public class SimpleResourceReloadMixin {
 		}
 
 		return reloaders;
+	}
+
+	@ModifyVariable(
+			method = "start(Lnet/minecraft/resource/ResourceManager;Ljava/util/List;Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Ljava/util/concurrent/CompletableFuture;Z)Lnet/minecraft/resource/ResourceReload;",
+			at = @At(value = "LOAD", ordinal = 0),
+			argsOnly = true
+	)
+	private static boolean adjustProfiledCheck(boolean profiled) {
+		return profiled || ResourceLoaderImpl.DEBUG_PROFILE_RESOURCE_RELOADERS;
 	}
 }


### PR DESCRIPTION
As the title states, especially as the current way requires to put specific loggers in debug mode which is not easy to access.

I've also reintroduced a change that was discarded from the Resource Loader v1 PR to override `getName` for Vanilla resource reloaders, as this is super important in production environments where only having the class name would be equivalent to gibberish.