### PR TITLE
Only sync attachment change if client supports the AttachmentType

### DIFF
--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentTargetImpl.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentTargetImpl.java
@@ -30,7 +30,6 @@ import net.fabricmc.fabric.api.attachment.v1.AttachmentTarget;
 import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
 import net.fabricmc.fabric.impl.attachment.sync.AttachmentChange;
 import net.fabricmc.fabric.impl.attachment.sync.AttachmentTargetInfo;
-import net.fabricmc.fabric.impl.attachment.sync.s2c.AttachmentSyncPayloadS2C;
 
 public interface AttachmentTargetImpl extends AttachmentTarget {
 	/**
@@ -85,7 +84,7 @@ public interface AttachmentTargetImpl extends AttachmentTarget {
 		throw new UnsupportedOperationException("Implemented via mixin");
 	}
 
-	default void fabric_syncChange(AttachmentType<?> type, AttachmentSyncPayloadS2C payload) {
+	default void fabric_syncChange(AttachmentType<?> type, AttachmentChange change) {
 	}
 
 	default void fabric_markChanged(AttachmentType<?> type) {

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/sync/AttachmentSync.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/sync/AttachmentSync.java
@@ -51,13 +51,12 @@ public class AttachmentSync implements ModInitializer {
 		return new AcceptedAttachmentsPayloadC2S(AttachmentRegistryImpl.getSyncableAttachments());
 	}
 
-	public static void trySync(AttachmentSyncPayloadS2C payload, ServerPlayerEntity player) {
+	public static void trySync(AttachmentChange change, ServerPlayerEntity player) {
 		Set<Identifier> supported = ((SupportedAttachmentsClientConnection) ((ServerCommonNetworkHandlerAccessor) player.networkHandler).getConnection())
 				.fabric_getSupportedAttachments();
 
-		if (!payload.attachments().isEmpty() && supported.contains(payload.attachments().getFirst().type().identifier())) {
-			// the payload will always contain exactly one AttachmentChange
-			ServerPlayNetworking.send(player, payload);
+		if (supported.contains(change.type().identifier())) {
+			ServerPlayNetworking.send(player, new AttachmentSyncPayloadS2C(List.of(change)));
 		}
 	}
 

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/sync/AttachmentSync.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/sync/AttachmentSync.java
@@ -52,7 +52,11 @@ public class AttachmentSync implements ModInitializer {
 	}
 
 	public static void trySync(AttachmentSyncPayloadS2C payload, ServerPlayerEntity player) {
-		if (!payload.attachments().isEmpty()) {
+		Set<Identifier> supported = ((SupportedAttachmentsClientConnection) ((ServerCommonNetworkHandlerAccessor) player.networkHandler).getConnection())
+				.fabric_getSupportedAttachments();
+
+		if (!payload.attachments().isEmpty() && supported.contains(payload.attachments().getFirst().type().identifier())) {
+			// the payload will always contain exactly one AttachmentChange
 			ServerPlayNetworking.send(player, payload);
 		}
 	}

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
@@ -17,7 +17,6 @@
 package net.fabricmc.fabric.mixin.attachment;
 
 import java.util.IdentityHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -44,7 +43,6 @@ import net.fabricmc.fabric.impl.attachment.AttachmentSerializingImpl;
 import net.fabricmc.fabric.impl.attachment.AttachmentTargetImpl;
 import net.fabricmc.fabric.impl.attachment.AttachmentTypeImpl;
 import net.fabricmc.fabric.impl.attachment.sync.AttachmentChange;
-import net.fabricmc.fabric.impl.attachment.sync.s2c.AttachmentSyncPayloadS2C;
 
 @Mixin({BlockEntity.class, Entity.class, World.class, Chunk.class})
 abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
@@ -95,7 +93,7 @@ abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
 			if (this.fabric_shouldTryToSync() && type.isSynced()) {
 				AttachmentChange change = AttachmentChange.create(fabric_getSyncTargetInfo(), type, value, fabric_getDynamicRegistryManager());
 				acknowledgeSyncedEntry(type, change);
-				this.fabric_syncChange(type, new AttachmentSyncPayloadS2C(List.of(change)));
+				this.fabric_syncChange(type, change);
 			}
 		}
 

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/BlockEntityMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/BlockEntityMixin.java
@@ -35,9 +35,9 @@ import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
 import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
 import net.fabricmc.fabric.impl.attachment.AttachmentTargetImpl;
 import net.fabricmc.fabric.impl.attachment.AttachmentTypeImpl;
+import net.fabricmc.fabric.impl.attachment.sync.AttachmentChange;
 import net.fabricmc.fabric.impl.attachment.sync.AttachmentSync;
 import net.fabricmc.fabric.impl.attachment.sync.AttachmentTargetInfo;
-import net.fabricmc.fabric.impl.attachment.sync.s2c.AttachmentSyncPayloadS2C;
 
 @Mixin(BlockEntity.class)
 abstract class BlockEntityMixin implements AttachmentTargetImpl {
@@ -81,11 +81,11 @@ abstract class BlockEntityMixin implements AttachmentTargetImpl {
 	}
 
 	@Override
-	public void fabric_syncChange(AttachmentType<?> type, AttachmentSyncPayloadS2C payload) {
+	public void fabric_syncChange(AttachmentType<?> type, AttachmentChange change) {
 		PlayerLookup.tracking((BlockEntity) (Object) this)
 				.forEach(player -> {
 					if (((AttachmentTypeImpl<?>) type).syncPredicate().test(this, player)) {
-						AttachmentSync.trySync(payload, player);
+						AttachmentSync.trySync(change, player);
 					}
 				});
 	}

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/EntityMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/EntityMixin.java
@@ -34,9 +34,9 @@ import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
 import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
 import net.fabricmc.fabric.impl.attachment.AttachmentTargetImpl;
 import net.fabricmc.fabric.impl.attachment.AttachmentTypeImpl;
+import net.fabricmc.fabric.impl.attachment.sync.AttachmentChange;
 import net.fabricmc.fabric.impl.attachment.sync.AttachmentSync;
 import net.fabricmc.fabric.impl.attachment.sync.AttachmentTargetInfo;
-import net.fabricmc.fabric.impl.attachment.sync.s2c.AttachmentSyncPayloadS2C;
 
 @Mixin(Entity.class)
 abstract class EntityMixin implements AttachmentTargetImpl {
@@ -68,19 +68,19 @@ abstract class EntityMixin implements AttachmentTargetImpl {
 	}
 
 	@Override
-	public void fabric_syncChange(AttachmentType<?> type, AttachmentSyncPayloadS2C payload) {
+	public void fabric_syncChange(AttachmentType<?> type, AttachmentChange change) {
 		if (!this.getEntityWorld().isClient()) {
 			AttachmentSyncPredicate predicate = ((AttachmentTypeImpl<?>) type).syncPredicate();
 
 			if ((Object) this instanceof ServerPlayerEntity self && predicate.test(this, self)) {
 				// Players do not track themselves
-				AttachmentSync.trySync(payload, self);
+				AttachmentSync.trySync(change, self);
 			}
 
 			PlayerLookup.tracking((Entity) (Object) this)
 					.forEach(player -> {
 						if (predicate.test(this, player)) {
-							AttachmentSync.trySync(payload, player);
+							AttachmentSync.trySync(change, player);
 						}
 					});
 		}

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/ServerWorldMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/ServerWorldMixin.java
@@ -38,9 +38,9 @@ import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
 import net.fabricmc.fabric.impl.attachment.AttachmentPersistentState;
 import net.fabricmc.fabric.impl.attachment.AttachmentTargetImpl;
 import net.fabricmc.fabric.impl.attachment.AttachmentTypeImpl;
+import net.fabricmc.fabric.impl.attachment.sync.AttachmentChange;
 import net.fabricmc.fabric.impl.attachment.sync.AttachmentSync;
 import net.fabricmc.fabric.impl.attachment.sync.AttachmentTargetInfo;
-import net.fabricmc.fabric.impl.attachment.sync.s2c.AttachmentSyncPayloadS2C;
 
 @Mixin(ServerWorld.class)
 abstract class ServerWorldMixin extends World implements AttachmentTargetImpl {
@@ -75,12 +75,12 @@ abstract class ServerWorldMixin extends World implements AttachmentTargetImpl {
 	}
 
 	@Override
-	public void fabric_syncChange(AttachmentType<?> type, AttachmentSyncPayloadS2C payload) {
+	public void fabric_syncChange(AttachmentType<?> type, AttachmentChange change) {
 		if ((Object) this instanceof ServerWorld serverWorld) {
 			PlayerLookup.world(serverWorld)
 					.forEach(player -> {
 						if (((AttachmentTypeImpl<?>) type).syncPredicate().test(this, player)) {
-							AttachmentSync.trySync(payload, player);
+							AttachmentSync.trySync(change, player);
 						}
 					});
 		}

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WorldChunkMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WorldChunkMixin.java
@@ -42,7 +42,6 @@ import net.fabricmc.fabric.impl.attachment.AttachmentTargetImpl;
 import net.fabricmc.fabric.impl.attachment.AttachmentTypeImpl;
 import net.fabricmc.fabric.impl.attachment.sync.AttachmentChange;
 import net.fabricmc.fabric.impl.attachment.sync.AttachmentSync;
-import net.fabricmc.fabric.impl.attachment.sync.s2c.AttachmentSyncPayloadS2C;
 
 @Mixin(WorldChunk.class)
 abstract class WorldChunkMixin extends AttachmentTargetsMixin implements AttachmentTargetImpl {
@@ -68,13 +67,13 @@ abstract class WorldChunkMixin extends AttachmentTargetsMixin implements Attachm
 	}
 
 	@Override
-	public void fabric_syncChange(AttachmentType<?> type, AttachmentSyncPayloadS2C payload) {
+	public void fabric_syncChange(AttachmentType<?> type, AttachmentChange change) {
 		if (this.world instanceof ServerWorld serverWorld) {
 			// can't shadow from Chunk because this already extends a supermixin
 			PlayerLookup.tracking(serverWorld, ((Chunk) (Object) this).getPos())
 					.forEach(player -> {
 						if (((AttachmentTypeImpl<?>) type).syncPredicate().test(this, player)) {
-							AttachmentSync.trySync(payload, player);
+							AttachmentSync.trySync(change, player);
 						}
 					});
 		}

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WrapperProtoChunkMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/WrapperProtoChunkMixin.java
@@ -35,7 +35,6 @@ import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
 import net.fabricmc.fabric.impl.attachment.AttachmentTargetImpl;
 import net.fabricmc.fabric.impl.attachment.sync.AttachmentChange;
 import net.fabricmc.fabric.impl.attachment.sync.AttachmentTargetInfo;
-import net.fabricmc.fabric.impl.attachment.sync.s2c.AttachmentSyncPayloadS2C;
 
 @Mixin(WrapperProtoChunk.class)
 abstract class WrapperProtoChunkMixin extends AttachmentTargetsMixin {
@@ -96,8 +95,8 @@ abstract class WrapperProtoChunkMixin extends AttachmentTargetsMixin {
 	}
 
 	@Override
-	public void fabric_syncChange(AttachmentType<?> type, AttachmentSyncPayloadS2C payload) {
-		((AttachmentTargetImpl) wrapped).fabric_syncChange(type, payload);
+	public void fabric_syncChange(AttachmentType<?> type, AttachmentChange change) {
+		((AttachmentTargetImpl) wrapped).fabric_syncChange(type, change);
 	}
 
 	@Override


### PR DESCRIPTION
Currently when syncing initial attachment data, only the attachments that the client supports are synced. However, for attachment changes outside the initial sync, client support for the attachment is not checked. 

This means that when a mod with syncable attachents is installed on the server but not the client (and the client has Fabric API installed), the client will get disconnected with a `io.netty.handler.codec.DecoderException: Failed to decode packet 'clientbound/minecraft:custom_payload'` error.

This PR fixes that issue.