### PR TITLE
Tweak Lifecycle Events class names

### DIFF
--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiCacheImpl.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/impl/lookup/block/BlockApiCacheImpl.java
@@ -23,7 +23,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerBlockEntityEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerBlockEntityLifecycleEvents;
 import net.fabricmc.fabric.api.lookup.v1.block.BlockApiCache;
 import net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup;
 
@@ -129,11 +129,11 @@ public final class BlockApiCacheImpl<A, C> implements BlockApiCache<A, C> {
 	}
 
 	static {
-		ServerBlockEntityEvents.BLOCK_ENTITY_LOAD.register((blockEntity, world) -> {
+		ServerBlockEntityLifecycleEvents.BLOCK_ENTITY_LOAD.register((blockEntity, world) -> {
 			((ServerWorldCache) world).fabric_invalidateCache(blockEntity.getBlockPos());
 		});
 
-		ServerBlockEntityEvents.BLOCK_ENTITY_UNLOAD.register((blockEntity, world) -> {
+		ServerBlockEntityLifecycleEvents.BLOCK_ENTITY_UNLOAD.register((blockEntity, world) -> {
 			((ServerWorldCache) world).fabric_invalidateCache(blockEntity.getBlockPos());
 		});
 	}

--- a/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
+++ b/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
@@ -41,7 +41,7 @@ import net.fabricmc.fabric.api.attachment.v1.AttachmentSyncPredicate;
 import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
 import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
 import net.fabricmc.fabric.api.biome.v1.BiomeSelectors;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityLifecycleEvents;
 import net.fabricmc.fabric.api.event.player.UseBlockCallback;
 
 public class AttachmentTestMod implements ModInitializer {
@@ -120,7 +120,7 @@ public class AttachmentTestMod implements ModInitializer {
 			return InteractionResult.PASS;
 		});
 
-		ServerEntityEvents.ENTITY_LOAD.register((entity, world) -> {
+		ServerEntityLifecycleEvents.ENTITY_LOAD.register((entity, world) -> {
 			entity.onAttachedSet(SYNCED_ITEM).register((oldValue, newValue) -> {
 				if (newValue != null && !newValue.equals(oldValue) && newValue.is(Items.BRICK)) {
 					entity.hurtServer(world, world.damageSources().generic(), 1);

--- a/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/AttachmentClientTestMod.java
+++ b/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/AttachmentClientTestMod.java
@@ -22,13 +22,13 @@ import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.chat.Component;
 
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientEntityEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientEntityLifecycleEvents;
 import net.fabricmc.fabric.test.attachment.AttachmentTestMod;
 
 public class AttachmentClientTestMod implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
-		ClientEntityEvents.ENTITY_LOAD.register((entity, world) -> {
+		ClientEntityLifecycleEvents.ENTITY_LOAD.register((entity, world) -> {
 			if (entity instanceof LocalPlayer) {
 				entity.onAttachedSet(AttachmentTestMod.SYNCED_RENDER_DISTANCE).register((oldValue, newValue) -> {
 					OptionInstance<Integer> viewDistance = Minecraft.getInstance().options.renderDistance();

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientBlockEntityLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientBlockEntityLifecycleEvents.java
@@ -32,7 +32,7 @@ public final class ClientBlockEntityLifecycleEvents {
 	 * <p>When this event is called, the block entity is already in the level.
 	 * However, its data might not be loaded yet, so don't rely on it.
 	 */
-	public static final Event<Load> BLOCK_ENTITY_LOAD = EventFactory.createArrayBacked(ClientBlockEntityLifecycleEvents.Load.class, callbacks -> (blockEntity, level) -> {
+	public static final Event<Load> BLOCK_ENTITY_LOAD = EventFactory.createArrayBacked(Load.class, callbacks -> (blockEntity, level) -> {
 		for (Load callback : callbacks) {
 			callback.onLoad(blockEntity, level);
 		}
@@ -43,7 +43,7 @@ public final class ClientBlockEntityLifecycleEvents {
 	 *
 	 * <p>When this event is called, the block entity is still present on the world.
 	 */
-	public static final Event<Unload> BLOCK_ENTITY_UNLOAD = EventFactory.createArrayBacked(ClientBlockEntityLifecycleEvents.Unload.class, callbacks -> (blockEntity, level) -> {
+	public static final Event<Unload> BLOCK_ENTITY_UNLOAD = EventFactory.createArrayBacked(Unload.class, callbacks -> (blockEntity, level) -> {
 		for (Unload callback : callbacks) {
 			callback.onUnload(blockEntity, level);
 		}

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientBlockEntityLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientBlockEntityLifecycleEvents.java
@@ -22,8 +22,8 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
-public final class ClientBlockEntityEvents {
-	private ClientBlockEntityEvents() {
+public final class ClientBlockEntityLifecycleEvents {
+	private ClientBlockEntityLifecycleEvents() {
 	}
 
 	/**
@@ -32,7 +32,7 @@ public final class ClientBlockEntityEvents {
 	 * <p>When this event is called, the block entity is already in the level.
 	 * However, its data might not be loaded yet, so don't rely on it.
 	 */
-	public static final Event<ClientBlockEntityEvents.Load> BLOCK_ENTITY_LOAD = EventFactory.createArrayBacked(ClientBlockEntityEvents.Load.class, callbacks -> (blockEntity, level) -> {
+	public static final Event<ClientBlockEntityLifecycleEvents.Load> BLOCK_ENTITY_LOAD = EventFactory.createArrayBacked(ClientBlockEntityLifecycleEvents.Load.class, callbacks -> (blockEntity, level) -> {
 		for (Load callback : callbacks) {
 			callback.onLoad(blockEntity, level);
 		}
@@ -43,7 +43,7 @@ public final class ClientBlockEntityEvents {
 	 *
 	 * <p>When this event is called, the block entity is still present on the world.
 	 */
-	public static final Event<ClientBlockEntityEvents.Unload> BLOCK_ENTITY_UNLOAD = EventFactory.createArrayBacked(ClientBlockEntityEvents.Unload.class, callbacks -> (blockEntity, level) -> {
+	public static final Event<ClientBlockEntityLifecycleEvents.Unload> BLOCK_ENTITY_UNLOAD = EventFactory.createArrayBacked(ClientBlockEntityLifecycleEvents.Unload.class, callbacks -> (blockEntity, level) -> {
 		for (Unload callback : callbacks) {
 			callback.onUnload(blockEntity, level);
 		}

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientBlockEntityLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientBlockEntityLifecycleEvents.java
@@ -32,7 +32,7 @@ public final class ClientBlockEntityLifecycleEvents {
 	 * <p>When this event is called, the block entity is already in the level.
 	 * However, its data might not be loaded yet, so don't rely on it.
 	 */
-	public static final Event<ClientBlockEntityLifecycleEvents.Load> BLOCK_ENTITY_LOAD = EventFactory.createArrayBacked(ClientBlockEntityLifecycleEvents.Load.class, callbacks -> (blockEntity, level) -> {
+	public static final Event<Load> BLOCK_ENTITY_LOAD = EventFactory.createArrayBacked(ClientBlockEntityLifecycleEvents.Load.class, callbacks -> (blockEntity, level) -> {
 		for (Load callback : callbacks) {
 			callback.onLoad(blockEntity, level);
 		}
@@ -43,7 +43,7 @@ public final class ClientBlockEntityLifecycleEvents {
 	 *
 	 * <p>When this event is called, the block entity is still present on the world.
 	 */
-	public static final Event<ClientBlockEntityLifecycleEvents.Unload> BLOCK_ENTITY_UNLOAD = EventFactory.createArrayBacked(ClientBlockEntityLifecycleEvents.Unload.class, callbacks -> (blockEntity, level) -> {
+	public static final Event<Unload> BLOCK_ENTITY_UNLOAD = EventFactory.createArrayBacked(ClientBlockEntityLifecycleEvents.Unload.class, callbacks -> (blockEntity, level) -> {
 		for (Unload callback : callbacks) {
 			callback.onUnload(blockEntity, level);
 		}

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientChunkLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientChunkLifecycleEvents.java
@@ -31,7 +31,7 @@ public final class ClientChunkLifecycleEvents {
 	 *
 	 * <p>When this event is called, the chunk is already in the level.
 	 */
-	public static final Event<Load> CHUNK_LOAD = EventFactory.createArrayBacked(ClientChunkLifecycleEvents.Load.class, callbacks -> (clientLevel, chunk) -> {
+	public static final Event<Load> CHUNK_LOAD = EventFactory.createArrayBacked(Load.class, callbacks -> (clientLevel, chunk) -> {
 		for (Load callback : callbacks) {
 			callback.onChunkLoad(clientLevel, chunk);
 		}
@@ -42,7 +42,7 @@ public final class ClientChunkLifecycleEvents {
 	 *
 	 * <p>When this event is called, the chunk is still present in the level.
 	 */
-	public static final Event<Unload> CHUNK_UNLOAD = EventFactory.createArrayBacked(ClientChunkLifecycleEvents.Unload.class, callbacks -> (clientLevel, chunk) -> {
+	public static final Event<Unload> CHUNK_UNLOAD = EventFactory.createArrayBacked(Unload.class, callbacks -> (clientLevel, chunk) -> {
 		for (Unload callback : callbacks) {
 			callback.onChunkUnload(clientLevel, chunk);
 		}

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientChunkLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientChunkLifecycleEvents.java
@@ -31,7 +31,7 @@ public final class ClientChunkLifecycleEvents {
 	 *
 	 * <p>When this event is called, the chunk is already in the level.
 	 */
-	public static final Event<ClientChunkLifecycleEvents.Load> CHUNK_LOAD = EventFactory.createArrayBacked(ClientChunkLifecycleEvents.Load.class, callbacks -> (clientLevel, chunk) -> {
+	public static final Event<Load> CHUNK_LOAD = EventFactory.createArrayBacked(ClientChunkLifecycleEvents.Load.class, callbacks -> (clientLevel, chunk) -> {
 		for (Load callback : callbacks) {
 			callback.onChunkLoad(clientLevel, chunk);
 		}
@@ -42,7 +42,7 @@ public final class ClientChunkLifecycleEvents {
 	 *
 	 * <p>When this event is called, the chunk is still present in the level.
 	 */
-	public static final Event<ClientChunkLifecycleEvents.Unload> CHUNK_UNLOAD = EventFactory.createArrayBacked(ClientChunkLifecycleEvents.Unload.class, callbacks -> (clientLevel, chunk) -> {
+	public static final Event<Unload> CHUNK_UNLOAD = EventFactory.createArrayBacked(ClientChunkLifecycleEvents.Unload.class, callbacks -> (clientLevel, chunk) -> {
 		for (Unload callback : callbacks) {
 			callback.onChunkUnload(clientLevel, chunk);
 		}

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientChunkLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientChunkLifecycleEvents.java
@@ -22,8 +22,8 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
-public final class ClientChunkEvents {
-	private ClientChunkEvents() {
+public final class ClientChunkLifecycleEvents {
+	private ClientChunkLifecycleEvents() {
 	}
 
 	/**
@@ -31,7 +31,7 @@ public final class ClientChunkEvents {
 	 *
 	 * <p>When this event is called, the chunk is already in the level.
 	 */
-	public static final Event<ClientChunkEvents.Load> CHUNK_LOAD = EventFactory.createArrayBacked(ClientChunkEvents.Load.class, callbacks -> (clientLevel, chunk) -> {
+	public static final Event<ClientChunkLifecycleEvents.Load> CHUNK_LOAD = EventFactory.createArrayBacked(ClientChunkLifecycleEvents.Load.class, callbacks -> (clientLevel, chunk) -> {
 		for (Load callback : callbacks) {
 			callback.onChunkLoad(clientLevel, chunk);
 		}
@@ -42,7 +42,7 @@ public final class ClientChunkEvents {
 	 *
 	 * <p>When this event is called, the chunk is still present in the level.
 	 */
-	public static final Event<ClientChunkEvents.Unload> CHUNK_UNLOAD = EventFactory.createArrayBacked(ClientChunkEvents.Unload.class, callbacks -> (clientLevel, chunk) -> {
+	public static final Event<ClientChunkLifecycleEvents.Unload> CHUNK_UNLOAD = EventFactory.createArrayBacked(ClientChunkLifecycleEvents.Unload.class, callbacks -> (clientLevel, chunk) -> {
 		for (Unload callback : callbacks) {
 			callback.onChunkUnload(clientLevel, chunk);
 		}

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientEntityLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientEntityLifecycleEvents.java
@@ -31,7 +31,7 @@ public final class ClientEntityLifecycleEvents {
 	 *
 	 * <p>When this event is called, the chunk is already in the level.
 	 */
-	public static final Event<Load> ENTITY_LOAD = EventFactory.createArrayBacked(ClientEntityLifecycleEvents.Load.class, callbacks -> (entity, level) -> {
+	public static final Event<Load> ENTITY_LOAD = EventFactory.createArrayBacked(Load.class, callbacks -> (entity, level) -> {
 		for (Load callback : callbacks) {
 			callback.onLoad(entity, level);
 		}
@@ -42,7 +42,7 @@ public final class ClientEntityLifecycleEvents {
 	 *
 	 * <p>This event is called before the entity is unloaded from the level.
 	 */
-	public static final Event<Unload> ENTITY_UNLOAD = EventFactory.createArrayBacked(ClientEntityLifecycleEvents.Unload.class, callbacks -> (entity, level) -> {
+	public static final Event<Unload> ENTITY_UNLOAD = EventFactory.createArrayBacked(Unload.class, callbacks -> (entity, level) -> {
 		for (Unload callback : callbacks) {
 			callback.onUnload(entity, level);
 		}

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientEntityLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientEntityLifecycleEvents.java
@@ -22,8 +22,8 @@ import net.minecraft.world.entity.Entity;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
-public final class ClientEntityEvents {
-	private ClientEntityEvents() {
+public final class ClientEntityLifecycleEvents {
+	private ClientEntityLifecycleEvents() {
 	}
 
 	/**
@@ -31,7 +31,7 @@ public final class ClientEntityEvents {
 	 *
 	 * <p>When this event is called, the chunk is already in the level.
 	 */
-	public static final Event<ClientEntityEvents.Load> ENTITY_LOAD = EventFactory.createArrayBacked(ClientEntityEvents.Load.class, callbacks -> (entity, level) -> {
+	public static final Event<ClientEntityLifecycleEvents.Load> ENTITY_LOAD = EventFactory.createArrayBacked(ClientEntityLifecycleEvents.Load.class, callbacks -> (entity, level) -> {
 		for (Load callback : callbacks) {
 			callback.onLoad(entity, level);
 		}
@@ -42,7 +42,7 @@ public final class ClientEntityEvents {
 	 *
 	 * <p>This event is called before the entity is unloaded from the level.
 	 */
-	public static final Event<ClientEntityEvents.Unload> ENTITY_UNLOAD = EventFactory.createArrayBacked(ClientEntityEvents.Unload.class, callbacks -> (entity, level) -> {
+	public static final Event<ClientEntityLifecycleEvents.Unload> ENTITY_UNLOAD = EventFactory.createArrayBacked(ClientEntityLifecycleEvents.Unload.class, callbacks -> (entity, level) -> {
 		for (Unload callback : callbacks) {
 			callback.onUnload(entity, level);
 		}

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientEntityLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientEntityLifecycleEvents.java
@@ -31,7 +31,7 @@ public final class ClientEntityLifecycleEvents {
 	 *
 	 * <p>When this event is called, the chunk is already in the level.
 	 */
-	public static final Event<ClientEntityLifecycleEvents.Load> ENTITY_LOAD = EventFactory.createArrayBacked(ClientEntityLifecycleEvents.Load.class, callbacks -> (entity, level) -> {
+	public static final Event<Load> ENTITY_LOAD = EventFactory.createArrayBacked(ClientEntityLifecycleEvents.Load.class, callbacks -> (entity, level) -> {
 		for (Load callback : callbacks) {
 			callback.onLoad(entity, level);
 		}
@@ -42,7 +42,7 @@ public final class ClientEntityLifecycleEvents {
 	 *
 	 * <p>This event is called before the entity is unloaded from the level.
 	 */
-	public static final Event<ClientEntityLifecycleEvents.Unload> ENTITY_UNLOAD = EventFactory.createArrayBacked(ClientEntityLifecycleEvents.Unload.class, callbacks -> (entity, level) -> {
+	public static final Event<Unload> ENTITY_UNLOAD = EventFactory.createArrayBacked(ClientEntityLifecycleEvents.Unload.class, callbacks -> (entity, level) -> {
 		for (Unload callback : callbacks) {
 			callback.onUnload(entity, level);
 		}

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientLevelLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientLevelLifecycleEvents.java
@@ -22,8 +22,8 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
-public final class ClientLevelEvents {
-	private ClientLevelEvents() {
+public final class ClientLevelLifecycleEvents {
+	private ClientLevelLifecycleEvents() {
 	}
 
 	/**

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/impl/client/event/lifecycle/ClientLifecycleEventsImpl.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/impl/client/event/lifecycle/ClientLifecycleEventsImpl.java
@@ -19,25 +19,25 @@ package net.fabricmc.fabric.impl.client.event.lifecycle;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientBlockEntityEvents;
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientChunkEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientBlockEntityLifecycleEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientChunkLifecycleEvents;
 import net.fabricmc.fabric.impl.event.lifecycle.LoadedChunksCache;
 
 public final class ClientLifecycleEventsImpl implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
 		// Part of impl for block entity events
-		ClientChunkEvents.CHUNK_LOAD.register((level, chunk) -> {
+		ClientChunkLifecycleEvents.CHUNK_LOAD.register((level, chunk) -> {
 			((LoadedChunksCache) level).fabric_markLoaded(chunk);
 		});
 
-		ClientChunkEvents.CHUNK_UNLOAD.register((level, chunk) -> {
+		ClientChunkLifecycleEvents.CHUNK_UNLOAD.register((level, chunk) -> {
 			((LoadedChunksCache) level).fabric_markUnloaded(chunk);
 		});
 
-		ClientChunkEvents.CHUNK_UNLOAD.register((level, chunk) -> {
+		ClientChunkLifecycleEvents.CHUNK_UNLOAD.register((level, chunk) -> {
 			for (BlockEntity blockEntity : chunk.getBlockEntities().values()) {
-				ClientBlockEntityEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(blockEntity, level);
+				ClientBlockEntityLifecycleEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(blockEntity, level);
 			}
 		});
 	}

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/ClientChunkCacheMixin.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/ClientChunkCacheMixin.java
@@ -36,7 +36,7 @@ import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.levelgen.Heightmap;
 
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientChunkEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientChunkLifecycleEvents;
 
 @Mixin(ClientChunkCache.class)
 public abstract class ClientChunkCacheMixin {
@@ -46,19 +46,19 @@ public abstract class ClientChunkCacheMixin {
 
 	@Inject(method = "replaceWithPacketData", at = @At("TAIL"))
 	private void onChunkLoad(int x, int z, FriendlyByteBuf friendlyByteBuf, Map<Heightmap.Types, long[]> highmap, Consumer<ClientboundLevelChunkPacketData.BlockEntityTagOutput> consumer, CallbackInfoReturnable<LevelChunk> info) {
-		ClientChunkEvents.CHUNK_LOAD.invoker().onChunkLoad(this.level, info.getReturnValue());
+		ClientChunkLifecycleEvents.CHUNK_LOAD.invoker().onChunkLoad(this.level, info.getReturnValue());
 	}
 
 	@Inject(method = "replaceWithPacketData", at = @At(value = "NEW", target = "net/minecraft/world/level/chunk/LevelChunk", shift = At.Shift.BEFORE))
 	private void onChunkUnload(int x, int z, FriendlyByteBuf buf, Map<Heightmap.Types, long[]> highmap, Consumer<ClientboundLevelChunkPacketData.BlockEntityTagOutput> consumer, CallbackInfoReturnable<LevelChunk> info, @Local LevelChunk levelChunk) {
 		if (levelChunk != null) {
-			ClientChunkEvents.CHUNK_UNLOAD.invoker().onChunkUnload(this.level, levelChunk);
+			ClientChunkLifecycleEvents.CHUNK_UNLOAD.invoker().onChunkUnload(this.level, levelChunk);
 		}
 	}
 
 	@Inject(method = "drop", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/multiplayer/ClientChunkCache$Storage;drop(ILnet/minecraft/world/level/chunk/LevelChunk;)V"))
 	private void onChunkUnload(ChunkPos pos, CallbackInfo ci, @Local LevelChunk chunk) {
-		ClientChunkEvents.CHUNK_UNLOAD.invoker().onChunkUnload(this.level, chunk);
+		ClientChunkLifecycleEvents.CHUNK_UNLOAD.invoker().onChunkUnload(this.level, chunk);
 	}
 
 	@Inject(
@@ -70,7 +70,7 @@ public abstract class ClientChunkCacheMixin {
 	)
 	private void onUpdateLoadDistance(int loadDistance, CallbackInfo ci, @Local ClientChunkCache.Storage clientChunkCacheStorage, @Local LevelChunk oldChunk, @Local ChunkPos chunkPos) {
 		if (!clientChunkCacheStorage.inRange(chunkPos.x, chunkPos.z)) {
-			ClientChunkEvents.CHUNK_UNLOAD.invoker().onChunkUnload(this.level, oldChunk);
+			ClientChunkLifecycleEvents.CHUNK_UNLOAD.invoker().onChunkUnload(this.level, oldChunk);
 		}
 	}
 }

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/ClientLevelEntityCallbacksMixin.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/ClientLevelEntityCallbacksMixin.java
@@ -26,7 +26,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.world.entity.Entity;
 
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientEntityEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientEntityLifecycleEvents;
 
 @Mixin(targets = "net.minecraft.client.multiplayer.ClientLevel$EntityCallbacks")
 abstract class ClientLevelEntityCallbacksMixin {
@@ -39,12 +39,12 @@ abstract class ClientLevelEntityCallbacksMixin {
 	// Call our load event after vanilla has loaded the entity
 	@Inject(method = "onTrackingStart(Lnet/minecraft/world/entity/Entity;)V", at = @At("TAIL"))
 	private void invokeLoadEntity(Entity entity, CallbackInfo ci) {
-		ClientEntityEvents.ENTITY_LOAD.invoker().onLoad(entity, this.this$0);
+		ClientEntityLifecycleEvents.ENTITY_LOAD.invoker().onLoad(entity, this.this$0);
 	}
 
 	// Call our unload event before vanilla does.
 	@Inject(method = "onTrackingEnd(Lnet/minecraft/world/entity/Entity;)V", at = @At("HEAD"))
 	private void invokeUnloadEntity(Entity entity, CallbackInfo ci) {
-		ClientEntityEvents.ENTITY_UNLOAD.invoker().onUnload(entity, this.this$0);
+		ClientEntityLifecycleEvents.ENTITY_UNLOAD.invoker().onUnload(entity, this.this$0);
 	}
 }

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/ClientPacketListenerMixin.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/ClientPacketListenerMixin.java
@@ -33,8 +33,8 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.LevelChunk;
 
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientBlockEntityEvents;
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientEntityEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientBlockEntityLifecycleEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientEntityLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.CommonLifecycleEvents;
 import net.fabricmc.fabric.impl.event.lifecycle.LoadedChunksCache;
 
@@ -52,12 +52,12 @@ abstract class ClientPacketListenerMixin {
 		// If a world already exists, we need to unload all (block)entities in the world.
 		if (this.level != null) {
 			for (Entity entity : this.level.entitiesForRendering()) {
-				ClientEntityEvents.ENTITY_UNLOAD.invoker().onUnload(entity, this.level);
+				ClientEntityLifecycleEvents.ENTITY_UNLOAD.invoker().onUnload(entity, this.level);
 			}
 
 			for (LevelChunk chunk : ((LoadedChunksCache) this.level).fabric_getLoadedChunks()) {
 				for (BlockEntity blockEntity : chunk.getBlockEntities().values()) {
-					ClientBlockEntityEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(blockEntity, this.level);
+					ClientBlockEntityLifecycleEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(blockEntity, this.level);
 				}
 			}
 		}
@@ -74,12 +74,12 @@ abstract class ClientPacketListenerMixin {
 		// If a world already exists, we need to unload all (block)entities in the world.
 		if (this.level != null) {
 			for (Entity entity : level.entitiesForRendering()) {
-				ClientEntityEvents.ENTITY_UNLOAD.invoker().onUnload(entity, this.level);
+				ClientEntityLifecycleEvents.ENTITY_UNLOAD.invoker().onUnload(entity, this.level);
 			}
 
 			for (LevelChunk chunk : ((LoadedChunksCache) this.level).fabric_getLoadedChunks()) {
 				for (BlockEntity blockEntity : chunk.getBlockEntities().values()) {
-					ClientBlockEntityEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(blockEntity, this.level);
+					ClientBlockEntityLifecycleEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(blockEntity, this.level);
 				}
 			}
 		}
@@ -91,12 +91,12 @@ abstract class ClientPacketListenerMixin {
 		// If a world already exists, we need to unload all (block)entities in the world.
 		if (this.level != null) {
 			for (Entity entity : this.level.entitiesForRendering()) {
-				ClientEntityEvents.ENTITY_UNLOAD.invoker().onUnload(entity, this.level);
+				ClientEntityLifecycleEvents.ENTITY_UNLOAD.invoker().onUnload(entity, this.level);
 			}
 
 			for (LevelChunk chunk : ((LoadedChunksCache) this.level).fabric_getLoadedChunks()) {
 				for (BlockEntity blockEntity : chunk.getBlockEntities().values()) {
-					ClientBlockEntityEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(blockEntity, this.level);
+					ClientBlockEntityLifecycleEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(blockEntity, this.level);
 				}
 			}
 		}

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/LevelChunkMixin.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/LevelChunkMixin.java
@@ -36,8 +36,8 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.LevelChunk;
 
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientBlockEntityEvents;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerBlockEntityEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientBlockEntityLifecycleEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerBlockEntityLifecycleEvents;
 
 @Mixin(LevelChunk.class)
 abstract class LevelChunkMixin {
@@ -52,9 +52,9 @@ abstract class LevelChunkMixin {
 		// Only fire the load event if the block entity has actually changed
 		if (blockEntity != null && blockEntity != removedBlockEntity) {
 			if (this.getLevel() instanceof ServerLevel) {
-				ServerBlockEntityEvents.BLOCK_ENTITY_LOAD.invoker().onLoad(blockEntity, (ServerLevel) this.getLevel());
+				ServerBlockEntityLifecycleEvents.BLOCK_ENTITY_LOAD.invoker().onLoad(blockEntity, (ServerLevel) this.getLevel());
 			} else if (this.getLevel() instanceof ClientLevel) {
-				ClientBlockEntityEvents.BLOCK_ENTITY_LOAD.invoker().onLoad(blockEntity, (ClientLevel) this.getLevel());
+				ClientBlockEntityLifecycleEvents.BLOCK_ENTITY_LOAD.invoker().onLoad(blockEntity, (ClientLevel) this.getLevel());
 			}
 		}
 
@@ -65,9 +65,9 @@ abstract class LevelChunkMixin {
 	private void onRemoveBlockEntity(BlockEntity blockEntity, CallbackInfo info, @Local(ordinal = 1) BlockEntity removedBlockEntity) {
 		if (removedBlockEntity != null) {
 			if (this.getLevel() instanceof ServerLevel) {
-				ServerBlockEntityEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(removedBlockEntity, (ServerLevel) this.getLevel());
+				ServerBlockEntityLifecycleEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(removedBlockEntity, (ServerLevel) this.getLevel());
 			} else if (this.getLevel() instanceof ClientLevel) {
-				ClientBlockEntityEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(removedBlockEntity, (ClientLevel) this.getLevel());
+				ClientBlockEntityLifecycleEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(removedBlockEntity, (ClientLevel) this.getLevel());
 			}
 		}
 	}
@@ -80,9 +80,9 @@ abstract class LevelChunkMixin {
 
 		if (removed != null) {
 			if (this.getLevel() instanceof ServerLevel) {
-				ServerBlockEntityEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload((BlockEntity) removed, (ServerLevel) this.getLevel());
+				ServerBlockEntityLifecycleEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload((BlockEntity) removed, (ServerLevel) this.getLevel());
 			} else if (this.getLevel() instanceof ClientLevel) {
-				ClientBlockEntityEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload((BlockEntity) removed, (ClientLevel) this.getLevel());
+				ClientBlockEntityLifecycleEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload((BlockEntity) removed, (ClientLevel) this.getLevel());
 			}
 		}
 
@@ -93,9 +93,9 @@ abstract class LevelChunkMixin {
 	private void onRemoveBlockEntity(BlockPos pos, CallbackInfo ci, @Local @Nullable BlockEntity removed) {
 		if (removed != null) {
 			if (this.getLevel() instanceof ServerLevel) {
-				ServerBlockEntityEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(removed, (ServerLevel) this.getLevel());
+				ServerBlockEntityLifecycleEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(removed, (ServerLevel) this.getLevel());
 			} else if (this.getLevel() instanceof ClientLevel) {
-				ClientBlockEntityEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(removed, (ClientLevel) this.getLevel());
+				ClientBlockEntityLifecycleEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(removed, (ClientLevel) this.getLevel());
 			}
 		}
 	}

--- a/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/MinecraftMixin.java
+++ b/fabric-lifecycle-events-v1/src/client/java/net/fabricmc/fabric/mixin/event/lifecycle/client/MinecraftMixin.java
@@ -24,7 +24,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLevelEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLevelLifecycleEvents;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 
@@ -55,7 +55,7 @@ public abstract class MinecraftMixin {
 	private void afterClientWorldChange(ClientLevel world, CallbackInfo ci) {
 		if (world != null) {
 			Minecraft client = (Minecraft) (Object) this;
-			ClientLevelEvents.AFTER_CLIENT_LEVEL_CHANGE.invoker().afterLevelChange(client, world);
+			ClientLevelLifecycleEvents.AFTER_CLIENT_LEVEL_CHANGE.invoker().afterLevelChange(client, world);
 		}
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerBlockEntityLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerBlockEntityLifecycleEvents.java
@@ -32,7 +32,7 @@ public final class ServerBlockEntityLifecycleEvents {
 	 * <p>When this is event is called, the block entity is already in the level.
 	 * However, its data might not be loaded yet, so don't rely on it.
 	 */
-	public static final Event<Load> BLOCK_ENTITY_LOAD = EventFactory.createArrayBacked(ServerBlockEntityLifecycleEvents.Load.class, callbacks -> (blockEntity, level) -> {
+	public static final Event<Load> BLOCK_ENTITY_LOAD = EventFactory.createArrayBacked(Load.class, callbacks -> (blockEntity, level) -> {
 		for (Load callback : callbacks) {
 			callback.onLoad(blockEntity, level);
 		}
@@ -43,7 +43,7 @@ public final class ServerBlockEntityLifecycleEvents {
 	 *
 	 * <p>When this event is called, the block entity is still present on the level.
 	 */
-	public static final Event<Unload> BLOCK_ENTITY_UNLOAD = EventFactory.createArrayBacked(ServerBlockEntityLifecycleEvents.Unload.class, callbacks -> (blockEntity, level) -> {
+	public static final Event<Unload> BLOCK_ENTITY_UNLOAD = EventFactory.createArrayBacked(Unload.class, callbacks -> (blockEntity, level) -> {
 		for (Unload callback : callbacks) {
 			callback.onUnload(blockEntity, level);
 		}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerBlockEntityLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerBlockEntityLifecycleEvents.java
@@ -32,7 +32,7 @@ public final class ServerBlockEntityLifecycleEvents {
 	 * <p>When this is event is called, the block entity is already in the level.
 	 * However, its data might not be loaded yet, so don't rely on it.
 	 */
-	public static final Event<ServerBlockEntityLifecycleEvents.Load> BLOCK_ENTITY_LOAD = EventFactory.createArrayBacked(ServerBlockEntityLifecycleEvents.Load.class, callbacks -> (blockEntity, level) -> {
+	public static final Event<Load> BLOCK_ENTITY_LOAD = EventFactory.createArrayBacked(ServerBlockEntityLifecycleEvents.Load.class, callbacks -> (blockEntity, level) -> {
 		for (Load callback : callbacks) {
 			callback.onLoad(blockEntity, level);
 		}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerBlockEntityLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerBlockEntityLifecycleEvents.java
@@ -22,8 +22,8 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
-public final class ServerBlockEntityEvents {
-	private ServerBlockEntityEvents() {
+public final class ServerBlockEntityLifecycleEvents {
+	private ServerBlockEntityLifecycleEvents() {
 	}
 
 	/**
@@ -32,7 +32,7 @@ public final class ServerBlockEntityEvents {
 	 * <p>When this is event is called, the block entity is already in the level.
 	 * However, its data might not be loaded yet, so don't rely on it.
 	 */
-	public static final Event<ServerBlockEntityEvents.Load> BLOCK_ENTITY_LOAD = EventFactory.createArrayBacked(ServerBlockEntityEvents.Load.class, callbacks -> (blockEntity, level) -> {
+	public static final Event<ServerBlockEntityLifecycleEvents.Load> BLOCK_ENTITY_LOAD = EventFactory.createArrayBacked(ServerBlockEntityLifecycleEvents.Load.class, callbacks -> (blockEntity, level) -> {
 		for (Load callback : callbacks) {
 			callback.onLoad(blockEntity, level);
 		}
@@ -43,7 +43,7 @@ public final class ServerBlockEntityEvents {
 	 *
 	 * <p>When this event is called, the block entity is still present on the level.
 	 */
-	public static final Event<Unload> BLOCK_ENTITY_UNLOAD = EventFactory.createArrayBacked(ServerBlockEntityEvents.Unload.class, callbacks -> (blockEntity, level) -> {
+	public static final Event<Unload> BLOCK_ENTITY_UNLOAD = EventFactory.createArrayBacked(ServerBlockEntityLifecycleEvents.Unload.class, callbacks -> (blockEntity, level) -> {
 		for (Unload callback : callbacks) {
 			callback.onUnload(blockEntity, level);
 		}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkLifecycleEvents.java
@@ -40,7 +40,7 @@ public final class ServerChunkLifecycleEvents {
 	 *
 	 * @see ServerChunkLifecycleEvents#CHUNK_STATUS_CHANGE
 	 */
-	public static final Event<ServerChunkLifecycleEvents.Load> CHUNK_LOAD = EventFactory.createArrayBacked(ServerChunkLifecycleEvents.Load.class, callbacks -> (serverLevel, chunk) -> {
+	public static final Event<Load> CHUNK_LOAD = EventFactory.createArrayBacked(ServerChunkLifecycleEvents.Load.class, callbacks -> (serverLevel, chunk) -> {
 		for (Load callback : callbacks) {
 			callback.onChunkLoad(serverLevel, chunk);
 		}
@@ -51,7 +51,7 @@ public final class ServerChunkLifecycleEvents {
 	 *
 	 * <p>When this event is called, the chunk is already in the level.
 	 */
-	public static final Event<ServerChunkLifecycleEvents.Generate> CHUNK_GENERATE = EventFactory.createArrayBacked(ServerChunkLifecycleEvents.Generate.class, callbacks -> (serverLevel, chunk) -> {
+	public static final Event<Generate> CHUNK_GENERATE = EventFactory.createArrayBacked(ServerChunkLifecycleEvents.Generate.class, callbacks -> (serverLevel, chunk) -> {
 		for (Generate callback : callbacks) {
 			callback.onChunkGenerate(serverLevel, chunk);
 		}
@@ -66,7 +66,7 @@ public final class ServerChunkLifecycleEvents {
 	 * (and not immediately when the chunk becomes inaccessible). To know when a chunk first becomes inaccessible, see
 	 * {@link ServerChunkLifecycleEvents#CHUNK_STATUS_CHANGE}.
 	 */
-	public static final Event<ServerChunkLifecycleEvents.Unload> CHUNK_UNLOAD = EventFactory.createArrayBacked(ServerChunkLifecycleEvents.Unload.class, callbacks -> (serverLevel, chunk) -> {
+	public static final Event<Unload> CHUNK_UNLOAD = EventFactory.createArrayBacked(ServerChunkLifecycleEvents.Unload.class, callbacks -> (serverLevel, chunk) -> {
 		for (Unload callback : callbacks) {
 			callback.onChunkUnload(serverLevel, chunk);
 		}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkLifecycleEvents.java
@@ -40,7 +40,7 @@ public final class ServerChunkLifecycleEvents {
 	 *
 	 * @see ServerChunkLifecycleEvents#CHUNK_STATUS_CHANGE
 	 */
-	public static final Event<Load> CHUNK_LOAD = EventFactory.createArrayBacked(ServerChunkLifecycleEvents.Load.class, callbacks -> (serverLevel, chunk) -> {
+	public static final Event<Load> CHUNK_LOAD = EventFactory.createArrayBacked(Load.class, callbacks -> (serverLevel, chunk) -> {
 		for (Load callback : callbacks) {
 			callback.onChunkLoad(serverLevel, chunk);
 		}
@@ -51,7 +51,7 @@ public final class ServerChunkLifecycleEvents {
 	 *
 	 * <p>When this event is called, the chunk is already in the level.
 	 */
-	public static final Event<Generate> CHUNK_GENERATE = EventFactory.createArrayBacked(ServerChunkLifecycleEvents.Generate.class, callbacks -> (serverLevel, chunk) -> {
+	public static final Event<Generate> CHUNK_GENERATE = EventFactory.createArrayBacked(Generate.class, callbacks -> (serverLevel, chunk) -> {
 		for (Generate callback : callbacks) {
 			callback.onChunkGenerate(serverLevel, chunk);
 		}
@@ -66,7 +66,7 @@ public final class ServerChunkLifecycleEvents {
 	 * (and not immediately when the chunk becomes inaccessible). To know when a chunk first becomes inaccessible, see
 	 * {@link ServerChunkLifecycleEvents#CHUNK_STATUS_CHANGE}.
 	 */
-	public static final Event<Unload> CHUNK_UNLOAD = EventFactory.createArrayBacked(ServerChunkLifecycleEvents.Unload.class, callbacks -> (serverLevel, chunk) -> {
+	public static final Event<Unload> CHUNK_UNLOAD = EventFactory.createArrayBacked(Unload.class, callbacks -> (serverLevel, chunk) -> {
 		for (Unload callback : callbacks) {
 			callback.onChunkUnload(serverLevel, chunk);
 		}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkLifecycleEvents.java
@@ -27,8 +27,8 @@ import net.minecraft.world.level.chunk.status.ChunkStatus;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
-public final class ServerChunkEvents {
-	private ServerChunkEvents() {
+public final class ServerChunkLifecycleEvents {
+	private ServerChunkLifecycleEvents() {
 	}
 
 	/**
@@ -38,9 +38,9 @@ public final class ServerChunkEvents {
 	 *
 	 * <p>Note that this event is not called for chunks that become accessible without previously being unloaded.
 	 *
-	 * @see ServerChunkEvents#CHUNK_STATUS_CHANGE
+	 * @see ServerChunkLifecycleEvents#CHUNK_STATUS_CHANGE
 	 */
-	public static final Event<ServerChunkEvents.Load> CHUNK_LOAD = EventFactory.createArrayBacked(ServerChunkEvents.Load.class, callbacks -> (serverLevel, chunk) -> {
+	public static final Event<ServerChunkLifecycleEvents.Load> CHUNK_LOAD = EventFactory.createArrayBacked(ServerChunkLifecycleEvents.Load.class, callbacks -> (serverLevel, chunk) -> {
 		for (Load callback : callbacks) {
 			callback.onChunkLoad(serverLevel, chunk);
 		}
@@ -51,7 +51,7 @@ public final class ServerChunkEvents {
 	 *
 	 * <p>When this event is called, the chunk is already in the level.
 	 */
-	public static final Event<ServerChunkEvents.Generate> CHUNK_GENERATE = EventFactory.createArrayBacked(ServerChunkEvents.Generate.class, callbacks -> (serverLevel, chunk) -> {
+	public static final Event<ServerChunkLifecycleEvents.Generate> CHUNK_GENERATE = EventFactory.createArrayBacked(ServerChunkLifecycleEvents.Generate.class, callbacks -> (serverLevel, chunk) -> {
 		for (Generate callback : callbacks) {
 			callback.onChunkGenerate(serverLevel, chunk);
 		}
@@ -64,9 +64,9 @@ public final class ServerChunkEvents {
 	 *
 	 * <p>Note that the server typically unloads chunks when the chunk's load level goes above {@link ChunkLevel#MAX_LEVEL}
 	 * (and not immediately when the chunk becomes inaccessible). To know when a chunk first becomes inaccessible, see
-	 * {@link ServerChunkEvents#CHUNK_STATUS_CHANGE}.
+	 * {@link ServerChunkLifecycleEvents#CHUNK_STATUS_CHANGE}.
 	 */
-	public static final Event<ServerChunkEvents.Unload> CHUNK_UNLOAD = EventFactory.createArrayBacked(ServerChunkEvents.Unload.class, callbacks -> (serverLevel, chunk) -> {
+	public static final Event<ServerChunkLifecycleEvents.Unload> CHUNK_UNLOAD = EventFactory.createArrayBacked(ServerChunkLifecycleEvents.Unload.class, callbacks -> (serverLevel, chunk) -> {
 		for (Unload callback : callbacks) {
 			callback.onChunkUnload(serverLevel, chunk);
 		}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerEntityLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerEntityLifecycleEvents.java
@@ -34,7 +34,7 @@ public final class ServerEntityLifecycleEvents {
 	 *
 	 * <p>When this event is called, the entity is already in the level.
 	 */
-	public static final Event<ServerEntityLifecycleEvents.Load> ENTITY_LOAD = EventFactory.createArrayBacked(ServerEntityLifecycleEvents.Load.class, callbacks -> (entity, level) -> {
+	public static final Event<Load> ENTITY_LOAD = EventFactory.createArrayBacked(ServerEntityLifecycleEvents.Load.class, callbacks -> (entity, level) -> {
 		for (Load callback : callbacks) {
 			callback.onLoad(entity, level);
 		}
@@ -45,7 +45,7 @@ public final class ServerEntityLifecycleEvents {
 	 *
 	 * <p>This event is called before the entity is removed from the level.
 	 */
-	public static final Event<ServerEntityLifecycleEvents.Unload> ENTITY_UNLOAD = EventFactory.createArrayBacked(ServerEntityLifecycleEvents.Unload.class, callbacks -> (entity, level) -> {
+	public static final Event<Unload> ENTITY_UNLOAD = EventFactory.createArrayBacked(ServerEntityLifecycleEvents.Unload.class, callbacks -> (entity, level) -> {
 		for (Unload callback : callbacks) {
 			callback.onUnload(entity, level);
 		}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerEntityLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerEntityLifecycleEvents.java
@@ -34,7 +34,7 @@ public final class ServerEntityLifecycleEvents {
 	 *
 	 * <p>When this event is called, the entity is already in the level.
 	 */
-	public static final Event<Load> ENTITY_LOAD = EventFactory.createArrayBacked(ServerEntityLifecycleEvents.Load.class, callbacks -> (entity, level) -> {
+	public static final Event<Load> ENTITY_LOAD = EventFactory.createArrayBacked(Load.class, callbacks -> (entity, level) -> {
 		for (Load callback : callbacks) {
 			callback.onLoad(entity, level);
 		}
@@ -45,7 +45,7 @@ public final class ServerEntityLifecycleEvents {
 	 *
 	 * <p>This event is called before the entity is removed from the level.
 	 */
-	public static final Event<Unload> ENTITY_UNLOAD = EventFactory.createArrayBacked(ServerEntityLifecycleEvents.Unload.class, callbacks -> (entity, level) -> {
+	public static final Event<Unload> ENTITY_UNLOAD = EventFactory.createArrayBacked(Unload.class, callbacks -> (entity, level) -> {
 		for (Unload callback : callbacks) {
 			callback.onUnload(entity, level);
 		}
@@ -57,7 +57,7 @@ public final class ServerEntityLifecycleEvents {
 	 * <p>This event is also called when the entity joins the level.
 	 * A change in equipment is determined by {@link ItemStack#matches(ItemStack, ItemStack)}.
 	 */
-	public static final Event<EquipmentChange> EQUIPMENT_CHANGE = EventFactory.createArrayBacked(ServerEntityLifecycleEvents.EquipmentChange.class, callbacks -> (livingEntity, equipmentSlot, previous, next) -> {
+	public static final Event<EquipmentChange> EQUIPMENT_CHANGE = EventFactory.createArrayBacked(EquipmentChange.class, callbacks -> (livingEntity, equipmentSlot, previous, next) -> {
 		for (EquipmentChange callback : callbacks) {
 			callback.onChange(livingEntity, equipmentSlot, previous, next);
 		}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerEntityLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerEntityLifecycleEvents.java
@@ -25,8 +25,8 @@ import net.minecraft.world.item.ItemStack;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
-public final class ServerEntityEvents {
-	private ServerEntityEvents() {
+public final class ServerEntityLifecycleEvents {
+	private ServerEntityLifecycleEvents() {
 	}
 
 	/**
@@ -34,7 +34,7 @@ public final class ServerEntityEvents {
 	 *
 	 * <p>When this event is called, the entity is already in the level.
 	 */
-	public static final Event<ServerEntityEvents.Load> ENTITY_LOAD = EventFactory.createArrayBacked(ServerEntityEvents.Load.class, callbacks -> (entity, level) -> {
+	public static final Event<ServerEntityLifecycleEvents.Load> ENTITY_LOAD = EventFactory.createArrayBacked(ServerEntityLifecycleEvents.Load.class, callbacks -> (entity, level) -> {
 		for (Load callback : callbacks) {
 			callback.onLoad(entity, level);
 		}
@@ -45,7 +45,7 @@ public final class ServerEntityEvents {
 	 *
 	 * <p>This event is called before the entity is removed from the level.
 	 */
-	public static final Event<ServerEntityEvents.Unload> ENTITY_UNLOAD = EventFactory.createArrayBacked(ServerEntityEvents.Unload.class, callbacks -> (entity, level) -> {
+	public static final Event<ServerEntityLifecycleEvents.Unload> ENTITY_UNLOAD = EventFactory.createArrayBacked(ServerEntityLifecycleEvents.Unload.class, callbacks -> (entity, level) -> {
 		for (Unload callback : callbacks) {
 			callback.onUnload(entity, level);
 		}
@@ -57,7 +57,7 @@ public final class ServerEntityEvents {
 	 * <p>This event is also called when the entity joins the level.
 	 * A change in equipment is determined by {@link ItemStack#matches(ItemStack, ItemStack)}.
 	 */
-	public static final Event<EquipmentChange> EQUIPMENT_CHANGE = EventFactory.createArrayBacked(ServerEntityEvents.EquipmentChange.class, callbacks -> (livingEntity, equipmentSlot, previous, next) -> {
+	public static final Event<EquipmentChange> EQUIPMENT_CHANGE = EventFactory.createArrayBacked(ServerEntityLifecycleEvents.EquipmentChange.class, callbacks -> (livingEntity, equipmentSlot, previous, next) -> {
 		for (EquipmentChange callback : callbacks) {
 			callback.onChange(livingEntity, equipmentSlot, previous, next);
 		}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerLevelLifecycleEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerLevelLifecycleEvents.java
@@ -23,7 +23,7 @@ import net.minecraft.world.level.saveddata.SavedData;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
-public final class ServerLevelEvents {
+public final class ServerLevelLifecycleEvents {
 	/**
 	 * Called just after a level is loaded by a Minecraft server.
 	 *
@@ -57,6 +57,6 @@ public final class ServerLevelEvents {
 		void onLevelUnload(MinecraftServer server, ServerLevel level);
 	}
 
-	private ServerLevelEvents() {
+	private ServerLevelLifecycleEvents() {
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/impl/event/lifecycle/ChunkLevelTypeEventTracker.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/impl/event/lifecycle/ChunkLevelTypeEventTracker.java
@@ -18,10 +18,10 @@ package net.fabricmc.fabric.impl.event.lifecycle;
 
 import net.minecraft.server.level.FullChunkStatus;
 
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkLifecycleEvents;
 
 /**
- * A marker interface that tracks the current {@link ServerChunkEvents#CHUNK_STATUS_CHANGE} level type.
+ * A marker interface that tracks the current {@link ServerChunkLifecycleEvents#CHUNK_STATUS_CHANGE} level type.
  */
 public interface ChunkLevelTypeEventTracker {
 	void fabric_setCurrentEventChunkStatus(FullChunkStatus levelType);

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/impl/event/lifecycle/LifecycleEventsImpl.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/impl/event/lifecycle/LifecycleEventsImpl.java
@@ -21,41 +21,41 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.LevelChunk;
 
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerBlockEntityEvents;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityEvents;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLevelEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerBlockEntityLifecycleEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkLifecycleEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityLifecycleEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLevelLifecycleEvents;
 
 public final class LifecycleEventsImpl implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		// Part of impl for block entity events
-		ServerChunkEvents.CHUNK_LOAD.register((level, chunk) -> {
+		ServerChunkLifecycleEvents.CHUNK_LOAD.register((level, chunk) -> {
 			((LoadedChunksCache) level).fabric_markLoaded(chunk);
 		});
 
-		ServerChunkEvents.CHUNK_UNLOAD.register((level, chunk) -> {
+		ServerChunkLifecycleEvents.CHUNK_UNLOAD.register((level, chunk) -> {
 			((LoadedChunksCache) level).fabric_markUnloaded(chunk);
 		});
 
 		// Fire block entity unload events.
 		// This handles the edge case where going through a portal will cause block entities to unload without warning.
-		ServerChunkEvents.CHUNK_UNLOAD.register((level, chunk) -> {
+		ServerChunkLifecycleEvents.CHUNK_UNLOAD.register((level, chunk) -> {
 			for (BlockEntity blockEntity : chunk.getBlockEntities().values()) {
-				ServerBlockEntityEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(blockEntity, level);
+				ServerBlockEntityLifecycleEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(blockEntity, level);
 			}
 		});
 
 		// We use the world unload event so worlds that are dynamically hot(un)loaded get (block) entity unload events fired when shut down.
-		ServerLevelEvents.UNLOAD.register((server, level) -> {
+		ServerLevelLifecycleEvents.UNLOAD.register((server, level) -> {
 			for (LevelChunk chunk : ((LoadedChunksCache) level).fabric_getLoadedChunks()) {
 				for (BlockEntity blockEntity : chunk.getBlockEntities().values()) {
-					ServerBlockEntityEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(blockEntity, level);
+					ServerBlockEntityLifecycleEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(blockEntity, level);
 				}
 			}
 
 			for (Entity entity : level.getAllEntities()) {
-				ServerEntityEvents.ENTITY_UNLOAD.invoker().onUnload(entity, level);
+				ServerEntityLifecycleEvents.ENTITY_UNLOAD.invoker().onUnload(entity, level);
 			}
 		});
 	}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkHolderMixin.java
@@ -42,7 +42,7 @@ import net.minecraft.world.level.LevelHeightAccessor;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.status.ChunkStatus;
 
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkLifecycleEvents;
 import net.fabricmc.fabric.impl.event.lifecycle.ChunkLevelTypeEventTracker;
 
 @Mixin(ChunkHolder.class)
@@ -70,7 +70,7 @@ public abstract class ChunkHolderMixin extends GenerationChunkHolder implements 
 	@Inject(method = "updateFutures", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ChunkHolder;addSaveDependency(Ljava/util/concurrent/CompletableFuture;)V", shift = At.Shift.AFTER, ordinal = 0))
 	private void updateFutures$inaccessibleToFull(ChunkMap chunkMap, Executor executor, CallbackInfo ci) {
 		if (this.getChunkIfPresentUnchecked(ChunkStatus.FULL) instanceof LevelChunk && this.fabric_currentEventChunkStatus == INACCESSIBLE) { // prevent duplicate events with ChunkStatusTasksMixin
-			ServerChunkEvents.CHUNK_STATUS_CHANGE.invoker().onChunkStatusChange((ServerLevel) levelHeightAccessor, (LevelChunk) this.getChunkIfPresentUnchecked(ChunkStatus.FULL), INACCESSIBLE, FULL);
+			ServerChunkLifecycleEvents.CHUNK_STATUS_CHANGE.invoker().onChunkStatusChange((ServerLevel) levelHeightAccessor, (LevelChunk) this.getChunkIfPresentUnchecked(ChunkStatus.FULL), INACCESSIBLE, FULL);
 			this.fabric_currentEventChunkStatus = FULL;
 		}
 	}
@@ -81,7 +81,7 @@ public abstract class ChunkHolderMixin extends GenerationChunkHolder implements 
 	@Inject(method = "updateFutures", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ChunkHolder;addSaveDependency(Ljava/util/concurrent/CompletableFuture;)V", shift = At.Shift.AFTER, ordinal = 1))
 	private void updateFutures$fullToBlockTicking(ChunkMap chunkMap, Executor executor, CallbackInfo ci) {
 		if (fabric_currentEventChunkStatus == FULL) { // if INACCESSIBLE->FULL did not fire immediately, then ChunkStatusTasksMixin will handle this later.
-			ServerChunkEvents.CHUNK_STATUS_CHANGE.invoker().onChunkStatusChange((ServerLevel) levelHeightAccessor, (LevelChunk) this.getChunkIfPresentUnchecked(ChunkStatus.FULL), FULL, BLOCK_TICKING);
+			ServerChunkLifecycleEvents.CHUNK_STATUS_CHANGE.invoker().onChunkStatusChange((ServerLevel) levelHeightAccessor, (LevelChunk) this.getChunkIfPresentUnchecked(ChunkStatus.FULL), FULL, BLOCK_TICKING);
 			this.fabric_currentEventChunkStatus = BLOCK_TICKING;
 		}
 	}
@@ -92,7 +92,7 @@ public abstract class ChunkHolderMixin extends GenerationChunkHolder implements 
 	@Inject(method = "updateFutures", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ChunkHolder;addSaveDependency(Ljava/util/concurrent/CompletableFuture;)V", shift = At.Shift.AFTER, ordinal = 2))
 	private void updateFutures$blockTickingToEntityTicking(ChunkMap chunkMap, Executor executor, CallbackInfo ci) {
 		if (fabric_currentEventChunkStatus == BLOCK_TICKING) { // if INACCESSIBLE->FULL->BLOCK_TICKING did not fire immediately, then ChunkStatusTasksMixin will handle this later.
-			ServerChunkEvents.CHUNK_STATUS_CHANGE.invoker().onChunkStatusChange((ServerLevel) levelHeightAccessor, (LevelChunk) this.getChunkIfPresentUnchecked(ChunkStatus.FULL), BLOCK_TICKING, ENTITY_TICKING);
+			ServerChunkLifecycleEvents.CHUNK_STATUS_CHANGE.invoker().onChunkStatusChange((ServerLevel) levelHeightAccessor, (LevelChunk) this.getChunkIfPresentUnchecked(ChunkStatus.FULL), BLOCK_TICKING, ENTITY_TICKING);
 			this.fabric_currentEventChunkStatus = ENTITY_TICKING;
 		}
 	}
@@ -109,7 +109,7 @@ public abstract class ChunkHolderMixin extends GenerationChunkHolder implements 
 			FullChunkStatus oldLevelType = fabric_CHUNK_LEVEL_TYPES[i];
 			FullChunkStatus newLevelType = fabric_CHUNK_LEVEL_TYPES[i-1];
 			if (this.fabric_currentEventChunkStatus.isOrAfter(oldLevelType)) { // if a promotion event got cancelled or never finished, then do _not_ fire an equivalent demotion event
-				ServerChunkEvents.CHUNK_STATUS_CHANGE.invoker().onChunkStatusChange(serverWorld, (LevelChunk) this.getChunkIfPresentUnchecked(ChunkStatus.FULL), oldLevelType, newLevelType);
+				ServerChunkLifecycleEvents.CHUNK_STATUS_CHANGE.invoker().onChunkStatusChange(serverWorld, (LevelChunk) this.getChunkIfPresentUnchecked(ChunkStatus.FULL), oldLevelType, newLevelType);
 				this.fabric_currentEventChunkStatus = newLevelType;
 			}
 		}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkMapMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkMapMixin.java
@@ -32,7 +32,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunk;
 
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkLifecycleEvents;
 
 @Mixin(ChunkMap.class)
 public abstract class ChunkMapMixin {
@@ -47,7 +47,7 @@ public abstract class ChunkMapMixin {
 	@Inject(method = "lambda$scheduleUnload$0", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ChunkMap;save(Lnet/minecraft/world/level/chunk/ChunkAccess;)Z"))
 	private void onChunkUnload(ChunkHolder chunkHolder, CompletableFuture<?> completableFuture, long l, CallbackInfo ci, @Local ChunkAccess chunk) {
 		if (chunk instanceof LevelChunk levelChunk) {
-			ServerChunkEvents.CHUNK_UNLOAD.invoker().onChunkUnload(this.level, levelChunk);
+			ServerChunkLifecycleEvents.CHUNK_UNLOAD.invoker().onChunkUnload(this.level, levelChunk);
 		}
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkStatusTasksMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkStatusTasksMixin.java
@@ -30,7 +30,7 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.status.ChunkStatusTasks;
 import net.minecraft.world.level.chunk.status.WorldGenContext;
 
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkLifecycleEvents;
 import net.fabricmc.fabric.impl.event.lifecycle.ChunkLevelTypeEventTracker;
 
 @Mixin(ChunkStatusTasks.class)
@@ -43,10 +43,10 @@ abstract class ChunkStatusTasksMixin {
 		LevelChunk levelChunk = (LevelChunk) callbackInfoReturnable.getReturnValue();
 
 		// We fire the event at TAIL since the chunk is guaranteed to be a LevelChunk then.
-		ServerChunkEvents.CHUNK_LOAD.invoker().onChunkLoad(worldGenContext.level(), levelChunk);
+		ServerChunkLifecycleEvents.CHUNK_LOAD.invoker().onChunkLoad(worldGenContext.level(), levelChunk);
 
 		if (!(chunk instanceof ImposterProtoChunk)) {
-			ServerChunkEvents.CHUNK_GENERATE.invoker().onChunkGenerate(worldGenContext.level(), levelChunk);
+			ServerChunkLifecycleEvents.CHUNK_GENERATE.invoker().onChunkGenerate(worldGenContext.level(), levelChunk);
 		}
 
 		// Handles the case where the chunk becomes accessible from being completed unloaded, only fires if chunkHolder has been set to at least that level type
@@ -55,7 +55,7 @@ abstract class ChunkStatusTasksMixin {
 		for (int i = levelTypeTracker.fabric_getCurrentEventChunkStatus().ordinal(); i < chunkHolder.getFullStatus().ordinal(); i++) {
 			FullChunkStatus oldLevelType = fabric_CHUNK_LEVEL_TYPES[i];
 			FullChunkStatus newLevelType = fabric_CHUNK_LEVEL_TYPES[i+1];
-			ServerChunkEvents.CHUNK_STATUS_CHANGE.invoker().onChunkStatusChange(worldGenContext.level(), levelChunk, oldLevelType, newLevelType);
+			ServerChunkLifecycleEvents.CHUNK_STATUS_CHANGE.invoker().onChunkStatusChange(worldGenContext.level(), levelChunk, oldLevelType, newLevelType);
 			levelTypeTracker.fabric_setCurrentEventChunkStatus(newLevelType);
 		}
 	}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/LivingEntityMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/LivingEntityMixin.java
@@ -29,12 +29,12 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityLifecycleEvents;
 
 @Mixin(LivingEntity.class)
 public abstract class LivingEntityMixin {
 	@Inject(method = "collectEquipmentChanges", at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"))
 	private void getEquipmentChanges(CallbackInfoReturnable<@Nullable Map<EquipmentSlot, ItemStack>> cir, @Local EquipmentSlot equipmentSlot, @Local(ordinal = 0) ItemStack previousStack, @Local(ordinal = 1) ItemStack currentStack) {
-		ServerEntityEvents.EQUIPMENT_CHANGE.invoker().onChange((LivingEntity) (Object) this, equipmentSlot, previousStack, currentStack);
+		ServerEntityLifecycleEvents.EQUIPMENT_CHANGE.invoker().onChange((LivingEntity) (Object) this, equipmentSlot, previousStack, currentStack);
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
@@ -34,7 +34,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLevelEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLevelLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 
@@ -76,14 +76,14 @@ public abstract class MinecraftServerMixin {
 	@WrapOperation(method = "createLevels", at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"))
 	private <K, V> V onLoadWorld(Map<K, V> levels, K dimension, V level, Operation<V> original) {
 		final V result = original.call(levels, dimension, level);
-		ServerLevelEvents.LOAD.invoker().onLevelLoad((MinecraftServer) (Object) this, (ServerLevel) level);
+		ServerLevelLifecycleEvents.LOAD.invoker().onLevelLoad((MinecraftServer) (Object) this, (ServerLevel) level);
 
 		return result;
 	}
 
 	@Inject(method = "stopServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerLevel;close()V"))
 	private void onUnloadWorldAtShutdown(CallbackInfo ci, @Local ServerLevel world) {
-		ServerLevelEvents.UNLOAD.invoker().onLevelUnload((MinecraftServer) (Object) this, world);
+		ServerLevelLifecycleEvents.UNLOAD.invoker().onLevelUnload((MinecraftServer) (Object) this, world);
 	}
 
 	@Inject(method = "reloadResources", at = @At("HEAD"))

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ServerWorldServerEntityHandlerMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ServerWorldServerEntityHandlerMixin.java
@@ -26,7 +26,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityLifecycleEvents;
 
 @Mixin(targets = "net.minecraft.server.level.ServerLevel$EntityCallbacks")
 abstract class ServerWorldServerEntityHandlerMixin {
@@ -37,11 +37,11 @@ abstract class ServerWorldServerEntityHandlerMixin {
 
 	@Inject(method = "onTrackingStart(Lnet/minecraft/world/entity/Entity;)V", at = @At("TAIL"))
 	private void invokeEntityLoadEvent(Entity entity, CallbackInfo ci) {
-		ServerEntityEvents.ENTITY_LOAD.invoker().onLoad(entity, this.this$0);
+		ServerEntityLifecycleEvents.ENTITY_LOAD.invoker().onLoad(entity, this.this$0);
 	}
 
 	@Inject(method = "onTrackingEnd(Lnet/minecraft/world/entity/Entity;)V", at = @At("HEAD"))
 	private void invokeEntityUnloadEvent(Entity entity, CallbackInfo info) {
-		ServerEntityEvents.ENTITY_UNLOAD.invoker().onUnload(entity, this.this$0);
+		ServerEntityLifecycleEvents.ENTITY_UNLOAD.invoker().onUnload(entity, this.this$0);
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/server/LevelChunkMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/server/LevelChunkMixin.java
@@ -35,7 +35,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.LevelChunk;
 
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerBlockEntityEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerBlockEntityLifecycleEvents;
 
 /**
  * This is a server only mixin for good reason:
@@ -55,7 +55,7 @@ abstract class LevelChunkMixin {
 		// Only fire the load event if the block entity has actually changed
 		if (blockEntity != null && blockEntity != removedBlockEntity) {
 			if (this.getLevel() instanceof ServerLevel) {
-				ServerBlockEntityEvents.BLOCK_ENTITY_LOAD.invoker().onLoad(blockEntity, (ServerLevel) this.getLevel());
+				ServerBlockEntityLifecycleEvents.BLOCK_ENTITY_LOAD.invoker().onLoad(blockEntity, (ServerLevel) this.getLevel());
 			}
 		}
 
@@ -65,7 +65,7 @@ abstract class LevelChunkMixin {
 	@Inject(method = "setBlockEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/entity/BlockEntity;setRemoved()V", shift = At.Shift.AFTER))
 	private void onRemoveBlockEntity(BlockEntity blockEntity, CallbackInfo info, @Local(ordinal = 1) BlockEntity removedBlockEntity) {
 		if (this.getLevel() instanceof ServerLevel) {
-			ServerBlockEntityEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(removedBlockEntity, (ServerLevel) this.getLevel());
+			ServerBlockEntityLifecycleEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(removedBlockEntity, (ServerLevel) this.getLevel());
 		}
 	}
 
@@ -76,7 +76,7 @@ abstract class LevelChunkMixin {
 		@Nullable final V removed = map.remove(key);
 
 		if (removed != null && this.getLevel() instanceof ServerLevel) {
-			ServerBlockEntityEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload((BlockEntity) removed, (ServerLevel) this.getLevel());
+			ServerBlockEntityLifecycleEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload((BlockEntity) removed, (ServerLevel) this.getLevel());
 		}
 
 		return removed;
@@ -85,7 +85,7 @@ abstract class LevelChunkMixin {
 	@Inject(method = "removeBlockEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/entity/BlockEntity;setRemoved()V"))
 	private void onRemoveBlockEntity(BlockPos pos, CallbackInfo ci, @Local @Nullable BlockEntity removed) {
 		if (removed != null && this.getLevel() instanceof ServerLevel) {
-			ServerBlockEntityEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(removed, (ServerLevel) this.getLevel());
+			ServerBlockEntityLifecycleEvents.BLOCK_ENTITY_UNLOAD.invoker().onUnload(removed, (ServerLevel) this.getLevel());
 		}
 	}
 }

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerBlockEntityLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerBlockEntityLifecycleTests.java
@@ -27,7 +27,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.LevelChunk;
 
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerBlockEntityEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerBlockEntityLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.impl.event.lifecycle.LoadedChunksCache;
@@ -40,7 +40,7 @@ public final class ServerBlockEntityLifecycleTests implements ModInitializer {
 	public void onInitialize() {
 		final Logger logger = ServerLifecycleTests.LOGGER;
 
-		ServerBlockEntityEvents.BLOCK_ENTITY_LOAD.register((blockEntity, level) -> {
+		ServerBlockEntityLifecycleEvents.BLOCK_ENTITY_LOAD.register((blockEntity, level) -> {
 			this.serverBlockEntities.add(blockEntity);
 
 			if (PRINT_SERVER_BLOCKENTITY_MESSAGES) {
@@ -48,7 +48,7 @@ public final class ServerBlockEntityLifecycleTests implements ModInitializer {
 			}
 		});
 
-		ServerBlockEntityEvents.BLOCK_ENTITY_UNLOAD.register((blockEntity, level) -> {
+		ServerBlockEntityLifecycleEvents.BLOCK_ENTITY_UNLOAD.register((blockEntity, level) -> {
 			this.serverBlockEntities.remove(blockEntity);
 
 			if (PRINT_SERVER_BLOCKENTITY_MESSAGES) {

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
@@ -29,7 +29,7 @@ import net.minecraft.server.level.FullChunkStatus;
 import net.minecraft.world.level.ChunkPos;
 
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 
@@ -59,7 +59,7 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 			}
 		});
 
-		ServerChunkEvents.CHUNK_GENERATE.register((level, chunk) -> {
+		ServerChunkLifecycleEvents.CHUNK_GENERATE.register((level, chunk) -> {
 			generated.mergeInt(level.dimension().identifier(), 1, Integer::sum);
 		});
 	}
@@ -74,7 +74,7 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 		final Object2ObjectMap<Identifier, Object2IntMap<FullChunkStatus>> levelsChunkLevelEvents = new Object2ObjectOpenHashMap<>();
 		final Object2ObjectMap<Identifier, Long2ObjectOpenHashMap<ChunkStatusEvent>> levelsChunkStatusTracker = new Object2ObjectOpenHashMap<>();
 
-		ServerChunkEvents.CHUNK_STATUS_CHANGE.register((level, levelChunk, oldChunkStatus, newChunkStatus) -> {
+		ServerChunkLifecycleEvents.CHUNK_STATUS_CHANGE.register((level, levelChunk, oldChunkStatus, newChunkStatus) -> {
 			final Identifier dimensionId = level.dimension().identifier();
 
 			if (!level.getServer().isSameThread()) {

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerEntityLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerEntityLifecycleTests.java
@@ -26,7 +26,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 
@@ -42,7 +42,7 @@ public final class ServerEntityLifecycleTests implements ModInitializer {
 	public void onInitialize() {
 		final Logger logger = ServerLifecycleTests.LOGGER;
 
-		ServerEntityEvents.ENTITY_LOAD.register((entity, level) -> {
+		ServerEntityLifecycleEvents.ENTITY_LOAD.register((entity, level) -> {
 			this.serverEntities.add(entity);
 
 			if (PRINT_SERVER_ENTITY_MESSAGES) {
@@ -50,7 +50,7 @@ public final class ServerEntityLifecycleTests implements ModInitializer {
 			}
 		});
 
-		ServerEntityEvents.ENTITY_UNLOAD.register((entity, level) -> {
+		ServerEntityLifecycleEvents.ENTITY_UNLOAD.register((entity, level) -> {
 			this.serverEntities.remove(entity);
 
 			if (PRINT_SERVER_ENTITY_MESSAGES) {
@@ -58,7 +58,7 @@ public final class ServerEntityLifecycleTests implements ModInitializer {
 			}
 		});
 
-		ServerEntityEvents.EQUIPMENT_CHANGE.register((livingEntity, equipmentSlot, previousStack, currentStack) -> {
+		ServerEntityLifecycleEvents.EQUIPMENT_CHANGE.register((livingEntity, equipmentSlot, previousStack, currentStack) -> {
 			if (PRINT_SERVER_ENTITY_MESSAGES) {
 				logger.info("[SERVER] Entity equipment change: Entity: {}, Slot {}, Previous: {}, Current {} ", livingEntity, equipmentSlot.name(), previousStack, currentStack);
 			}

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerLifecycleTests.java
@@ -20,7 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLevelEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLevelLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 
 /**
@@ -43,11 +43,11 @@ public final class ServerLifecycleTests implements ModInitializer {
 			LOGGER.info("Stopped Server!");
 		});
 
-		ServerLevelEvents.LOAD.register((server, level) -> {
+		ServerLevelLifecycleEvents.LOAD.register((server, level) -> {
 			LOGGER.info("Loaded level " + level.dimension().identifier().toString());
 		});
 
-		ServerLevelEvents.UNLOAD.register((server, level) -> {
+		ServerLevelLifecycleEvents.UNLOAD.register((server, level) -> {
 			LOGGER.info("Unloaded level " + level.dimension().identifier().toString());
 		});
 

--- a/fabric-lifecycle-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientBlockEntityLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientBlockEntityLifecycleTests.java
@@ -26,7 +26,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.LevelChunk;
 
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientBlockEntityEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientBlockEntityLifecycleEvents;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.impl.event.lifecycle.LoadedChunksCache;
@@ -41,7 +41,7 @@ public final class ClientBlockEntityLifecycleTests implements ClientModInitializ
 	public void onInitializeClient() {
 		final Logger logger = ServerLifecycleTests.LOGGER;
 
-		ClientBlockEntityEvents.BLOCK_ENTITY_LOAD.register((blockEntity, level) -> {
+		ClientBlockEntityLifecycleEvents.BLOCK_ENTITY_LOAD.register((blockEntity, level) -> {
 			this.clientBlockEntities.add(blockEntity);
 
 			if (PRINT_CLIENT_BLOCKENTITY_MESSAGES) {
@@ -49,7 +49,7 @@ public final class ClientBlockEntityLifecycleTests implements ClientModInitializ
 			}
 		});
 
-		ClientBlockEntityEvents.BLOCK_ENTITY_UNLOAD.register((blockEntity, level) -> {
+		ClientBlockEntityLifecycleEvents.BLOCK_ENTITY_UNLOAD.register((blockEntity, level) -> {
 			this.clientBlockEntities.remove(blockEntity);
 
 			if (PRINT_CLIENT_BLOCKENTITY_MESSAGES) {

--- a/fabric-lifecycle-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientEntityLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientEntityLifecycleTests.java
@@ -26,7 +26,7 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.entity.Entity;
 
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientEntityEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientEntityLifecycleEvents;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.test.event.lifecycle.ServerLifecycleTests;
@@ -43,7 +43,7 @@ public final class ClientEntityLifecycleTests implements ClientModInitializer {
 	public void onInitializeClient() {
 		final Logger logger = ServerLifecycleTests.LOGGER;
 
-		ClientEntityEvents.ENTITY_LOAD.register((entity, level) -> {
+		ClientEntityLifecycleEvents.ENTITY_LOAD.register((entity, level) -> {
 			this.clientEntities.add(entity);
 
 			if (PRINT_CLIENT_ENTITY_MESSAGES) {
@@ -51,7 +51,7 @@ public final class ClientEntityLifecycleTests implements ClientModInitializer {
 			}
 		});
 
-		ClientEntityEvents.ENTITY_UNLOAD.register((entity, level) -> {
+		ClientEntityLifecycleEvents.ENTITY_UNLOAD.register((entity, level) -> {
 			this.clientEntities.remove(entity);
 
 			if (PRINT_CLIENT_ENTITY_MESSAGES) {

--- a/fabric-lifecycle-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmodClient/java/net/fabricmc/fabric/test/event/lifecycle/client/ClientLifecycleTests.java
@@ -20,7 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLevelEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLevelLifecycleEvents;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 
 public final class ClientLifecycleTests implements ClientModInitializer {
@@ -50,7 +50,7 @@ public final class ClientLifecycleTests implements ClientModInitializer {
 			System.out.println("Client has started stopping!");
 		});
 
-		ClientLevelEvents.AFTER_CLIENT_LEVEL_CHANGE.register((client, level) -> {
+		ClientLevelLifecycleEvents.AFTER_CLIENT_LEVEL_CHANGE.register((client, level) -> {
 			LOGGER.info("Client level changed to {}", level.dimension().identifier());
 		});
 	}

--- a/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/common/NetworkingCommonTest.java
+++ b/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/common/NetworkingCommonTest.java
@@ -29,7 +29,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
 
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.api.networking.v1.ServerConfigurationConnectionEvents;
@@ -63,7 +63,7 @@ public class NetworkingCommonTest implements ModInitializer {
 		AtomicReference<String> uuid = new AtomicReference<>();
 
 		// Ensure that the packets were received on the server
-		ServerEntityEvents.ENTITY_LOAD.register((entity, level) -> {
+		ServerEntityLifecycleEvents.ENTITY_LOAD.register((entity, level) -> {
 			if (!firstLoad) {
 				// No need to check again if the player changes dimensions
 				return;


### PR DESCRIPTION
This does not relate to the Great Big Renaming of everything, however this is the best time to do it.

Names like `ClientEntityEvents` in the `fabric-lifecycle-events-v1` module sound too generic and confusing, so I changed them by adding the "Lifecycle" suffix, just like other classes of this module.

The rest of the commits do a little code cleanup like:
```patch
class XXXEvents {
- Event<XXXEvents.XXXCallback> XXX_EVENT = createArrayBacked(XXXEvents.XXXCallback.class, ...;
+ Event<XXXCallback> XXX_EVENT = createArrayBacked(XXXCallback.class, ...;

  interface XXXCallback {}
}
```
Since the affected lines are modified anyway, no unnecessary changes.

`ClientBlockEntityEvents` ->`ClientBlockEntityLifecycleEvents`
`ServerBlockEntityEvents` -> `ServerBlockEntityLifecycleEvents`
`ClientChunkEvents` ->`ClientChunkLifecycleEvents`
`ServerChunkEvents` -> `ServerChunkLifecycleEvents`
`ClientEntityEvents` ->`ClientEntityLifecycleEvents`
`ServerEntityEvents` -> `ServerEntityLifecycleEvents`
`ClientLevelEvents` ->`ClientLevelLifecycleEvents`
`ServerLevelEvents` -> `ServerLevelLifecycleEvents`
`ClientLifecycleEvents` -> same
`ServerLifecycleEvents` -> same
`ClientTickEvents` -> same
`ServerTickEvents` -> same