### PR TITLE
Add Enigma task for javadoc injection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java-library"
 	id "eclipse"
 	id "maven-publish"
-	id "fabric-loom" version "1.11.7" apply false
+	id "fabric-loom" version "1.12.5" apply false
 	id "com.diffplug.spotless" version "7.2.1"
 	id "me.modmuss50.remotesign" version "0.5.0" apply false
 	id "me.modmuss50.mod-publish-plugin" version "0.8.4"
@@ -322,6 +322,12 @@ allprojects {
 		classpath.from(sourceSets.testmodClient.compileClasspath)
 	}
 	build.dependsOn remapTestmodJar
+
+	tasks.register('enigma', net.fabricmc.loom.task.tool.ModEnigmaTask) {
+		def clientOnly = file('src/client').exists() && !file('src/main').exists()
+		def dir = clientOnly ? file('src/client/resources') : file('src/main/resources')
+		mappingFile = new File(dir, project.name + '.mapping')
+	}
 
 	tasks.register('validateMixinNames', net.fabricmc.loom.task.ValidateMixinNameTask) {
 		source(sourceSets.main.output)

--- a/fabric-content-registries-v0/src/main/resources/fabric-content-registries-v0.mapping
+++ b/fabric-content-registries-v0/src/main/resources/fabric-content-registries-v0.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_5955
+	COMMENT @see net.fabricmc.fabric.api.registry.OxidizableBlocksRegistry registry for modded oxidizable blocks

--- a/fabric-content-registries-v0/src/main/resources/fabric.mod.json
+++ b/fabric-content-registries-v0/src/main/resources/fabric.mod.json
@@ -28,6 +28,7 @@
   "accessWidener" : "fabric-content-registries-v0.accesswidener",
   "custom": {
     "fabric-api:module-lifecycle": "stable",
+    "loom:provided_javadoc": "fabric-content-registries-v0.mapping",
     "loom:injected_interfaces": {
       "net/minecraft/class_1845\u0024class_9665": ["net/fabricmc/fabric/api/registry/FabricBrewingRecipeRegistryBuilder"]
     }


### PR DESCRIPTION
Adds a Gradle task for writing mod-provided javadoc directly in Enigma instead of writing mapping files manually. There's also an example javadoc file adding javadoc to the `Oxidizable` interface that points to FAPI's registry for oxidisable blocks.

---

Usage example: Run `gradlew :fabric-content-registries-v0:enigma` to open Enigma for that module. If the mapping file doesn't exist beforehand, you need to create it. Before adding it to the fabric.mod.json, make sure that it's not empty so that MIO can detect the format correctly.

You can then go to a class (or method/field) and document it:
<img width="554" height="159" alt="Enigma showing class_5955 with injected javadoc" src="https://github.com/user-attachments/assets/20d8489a-f8f2-4473-ad64-f6adf7febb30" />

After generating sources, you will now see the added javadoc in the decompiled vanilla source:
<img width="631" height="91" alt="IDEA showing Oxidizable with injected javadoc" src="https://github.com/user-attachments/assets/ba2408ba-a523-4b27-a921-d8add28e53bb" />

---

Depends on #4952.

**Using mods with Enigma format javadoc files requires the latest Loom 1.12 build (1.12.5+) due to critical bug fixes.** Older versions of Loom will crash with Enigma format javadoc, and also don't work correctly with Tiny format javadoc.