### PR TITLE
Remove provides for legacy `fabric` modid.

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,9 +1,6 @@
 {
   "schemaVersion": 1,
   "id": "fabric-api",
-  "provides": [
-    "fabric"
-  ],
   "name": "Fabric API",
   "version": "${version}",
   "environment": "*",


### PR DESCRIPTION
The `fabric` mod id is a common source of confusion, with this change all mods must now depend on `fabric-api`. They have had 3 years to update.