### PR TITLE
Fix registries access in resource reloaders.

### DIFF
--- a/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/impl/resource/v1/DataResourceLoaderImpl.java
+++ b/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/impl/resource/v1/DataResourceLoaderImpl.java
@@ -73,7 +73,7 @@ public final class DataResourceLoaderImpl extends ResourceLoaderImpl implements 
 			throw new IllegalStateException("The setup marker should not be null for data resource loading.");
 		}
 
-		HolderLookup.Provider registries = setupMarker.dataPackContents().fullRegistries().lookup();
+		HolderLookup.Provider registries = setupMarker.registries();
 		Set<Map.Entry<Identifier, PreparableReloadListener>> reloadersToAdd = super.collectReloadersToAdd(setupMarker);
 
 		for (Map.Entry<Identifier, Function<HolderLookup.Provider, PreparableReloadListener>> entry

--- a/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/impl/resource/v1/SetupMarkerResourceReloader.java
+++ b/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/impl/resource/v1/SetupMarkerResourceReloader.java
@@ -25,11 +25,14 @@ import net.minecraft.world.flag.FeatureFlagSet;
 import net.fabricmc.fabric.api.resource.v1.DataResourceLoader;
 
 // Used to inject into the ResourceReloader store.
-public record SetupMarkerResourceReloader(ReloadableServerResources dataPackContents, FeatureFlagSet featureSet) implements ResourceManagerReloadListener {
+public record SetupMarkerResourceReloader(
+		ReloadableServerResources dataPackContents,
+		HolderLookup.Provider registries,
+		FeatureFlagSet featureSet
+) implements ResourceManagerReloadListener {
 	@Override
 	public void prepareSharedState(SharedState store) {
-		HolderLookup.Provider registries = this.dataPackContents.fullRegistries().lookup();
-		store.set(DataResourceLoader.RELOADER_REGISTRY_LOOKUP_KEY, registries);
+		store.set(DataResourceLoader.RELOADER_REGISTRY_LOOKUP_KEY, this.registries);
 		store.set(DataResourceLoader.RELOADER_FEATURE_SET_KEY, this.featureSet);
 		store.set(DataResourceLoader.ADVANCEMENT_LOADER_KEY, this.dataPackContents.getAdvancements());
 		store.set(DataResourceLoader.RECIPE_MANAGER_KEY, this.dataPackContents.getRecipeManager());

--- a/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/mixin/resource/v1/ReloadableServerResourcesMixin.java
+++ b/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/mixin/resource/v1/ReloadableServerResourcesMixin.java
@@ -26,6 +26,7 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 
+import net.minecraft.server.ReloadableServerRegistries;
 import net.minecraft.server.ReloadableServerResources;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.world.flag.FeatureFlagSet;
@@ -49,6 +50,7 @@ public class ReloadableServerResourcesMixin implements FabricDataResourceStoreHo
 	)
 	private static List<PreparableReloadListener> onSetupDataReloaders(
 			List<PreparableReloadListener> reloaders,
+			@Local(argsOnly = true) ReloadableServerRegistries.LoadResult loadResult,
 			@Local(argsOnly = true) FeatureFlagSet featureSet,
 			@Local ReloadableServerResources dataPackContents
 	) {
@@ -56,6 +58,7 @@ public class ReloadableServerResourcesMixin implements FabricDataResourceStoreHo
 		list.addFirst(
 				new SetupMarkerResourceReloader(
 						dataPackContents,
+						loadResult.lookupWithUpdatedTags(),
 						featureSet
 				)
 		);

--- a/fabric-resource-loader-v1/src/testmod/java/net/fabricmc/fabric/test/resource/loader/v1/ResourceReloaderTestMod.java
+++ b/fabric-resource-loader-v1/src/testmod/java/net/fabricmc/fabric/test/resource/loader/v1/ResourceReloaderTestMod.java
@@ -25,6 +25,7 @@ import net.minecraft.resources.Identifier;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
+import net.minecraft.tags.ItemTags;
 import net.minecraft.world.item.enchantment.Enchantments;
 
 import net.fabricmc.api.EnvType;
@@ -97,6 +98,7 @@ public class ResourceReloaderTestMod implements ModInitializer {
 		public CompletableFuture<Void> reload(SharedState store, Executor prepareExecutor, PreparationBarrier reloadSynchronizer, Executor applyExecutor) {
 			HolderLookup.Provider registries = store.get(ResourceLoader.RELOADER_REGISTRY_LOOKUP_KEY);
 			registries.lookupOrThrow(Registries.ENCHANTMENT).getOrThrow(Enchantments.FORTUNE);
+			registries.lookupOrThrow(Registries.ITEM).getOrThrow(ItemTags.AXES);
 			return reloadSynchronizer.wait(null).thenRunAsync(
 					() -> store.get(DataResourceLoader.DATA_RESOURCE_STORE_KEY)
 							.put(STORE_KEY, "Hello from RegistryReloader."),
@@ -111,6 +113,7 @@ public class ResourceReloaderTestMod implements ModInitializer {
 		@Override
 		public CompletableFuture<Void> reload(SharedState store, Executor prepareExecutor, PreparationBarrier reloadSynchronizer, Executor applyExecutor) {
 			this.registries.lookupOrThrow(Registries.ENCHANTMENT).getOrThrow(Enchantments.FORTUNE);
+			this.registries.lookupOrThrow(Registries.ITEM).getOrThrow(ItemTags.AXES);
 			return reloadSynchronizer.wait(null);
 		}
 	}


### PR DESCRIPTION
Fix #4983. Forward-port of #4991.

Resource reloaders are given a registries lookup that doesn't have the pending tags applied, which leads to invalid loads as highlighted in the linked issue.