### PR TITLE
Fix registries access in resource reloaders.

### DIFF
--- a/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/impl/resource/v1/DataResourceLoaderImpl.java
+++ b/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/impl/resource/v1/DataResourceLoaderImpl.java
@@ -73,7 +73,7 @@ public final class DataResourceLoaderImpl extends ResourceLoaderImpl implements 
 			throw new IllegalStateException("The setup marker should not be null for data resource loading.");
 		}
 
-		RegistryWrapper.WrapperLookup registries = setupMarker.dataPackContents().getReloadableRegistries().createRegistryLookup();
+		RegistryWrapper.WrapperLookup registries = setupMarker.registries();
 		Set<Map.Entry<Identifier, ResourceReloader>> reloadersToAdd = super.collectReloadersToAdd(setupMarker);
 
 		for (Map.Entry<Identifier, Function<RegistryWrapper.WrapperLookup, ResourceReloader>> entry

--- a/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/impl/resource/v1/SetupMarkerResourceReloader.java
+++ b/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/impl/resource/v1/SetupMarkerResourceReloader.java
@@ -25,11 +25,14 @@ import net.minecraft.server.DataPackContents;
 import net.fabricmc.fabric.api.resource.v1.DataResourceLoader;
 
 // Used to inject into the ResourceReloader store.
-public record SetupMarkerResourceReloader(DataPackContents dataPackContents, FeatureSet featureSet) implements SynchronousResourceReloader {
+public record SetupMarkerResourceReloader(
+		DataPackContents dataPackContents,
+		RegistryWrapper.WrapperLookup registries,
+		FeatureSet featureSet
+) implements SynchronousResourceReloader {
 	@Override
 	public void prepareSharedState(Store store) {
-		RegistryWrapper.WrapperLookup registries = this.dataPackContents.getReloadableRegistries().createRegistryLookup();
-		store.put(DataResourceLoader.RELOADER_REGISTRY_LOOKUP_KEY, registries);
+		store.put(DataResourceLoader.RELOADER_REGISTRY_LOOKUP_KEY, this.registries);
 		store.put(DataResourceLoader.RELOADER_FEATURE_SET_KEY, this.featureSet);
 		store.put(DataResourceLoader.ADVANCEMENT_LOADER_KEY, this.dataPackContents.getServerAdvancementLoader());
 		store.put(DataResourceLoader.RECIPE_MANAGER_KEY, this.dataPackContents.getRecipeManager());

--- a/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/mixin/resource/v1/DataPackContentsMixin.java
+++ b/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/mixin/resource/v1/DataPackContentsMixin.java
@@ -26,6 +26,7 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 
+import net.minecraft.registry.ReloadableRegistries;
 import net.minecraft.resource.ResourceReloader;
 import net.minecraft.resource.featuretoggle.FeatureSet;
 import net.minecraft.server.DataPackContents;
@@ -49,6 +50,7 @@ public class DataPackContentsMixin implements FabricDataResourceStoreHolder {
 	)
 	private static List<ResourceReloader> onSetupDataReloaders(
 			List<ResourceReloader> reloaders,
+			@Local(argsOnly = true) ReloadableRegistries.ReloadResult loadResult,
 			@Local(argsOnly = true) FeatureSet featureSet,
 			@Local DataPackContents dataPackContents
 	) {
@@ -56,6 +58,7 @@ public class DataPackContentsMixin implements FabricDataResourceStoreHolder {
 		list.addFirst(
 				new SetupMarkerResourceReloader(
 						dataPackContents,
+						loadResult.lookupWithUpdatedTags(),
 						featureSet
 				)
 		);

--- a/fabric-resource-loader-v1/src/testmod/java/net/fabricmc/fabric/test/resource/loader/v1/ResourceReloaderTestMod.java
+++ b/fabric-resource-loader-v1/src/testmod/java/net/fabricmc/fabric/test/resource/loader/v1/ResourceReloaderTestMod.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Executor;
 import net.minecraft.enchantment.Enchantments;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.RegistryWrapper;
+import net.minecraft.registry.tag.ItemTags;
 import net.minecraft.resource.ResourceReloader;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.resource.SynchronousResourceReloader;
@@ -97,6 +98,7 @@ public class ResourceReloaderTestMod implements ModInitializer {
 		public CompletableFuture<Void> reload(Store store, Executor prepareExecutor, Synchronizer reloadSynchronizer, Executor applyExecutor) {
 			RegistryWrapper.WrapperLookup registries = store.getOrThrow(ResourceLoader.RELOADER_REGISTRY_LOOKUP_KEY);
 			registries.getOrThrow(RegistryKeys.ENCHANTMENT).getOrThrow(Enchantments.FORTUNE);
+			registries.getOrThrow(RegistryKeys.ITEM).getOrThrow(ItemTags.AXES);
 			return reloadSynchronizer.whenPrepared(null).thenRunAsync(
 					() -> store.getOrThrow(DataResourceLoader.DATA_RESOURCE_STORE_KEY)
 							.put(STORE_KEY, "Hello from RegistryReloader."),
@@ -111,6 +113,7 @@ public class ResourceReloaderTestMod implements ModInitializer {
 		@Override
 		public CompletableFuture<Void> reload(Store store, Executor prepareExecutor, Synchronizer reloadSynchronizer, Executor applyExecutor) {
 			this.registries.getOrThrow(RegistryKeys.ENCHANTMENT).getOrThrow(Enchantments.FORTUNE);
+			this.registries.getOrThrow(RegistryKeys.ITEM).getOrThrow(ItemTags.AXES);
 			return reloadSynchronizer.whenPrepared(null);
 		}
 	}


### PR DESCRIPTION
Fix #4983.

Resource reloaders are given a registries lookup that doesn't have the pending tags applied, which leads to invalid loads as highlighted in the linked issue.