### PR TITLE
Implement methods to allow duplicating a render pipeline without discarding fabric & modded additions

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/FabricRenderPipeline.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/FabricRenderPipeline.java
@@ -17,8 +17,11 @@
 package net.fabricmc.fabric.api.client.rendering.v1;
 
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import com.mojang.blaze3d.pipeline.RenderPipeline;
+
+import net.fabricmc.fabric.impl.client.rendering.FabricRenderPipelineImpl;
 
 /**
  * General purpose Fabric extensions to the {@link RenderPipeline} class.
@@ -33,6 +36,41 @@ public interface FabricRenderPipeline {
 	 */
 	default boolean usePipelineDrawModeForGui() {
 		throw new AssertionError("Implemented in Mixin");
+	}
+
+	/**
+	 * Creates a builder that when built would create this pipeline.
+	 * Note that the caller must call {@link RenderPipeline.Builder#withLocation(net.minecraft.resources.Identifier)} returned builder before building.
+	 *
+	 * @return a builder that could build this pipeline
+	 */
+	default RenderPipeline.Builder toBuilder() {
+		RenderPipeline $self = (RenderPipeline) this;
+		RenderPipeline.Builder builder = RenderPipeline.builder()
+				.withLocation($self.getLocation())
+				.withVertexShader($self.getVertexShader())
+				.withFragmentShader($self.getFragmentShader())
+				.withDepthTestFunction($self.getDepthTestFunction())
+				.withPolygonMode($self.getPolygonMode())
+				.withCull($self.isCull())
+				.withColorLogic($self.getColorLogic())
+				.withColorWrite($self.isWriteColor(), $self.isWriteAlpha())
+				.withDepthWrite($self.isWriteDepth())
+				.withVertexFormat($self.getVertexFormat(), $self.getVertexFormatMode())
+				.withDepthBias($self.getDepthBiasScaleFactor(), $self.getDepthBiasConstant())
+				.withUsePipelineDrawModeForGui($self.usePipelineDrawModeForGui());
+		$self.getShaderDefines().values().forEach((v1, v2) -> ((FabricRenderPipelineImpl.BuilderImpl) builder).fabric$getShaderDefines().define(v1, v2));
+		$self.getShaderDefines().flags().forEach(flag -> ((FabricRenderPipelineImpl.BuilderImpl) builder).fabric$getShaderDefines().define(flag));
+		return builder;
+	}
+
+	/**
+	 * Creates a snippet that describes this pipeline.
+	 *
+	 * @return a snippet that describes this pipeline
+	 */
+	default RenderPipeline.Snippet toSnippet() {
+		return toBuilder().buildSnippet();
 	}
 
 	/**
@@ -74,6 +112,18 @@ public interface FabricRenderPipeline {
 		 */
 		default Optional<Boolean> usePipelineDrawModeForGui() {
 			throw new AssertionError("Implemented in Mixin");
+		}
+
+		/**
+		 * Creates a new snippet that is identical to this one aside from the changes induced by {@code mutator}.
+		 *
+		 * @param mutator the changes to make to this snippet
+		 * @return a new snippet identical to this one aside from the changes applied by mutator
+		 */
+		default RenderPipeline.Snippet with(Consumer<RenderPipeline.Builder> mutator) {
+			RenderPipeline.Builder builder = RenderPipeline.builder((RenderPipeline.Snippet) this);
+			mutator.accept(builder);
+			return builder.buildSnippet();
 		}
 
 		/**

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/FabricRenderPipelineImpl.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/FabricRenderPipelineImpl.java
@@ -16,8 +16,14 @@
 
 package net.fabricmc.fabric.impl.client.rendering;
 
+import net.minecraft.client.renderer.ShaderDefines;
+
 import net.fabricmc.fabric.api.client.rendering.v1.FabricRenderPipeline;
 
 public interface FabricRenderPipelineImpl extends FabricRenderPipeline {
 	void fabric$setUsePipelineDrawModeForGuiSetter(boolean usePipelineDrawModeForGui);
+
+	interface BuilderImpl extends FabricRenderPipeline.Builder {
+		ShaderDefines.Builder fabric$getShaderDefines();
+	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/RenderPipelineBuilderMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/RenderPipelineBuilderMixin.java
@@ -29,6 +29,7 @@ import com.mojang.blaze3d.platform.LogicOp;
 import com.mojang.blaze3d.platform.PolygonMode;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -37,12 +38,13 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import net.minecraft.client.renderer.ShaderDefines;
 import net.minecraft.resources.Identifier;
 
-import net.fabricmc.fabric.api.client.rendering.v1.FabricRenderPipeline;
 import net.fabricmc.fabric.impl.client.rendering.FabricRenderPipelineImpl;
 import net.fabricmc.fabric.impl.client.rendering.FabricRenderPipelineInternals;
 
 @Mixin(RenderPipeline.Builder.class)
-class RenderPipelineBuilderMixin implements FabricRenderPipeline.Builder {
+class RenderPipelineBuilderMixin implements FabricRenderPipelineImpl.BuilderImpl {
+	@Shadow
+	private Optional<ShaderDefines.Builder> definesBuilder;
 	@Unique
 	private Optional<Boolean> usePipelineDrawModeForGui = Optional.empty();
 
@@ -101,5 +103,14 @@ class RenderPipelineBuilderMixin implements FabricRenderPipeline.Builder {
 	private RenderPipeline copyUsePipelineDrawModeForGuiToPipeline(RenderPipeline original) {
 		((FabricRenderPipelineImpl) original).fabric$setUsePipelineDrawModeForGuiSetter(this.usePipelineDrawModeForGui.orElse(false));
 		return original;
+	}
+
+	@Override
+	public ShaderDefines.Builder fabric$getShaderDefines() {
+		if (this.definesBuilder.isEmpty()) {
+			this.definesBuilder = Optional.of(ShaderDefines.builder());
+		}
+
+		return definesBuilder.orElseThrow();
 	}
 }


### PR DESCRIPTION
adds methods to copy a render pipeline. this is useful when you need to draw with a given pipeline, but need to enable depth testing, or need to add a uniform, or for various other miscellaneous reasons