### PR TITLE
Backport `FabricRenderState` to 1.21.8

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/FabricRenderState.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/FabricRenderState.java
@@ -47,6 +47,17 @@ public interface FabricRenderState {
 	}
 
 	/**
+	 * Get extra render data from the render state, or a default value if it cannot be found.
+	 * @param key the key of the data
+	 * @param defaultValue the default value
+	 * @param <T> the type of the data
+	 * @return the data, or the default value if it cannot be found.
+	 */
+	default <T> T getDataOrDefault(RenderStateDataKey<T> key, T defaultValue) {
+		throw new UnsupportedOperationException("Implemented via mixin");
+	}
+
+	/**
 	 * Set extra render data to the render state.
 	 * @param key the key of the data
 	 * @param value the data

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/FabricRenderState.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/FabricRenderState.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.client.rendering.v1;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.client.render.MapRenderState;
+import net.minecraft.client.render.entity.state.EntityRenderState;
+import net.minecraft.client.render.item.ItemRenderState;
+
+/**
+ * Fabric-provided extensions for render states, allowing for the addition of extra render data.
+ *
+ * <p>Note: This interface is automatically implemented on the following classes via Mixin and interface injection:
+ * <ul>
+ *     <li>{@link EntityRenderState},
+ *     <li>{@link ItemRenderState} and {@link ItemRenderState.LayerRenderState}
+ *     <li>{@link MapRenderState} and {@link MapRenderState.Decoration}
+ * </ul>
+ */
+@ApiStatus.NonExtendable
+public interface FabricRenderState {
+	/**
+	 * Get extra render data from the render state.
+	 * @param key the key of the data
+	 * @param <T> the type of the data
+	 * @return the data, or {@code null} if it cannot be found.
+	 */
+	@Nullable
+	default <T> T getData(RenderStateDataKey<T> key) {
+		throw new UnsupportedOperationException("Implemented via mixin");
+	}
+
+	/**
+	 * Set extra render data to the render state.
+	 * @param key the key of the data
+	 * @param value the data
+	 * @param <T> the type of the data
+	 */
+	default <T> void setData(RenderStateDataKey<T> key, @Nullable T value) {
+		throw new UnsupportedOperationException("Implemented via mixin");
+	}
+
+	/**
+	 * Clears all extra render data on the render state.
+	 */
+	default void clearExtraData() {
+		throw new UnsupportedOperationException("Implemented via mixin");
+	}
+}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/RenderStateDataKey.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/RenderStateDataKey.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.client.rendering.v1;
+
+import java.util.function.Supplier;
+
+/**
+ * A unique key representing extra data to attach to a render state.
+ * @param <T> The type of the render state data.
+ * @see FabricRenderState#getData(RenderStateDataKey)
+ * @see FabricRenderState#setData(RenderStateDataKey, Object)
+ */
+public final class RenderStateDataKey<T> {
+	private final Supplier<String> name;
+
+	private RenderStateDataKey(Supplier<String> debugName) {
+		this.name = debugName;
+	}
+
+	/**
+	 * Creates a new unique data key.
+	 * @param debugName The name of this data key, shown in error messages.
+	 * @param <T> The type of the render state data.
+	 * @return The newly created data key.
+	 */
+	public static <T> RenderStateDataKey<T> create(Supplier<String> debugName) {
+		return new RenderStateDataKey<>(debugName);
+	}
+
+	/**
+	 * Creates a new unique data key.
+	 * @param <T> The type of the render state data.
+	 * @return The newly created data key.
+	 */
+	public static <T> RenderStateDataKey<T> create() {
+		return new RenderStateDataKey<>(() -> "unnamed");
+	}
+
+	@Override
+	public String toString() {
+		return "RenderStateDataKey(" + name.get() + ")";
+	}
+}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/RenderStateMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/RenderStateMixin.java
@@ -49,6 +49,12 @@ public abstract class RenderStateMixin implements FabricRenderState {
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
+	public <T> T getDataOrDefault(RenderStateDataKey<T> key, T defaultValue) {
+		return renderStateData == null ? defaultValue : (T) renderStateData.getOrDefault(key, defaultValue);
+	}
+
+	@Override
 	public <T> void setData(RenderStateDataKey<T> key, T value) {
 		if (renderStateData == null) {
 			renderStateData = new Reference2ObjectOpenHashMap<>();

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/RenderStateMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/RenderStateMixin.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.rendering;
+
+import java.util.Map;
+
+import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+import net.minecraft.client.render.MapRenderState;
+import net.minecraft.client.render.entity.state.EntityRenderState;
+import net.minecraft.client.render.item.ItemRenderState;
+
+import net.fabricmc.fabric.api.client.rendering.v1.FabricRenderState;
+import net.fabricmc.fabric.api.client.rendering.v1.RenderStateDataKey;
+
+@Mixin({
+		EntityRenderState.class,
+		ItemRenderState.class,
+		ItemRenderState.LayerRenderState.class,
+		MapRenderState.class,
+		MapRenderState.Decoration.class,
+})
+public abstract class RenderStateMixin implements FabricRenderState {
+	@Unique
+	@Nullable
+	private Map<RenderStateDataKey<?>, Object> renderStateData;
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> @Nullable T getData(RenderStateDataKey<T> key) {
+		return renderStateData == null ? null : (T) renderStateData.get(key);
+	}
+
+	@Override
+	public <T> void setData(RenderStateDataKey<T> key, T value) {
+		if (renderStateData == null) {
+			renderStateData = new Reference2ObjectOpenHashMap<>();
+		}
+
+		renderStateData.put(key, value);
+	}
+
+	@Override
+	public void clearExtraData() {
+		if (renderStateData != null) {
+			renderStateData.clear();
+		}
+	}
+}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/renderstate/ItemRenderStateLayerRenderStateMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/renderstate/ItemRenderStateLayerRenderStateMixin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.rendering.renderstate;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.render.item.ItemRenderState;
+
+import net.fabricmc.fabric.api.client.rendering.v1.FabricRenderState;
+
+@Mixin(ItemRenderState.LayerRenderState.class)
+public class ItemRenderStateLayerRenderStateMixin {
+	@Inject(method = "clear", at = @At("TAIL"))
+	private void clearExtraRenderData(CallbackInfo ci) {
+		((FabricRenderState) this).clearExtraData();
+	}
+}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/renderstate/ItemRenderStateMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/renderstate/ItemRenderStateMixin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.rendering.renderstate;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.render.item.ItemRenderState;
+
+import net.fabricmc.fabric.api.client.rendering.v1.FabricRenderState;
+
+@Mixin(ItemRenderState.class)
+public class ItemRenderStateMixin {
+	@Inject(method = "clear", at = @At("TAIL"))
+	private void clearExtraRenderData(CallbackInfo ci) {
+		((FabricRenderState) this).clearExtraData();
+	}
+}

--- a/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
+++ b/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
@@ -23,9 +23,12 @@
     "LivingEntityRendererAccessor",
     "LivingEntityRendererMixin",
     "RenderLayersMixin",
+    "RenderStateMixin",
     "SpecialModelTypesMixin",
     "TooltipComponentMixin",
-    "WorldRendererMixin"
+    "WorldRendererMixin",
+    "renderstate.ItemRenderStateLayerRenderStateMixin",
+    "renderstate.ItemRenderStateMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/fabric-rendering-v1/src/client/resources/fabric.mod.json
+++ b/fabric-rendering-v1/src/client/resources/fabric.mod.json
@@ -30,6 +30,23 @@
     "fabric-rendering-v1.mixins.json"
   ],
   "custom": {
-    "fabric-api:module-lifecycle": "stable"
+    "fabric-api:module-lifecycle": "stable",
+    "loom:injected_interfaces": {
+      "net/minecraft/class_10017": [
+        "net/fabricmc/fabric/api/client/rendering/v1/FabricRenderState"
+      ],
+      "net/minecraft/class_10090": [
+        "net/fabricmc/fabric/api/client/rendering/v1/FabricRenderState"
+      ],
+      "net/minecraft/class_10090\u0024class_10091": [
+        "net/fabricmc/fabric/api/client/rendering/v1/FabricRenderState"
+      ],
+      "net/minecraft/class_10444": [
+        "net/fabricmc/fabric/api/client/rendering/v1/FabricRenderState"
+      ],
+      "net/minecraft/class_10444\u0024class_10446": [
+        "net/fabricmc/fabric/api/client/rendering/v1/FabricRenderState"
+      ]
+    }
   }
 }

--- a/fabric-rendering-v1/src/test/java/net/fabricmc/fabric/impl/client/rendering/state/RenderStateDataTest.java
+++ b/fabric-rendering-v1/src/test/java/net/fabricmc/fabric/impl/client/rendering/state/RenderStateDataTest.java
@@ -65,10 +65,13 @@ public class RenderStateDataTest {
 
 		for (FabricRenderState state : states) {
 			Assertions.assertNull(state.getData(DEBUG));
+			Assertions.assertEquals("pass", state.getDataOrDefault(DEBUG, "pass"));
 			state.setData(DEBUG, "test");
 			Assertions.assertEquals("test", state.getData(DEBUG));
+			Assertions.assertEquals("test", state.getDataOrDefault(DEBUG, "fail"));
 			state.clearExtraData();
 			Assertions.assertNull(state.getData(DEBUG));
+			Assertions.assertEquals("pass", state.getDataOrDefault(DEBUG, "pass"));
 		}
 	}
 }

--- a/fabric-rendering-v1/src/test/java/net/fabricmc/fabric/impl/client/rendering/state/RenderStateDataTest.java
+++ b/fabric-rendering-v1/src/test/java/net/fabricmc/fabric/impl/client/rendering/state/RenderStateDataTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.rendering.state;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import net.minecraft.Bootstrap;
+import net.minecraft.SharedConstants;
+import net.minecraft.client.render.MapRenderState;
+import net.minecraft.client.render.block.MovingBlockRenderState;
+import net.minecraft.client.render.block.entity.state.BlockEntityRenderState;
+import net.minecraft.client.render.entity.state.EntityRenderState;
+import net.minecraft.client.render.item.ItemRenderState;
+import net.minecraft.client.render.state.CameraRenderState;
+import net.minecraft.client.render.state.SkyRenderState;
+import net.minecraft.client.render.state.WeatherRenderState;
+import net.minecraft.client.render.state.WorldBorderRenderState;
+import net.minecraft.client.render.state.WorldRenderState;
+
+import net.fabricmc.fabric.api.client.rendering.v1.FabricRenderState;
+import net.fabricmc.fabric.api.client.rendering.v1.RenderStateDataKey;
+
+public class RenderStateDataTest {
+	private static final RenderStateDataKey<String> DEBUG = RenderStateDataKey.create(() -> "Debug");
+
+	@BeforeAll
+	static void beforeAll() {
+		SharedConstants.createGameVersion();
+		Bootstrap.initialize();
+	}
+
+	@Test
+	void assertFabricRenderStateMethods() {
+		ItemRenderState itemRenderState = new ItemRenderState();
+		FabricRenderState[] states = new FabricRenderState[]{
+				new EntityRenderState(),
+				new BlockEntityRenderState(),
+				itemRenderState,
+				itemRenderState.new LayerRenderState(),
+				new MapRenderState(),
+				new MapRenderState.Decoration(),
+				new MovingBlockRenderState(),
+				new WorldRenderState(),
+				new CameraRenderState(),
+				new WeatherRenderState(),
+				new WorldBorderRenderState(),
+				new SkyRenderState()
+		};
+
+		for (FabricRenderState state : states) {
+			Assertions.assertNull(state.getData(DEBUG));
+			state.setData(DEBUG, "test");
+			Assertions.assertEquals("test", state.getData(DEBUG));
+			state.clearExtraData();
+			Assertions.assertNull(state.getData(DEBUG));
+		}
+	}
+}

--- a/fabric-rendering-v1/src/test/java/net/fabricmc/fabric/impl/client/rendering/state/RenderStateDataTest.java
+++ b/fabric-rendering-v1/src/test/java/net/fabricmc/fabric/impl/client/rendering/state/RenderStateDataTest.java
@@ -23,15 +23,8 @@ import org.junit.jupiter.api.Test;
 import net.minecraft.Bootstrap;
 import net.minecraft.SharedConstants;
 import net.minecraft.client.render.MapRenderState;
-import net.minecraft.client.render.block.MovingBlockRenderState;
-import net.minecraft.client.render.block.entity.state.BlockEntityRenderState;
 import net.minecraft.client.render.entity.state.EntityRenderState;
 import net.minecraft.client.render.item.ItemRenderState;
-import net.minecraft.client.render.state.CameraRenderState;
-import net.minecraft.client.render.state.SkyRenderState;
-import net.minecraft.client.render.state.WeatherRenderState;
-import net.minecraft.client.render.state.WorldBorderRenderState;
-import net.minecraft.client.render.state.WorldRenderState;
 
 import net.fabricmc.fabric.api.client.rendering.v1.FabricRenderState;
 import net.fabricmc.fabric.api.client.rendering.v1.RenderStateDataKey;
@@ -50,17 +43,10 @@ public class RenderStateDataTest {
 		ItemRenderState itemRenderState = new ItemRenderState();
 		FabricRenderState[] states = new FabricRenderState[]{
 				new EntityRenderState(),
-				new BlockEntityRenderState(),
 				itemRenderState,
 				itemRenderState.new LayerRenderState(),
 				new MapRenderState(),
 				new MapRenderState.Decoration(),
-				new MovingBlockRenderState(),
-				new WorldRenderState(),
-				new CameraRenderState(),
-				new WeatherRenderState(),
-				new WorldBorderRenderState(),
-				new SkyRenderState()
 		};
 
 		for (FabricRenderState state : states) {

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/mixin/PigEntityRendererMixin.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/mixin/PigEntityRendererMixin.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.rendering.client.mixin;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.entity.EntityRenderer;
+import net.minecraft.client.render.entity.state.EntityRenderState;
+import net.minecraft.client.render.entity.state.FallingBlockEntityRenderState;
+
+import net.minecraft.entity.Entity;
+
+import net.minecraft.entity.EntityType;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.block.BlockRenderType;
+import net.minecraft.block.BlockState;
+import net.minecraft.client.render.entity.PigEntityRenderer;
+import net.minecraft.client.render.entity.state.PigEntityRenderState;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.passive.PigEntity;
+
+import net.fabricmc.fabric.api.client.rendering.v1.FabricRenderState;
+import net.fabricmc.fabric.api.client.rendering.v1.RenderStateDataKey;
+
+/**
+ * Tests {@link RenderStateDataKey} and {@link FabricRenderState}. Pigs will render the block they're standing on at their location.
+ */
+@Mixin(PigEntityRenderer.class)
+public class PigEntityRendererMixin {
+	@Unique
+	private static final RenderStateDataKey<FallingBlockEntityRenderState> MOVING_BLOCK = RenderStateDataKey.create(() -> "Moving block");
+
+	@Inject(method = "updateRenderState(Lnet/minecraft/entity/passive/PigEntity;Lnet/minecraft/client/render/entity/state/PigEntityRenderState;F)V", at = @At("TAIL"))
+	private void updateRenderStateData(PigEntity entity, PigEntityRenderState state, float tickProgress, CallbackInfo ci) {
+		BlockState blockState = entity.getSteppingBlockState();
+
+		if (blockState.getRenderType() != BlockRenderType.INVISIBLE) {
+			FallingBlockEntityRenderState movingBlockRenderState = new FallingBlockEntityRenderState();
+			movingBlockRenderState.entityType = EntityType.FALLING_BLOCK;
+			movingBlockRenderState.fallingBlockPos = entity.getSteppingPos();
+			movingBlockRenderState.currentPos = entity.getBlockPos();
+			movingBlockRenderState.blockState = entity.getSteppingBlockState();
+			movingBlockRenderState.biome = entity.getWorld().getBiome(entity.getBlockPos());
+			movingBlockRenderState.world = entity.getWorld();
+			state.setData(MOVING_BLOCK, movingBlockRenderState);
+		}
+	}
+
+	@Inject(method = "render(Lnet/minecraft/client/render/entity/state/PigEntityRenderState;Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/entity/MobEntityRenderer;render(Lnet/minecraft/client/render/entity/state/LivingEntityRenderState;Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V"))
+	private void renderUsingRenderStateData(PigEntityRenderState state, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
+		FallingBlockEntityRenderState movingBlockRenderState = state.getData(MOVING_BLOCK);
+
+		if (movingBlockRenderState != null) {
+			MinecraftClient.getInstance()
+					.getEntityRenderDispatcher()
+					.getRenderer(movingBlockRenderState)
+					// there is a chance that the renderer is null but in that case it should error
+					.render(movingBlockRenderState, matrices, vertexConsumers, light);
+		}
+	}
+}

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/mixin/PigEntityRendererMixin.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/mixin/PigEntityRendererMixin.java
@@ -16,16 +16,6 @@
 
 package net.fabricmc.fabric.test.rendering.client.mixin;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.render.VertexConsumerProvider;
-import net.minecraft.client.render.entity.EntityRenderer;
-import net.minecraft.client.render.entity.state.EntityRenderState;
-import net.minecraft.client.render.entity.state.FallingBlockEntityRenderState;
-
-import net.minecraft.entity.Entity;
-
-import net.minecraft.entity.EntityType;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -34,9 +24,13 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.block.BlockRenderType;
 import net.minecraft.block.BlockState;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.entity.PigEntityRenderer;
+import net.minecraft.client.render.entity.state.FallingBlockEntityRenderState;
 import net.minecraft.client.render.entity.state.PigEntityRenderState;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.EntityType;
 import net.minecraft.entity.passive.PigEntity;
 
 import net.fabricmc.fabric.api.client.rendering.v1.FabricRenderState;

--- a/fabric-rendering-v1/src/testmodClient/resources/fabric-rendering-v1-testmod.client.mixins.json
+++ b/fabric-rendering-v1/src/testmodClient/resources/fabric-rendering-v1-testmod.client.mixins.json
@@ -4,7 +4,8 @@
   "compatibilityLevel": "JAVA_21",
   "client": [
     "GameRendererAccessor",
-    "GuiRendererAccessor"
+    "GuiRendererAccessor",
+    "PigEntityRendererMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Backports #4847 and #4917 to 1.21.8.

Removed references to some RenderState classes as they do not exist in 1.21.8.