### PR TITLE
Fix attachments being dropped when partitioned

### DIFF
--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/sync/AttachmentChange.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/sync/AttachmentChange.java
@@ -106,8 +106,8 @@ public record AttachmentChange(AttachmentTargetInfo<?> targetInfo, AttachmentTyp
 
 			int size = MAX_PADDING_SIZE_IN_BYTES + change.data.length;
 
-			if (byteSize + size > MAX_DATA_SIZE_IN_BYTES) {
-				ServerPlayNetworking.send(player, new AttachmentSyncPayloadS2C(packetChanges));
+			if (!packetChanges.isEmpty() && byteSize + size > MAX_DATA_SIZE_IN_BYTES) {
+				ServerPlayNetworking.send(player, new AttachmentSyncPayloadS2C(List.copyOf(packetChanges)));
 				packetChanges.clear();
 				byteSize = maxVarIntSize;
 			}


### PR DESCRIPTION
Packets are not serialized immediately, but rather in the netty event loop. Therefore, care should be taken not to mutate the packet after creation.

List.copyOf is used to ensure that the subsequent packetChanges.clear() doesn't clear all the changes in the packet