### PR TITLE
Fix incorrect class name in content registries provided javadoc

### DIFF
--- a/fabric-content-registries-v0/src/main/resources/fabric-content-registries-v0.mapping
+++ b/fabric-content-registries-v0/src/main/resources/fabric-content-registries-v0.mapping
@@ -1,2 +1,2 @@
-CLASS net/minecraft/class_5955
+CLASS net/minecraft/world/level/block/WeatheringCopper
 	COMMENT @see net.fabricmc.fabric.api.registry.OxidizableBlocksRegistry registry for modded oxidizable blocks


### PR DESCRIPTION
The class name in the comment also needs adjusting with the rename PR.