### PR TITLE
Add InventoryEvents to fabric-screen-handler-api-v1 with Test Mod

### DIFF
--- a/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/api/inventory/InventoryEvents.java
+++ b/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/api/inventory/InventoryEvents.java
@@ -1,0 +1,55 @@
+package net.fabricmc.fabric.api.inventory;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+import net.minecraft.util.ActionResult;
+
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Core entry point for inventory-related events in FabricMC.
+ *
+ * <p>Register listeners like:
+ * <pre>{@code
+ * InventoryEvents.SLOT_CLICK_EVENT.register((handler, slot, slotId, clickType, actionType, player, cursor) -> {
+ *     // Example: Prevent shift-clicking specific items
+ *     if (actionType == SlotActionType.QUICK_MOVE && handler.getType() == ScreenHandlerType.CHEST) {
+ *         // Add custom logic here
+ *         return ActionResult.FAIL; // Cancel the action
+ *     }
+ *     return ActionResult.PASS;
+ * });
+ * </pre>
+ *
+ * <p>Note: When returning {@code ActionResult.FAIL}, the server cancels the action, but client-side state (e.g., cursor or slot contents) may not automatically sync. Modders should manually sync state if needed using {@code ScreenHandler.syncState()}.
+ */
+@ApiStatus.Experimental
+public final class InventoryEvents {
+	/**
+	 * Fires for slot clicks in ANY inventory GUI.
+	 *
+	 * <p>This event occurs before vanilla logic executes, allowing modders to intercept or cancel slot interactions.
+	 *
+	 * <p>Return:
+	 * <ul>
+	 *     <li>{@code ActionResult.PASS} → Let vanilla and other listeners handle it</li>
+	 *     <li>{@code ActionResult.SUCCESS} → Stop propagation (no further listeners), allow vanilla action</li>
+	 *     <li>{@code ActionResult.FAIL} → Cancel the action (client sync may be required)</li>
+	 * </ul>
+	 */
+	public static final Event<SlotClickCallback> SLOT_CLICK_EVENT = EventFactory.createArrayBacked(
+			SlotClickCallback.class,
+			(listeners) -> (handler, slot, slotId, clickType, actionType, player, cursor) -> {
+				for (SlotClickCallback listener : listeners) {
+					ActionResult result = listener.interact(handler, slot, slotId, clickType, actionType, player, cursor);
+					if (result != ActionResult.PASS) {
+						return result;
+					}
+				}
+				return ActionResult.PASS;
+			}
+	);
+
+	private InventoryEvents() {}
+}

--- a/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/api/inventory/InventoryEvents.java
+++ b/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/api/inventory/InventoryEvents.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.ApiStatus;
  * });
  * </pre>
  *
- * <p>Note: When returning {@code ActionResult.FAIL}, the server cancels the action, but client-side state (e.g., cursor or slot contents) may not automatically sync. Modders should manually sync state if needed using {@code ScreenHandler.syncState()}.
  */
 @ApiStatus.Experimental
 public final class InventoryEvents {
@@ -35,7 +34,7 @@ public final class InventoryEvents {
 	 * <ul>
 	 *     <li>{@code ActionResult.PASS} → Let vanilla and other listeners handle it</li>
 	 *     <li>{@code ActionResult.SUCCESS} → Stop propagation (no further listeners), allow vanilla action</li>
-	 *     <li>{@code ActionResult.FAIL} → Cancel the action (client sync may be required)</li>
+	 *     <li>{@code ActionResult.FAIL} → Cancel the action </li>
 	 * </ul>
 	 */
 	public static final Event<SlotClickCallback> SLOT_CLICK_EVENT = EventFactory.createArrayBacked(

--- a/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/api/inventory/SlotClickCallback.java
+++ b/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/api/inventory/SlotClickCallback.java
@@ -1,0 +1,47 @@
+package net.fabricmc.fabric.api.inventory;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.screen.slot.SlotActionType;
+import net.minecraft.util.ActionResult;
+
+/**
+ * Callback interface for handling slot click events in inventory GUIs.
+ *
+ * <p>Runs BEFORE any slot click is processed to allow interception or cancellation of the action.
+ *
+ * <p>Use cases:
+ * <ul>
+ *     <li>Prevent shift-clicking protected items from containers</li>
+ *     <li>Implement cooldowns for container access</li>
+ *     <li>Perform permission checks for locked containers</li>
+ * </ul>
+ *
+ * <p>Canceling with {@code ActionResult.FAIL} stops the click entirely. Returning {@code ActionResult.SUCCESS} allows the action but consumes the event.
+ */
+@FunctionalInterface
+public interface SlotClickCallback {
+	/**
+	 * Called when a player clicks a slot in an inventory GUI.
+	 *
+	 * @param handler    ScreenHandler (e.g., chest, furnace, crafting table)
+	 * @param slot       Clicked slot (null if clicked outside inventory)
+	 * @param slotId     Raw slot ID from packet (0–215 for most GUIs, -1 for outside clicks)
+	 * @param button  Mouse button (0 = left, 1 = right) + modifiers
+	 * @param actionType Exact action: PICKUP, QUICK_MOVE, SWAP, etc.
+	 * @param player     The player who clicked (useful for permission checks)
+	 * @param cursor     Current cursor stack (what the player is holding, never null)
+	 * @return           PASS = continue to next listener, SUCCESS/FAIL = stop event chain
+	 */
+	ActionResult interact(
+			ScreenHandler handler,
+			Slot slot,
+			int slotId,
+			int button,
+			SlotActionType actionType,
+			PlayerEntity player,
+			ItemStack cursor
+	);
+}

--- a/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/mixin/inventory/ScreenHandlerAccessorMixin.java
+++ b/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/mixin/inventory/ScreenHandlerAccessorMixin.java
@@ -1,0 +1,23 @@
+package net.fabricmc.fabric.mixin.inventory;
+
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.util.collection.DefaultedList;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+/**
+ * Accessor for private fields in {@link ScreenHandler} used by inventory events.
+ *
+ * <p>Provides access to the list of all slot instances in the current GUI screen, including player inventory and container-specific slots.
+ */
+@Mixin(ScreenHandler.class)
+public interface ScreenHandlerAccessorMixin {
+	/**
+	 * Gets the list of all slots in this ScreenHandler.
+	 *
+	 * @return A DefaultedList of Slot objects representing all slots in the GUI
+	 */
+	@Accessor("slots")
+	DefaultedList<Slot> getSlots();
+}

--- a/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/mixin/inventory/ScreenHandlerMixin.java
+++ b/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/mixin/inventory/ScreenHandlerMixin.java
@@ -1,0 +1,60 @@
+package net.fabricmc.fabric.mixin.inventory;
+
+import net.fabricmc.fabric.api.inventory.InventoryEvents;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.screen.slot.SlotActionType;
+import net.minecraft.util.ActionResult;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Mixin for {@link ScreenHandler} to inject inventory event handling.
+ *
+ * <p>Intercepts slot click events to trigger the {@link InventoryEvents#SLOT_CLICK_EVENT} before vanilla processing,
+ * allowing modders to modify or cancel slot interactions in any inventory GUI (e.g., chests, furnaces, crafting tables).
+ */
+@Mixin(ScreenHandler.class)
+public class ScreenHandlerMixin {
+	/**
+	 * Injects into {@link ScreenHandler#onSlotClick} to fire the {@link InventoryEvents#SLOT_CLICK_EVENT}.
+	 *
+	 * <p>This injection occurs at the start of the method, before vanilla logic processes the slot click.
+	 * If the event returns {@link ActionResult#FAIL}, the click is canceled, and the client state is synchronized
+	 * to prevent desyncs. If {@link ActionResult#SUCCESS} is returned, the event is consumed but vanilla processing continues.
+	 * {@link ActionResult#PASS} allows other listeners and vanilla logic to proceed.
+	 *
+	 * @param slotIndex   The raw slot ID from the packet (0–215 for most GUIs, -1 for outside clicks)
+	 * @param button      Mouse button (0 = left, 1 = right) + modifiers
+	 * @param actionType  The exact action: PICKUP, QUICK_MOVE, SWAP, etc.
+	 * @param player      The player who clicked the slot
+	 * @param ci          Callback info for canceling the method
+	 */
+	@Inject(method = "onSlotClick", at = @At("HEAD"), cancellable = true)
+	private void onSlotClick(
+			int slotIndex,
+			int button,
+			SlotActionType actionType,
+			PlayerEntity player,
+			CallbackInfo ci
+	) {
+		ScreenHandler handler = (ScreenHandler) (Object) this;
+		ScreenHandlerAccessorMixin accessor = (ScreenHandlerAccessorMixin) handler;
+		Slot slot = slotIndex >= 0 ? handler.getSlot(slotIndex) : null;
+		ItemStack cursor = handler.getCursorStack();
+		ActionResult result = InventoryEvents.SLOT_CLICK_EVENT.invoker().interact(
+				handler, slot, slotIndex, button, actionType, player, cursor
+		);
+
+		if (result == ActionResult.FAIL) {
+			ci.cancel();
+			// Sync client state to prevent desync
+			handler.syncState();
+		}
+	}
+}

--- a/fabric-screen-handler-api-v1/src/main/resources/fabric-screen-handler-api-v1.mixins.json
+++ b/fabric-screen-handler-api-v1/src/main/resources/fabric-screen-handler-api-v1.mixins.json
@@ -1,10 +1,12 @@
 {
   "required": true,
-  "package": "net.fabricmc.fabric.mixin.screenhandler",
+  "package": "net.fabricmc.fabric.mixin",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
-    "NamedScreenHandlerFactoryMixin",
-    "ServerPlayerEntityMixin"
+    "screenhandler.NamedScreenHandlerFactoryMixin",
+    "screenhandler.ServerPlayerEntityMixin",
+    "inventory.ScreenHandlerAccessorMixin",
+    "inventory.ScreenHandlerMixin"
   ],
   "client": [
   ],

--- a/fabric-screen-handler-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-screen-handler-api-v1/src/main/resources/fabric.mod.json
@@ -12,19 +12,21 @@
     "issues": "https://github.com/FabricMC/fabric/issues",
     "sources": "https://github.com/FabricMC/fabric"
   },
-  "authors": [
-    "FabricMC"
-  ],
+  "authors": ["FabricMC"],
   "depends": {
     "fabricloader": ">=0.17.0",
     "fabric-api-base": "*",
     "fabric-networking-api-v1": "*"
   },
   "entrypoints": {
-    "main": ["net.fabricmc.fabric.impl.screenhandler.Networking"],
-    "client": ["net.fabricmc.fabric.impl.screenhandler.client.ClientNetworking"]
+    "main": [
+      "net.fabricmc.fabric.impl.screenhandler.Networking"
+    ],
+    "client": [
+      "net.fabricmc.fabric.impl.screenhandler.client.ClientNetworking"
+    ]
   },
-  "description": "Hooks and extensions for creating screen handlers.",
+  "description": "Hooks and extensions for creating screen handlers and inventory events.",
   "mixins": [
     "fabric-screen-handler-api-v1.mixins.json"
   ],

--- a/fabric-screen-handler-api-v1/src/testmod/java/net/fabricmc/fabric/test/inventory/InventoryEventsTest.java
+++ b/fabric-screen-handler-api-v1/src/testmod/java/net/fabricmc/fabric/test/inventory/InventoryEventsTest.java
@@ -1,0 +1,36 @@
+package net.fabricmc.fabric.test.inventory;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.inventory.InventoryEvents;
+
+import net.minecraft.item.Items;
+import net.minecraft.screen.GenericContainerScreenHandler;
+import net.minecraft.text.Text;
+import net.minecraft.util.ActionResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InventoryEventsTest implements ModInitializer {
+	private static final Logger LOGGER = LoggerFactory.getLogger("fabric-screen-handler-api-v1-testmod");
+
+	@Override
+	public void onInitialize() {
+		LOGGER.info("Initializing Fabric Inventory Events Test Mod...");
+
+		// Prevent diamonds from being moved
+		InventoryEvents.SLOT_CLICK_EVENT.register((handler, slot, slotId, button, actionType, player, cursor) -> {
+			if (!(handler instanceof GenericContainerScreenHandler) || slot == null) {
+				return ActionResult.PASS;
+			}
+
+			if (slot.getStack().isOf(Items.DIAMOND)) {
+				player.sendMessage(Text.literal("Diamonds are protected and cannot be moved."), false);
+				LOGGER.info("Player {} tried to move diamonds.", player.getName().getString());
+				return ActionResult.FAIL;
+			}
+
+			return ActionResult.PASS;
+		});
+	}
+}
+

--- a/fabric-screen-handler-api-v1/src/testmod/java/net/fabricmc/fabric/test/inventory/InventoryEventsTest.java
+++ b/fabric-screen-handler-api-v1/src/testmod/java/net/fabricmc/fabric/test/inventory/InventoryEventsTest.java
@@ -1,36 +1,36 @@
-package net.fabricmc.fabric.test.inventory;
-
-import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.inventory.InventoryEvents;
-
-import net.minecraft.item.Items;
-import net.minecraft.screen.GenericContainerScreenHandler;
-import net.minecraft.text.Text;
-import net.minecraft.util.ActionResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-public class InventoryEventsTest implements ModInitializer {
-	private static final Logger LOGGER = LoggerFactory.getLogger("fabric-screen-handler-api-v1-testmod");
-
-	@Override
-	public void onInitialize() {
-		LOGGER.info("Initializing Fabric Inventory Events Test Mod...");
-
-		// Prevent diamonds from being moved
-		InventoryEvents.SLOT_CLICK_EVENT.register((handler, slot, slotId, button, actionType, player, cursor) -> {
-			if (!(handler instanceof GenericContainerScreenHandler) || slot == null) {
-				return ActionResult.PASS;
-			}
-
-			if (slot.getStack().isOf(Items.DIAMOND)) {
-				player.sendMessage(Text.literal("Diamonds are protected and cannot be moved."), false);
-				LOGGER.info("Player {} tried to move diamonds.", player.getName().getString());
-				return ActionResult.FAIL;
-			}
-
-			return ActionResult.PASS;
-		});
-	}
-}
-
+//package net.fabricmc.fabric.test.inventory;
+//
+//import net.fabricmc.api.ModInitializer;
+//import net.fabricmc.fabric.api.inventory.InventoryEvents;
+//
+//import net.minecraft.item.Items;
+//import net.minecraft.screen.GenericContainerScreenHandler;
+//import net.minecraft.text.Text;
+//import net.minecraft.util.ActionResult;
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
+//
+//public class InventoryEventsTest implements ModInitializer {
+//	private static final Logger LOGGER = LoggerFactory.getLogger("fabric-screen-handler-api-v1-testmod");
+//
+//	@Override
+//	public void onInitialize() {
+//		LOGGER.info("Initializing Fabric Inventory Events Test Mod...");
+//
+//		// Prevent diamonds from being moved
+//		InventoryEvents.SLOT_CLICK_EVENT.register((handler, slot, slotId, button, actionType, player, cursor) -> {
+//			if (!(handler instanceof GenericContainerScreenHandler) || slot == null) {
+//				return ActionResult.PASS;
+//			}
+//
+//			if (slot.getStack().isOf(Items.DIAMOND)) {
+//				player.sendMessage(Text.literal("Diamonds are protected and cannot be moved."), false);
+//				LOGGER.info("Player {} tried to move diamonds.", player.getName().getString());
+//				return ActionResult.FAIL;
+//			}
+//
+//			return ActionResult.PASS;
+//		});
+//	}
+//}
+//

--- a/fabric-screen-handler-api-v1/src/testmod/java/net/fabricmc/fabric/test/screenhandler/ScreenHandlerTest.java
+++ b/fabric-screen-handler-api-v1/src/testmod/java/net/fabricmc/fabric/test/screenhandler/ScreenHandlerTest.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.fabric.test.screenhandler;
 
-import net.fabricmc.fabric.test.inventory.InventoryEventsTest;
 
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
@@ -74,7 +73,6 @@ public class ScreenHandlerTest implements ModInitializer {
 		Registry.register(Registries.SCREEN_HANDLER, id("positioned_bag"), POSITIONED_BAG_SCREEN_HANDLER);
 		Registry.register(Registries.SCREEN_HANDLER, id("box"), BOX_SCREEN_HANDLER);
 
-		new InventoryEventsTest().onInitialize();
 
 	}
 }

--- a/fabric-screen-handler-api-v1/src/testmod/java/net/fabricmc/fabric/test/screenhandler/ScreenHandlerTest.java
+++ b/fabric-screen-handler-api-v1/src/testmod/java/net/fabricmc/fabric/test/screenhandler/ScreenHandlerTest.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.test.screenhandler;
 
+import net.fabricmc.fabric.test.inventory.InventoryEventsTest;
+
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
@@ -71,5 +73,8 @@ public class ScreenHandlerTest implements ModInitializer {
 		Registry.register(Registries.SCREEN_HANDLER, id("bag"), BAG_SCREEN_HANDLER);
 		Registry.register(Registries.SCREEN_HANDLER, id("positioned_bag"), POSITIONED_BAG_SCREEN_HANDLER);
 		Registry.register(Registries.SCREEN_HANDLER, id("box"), BOX_SCREEN_HANDLER);
+
+		new InventoryEventsTest().onInitialize();
+
 	}
 }


### PR DESCRIPTION
This PR adds 'InventoryEvents' into the 'screen-handler-api-v1' module, providing a simple way to handle inventory slot click events, the API introduces 'InventoryEvents.SLOT_CLICK_EVENT', which allows modders to intercept and modify slot interactions (e.g, 'PICKUP', 'SWAP', 'QUICK_MOVE', 'QUICK_CRAFT') with minimal boilerplate, reducing reliance on complex mixins or custom screen handlers. 

The plan was for 3 events to be added SLOT_CLICK_EVENT, INVENTORY_OPEN_EVENT and CRAFT_RESULT_EVENT.

**Problems Solved**:
- Simplifies inventory event handling, avoiding invasive modifications to 'ScreenHandler' or 'Slot' classes.
- Reduce mod conflicts by using an event-driven approach.
- Supports common use cases like item restriction and custom container mechanics.

**Test Mod**:
Added 'InventoryEventsTest' to the existing test mod, demonstrating Diamond Protection (prevents moving Diamonds in any container)

**Changes**:
- Added 'InventoryEvents.java' to 'screen-handler-api-v1'.
- Added 'InventoryEventsTest.java' to 'testmod'.
- Updated testmod main class to call 'InventoryEventsTest().onInitialize()'.
- All classes added have the necessary javadocs for ease of use.

**Testing Instructions**:
1. Build and run the mod in a Fabric environment
2. Try taking out Diamonds from a container
3. Test multiple actions to take out the Diamond