### PR TITLE
Add `FabricRenderState#getDataOrDefault`

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/FabricRenderState.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/FabricRenderState.java
@@ -63,6 +63,17 @@ public interface FabricRenderState {
 	}
 
 	/**
+	 * Get extra render data from the render state, or a default value if it cannot be found.
+	 * @param key the key of the data
+	 * @param defaultValue the default value
+	 * @param <T> the type of the data
+	 * @return the data, or the default value if it cannot be found.
+	 */
+	default <T> T getDataOrDefault(RenderStateDataKey<T> key, T defaultValue) {
+		throw new UnsupportedOperationException("Implemented via mixin");
+	}
+
+	/**
 	 * Set extra render data to the render state.
 	 * @param key the key of the data
 	 * @param value the data

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/RenderStateMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/RenderStateMixin.java
@@ -65,6 +65,12 @@ public abstract class RenderStateMixin implements FabricRenderState {
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
+	public <T> T getDataOrDefault(RenderStateDataKey<T> key, T defaultValue) {
+		return renderStateData == null ? defaultValue : (T) renderStateData.getOrDefault(key, defaultValue);
+	}
+
+	@Override
 	public <T> void setData(RenderStateDataKey<T> key, T value) {
 		if (renderStateData == null) {
 			renderStateData = new Reference2ObjectOpenHashMap<>();

--- a/fabric-rendering-v1/src/test/java/net/fabricmc/fabric/impl/client/rendering/state/RenderStateDataTest.java
+++ b/fabric-rendering-v1/src/test/java/net/fabricmc/fabric/impl/client/rendering/state/RenderStateDataTest.java
@@ -65,10 +65,13 @@ public class RenderStateDataTest {
 
 		for (FabricRenderState state : states) {
 			Assertions.assertNull(state.getData(DEBUG));
+			Assertions.assertEquals("pass", state.getDataOrDefault(DEBUG, "pass"));
 			state.setData(DEBUG, "test");
 			Assertions.assertEquals("test", state.getData(DEBUG));
+			Assertions.assertEquals("test", state.getDataOrDefault(DEBUG, "fail"));
 			state.clearExtraData();
 			Assertions.assertNull(state.getData(DEBUG));
+			Assertions.assertEquals("pass", state.getDataOrDefault(DEBUG, "pass"));
 		}
 	}
 }


### PR DESCRIPTION
After working with `FabricRenderState` for a while I found that a `getOrDefault` equivalent would be quite useful, especially when working with primitive types, since I often end up doing a bunch of null checks on wrapper objects.