### PR TITLE
Early 1.21.11 FRAPI fixes

### DIFF
--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/FabricLayerRenderState.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/FabricLayerRenderState.java
@@ -36,7 +36,7 @@ public interface FabricLayerRenderState {
 	 * {@linkplain ItemStackRenderState.LayerRenderState#prepareQuadList()}  vanilla quads} when this layer is rendered. Vertex
 	 * positions of geometry added to this emitter will automatically be output on
 	 * {@link ItemStackRenderState#visitExtents(Consumer)} ({@link ItemStackRenderState.LayerRenderState#setExtents(Supplier)} must still
-	 * be used to add positions of {@linkplain ItemStackRenderState.LayerRenderState#prepareQuadList()}  vanilla quads}). Adding quads
+	 * be used to add positions of {@linkplain ItemStackRenderState.LayerRenderState#prepareQuadList() vanilla quads}). Adding quads
 	 * that use animated sprites to this emitter will not automatically call {@link ItemStackRenderState#setAnimated()}. Any
 	 * quads added to this emitter will be cleared on {@link ItemStackRenderState.LayerRenderState#clear()}.
 	 *

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/RenderLayerHelper.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/render/RenderLayerHelper.java
@@ -45,7 +45,7 @@ public final class RenderLayerHelper {
 	 * {@link BlockState}.
 	 */
 	public static RenderType getEntityBlockLayer(ChunkSectionLayer layer) {
-		return layer == ChunkSectionLayer.TRANSLUCENT ? Sheets.translucentItemSheet() : Sheets.cutoutBlockSheet();
+		return layer == ChunkSectionLayer.TRANSLUCENT ? Sheets.translucentBlockItemSheet() : Sheets.cutoutBlockSheet();
 	}
 
 	/**

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/sprite/FabricErrorCollectingSpriteGetter.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/renderer/v1/sprite/FabricErrorCollectingSpriteGetter.java
@@ -26,7 +26,7 @@ import net.fabricmc.fabric.api.renderer.v1.model.SpriteFinder;
  */
 public interface FabricErrorCollectingSpriteGetter {
 	/**
-	 * {@return the sprite finder for the given atlas ID}
+	 * {@return the sprite finder for the given atlas texture ID}
 	 */
 	default SpriteFinder spriteFinder(Identifier atlasId) {
 		throw new UnsupportedOperationException();

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/item/BlockModelWrapperMixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/item/BlockModelWrapperMixin.java
@@ -30,8 +30,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import net.minecraft.client.renderer.item.BlockModelWrapper;
 import net.minecraft.client.renderer.item.ItemModel;
 import net.minecraft.client.renderer.item.ItemStackRenderState;
+import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.resources.model.SpriteGetter;
-import net.minecraft.data.AtlasIds;
 
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
 import net.fabricmc.fabric.api.renderer.v1.model.SpriteFinder;
@@ -60,7 +60,7 @@ abstract class BlockModelWrapperMixin implements ItemModel, BasicItemModelExtens
 		this.mesh = mesh;
 
 		if (!animated) {
-			SpriteFinder spriteFinder = spriteGetter.spriteFinder(AtlasIds.BLOCKS);
+			SpriteFinder spriteFinder = spriteGetter.spriteFinder(TextureAtlas.LOCATION_BLOCKS);
 
 			mesh.forEach(quad -> {
 				if (animated) {

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/sprite/BakedModelManager1Mixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/renderer/client/sprite/BakedModelManager1Mixin.java
@@ -23,9 +23,9 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 
 import net.minecraft.client.renderer.texture.SpriteLoader;
+import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.SpriteGetter;
-import net.minecraft.data.AtlasIds;
 import net.minecraft.resources.Identifier;
 
 import net.fabricmc.fabric.api.renderer.v1.model.SpriteFinder;
@@ -39,6 +39,9 @@ abstract class BakedModelManager1Mixin implements SpriteGetter {
 	@Shadow
 	@Final
 	SpriteLoader.Preparations val$blockAtlas;
+	@Shadow
+	@Final
+	SpriteLoader.Preparations val$itemAtlas;
 
 	@Unique
 	@Nullable
@@ -46,8 +49,10 @@ abstract class BakedModelManager1Mixin implements SpriteGetter {
 
 	@Override
 	public SpriteFinder spriteFinder(Identifier atlasId) {
-		if (atlasId.equals(AtlasIds.BLOCKS)) {
+		if (atlasId.equals(TextureAtlas.LOCATION_BLOCKS)) {
 			return val$blockAtlas.spriteFinder();
+		} else if (atlasId.equals(TextureAtlas.LOCATION_ITEMS)) {
+			return val$itemAtlas.spriteFinder();
 		}
 
 		MissingSpriteFinderImpl result = missingSpriteFinder;

--- a/fabric-renderer-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/renderer/client/BuiltInMeshUnbakedModelDeserializer.java
+++ b/fabric-renderer-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/renderer/client/BuiltInMeshUnbakedModelDeserializer.java
@@ -30,6 +30,9 @@ import net.minecraft.util.GsonHelper;
 import net.fabricmc.fabric.api.client.model.loading.v1.UnbakedModelDeserializer;
 import net.fabricmc.fabric.api.renderer.v1.mesh.ShadeMode;
 
+// FIXME 1.21.11: Items that use this model render as empty because the custom geometry has no vanilla quads which
+//  causes BlockModelWrapper to select a render type that uses the item atlas, which is then used because all quads in
+//  the mesh use the default render type.
 public class BuiltInMeshUnbakedModelDeserializer implements UnbakedModelDeserializer {
 	@Override
 	public UnbakedModel deserialize(JsonObject jsonObject, JsonDeserializationContext context) {

--- a/fabric-renderer-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/renderer/client/FrameGeometry.java
+++ b/fabric-renderer-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/renderer/client/FrameGeometry.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.test.renderer.client;
 
 import net.minecraft.client.renderer.block.model.TextureSlots;
+import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.ModelBaker;
 import net.minecraft.client.resources.model.ModelDebugName;
@@ -24,7 +25,6 @@ import net.minecraft.client.resources.model.ModelState;
 import net.minecraft.client.resources.model.QuadCollection;
 import net.minecraft.client.resources.model.UnbakedGeometry;
 import net.minecraft.core.Direction;
-import net.minecraft.data.AtlasIds;
 
 import net.fabricmc.fabric.api.renderer.v1.Renderer;
 import net.fabricmc.fabric.api.renderer.v1.mesh.MutableMesh;
@@ -38,7 +38,7 @@ public record FrameGeometry(boolean emissive) implements UnbakedGeometry {
 	public QuadCollection bake(TextureSlots textures, ModelBaker baker, ModelState settings, ModelDebugName model) {
 		MutableMesh builder = Renderer.get().mutableMesh();
 		QuadEmitter emitter = builder.emitter();
-		emitter.pushTransform(ModelBakeSettingsHelper.asQuadTransform(settings, baker.sprites().spriteFinder(AtlasIds.BLOCKS)));
+		emitter.pushTransform(ModelBakeSettingsHelper.asQuadTransform(settings, baker.sprites().spriteFinder(TextureAtlas.LOCATION_BLOCKS)));
 
 		TextureAtlasSprite sprite = baker.sprites().get(textures.getMaterial("frame"), model);
 

--- a/fabric-renderer-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/renderer/client/OctagonalColumnGeometry.java
+++ b/fabric-renderer-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/renderer/client/OctagonalColumnGeometry.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.test.renderer.client;
 
 import net.minecraft.client.renderer.block.model.TextureSlots;
 import net.minecraft.client.renderer.item.ItemStackRenderState;
+import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.ModelBaker;
 import net.minecraft.client.resources.model.ModelDebugName;
@@ -25,7 +26,6 @@ import net.minecraft.client.resources.model.ModelState;
 import net.minecraft.client.resources.model.QuadCollection;
 import net.minecraft.client.resources.model.UnbakedGeometry;
 import net.minecraft.core.Direction;
-import net.minecraft.data.AtlasIds;
 
 import net.fabricmc.fabric.api.renderer.v1.Renderer;
 import net.fabricmc.fabric.api.renderer.v1.mesh.MutableMesh;
@@ -45,7 +45,7 @@ public record OctagonalColumnGeometry(ShadeMode shadeMode) implements UnbakedGeo
 	public QuadCollection bake(TextureSlots textures, ModelBaker baker, ModelState settings, ModelDebugName model) {
 		MutableMesh builder = Renderer.get().mutableMesh();
 		QuadEmitter emitter = builder.emitter();
-		emitter.pushTransform(ModelBakeSettingsHelper.asQuadTransform(settings, baker.sprites().spriteFinder(AtlasIds.BLOCKS)));
+		emitter.pushTransform(ModelBakeSettingsHelper.asQuadTransform(settings, baker.sprites().spriteFinder(TextureAtlas.LOCATION_BLOCKS)));
 
 		TextureAtlasSprite sprite = baker.sprites().get(textures.getMaterial("column"), model);
 

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ItemRenderContext.java
@@ -151,7 +151,7 @@ public class ItemRenderContext extends AbstractRenderContext {
 
 		int cacheIndex;
 
-		if (layer == Sheets.translucentItemSheet()) {
+		if (layer == Sheets.translucentBlockItemSheet()) {
 			cacheIndex = 0;
 		} else if (layer == Sheets.cutoutBlockSheet()) {
 			cacheIndex = GLINT_COUNT;


### PR DESCRIPTION
- Allow `SpriteGetter.spriteFinder()` to return the item atlas' sprite finder
- Fix `SpriteGetter.spriteFinder()` accepting definition ID instead of texture ID
- Fix `RenderLayerHelper.getEntityBlockLayer()` and `ItemRenderContext.getVertexConsumer()` using the wrong translucent layer

Somewhat significant design changes are still necessary to accommodate the item atlas in FRAPI, but the fixes in this PR at least fix scenarios that work correctly in vanilla but not with FRAPI/Indigo.