### PR TITLE
Add generated info to `ServerChunkEvents#CHUNK_LOAD`

### DIFF
--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerChunkEvents.java
@@ -40,9 +40,9 @@ public final class ServerChunkEvents {
 	 *
 	 * @see ServerChunkEvents#FULL_CHUNK_STATUS_CHANGE
 	 */
-	public static final Event<ServerChunkEvents.Load> CHUNK_LOAD = EventFactory.createArrayBacked(ServerChunkEvents.Load.class, callbacks -> (serverLevel, chunk) -> {
+	public static final Event<ServerChunkEvents.Load> CHUNK_LOAD = EventFactory.createArrayBacked(ServerChunkEvents.Load.class, callbacks -> (serverLevel, chunk, generated) -> {
 		for (Load callback : callbacks) {
-			callback.onChunkLoad(serverLevel, chunk);
+			callback.onChunkLoad(serverLevel, chunk, generated);
 		}
 	});
 
@@ -50,7 +50,10 @@ public final class ServerChunkEvents {
 	 * Called when a newly generated chunk is loaded into a ServerLevel.
 	 *
 	 * <p>When this event is called, the chunk is already in the level.
+	 *
+	 * @deprecated use {@link ServerChunkEvents#CHUNK_LOAD} directly instead
 	 */
+	@Deprecated
 	public static final Event<ServerChunkEvents.Generate> CHUNK_GENERATE = EventFactory.createArrayBacked(ServerChunkEvents.Generate.class, callbacks -> (serverLevel, chunk) -> {
 		for (Generate callback : callbacks) {
 			callback.onChunkGenerate(serverLevel, chunk);
@@ -91,7 +94,7 @@ public final class ServerChunkEvents {
 
 	@FunctionalInterface
 	public interface Load {
-		void onChunkLoad(ServerLevel level, LevelChunk chunk);
+		void onChunkLoad(ServerLevel level, LevelChunk chunk, boolean generated);
 	}
 
 	@FunctionalInterface

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/impl/event/lifecycle/LifecycleEventsImpl.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/impl/event/lifecycle/LifecycleEventsImpl.java
@@ -30,7 +30,7 @@ public final class LifecycleEventsImpl implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		// Part of impl for block entity events
-		ServerChunkEvents.CHUNK_LOAD.register((level, chunk) -> {
+		ServerChunkEvents.CHUNK_LOAD.register((level, chunk, generated) -> {
 			((LoadedChunksCache) level).fabric_markLoaded(chunk);
 		});
 

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkStatusTasksMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/ChunkStatusTasksMixin.java
@@ -42,10 +42,12 @@ abstract class ChunkStatusTasksMixin {
 	private static void onChunkLoad(ChunkAccess chunk, WorldGenContext worldGenContext, GenerationChunkHolder chunkHolder, CallbackInfoReturnable<ChunkAccess> callbackInfoReturnable) {
 		LevelChunk levelChunk = (LevelChunk) callbackInfoReturnable.getReturnValue();
 
-		// We fire the event at TAIL since the chunk is guaranteed to be a LevelChunk then.
-		ServerChunkEvents.CHUNK_LOAD.invoker().onChunkLoad(worldGenContext.level(), levelChunk);
+		boolean generated = !(chunk instanceof ImposterProtoChunk);
 
-		if (!(chunk instanceof ImposterProtoChunk)) {
+		// We fire the event at TAIL since the chunk is guaranteed to be a LevelChunk then.
+		ServerChunkEvents.CHUNK_LOAD.invoker().onChunkLoad(worldGenContext.level(), levelChunk, generated);
+
+		if (generated) {
 			ServerChunkEvents.CHUNK_GENERATE.invoker().onChunkGenerate(worldGenContext.level(), levelChunk);
 		}
 

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerChunkLifecycleTests.java
@@ -49,18 +49,31 @@ public final class ServerChunkLifecycleTests implements ModInitializer {
 	 * Moving to an unexplored area will start logging again.
 	 */
 	private static void setupChunkGenerateTest() {
+		final Object2IntMap<Identifier> generatedDeprecated = new Object2IntOpenHashMap<>();
 		final Object2IntMap<Identifier> generated = new Object2IntOpenHashMap<>();
 
 		ServerTickEvents.END_LEVEL_TICK.register(level -> {
-			final int count = generated.removeInt(level.dimension().identifier());
+			Identifier dimensionId = level.dimension().identifier();
+			final int countDeprecated = generatedDeprecated.removeInt(dimensionId);
+			final int count = generated.removeInt(dimensionId);
+
+			if (count != countDeprecated) {
+				throw new AssertionError("count (" + count + ") != countDeprecated (" + countDeprecated + ") in setupChunkGenerateTest for " + dimensionId);
+			}
 
 			if (count > 0) {
-				LOGGER.info("Loaded {} freshly generated chunks in {} during tick #{}", count, level.dimension().identifier(), level.getServer().getTickCount());
+				LOGGER.info("Loaded {} freshly generated chunks in {} during tick #{}", count, dimensionId, level.getServer().getTickCount());
 			}
 		});
 
 		ServerChunkEvents.CHUNK_GENERATE.register((level, chunk) -> {
-			generated.mergeInt(level.dimension().identifier(), 1, Integer::sum);
+			generatedDeprecated.mergeInt(level.dimension().identifier(), 1, Integer::sum);
+		});
+
+		ServerChunkEvents.CHUNK_LOAD.register((level, chunk, generated1) -> {
+			if (generated1) {
+				generated.mergeInt(level.dimension().identifier(), 1, Integer::sum);
+			}
 		});
 	}
 


### PR DESCRIPTION
The `ServerChunkEvents#CHUNK_GENERATE` added earlier in #4183 did not consider the use cases of listening to loaded but not newly generated chunks. 

This PR addresses this by merging two events into the original `ServerChunkEvents#CHUNK_LOAD` event, which also brings this event in line with what most other platform is doing. 

