### PR TITLE
[Issue] - Add RecipeOutputMixin to support FabricRecipeExporter

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/RecipeOutputMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/RecipeOutputMixin.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.datagen.recipe;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import net.minecraft.data.recipes.RecipeOutput;
+
+import net.fabricmc.fabric.api.datagen.v1.recipe.FabricRecipeExporter;
+
+@Mixin(RecipeOutput.class)
+public interface RecipeOutputMixin extends FabricRecipeExporter {
+}

--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
@@ -16,6 +16,7 @@
     "loot.EntityLootSubProviderAccessor",
     "loot.EntityLootSubProviderMixin",
     "recipe.AllCraftingRecipeJsonBuildersMixin",
+    "recipe.RecipeOutputMixin",
     "recipe.SpecialRecipeBuilderMixin",
     "recipe.SmithingTransformRecipeBuilderMixin",
     "recipe.SmithingTrimRecipeBuilderMixin"


### PR DESCRIPTION
Issue - [5007](https://github.com/FabricMC/fabric/issues/5007)

This pull request introduces a new mixin to enhance recipe data generation by making `RecipeOutput` implement the `FabricRecipeExporter` interface. This allows for greater flexibility and integration with Fabric's data generation APIs. The changes include the addition of the new mixin class and its registration in the mixins configuration.

Enhancement to recipe data generation:

* Added `RecipeOutputMixin`, a mixin that makes the `RecipeOutput` class implement the `FabricRecipeExporter` interface, enabling Fabric-specific recipe export functionality. (`fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/RecipeOutputMixin.java`)
* Registered the new `RecipeOutputMixin` in the `fabric-data-generation-api-v1.mixins.json` configuration file to ensure it is applied at runtime. (`fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json`)