### PR TITLE
[Issue] - Updated Incorrect Documentation For Viscosity Formula.

### DIFF
--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidConstants.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidConstants.java
@@ -70,7 +70,7 @@ public final class FluidConstants {
 	public static final int LAVA_VISCOSITY = 6000;
 	public static final int LAVA_VISCOSITY_NETHER = 2000;
 	/**
-	 * For flowable fluids, the viscosity should match {@code VISCOSITY_RATIO} * {@link FlowingFluid#getSlopeFindDistance}.
+	 * For flowable fluids, the viscosity should match {@code VISCOSITY_RATIO} * {@link FlowingFluid#getTickDelay}.
 	 */
 	public static final int VISCOSITY_RATIO = 200;
 

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariantAttributeHandler.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariantAttributeHandler.java
@@ -87,7 +87,7 @@ public interface FluidVariantAttributeHandler {
 	 * Return a positive integer, representing the viscosity of this fluid.
 	 * Fluids with lower viscosity generally flow faster than fluids with higher viscosity.
 	 *
-	 * <p>More precisely, viscosity should be {@value FluidConstants#VISCOSITY_RATIO} * {@link FlowingFluid#getSlopeFindDistance} for flowable fluids.
+	 * <p>More precisely, viscosity should be {@value FluidConstants#VISCOSITY_RATIO} * {@link FlowingFluid#getTickDelay} for flowable fluids.
 	 * The reference values are {@value FluidConstants#WATER_VISCOSITY} for water,
 	 * {@value FluidConstants#LAVA_VISCOSITY_NETHER} for lava in ultrawarm dimensions (such as the nether),
 	 * and {@value FluidConstants#LAVA_VISCOSITY} for lava in other dimensions.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariantAttributes.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/fluid/FluidVariantAttributes.java
@@ -136,7 +136,7 @@ public final class FluidVariantAttributes {
 	 * Return a positive integer, representing the viscosity of this fluid variant.
 	 * Fluids with lower viscosity generally flow faster than fluids with higher viscosity.
 	 *
-	 * <p>More precisely, viscosity should be {@value FluidConstants#VISCOSITY_RATIO} * {@link FlowingFluid#getSlopeFindDistance} for flowable fluids.
+	 * <p>More precisely, viscosity should be {@value FluidConstants#VISCOSITY_RATIO} * {@link FlowingFluid#getTickDelay} for flowable fluids.
 	 * The reference values are {@value FluidConstants#WATER_VISCOSITY} for water,
 	 * {@value FluidConstants#LAVA_VISCOSITY_NETHER} for lava in ultrawarm dimensions (such as the nether),
 	 * and {@value FluidConstants#LAVA_VISCOSITY} for lava in other dimensions.


### PR DESCRIPTION
Issue – [#4929](https://github.com/FabricMC/fabric/issues/4929)

This pull request updates the documentation comments related to fluid viscosity calculations to reference the correct method for determining fluid flow timing. Specifically, it replaces references to `FlowingFluid#getSlopeFindDistance` with `FlowingFluid#getTickDelay`, clarifying how viscosity should be calculated for flowable fluids.

Documentation corrections for viscosity calculation:

* Updated the JavaDoc in `FluidConstants.java` to state that viscosity should match `VISCOSITY_RATIO * FlowingFluid#getTickDelay` instead of `getSlopeFindDistance`.
* Updated the JavaDoc in `FluidVariantAttributeHandler.java` to clarify that viscosity should be calculated using `FlowingFluid#getTickDelay`.
* Updated the JavaDoc in `FluidVariantAttributes.java` to reference `FlowingFluid#getTickDelay` for viscosity calculations.