### PR TITLE
[1.21.11] Add missing setDryFoliageColor to Biome Modification API

### DIFF
--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModificationContext.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/api/biome/v1/BiomeModificationContext.java
@@ -178,6 +178,36 @@ public interface BiomeModificationContext {
 		}
 
 		/**
+		 * @see BiomeSpecialEffects#dryFoliageColorOverride()
+		 * @see BiomeSpecialEffects.Builder#dryFoliageColorOverride(int)
+		 */
+		void setDryFoliageColor(Optional<Integer> color);
+
+		/**
+		 * @see BiomeSpecialEffects#dryFoliageColorOverride()
+		 * @see BiomeSpecialEffects.Builder#dryFoliageColorOverride(int)
+		 */
+		default void setDryFoliageColor(int color) {
+			setDryFoliageColor(Optional.of(color));
+		}
+
+		/**
+		 * @see BiomeSpecialEffects#dryFoliageColorOverride()
+		 * @see BiomeSpecialEffects.Builder#dryFoliageColorOverride(int)
+		 */
+		default void setDryFoliageColor(OptionalInt color) {
+			color.ifPresentOrElse(this::setDryFoliageColor, this::clearDryFoliageColor);
+		}
+
+		/**
+		 * @see BiomeSpecialEffects#dryFoliageColorOverride()
+		 * @see BiomeSpecialEffects.Builder#dryFoliageColorOverride(int)
+		 */
+		default void clearDryFoliageColor() {
+			setDryFoliageColor(Optional.empty());
+		}
+
+		/**
 		 * @see BiomeSpecialEffects#grassColorOverride()
 		 * @see BiomeSpecialEffects.Builder#grassColorOverride(int)
 		 */

--- a/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/modification/BiomeModificationContextImpl.java
+++ b/fabric-biome-api-v1/src/main/java/net/fabricmc/fabric/impl/biome/modification/BiomeModificationContextImpl.java
@@ -188,6 +188,11 @@ public class BiomeModificationContextImpl implements BiomeModificationContext {
 		}
 
 		@Override
+		public void setDryFoliageColor(Optional<Integer> color) {
+			effects.dryFoliageColorOverride = Objects.requireNonNull(color);
+		}
+
+		@Override
 		public void setGrassColor(Optional<Integer> color) {
 			effects.grassColorOverride = Objects.requireNonNull(color);
 		}

--- a/fabric-biome-api-v1/src/main/resources/fabric-biome-api-v1.accesswidener
+++ b/fabric-biome-api-v1/src/main/resources/fabric-biome-api-v1.accesswidener
@@ -18,6 +18,8 @@ accessible	field	net/minecraft/world/level/biome/BiomeSpecialEffects	waterColor	
 mutable	field	net/minecraft/world/level/biome/BiomeSpecialEffects	waterColor	I
 accessible	field	net/minecraft/world/level/biome/BiomeSpecialEffects	foliageColorOverride	Ljava/util/Optional;
 mutable	field	net/minecraft/world/level/biome/BiomeSpecialEffects	foliageColorOverride	Ljava/util/Optional;
+accessible	field	net/minecraft/world/level/biome/BiomeSpecialEffects	dryFoliageColorOverride	Ljava/util/Optional;
+mutable	field	net/minecraft/world/level/biome/BiomeSpecialEffects	dryFoliageColorOverride	Ljava/util/Optional;
 accessible	field	net/minecraft/world/level/biome/BiomeSpecialEffects	grassColorOverride	Ljava/util/Optional;
 mutable	field	net/minecraft/world/level/biome/BiomeSpecialEffects	grassColorOverride	Ljava/util/Optional;
 accessible	field	net/minecraft/world/level/biome/BiomeSpecialEffects	grassColorModifier	Lnet/minecraft/world/level/biome/BiomeSpecialEffects$GrassColorModifier;


### PR DESCRIPTION
Fix #5000 

Vanilla
<img width="966" height="620" alt="Vanilla" src="https://github.com/user-attachments/assets/5752ba11-3bde-4cfa-ab49-9488cdfcaa26" />

`setDryFoliageColor(0)`, `setDryFoliageColor(Optional.of(0))`, `setDryFoliageColor(OptionalInt.of(0))` (all works)
<img width="966" height="620" alt="setDryFoliageColor" src="https://github.com/user-attachments/assets/3568b0f2-d05a-4426-a3ee-fb66cf884ec5" />

Vanilla
<img width="966" height="620" alt="Vanilla" src="https://github.com/user-attachments/assets/d8671bd9-a98a-4f69-be6a-636cd679bc79" />

`clearDryFoliageColor`
<img width="966" height="620" alt="clearDryFoliageColor" src="https://github.com/user-attachments/assets/a3459d4d-4347-4748-8488-c3d9473424fd" />