### PR TITLE
[1.21.11] Allow subclasses of lang provider to change output path

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricLanguageProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricLanguageProvider.java
@@ -110,7 +110,7 @@ public abstract class FabricLanguageProvider implements DataProvider {
 
 	/**
 	 * Override this method to change where the generated language file is placed.
-	 * 
+	 *
 	 * @param code The language code (like "en_us") of the translations.
 	 */
 	protected Path getLangFilePath(String code) {

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricLanguageProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricLanguageProvider.java
@@ -108,7 +108,7 @@ public abstract class FabricLanguageProvider implements DataProvider {
 		});
 	}
 
-	private Path getLangFilePath(String code) {
+	protected Path getLangFilePath(String code) {
 		return dataOutput
 				.createPathProvider(PackOutput.Target.RESOURCE_PACK, "lang")
 				.json(Identifier.fromNamespaceAndPath(dataOutput.getModId(), code));

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricLanguageProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricLanguageProvider.java
@@ -110,6 +110,8 @@ public abstract class FabricLanguageProvider implements DataProvider {
 
 	/**
 	 * Override this method to change where the generated language file is placed.
+	 * 
+	 * @param code The language code (like "en_us") of the translations.
 	 */
 	protected Path getLangFilePath(String code) {
 		return dataOutput

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricLanguageProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricLanguageProvider.java
@@ -108,6 +108,9 @@ public abstract class FabricLanguageProvider implements DataProvider {
 		});
 	}
 
+	/**
+	 * Override this method to change where the generated language file is placed.
+	 */
 	protected Path getLangFilePath(String code) {
 		return dataOutput
 				.createPathProvider(PackOutput.Target.RESOURCE_PACK, "lang")


### PR DESCRIPTION
Just a nice-to-have. Useful when using [Nucleoid's Server-Translations](https://github.com/NucleoidMC/Server-Translations).