### PR TITLE
Provide (BlockBehaviour/Item).Properties#getId and getIdOrThrow

### DIFF
--- a/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/api/block/v1/FabricBlock.java
+++ b/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/api/block/v1/FabricBlock.java
@@ -16,13 +16,17 @@
 
 package net.fabricmc.fabric.api.block.v1;
 
+import java.util.Objects;
+
 import org.jspecify.annotations.Nullable;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 
 /**
@@ -100,5 +104,30 @@ public interface FabricBlock {
 	 */
 	default BlockState getAppearance(BlockState state, BlockAndTintGetter blockAndTintGetter, BlockPos pos, Direction side, @Nullable BlockState sourceState, @Nullable BlockPos sourcePos) {
 		return state;
+	}
+
+	/**
+	 * Fabric-provided extensions for {@link BlockBehaviour.Properties}.
+	 * This interface is automatically implemented on all block properties via Mixin and interface injection.
+	 */
+	interface Properties {
+		/**
+		 * Return the id of block that was defined by {@link BlockBehaviour.Properties#setId}.
+		 *
+		 * @return currently stored block id or null, if not set
+		 */
+		default @Nullable ResourceKey<Block> getId() {
+			throw new AssertionError("Implemented in Mixin");
+		}
+
+		/**
+		 * Return the id of block that was defined by {@link BlockBehaviour.Properties#setId}.
+		 *
+		 * @return currently stored block id
+		 * @throws NullPointerException if id is not set
+		 */
+		default ResourceKey<Block> getIdOrThrow() {
+			return Objects.requireNonNull(this.getId(), "Block id not set");
+		}
 	}
 }

--- a/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/api/block/v1/FabricBlock.java
+++ b/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/api/block/v1/FabricBlock.java
@@ -110,7 +110,7 @@ public interface FabricBlock {
 	 * Fabric-provided extensions for {@link BlockBehaviour.Properties}.
 	 * This interface is automatically implemented on all block properties via Mixin and interface injection.
 	 */
-	interface Properties {
+	interface FabricProperties {
 		/**
 		 * Return the id of block that was defined by {@link BlockBehaviour.Properties#setId}.
 		 *

--- a/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/mixin/block/BlockBehaviourPropertiesMixin.java
+++ b/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/mixin/block/BlockBehaviourPropertiesMixin.java
@@ -14,39 +14,25 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.mixin.item;
+package net.fabricmc.fabric.mixin.block;
 
 import org.jspecify.annotations.Nullable;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Shadow;
 
-import net.minecraft.resources.DependantName;
-import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockBehaviour;
 
-import net.fabricmc.fabric.api.item.v1.FabricItem;
+import net.fabricmc.fabric.api.block.v1.FabricBlock;
 
-@Mixin(Item.Properties.class)
-public class ItemPropertiesMixin implements FabricItem.Properties {
-	@Final
+@Mixin(BlockBehaviour.Properties.class)
+public class BlockBehaviourPropertiesMixin implements FabricBlock.Properties {
 	@Shadow
-	@Mutable
-	private DependantName<Item, Identifier> model;
-
-	@Shadow
-	private @Nullable ResourceKey<Item> id;
+	private @Nullable ResourceKey<Block> id;
 
 	@Override
-	public Item.Properties modelId(Identifier modelId) {
-		this.model = DependantName.fixed(modelId);
-		return FabricItem.Properties.super.modelId(modelId);
-	}
-
-	@Override
-	public @Nullable ResourceKey<Item> getId() {
+	public @Nullable ResourceKey<Block> getId() {
 		return this.id;
 	}
 }

--- a/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/mixin/block/BlockBehaviourPropertiesMixin.java
+++ b/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/mixin/block/BlockBehaviourPropertiesMixin.java
@@ -27,7 +27,7 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.fabricmc.fabric.api.block.v1.FabricBlock;
 
 @Mixin(BlockBehaviour.Properties.class)
-public class BlockBehaviourPropertiesMixin implements FabricBlock.Properties {
+public class BlockBehaviourPropertiesMixin implements FabricBlock.FabricProperties {
 	@Shadow
 	private @Nullable ResourceKey<Block> id;
 

--- a/fabric-block-api-v1/src/main/resources/fabric-block-api-v1.mixins.json
+++ b/fabric-block-api-v1/src/main/resources/fabric-block-api-v1.mixins.json
@@ -3,6 +3,7 @@
   "package": "net.fabricmc.fabric.mixin.block",
   "compatibilityLevel": "JAVA_25",
   "mixins": [
+    "BlockBehaviourPropertiesMixin",
     "BlockMixin",
     "BlockStateMixin",
     "ChunkSectionBlockStateCounterMixin",

--- a/fabric-block-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-block-api-v1/src/main/resources/fabric.mod.json
@@ -28,7 +28,7 @@
     "fabric-api:module-lifecycle": "stable",
     "loom:injected_interfaces": {
       "net/minecraft/world/level/block/Block": ["net/fabricmc/fabric/api/block/v1/FabricBlock"],
-      "net/minecraft/world/level/block/state/BlockBehaviour$Properties": ["net/fabricmc/fabric/api/block/v1/FabricBlock$Properties"],
+      "net/minecraft/world/level/block/state/BlockBehaviour\u0024Properties": ["net/fabricmc/fabric/api/block/v1/FabricBlock\u0024FabricProperties"],
       "net/minecraft/world/level/block/state/BlockState": ["net/fabricmc/fabric/api/block/v1/FabricBlockState"]
     }
   }

--- a/fabric-block-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-block-api-v1/src/main/resources/fabric.mod.json
@@ -28,6 +28,7 @@
     "fabric-api:module-lifecycle": "stable",
     "loom:injected_interfaces": {
       "net/minecraft/world/level/block/Block": ["net/fabricmc/fabric/api/block/v1/FabricBlock"],
+      "net/minecraft/world/level/block/state/BlockBehaviour$Properties": ["net/fabricmc/fabric/api/block/v1/FabricBlock$Properties"],
       "net/minecraft/world/level/block/state/BlockState": ["net/fabricmc/fabric/api/block/v1/FabricBlockState"]
     }
   }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
@@ -16,12 +16,16 @@
 
 package net.fabricmc.fabric.api.item.v1;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+
+import org.jspecify.annotations.Nullable;
 
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
@@ -194,6 +198,25 @@ public interface FabricItem {
 		 */
 		default Item.Properties modelId(Identifier modelId) {
 			return (Item.Properties) this;
+		}
+
+		/**
+		 * Return the id of item that was defined by {@link Item.Properties#setId}.
+		 *
+		 * @return currently stored item id or null, if not set
+		 */
+		default @Nullable ResourceKey<Item> getId() {
+			throw new AssertionError("Implemented in Mixin");
+		}
+
+		/**
+		 * Return the id of item that was defined by {@link Item.Properties#setId}.
+		 *
+		 * @return currently stored item id
+		 * @throws NullPointerException if id is not set
+		 */
+		default ResourceKey<Item> getIdOrThrow() {
+			return Objects.requireNonNull(this.getId(), "Item id not set");
 		}
 	}
 }


### PR DESCRIPTION
Pretty simple change. This add methods allowing to get the block/item id out of Properties objects.
The getId returns nullable value, while getIdOrThrow throws when it's null.

It can be useful to avoid having to additionally pass block/item id to the constructor, which can happen if you need to derive some values out of it.