### PR TITLE
Mark dependency on fabric-resource-loader-v1

### DIFF
--- a/fabric-item-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-item-api-v1/src/main/resources/fabric.mod.json
@@ -24,7 +24,8 @@
   ],
   "depends": {
     "fabricloader": ">=0.17.3",
-    "fabric-api-base": "*"
+    "fabric-api-base": "*",
+    "fabric-resource-loader-v1": "*"
   },
   "description": "Hooks for items",
   "custom": {


### PR DESCRIPTION
Small fix to Fabric Item API's dependency list to give a clearer error. Fixes #5037.