### PR TITLE
Apply @Nullmarked annotation to all packages

### DIFF
--- a/deprecated/fabric-loot-api-v2/src/main/java/net/fabricmc/fabric/api/loot/v2/package-info.java
+++ b/deprecated/fabric-loot-api-v2/src/main/java/net/fabricmc/fabric/api/loot/v2/package-info.java
@@ -32,4 +32,7 @@
  * They let you add pre-built objects instead of builders, and collections of objects to the builder
  * with one method call.
  */
+@NullMarked
 package net.fabricmc.fabric.api.loot.v2;
+
+import org.jspecify.annotations.NullMarked;

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/package-info.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/package-info.java
@@ -79,4 +79,8 @@
  *     <li>See {@link net.fabricmc.fabric.api.lookup.v1.custom.ApiLookupMap ApiLookupMap} for example code.</li>
  * </ul>
  */
+
+@NullMarked
 package net.fabricmc.fabric.api.lookup.v1;
+
+import org.jspecify.annotations.NullMarked;

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/context/package-info.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/context/package-info.java
@@ -1,4 +1,6 @@
 @ApiStatus.Experimental
+@NullMarked
 package net.fabricmc.fabric.api.client.gametest.v1.context;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/package-info.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/package-info.java
@@ -184,6 +184,8 @@
  * </table>
  */
 @ApiStatus.Experimental
+@NullMarked
 package net.fabricmc.fabric.api.client.gametest.v1;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/screenshot/package-info.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/screenshot/package-info.java
@@ -1,4 +1,6 @@
 @ApiStatus.Experimental
+@NullMarked
 package net.fabricmc.fabric.api.client.gametest.v1.screenshot;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/world/package-info.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/world/package-info.java
@@ -1,4 +1,6 @@
 @ApiStatus.Experimental
+@NullMarked
 package net.fabricmc.fabric.api.client.gametest.v1.world;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/api/client/command/v2/package-info.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/api/client/command/v2/package-info.java
@@ -19,4 +19,7 @@
  *
  * @see net.fabricmc.fabric.api.client.command.v2.ClientCommandManager
  */
+@NullMarked
 package net.fabricmc.fabric.api.client.command.v2;
+
+import org.jspecify.annotations.NullMarked;

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/package-info.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Includes methods for registering in-game logics.
  */
+@NullMarked
 package net.fabricmc.fabric.api.registry;
+
+import org.jspecify.annotations.NullMarked;

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/util/Block2ObjectMap.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/util/Block2ObjectMap.java
@@ -16,9 +16,12 @@
 
 package net.fabricmc.fabric.api.util;
 
+import org.jspecify.annotations.NullMarked;
+
 import net.minecraft.block.Block;
 import net.minecraft.registry.tag.TagKey;
 
+@NullMarked
 public interface Block2ObjectMap<V> {
 	V get(Block block);
 

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/util/Item2ObjectMap.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/util/Item2ObjectMap.java
@@ -16,10 +16,13 @@
 
 package net.fabricmc.fabric.api.util;
 
+import org.jspecify.annotations.NullMarked;
+
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemConvertible;
 import net.minecraft.registry.tag.TagKey;
 
+@NullMarked
 public interface Item2ObjectMap<V> {
 	V get(ItemConvertible item);
 

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/package-info.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/package-info.java
@@ -21,4 +21,7 @@
  *
  * <p>Use the {@link net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint} to register {@link net.minecraft.data.DataProvider} with the {@link net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator}.
  */
+@NullMarked
 package net.fabricmc.fabric.api.datagen.v1;
+
+import org.jspecify.annotations.NullMarked;

--- a/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/api/gametest/v1/package-info.java
+++ b/fabric-gametest-api-v1/src/main/java/net/fabricmc/fabric/api/gametest/v1/package-info.java
@@ -80,4 +80,8 @@
  *
  * @see net.fabricmc.fabric.api.gametest.v1.GameTest
  */
+
+@NullMarked
 package net.fabricmc.fabric.api.gametest.v1;
+
+import org.jspecify.annotations.NullMarked;

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/api/loot/v3/package-info.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/api/loot/v3/package-info.java
@@ -32,4 +32,8 @@
  * They let you add pre-built objects instead of builders, and collections of objects to the builder
  * with one method call.
  */
+
+@NullMarked
 package net.fabricmc.fabric.api.loot.v3;
+
+import org.jspecify.annotations.NullMarked;

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/package-info.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/package-info.java
@@ -44,4 +44,7 @@
  * </dl>
  */
 
+@NullMarked
 package net.fabricmc.fabric.api.client.networking.v1;
+
+import org.jspecify.annotations.NullMarked;

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/package-info.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/package-info.java
@@ -48,4 +48,7 @@
  * net.fabricmc.fabric.api.networking.v1.PlayerLookup player lookups}.
  */
 
+@NullMarked
 package net.fabricmc.fabric.api.networking.v1;
+
+import org.jspecify.annotations.NullMarked;

--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/package-info.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/package-info.java
@@ -51,4 +51,7 @@
  * net.fabricmc.fabric.api.resource.conditions.v1.ResourceCondition} to a generated file.
  * Please check the documentation of the Data Generation API.
  */
+@NullMarked
 package net.fabricmc.fabric.api.resource.conditions.v1;
+
+import org.jspecify.annotations.NullMarked;

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/package-info.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/api/resource/package-info.java
@@ -67,4 +67,7 @@
  * A resource reload listener can depend on another and vanilla resource reload listener identifiers may be found in {@link net.fabricmc.fabric.api.resource.ResourceReloadListenerKeys}.
  */
 
+@NullMarked
 package net.fabricmc.fabric.api.resource;
+
+import org.jspecify.annotations.NullMarked;

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/package-info.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/package-info.java
@@ -27,4 +27,7 @@
  *
  * @see net.fabricmc.fabric.api.client.screen.v1.Screens
  */
+@NullMarked
 package net.fabricmc.fabric.api.client.screen.v1;
+
+import org.jspecify.annotations.NullMarked;

--- a/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/api/screenhandler/v1/package-info.java
+++ b/fabric-screen-handler-api-v1/src/main/java/net/fabricmc/fabric/api/screenhandler/v1/package-info.java
@@ -50,4 +50,7 @@
  * on the screen handler factory to return {@code false} and passing that to the {@code
  * openHandledScreen} method, it will stop closing the screen and instead "overwrites" it.
  */
+@NullMarked
 package net.fabricmc.fabric.api.screenhandler.v1;
+
+import org.jspecify.annotations.NullMarked;

--- a/fabric-tag-api-v1/src/main/java/net/fabricmc/fabric/api/tag/v1/package-info.java
+++ b/fabric-tag-api-v1/src/main/java/net/fabricmc/fabric/api/tag/v1/package-info.java
@@ -49,4 +49,7 @@
  * tags almost fully indistinguishable since they get the exact same content, and you have to override the alias group
  * in a higher-priority data pack to unlink them.
  */
+@NullMarked
 package net.fabricmc.fabric.api.tag.v1;
+
+import org.jspecify.annotations.NullMarked;

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/package-info.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/package-info.java
@@ -68,4 +68,7 @@
  * that allows the returned APIs to interact with the containing inventory.
  * Notably, it is used by the {@code FluidStorage.ITEM} lookup for fluid-containing items.
  */
+@NullMarked
 package net.fabricmc.fabric.api.transfer.v1;
+
+import org.jspecify.annotations.NullMarked;

--- a/gradle/package-info.gradle
+++ b/gradle/package-info.gradle
@@ -7,10 +7,10 @@ for (def sourceSet in [
 	// We have to capture the source set name for the lazy string literals,
 	// otherwise it'll just be whatever the last source set is in the list.
 	def sourceSetName = sourceSet.name
-	def taskName = sourceSet.getTaskName('generate', 'ImplPackageInfos')
-	def task = tasks.register(taskName, GenerateImplPackageInfos) {
+	def taskName = sourceSet.getTaskName('generate', 'PackageInfos')
+	def task = tasks.register(taskName, GeneratePackageInfos) {
 		group = 'fabric'
-		description = "Generates package-info files for $sourceSetName implementation packages."
+		description = "Generates package-info files for $sourceSetName packages."
 
 		// Only apply to default source directory since we also add the generated
 		// sources to the source set.
@@ -20,14 +20,14 @@ for (def sourceSet in [
 	}
 	sourceSet.java.srcDir task
 
-	def cleanTask = tasks.register(sourceSet.getTaskName('clean', 'ImplPackageInfos'), Delete) {
+	def cleanTask = tasks.register(sourceSet.getTaskName('clean', 'PackageInfos'), Delete) {
 		group = 'fabric'
 		delete file("src/generated/$sourceSetName")
 	}
 	clean.dependsOn cleanTask
 }
 
-abstract class GenerateImplPackageInfos extends DefaultTask {
+abstract class GeneratePackageInfos extends DefaultTask {
 	@InputFile
 	File header
 
@@ -41,7 +41,7 @@ abstract class GenerateImplPackageInfos extends DefaultTask {
 	@OutputDirectory
 	final DirectoryProperty outputDir = project.objects.directoryProperty()
 
-	GenerateImplPackageInfos() {
+	GeneratePackageInfos() {
 		projectName.set(project.name)
 	}
 
@@ -52,35 +52,62 @@ abstract class GenerateImplPackageInfos extends DefaultTask {
 		def headerText = header.readLines().join("\n") // normalize line endings
 		def root = sourceRoot.get().asFile.toPath()
 
-		for (def dir in ['impl', 'mixin']) {
-			def implDir = root.resolve("net/fabricmc/fabric/$dir")
-
-			if (Files.notExists(implDir)) {
-				continue
+		root.eachDirRecurse {
+			def containsJava = Files.list(it).any {
+				Files.isRegularFile(it) && it.fileName.toString().endsWith('.java')
 			}
 
-			implDir.eachDirRecurse {
-				def containsJava = Files.list(it).any {
-					Files.isRegularFile(it) && it.fileName.toString().endsWith('.java')
+			if (!containsJava) {
+				return
+			}
+
+			// Check existing package-info.java to ensure it has @NullMarked
+			def existingPackageInfo = it.resolve('package-info.java')
+			if (Files.exists(existingPackageInfo)) {
+				if (!existingPackageInfo.text.contains("@NullMarked")) {
+					throw new RuntimeException("package-info.java ${existingPackageInfo} is missing @NullMarked annotation.")
 				}
 
-				if (containsJava && Files.notExists(it.resolve('package-info.java'))) {
-					def relativePath = root.relativize(it)
-					def target = output.resolve(relativePath)
-					Files.createDirectories(target)
+				return
+			}
 
-					target.resolve('package-info.java').withWriter {
-						def packageName = relativePath.toString().replace(File.separator, '.')
-						it.write("""$headerText
+			def relativePath = root.relativize(it)
+			def target = output.resolve(relativePath)
+			Files.createDirectories(target)
+
+			def packageName = relativePath.toString().replace(File.separator, '.')
+
+			if (packageName == "net.fabricmc.fabric.api.util" && projectName.get() == "fabric-content-registries-v0") {
+				// Hack: This package clashes with api-base, don't generate any annotations for it.
+				return
+			}
+
+			def implPattern = /^(net[\/\\]fabricmc[\/\\]fabric[\/\\](impl|mixin))/
+			def isImpl = relativePath.toString() ==~ implPattern
+
+			target.resolve('package-info.java').withWriter {
+				if (isImpl) {
+					it.write("""$headerText
 						|/**
 						| * Implementation code for ${projectName.get()}.
 						| */
 						|@ApiStatus.Internal
+						|@NullMarked
 						|package $packageName;
 						|
 						|import org.jetbrains.annotations.ApiStatus;
+						|import org.jspecify.annotations.NullMarked;
 						|""".stripMargin())
-					}
+				} else {
+					it.write("""$headerText
+						|/**
+						| * API code for ${projectName.get()}.
+						| */
+						|@NullMarked
+						|package $packageName;
+						|
+						|import org.jspecify.annotations.NullMarked;
+						|""".stripMargin())
 				}
 			}
 		}


### PR DESCRIPTION
Most packages have a package-info generated for them, if not any other package-info must contain @Nullmarked