### PR TITLE
Allow registering large payloads with deferred max packet size

### DIFF
--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/PayloadTypeRegistry.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/PayloadTypeRegistry.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.networking.v1;
 
+import java.util.function.IntSupplier;
+
 import org.jetbrains.annotations.ApiStatus;
 
 import net.minecraft.network.FriendlyByteBuf;
@@ -61,24 +63,25 @@ public interface PayloadTypeRegistry<B extends FriendlyByteBuf> {
 	<T extends CustomPacketPayload> CustomPacketPayload.TypeAndCodec<? super B, T> registerLarge(CustomPacketPayload.Type<T> type, StreamCodec<? super B, T> codec, int maxPacketSize);
 
 	/**
-	 * Sets the maximum size of an <strong>already registered</strong> payload type.
+	 * Registers a large custom payload type.
 	 *
-	 * <p>Larger payloads will be split into multiple packets, allowing to send packets larger than the vanilla limited size.
+	 * <p>This must be done on both the sending and receiving side, usually during mod initialization
+	 * and <strong>before registering a packet handler</strong>.
+	 *
+	 * <p>Payload types registered with this method will be split into multiple packets,
+	 * allowing to send packets larger than the vanilla limited size.
+	 *
+	 * <p>The {@code maxPacketSizeSupplier} will be called once, right before the first packet of this payload type
+	 * is sent/received on either side. This allows mods some leeway particularly during mod initialization to
+	 * dynamically determine a suitable max size.
 	 *
 	 * @param type		    the payload type
-	 * @param maxPacketSize the maximum size of payload packet
+	 * @param codec         the codec for the payload type
+	 * @param maxPacketSizeSupplier the function that returns the max size of payload packet
 	 * @param <T>           the payload type
+	 * @return the registered payload type
 	 */
-	<T extends CustomPacketPayload> void setMaxPacketSize(CustomPacketPayload.Type<T> type, int maxPacketSize);
-
-	/**
-	 * Returns the maximum size of an <strong>already registered</strong> payload type.
-	 *
-	 * @param type		    the payload type
-	 * @param <T>           the payload class
-	 * @return the maximum size of payload packet
-	 */
-	<T extends CustomPacketPayload> int getMaxPacketSize(CustomPacketPayload.Type<T> type);
+	<T extends CustomPacketPayload> CustomPacketPayload.TypeAndCodec<? super B, T> registerLarge(CustomPacketPayload.Type<T> type, StreamCodec<? super B, T> codec, IntSupplier maxPacketSizeSupplier);
 
 	/**
 	 * @return the {@link PayloadTypeRegistry} instance for the serverbound (client to server) configuration channel.

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/PayloadTypeRegistry.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/PayloadTypeRegistry.java
@@ -16,8 +16,6 @@
 
 package net.fabricmc.fabric.api.networking.v1;
 
-import net.minecraft.resources.Identifier;
-
 import org.jetbrains.annotations.ApiStatus;
 
 import net.minecraft.network.FriendlyByteBuf;
@@ -52,7 +50,7 @@ public interface PayloadTypeRegistry<B extends FriendlyByteBuf> {
 	 * and <strong>before registering a packet handler</strong>.
 	 *
 	 * <p>Payload types registered with this method will be split into multiple packets,
-	 * allowing to send packets larger than vanilla limited size.
+	 * allowing to send packets larger than the vanilla limited size.
 	 *
 	 * @param type          the payload type
 	 * @param codec         the codec for the payload type
@@ -63,22 +61,24 @@ public interface PayloadTypeRegistry<B extends FriendlyByteBuf> {
 	<T extends CustomPacketPayload> CustomPacketPayload.TypeAndCodec<? super B, T> registerLarge(CustomPacketPayload.Type<T> type, StreamCodec<? super B, T> codec, int maxPacketSize);
 
 	/**
-	 * Modifies the maximum size of an <strong>already registered</strong> large payload type via {@link PayloadTypeRegistry#registerLarge(CustomPacketPayload.Type, StreamCodec, int)}.
+	 * Sets the maximum size of an <strong>already registered</strong> payload type.
+	 *
+	 * <p>Larger payloads will be split into multiple packets, allowing to send packets larger than the vanilla limited size.
 	 *
 	 * @param type		    the payload type
 	 * @param maxPacketSize the maximum size of payload packet
 	 * @param <T>           the payload type
 	 */
-	<T extends CustomPacketPayload> void modifyLargePayloadMaxSize(CustomPacketPayload.Type<T> type, int maxPacketSize);
+	<T extends CustomPacketPayload> void setMaxPacketSize(CustomPacketPayload.Type<T> type, int maxPacketSize);
 
 	/**
 	 * Returns the maximum size of an <strong>already registered</strong> payload type.
 	 *
 	 * @param type		    the payload type
-	 * @param <T>           the payload type
+	 * @param <T>           the payload class
 	 * @return the maximum size of payload packet
 	 */
-	<T extends CustomPacketPayload> int getPayloadMaxSize(CustomPacketPayload.Type<T> type);
+	<T extends CustomPacketPayload> int getMaxPacketSize(CustomPacketPayload.Type<T> type);
 
 	/**
 	 * @return the {@link PayloadTypeRegistry} instance for the serverbound (client to server) configuration channel.

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/PayloadTypeRegistry.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/PayloadTypeRegistry.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.api.networking.v1;
 
+import net.minecraft.resources.Identifier;
+
 import org.jetbrains.annotations.ApiStatus;
 
 import net.minecraft.network.FriendlyByteBuf;
@@ -59,6 +61,24 @@ public interface PayloadTypeRegistry<B extends FriendlyByteBuf> {
 	 * @return the registered payload type
 	 */
 	<T extends CustomPacketPayload> CustomPacketPayload.TypeAndCodec<? super B, T> registerLarge(CustomPacketPayload.Type<T> type, StreamCodec<? super B, T> codec, int maxPacketSize);
+
+	/**
+	 * Modifies the maximum size of an <strong>already registered</strong> large payload type via {@link PayloadTypeRegistry#registerLarge(CustomPacketPayload.Type, StreamCodec, int)}.
+	 *
+	 * @param type		    the payload type
+	 * @param maxPacketSize the maximum size of payload packet
+	 * @param <T>           the payload type
+	 */
+	<T extends CustomPacketPayload> void modifyLargePayloadMaxSize(CustomPacketPayload.Type<T> type, int maxPacketSize);
+
+	/**
+	 * Returns the maximum size of an <strong>already registered</strong> payload type.
+	 *
+	 * @param type		    the payload type
+	 * @param <T>           the payload type
+	 * @return the maximum size of payload packet
+	 */
+	<T extends CustomPacketPayload> int getPayloadMaxSize(CustomPacketPayload.Type<T> type);
 
 	/**
 	 * @return the {@link PayloadTypeRegistry} instance for the serverbound (client to server) configuration channel.

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/PayloadTypeRegistryImpl.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/PayloadTypeRegistryImpl.java
@@ -107,7 +107,13 @@ public class PayloadTypeRegistryImpl<B extends FriendlyByteBuf> implements Paylo
 
 	@Override
 	public <T extends CustomPacketPayload> int getMaxPacketSize(CustomPacketPayload.Type<T> type) {
-		return this.maxPacketSizes.getOrDefault(type.id(), this.minimalSplittableSize);
+		Identifier id = type.id();
+
+		if (!this.packetTypes.containsKey(id)) {
+			throw new IllegalArgumentException("Packet type " + id + " has not been registered yet!");
+		}
+
+		return this.maxPacketSizes.getOrDefault(id, this.minimalSplittableSize);
 	}
 
 	private void padAndSetMaxPacketSize(Identifier id, int maxSize) {
@@ -122,7 +128,7 @@ public class PayloadTypeRegistryImpl<B extends FriendlyByteBuf> implements Paylo
 		}
 
 		// No need to enable splitting, if packet's max size is smaller than chunk
-		// If requested maxPacketSize <= previous max without padding, then ignore it.
+		// If maxPacketSize <= previous max, then ignore it.
 		if (maxPacketSize > Math.max(this.minimalSplittableSize, this.maxPacketSizes.getOrDefault(id, -1))) {
 			this.maxPacketSizes.put(id, maxPacketSize);
 		}

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/PayloadTypeRegistryImpl.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/PayloadTypeRegistryImpl.java
@@ -66,7 +66,7 @@ public class PayloadTypeRegistryImpl<B extends FriendlyByteBuf> implements Paylo
 
 	@Override
 	public <T extends CustomPacketPayload> CustomPacketPayload.TypeAndCodec<? super B, T> register(CustomPacketPayload.Type<T> type, StreamCodec<? super B, T> codec) {
-		Objects.requireNonNull(type, "id");
+		Objects.requireNonNull(type, "type");
 		Objects.requireNonNull(codec, "codec");
 
 		final CustomPacketPayload.TypeAndCodec<B, T> payloadType = new CustomPacketPayload.TypeAndCodec<>(type, codec.cast());
@@ -86,8 +86,33 @@ public class PayloadTypeRegistryImpl<B extends FriendlyByteBuf> implements Paylo
 		}
 
 		CustomPacketPayload.TypeAndCodec<? super B, T> typeAndCodec = register(type, codec);
+		setMaxPacketSize(type.id(), maxPayloadSize);
+		return typeAndCodec;
+	}
+
+	@Override
+	public <T extends CustomPacketPayload> void modifyLargePayloadMaxSize(CustomPacketPayload.Type<T> type, int maxPayloadSize) {
+		Identifier id = type.id();
+
+		if (!this.maxPacketSize.containsKey(id)) {
+			throw new IllegalArgumentException("Packet type " + id + " is not registered as a large payload!");
+		}
+
+		if (maxPayloadSize < 0) {
+			throw new IllegalArgumentException("Provided maxPayloadSize needs to be positive!");
+		}
+
+		setMaxPacketSize(id, maxPayloadSize);
+	}
+
+	@Override
+	public <T extends CustomPacketPayload> int getPayloadMaxSize(CustomPacketPayload.Type<T> type) {
+		return this.maxPacketSize.getOrDefault(type.id(), this.minimalSplittableSize);
+	}
+
+	private void setMaxPacketSize(Identifier id, int maxPayloadSize) {
 		// Defines max packet size, increased by length of packet's Identifier to cover full size of CustomPayloadX2YPackets.
-		int identifierSize = ByteBufUtil.utf8MaxBytes(type.id().toString());
+		int identifierSize = ByteBufUtil.utf8MaxBytes(id.toString());
 		int maxPacketSize = maxPayloadSize + VarInt.getByteSize(identifierSize) + identifierSize + 5 * 2;
 
 		// Prevent overflow
@@ -97,19 +122,19 @@ public class PayloadTypeRegistryImpl<B extends FriendlyByteBuf> implements Paylo
 
 		// No need to enable splitting, if packet's max size is smaller than chunk
 		if (maxPacketSize > this.minimalSplittableSize) {
-			this.maxPacketSize.put(type.id(), maxPacketSize);
+			this.maxPacketSize.put(id, maxPacketSize);
+		} else {
+			this.maxPacketSize.put(id, -1); // To indicate packet was registered as large, but currently does not require splitting
 		}
-
-		return typeAndCodec;
 	}
 
 	public CustomPacketPayload.@Nullable TypeAndCodec<B, ? extends CustomPacketPayload> get(Identifier id) {
 		return packetTypes.get(id);
 	}
 
-	public <T extends CustomPacketPayload> CustomPacketPayload.@Nullable TypeAndCodec<B, T> get(CustomPacketPayload.Type<T> id) {
+	public <T extends CustomPacketPayload> CustomPacketPayload.@Nullable TypeAndCodec<B, T> get(CustomPacketPayload.Type<T> type) {
 		//noinspection unchecked
-		return (CustomPacketPayload.TypeAndCodec<B, T>) packetTypes.get(id.id());
+		return (CustomPacketPayload.TypeAndCodec<B, T>) packetTypes.get(type.id());
 	}
 
 	public int getMaxPacketSize(Identifier id) {

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/PayloadTypeRegistryImpl.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/PayloadTypeRegistryImpl.java
@@ -123,7 +123,7 @@ public class PayloadTypeRegistryImpl<B extends FriendlyByteBuf> implements Paylo
 
 		// No need to enable splitting, if packet's max size is smaller than chunk
 		// If requested maxPacketSize <= previous max without padding, then ignore it.
-		if (maxPacketSize > Math.max(this.minimalSplittableSize, this.maxPacketSizes.getOrDefault(id, -1) - paddingSize)) {
+		if (maxPacketSize > Math.max(this.minimalSplittableSize, this.maxPacketSizes.getOrDefault(id, -1))) {
 			this.maxPacketSizes.put(id, maxPacketSize);
 		}
 	}

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/PayloadTypeRegistryImpl.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/PayloadTypeRegistryImpl.java
@@ -44,7 +44,7 @@ public class PayloadTypeRegistryImpl<B extends FriendlyByteBuf> implements Paylo
 	public static final PayloadTypeRegistryImpl<RegistryFriendlyByteBuf> SERVERBOUND_PLAY = new PayloadTypeRegistryImpl<>(ConnectionProtocol.PLAY, PacketFlow.SERVERBOUND);
 	public static final PayloadTypeRegistryImpl<RegistryFriendlyByteBuf> CLIENTBOUND_PLAY = new PayloadTypeRegistryImpl<>(ConnectionProtocol.PLAY, PacketFlow.CLIENTBOUND);
 	private final Map<Identifier, CustomPacketPayload.TypeAndCodec<B, ? extends CustomPacketPayload>> packetTypes = new HashMap<>();
-	private final Object2IntMap<Identifier> maxPacketSize = new Object2IntOpenHashMap<>();
+	private final Object2IntMap<Identifier> maxPacketSizes = new Object2IntOpenHashMap<>();
 	private final ConnectionProtocol protocol;
 	private final PacketFlow flow;
 	private final int minimalSplittableSize;
@@ -80,40 +80,41 @@ public class PayloadTypeRegistryImpl<B extends FriendlyByteBuf> implements Paylo
 	}
 
 	@Override
-	public <T extends CustomPacketPayload> CustomPacketPayload.TypeAndCodec<? super B, T> registerLarge(CustomPacketPayload.Type<T> type, StreamCodec<? super B, T> codec, int maxPayloadSize) {
-		if (maxPayloadSize < 0) {
-			throw new IllegalArgumentException("Provided maxPayloadSize needs to be positive!");
+	public <T extends CustomPacketPayload> CustomPacketPayload.TypeAndCodec<? super B, T> registerLarge(CustomPacketPayload.Type<T> type, StreamCodec<? super B, T> codec, int maxPacketSize) {
+		if (maxPacketSize < 0) {
+			throw new IllegalArgumentException("Provided maxPacketSize needs to be positive!");
 		}
 
 		CustomPacketPayload.TypeAndCodec<? super B, T> typeAndCodec = register(type, codec);
-		setMaxPacketSize(type.id(), maxPayloadSize);
+		padAndSetMaxPacketSize(type.id(), maxPacketSize);
 		return typeAndCodec;
 	}
 
 	@Override
-	public <T extends CustomPacketPayload> void modifyLargePayloadMaxSize(CustomPacketPayload.Type<T> type, int maxPayloadSize) {
+	public <T extends CustomPacketPayload> void setMaxPacketSize(CustomPacketPayload.Type<T> type, int maxPacketSize) {
 		Identifier id = type.id();
 
-		if (!this.maxPacketSize.containsKey(id)) {
-			throw new IllegalArgumentException("Packet type " + id + " is not registered as a large payload!");
+		if (!this.packetTypes.containsKey(id)) {
+			throw new IllegalArgumentException("Packet type " + id + " has not been registered yet!");
 		}
 
-		if (maxPayloadSize < 0) {
-			throw new IllegalArgumentException("Provided maxPayloadSize needs to be positive!");
+		if (maxPacketSize < 0) {
+			throw new IllegalArgumentException("Provided maxPacketSize needs to be positive!");
 		}
 
-		setMaxPacketSize(id, maxPayloadSize);
+		padAndSetMaxPacketSize(id, maxPacketSize);
 	}
 
 	@Override
-	public <T extends CustomPacketPayload> int getPayloadMaxSize(CustomPacketPayload.Type<T> type) {
-		return this.maxPacketSize.getOrDefault(type.id(), this.minimalSplittableSize);
+	public <T extends CustomPacketPayload> int getMaxPacketSize(CustomPacketPayload.Type<T> type) {
+		return this.maxPacketSizes.getOrDefault(type.id(), this.minimalSplittableSize);
 	}
 
-	private void setMaxPacketSize(Identifier id, int maxPayloadSize) {
+	private void padAndSetMaxPacketSize(Identifier id, int maxSize) {
 		// Defines max packet size, increased by length of packet's Identifier to cover full size of CustomPayloadX2YPackets.
 		int identifierSize = ByteBufUtil.utf8MaxBytes(id.toString());
-		int maxPacketSize = maxPayloadSize + VarInt.getByteSize(identifierSize) + identifierSize + 5 * 2;
+		int paddingSize = VarInt.getByteSize(identifierSize) + identifierSize + 5 * 2;
+		int maxPacketSize = maxSize + paddingSize;
 
 		// Prevent overflow
 		if (maxPacketSize < 0) {
@@ -121,10 +122,9 @@ public class PayloadTypeRegistryImpl<B extends FriendlyByteBuf> implements Paylo
 		}
 
 		// No need to enable splitting, if packet's max size is smaller than chunk
-		if (maxPacketSize > this.minimalSplittableSize) {
-			this.maxPacketSize.put(id, maxPacketSize);
-		} else {
-			this.maxPacketSize.put(id, -1); // To indicate packet was registered as large, but currently does not require splitting
+		// If requested maxPacketSize <= previous max without padding, then ignore it.
+		if (maxPacketSize > Math.max(this.minimalSplittableSize, this.maxPacketSizes.getOrDefault(id, -1) - paddingSize)) {
+			this.maxPacketSizes.put(id, maxPacketSize);
 		}
 	}
 
@@ -137,8 +137,11 @@ public class PayloadTypeRegistryImpl<B extends FriendlyByteBuf> implements Paylo
 		return (CustomPacketPayload.TypeAndCodec<B, T>) packetTypes.get(type.id());
 	}
 
-	public int getMaxPacketSize(Identifier id) {
-		return this.maxPacketSize.getOrDefault(id, -1);
+	/**
+	 * @return the max packet size, or -1 if the payload type does not need splitting.
+	 */
+	public int getMaxPacketSizeForSplitting(Identifier id) {
+		return this.maxPacketSizes.getOrDefault(id, -1);
 	}
 
 	public ConnectionProtocol getProtocol() {

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/PayloadTypeRegistryImpl.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/PayloadTypeRegistryImpl.java
@@ -19,10 +19,13 @@ package net.fabricmc.fabric.impl.networking;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.IntSupplier;
 
 import io.netty.buffer.ByteBufUtil;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.jspecify.annotations.Nullable;
 
 import net.minecraft.network.ConnectionProtocol;
@@ -45,6 +48,7 @@ public class PayloadTypeRegistryImpl<B extends FriendlyByteBuf> implements Paylo
 	public static final PayloadTypeRegistryImpl<RegistryFriendlyByteBuf> CLIENTBOUND_PLAY = new PayloadTypeRegistryImpl<>(ConnectionProtocol.PLAY, PacketFlow.CLIENTBOUND);
 	private final Map<Identifier, CustomPacketPayload.TypeAndCodec<B, ? extends CustomPacketPayload>> packetTypes = new HashMap<>();
 	private final Object2IntMap<Identifier> maxPacketSizes = new Object2IntOpenHashMap<>();
+	private final Object2ObjectMap<Identifier, IntSupplier> pendingMaxPacketSizes = new Object2ObjectOpenHashMap<>();
 	private final ConnectionProtocol protocol;
 	private final PacketFlow flow;
 	private final int minimalSplittableSize;
@@ -91,29 +95,12 @@ public class PayloadTypeRegistryImpl<B extends FriendlyByteBuf> implements Paylo
 	}
 
 	@Override
-	public <T extends CustomPacketPayload> void setMaxPacketSize(CustomPacketPayload.Type<T> type, int maxPacketSize) {
-		Identifier id = type.id();
+	public <T extends CustomPacketPayload> CustomPacketPayload.TypeAndCodec<? super B, T> registerLarge(CustomPacketPayload.Type<T> type, StreamCodec<? super B, T> codec, IntSupplier maxPacketSizeSupplier) {
+		Objects.requireNonNull(maxPacketSizeSupplier, "maxPacketSizeSupplier");
 
-		if (!this.packetTypes.containsKey(id)) {
-			throw new IllegalArgumentException("Packet type " + id + " has not been registered yet!");
-		}
-
-		if (maxPacketSize < 0) {
-			throw new IllegalArgumentException("Provided maxPacketSize needs to be positive!");
-		}
-
-		padAndSetMaxPacketSize(id, maxPacketSize);
-	}
-
-	@Override
-	public <T extends CustomPacketPayload> int getMaxPacketSize(CustomPacketPayload.Type<T> type) {
-		Identifier id = type.id();
-
-		if (!this.packetTypes.containsKey(id)) {
-			throw new IllegalArgumentException("Packet type " + id + " has not been registered yet!");
-		}
-
-		return this.maxPacketSizes.getOrDefault(id, this.minimalSplittableSize);
+		CustomPacketPayload.TypeAndCodec<? super B, T> typeAndCodec = register(type, codec);
+		pendingMaxPacketSizes.put(type.id(), maxPacketSizeSupplier);
+		return typeAndCodec;
 	}
 
 	private void padAndSetMaxPacketSize(Identifier id, int maxSize) {
@@ -128,8 +115,7 @@ public class PayloadTypeRegistryImpl<B extends FriendlyByteBuf> implements Paylo
 		}
 
 		// No need to enable splitting, if packet's max size is smaller than chunk
-		// If maxPacketSize <= previous max, then ignore it.
-		if (maxPacketSize > Math.max(this.minimalSplittableSize, this.maxPacketSizes.getOrDefault(id, -1))) {
+		if (maxPacketSize > this.minimalSplittableSize) {
 			this.maxPacketSizes.put(id, maxPacketSize);
 		}
 	}
@@ -147,6 +133,18 @@ public class PayloadTypeRegistryImpl<B extends FriendlyByteBuf> implements Paylo
 	 * @return the max packet size, or -1 if the payload type does not need splitting.
 	 */
 	public int getMaxPacketSizeForSplitting(Identifier id) {
+		IntSupplier supplier = this.pendingMaxPacketSizes.remove(id);
+
+		if (supplier != null) {
+			int maxPacketSize = supplier.getAsInt();
+
+			if (maxPacketSize < 0) {
+				throw new IllegalArgumentException("maxPacketSize supplier for packet type " + id + ": must be positive!");
+			}
+
+			padAndSetMaxPacketSize(id, maxPacketSize);
+		}
+
 		return this.maxPacketSizes.getOrDefault(id, -1);
 	}
 

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/splitter/FabricPacketMerger.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/splitter/FabricPacketMerger.java
@@ -82,7 +82,7 @@ public class FabricPacketMerger extends MessageToMessageDecoder<Packet<?>> {
 			Identifier payloadId = Identifier.STREAM_CODEC.decode(payload.byteBuf());
 
 			buf.readerIndex(readerIndex);
-			int maxSize = payloadTypeRegistry.getMaxPacketSize(payloadId);
+			int maxSize = payloadTypeRegistry.getMaxPacketSizeForSplitting(payloadId);
 
 			if (maxSize == -1) {
 				throw new DecoderException("Received '" + payloadId + "' packet doesn't support splitting, but received split data!");

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/ClientboundCustomPayloadPacketMixin.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/ClientboundCustomPayloadPacketMixin.java
@@ -79,7 +79,7 @@ public class ClientboundCustomPayloadPacketMixin implements SplittablePacket, Ge
 
 	@Override
 	public void fabric_split(PayloadTypeRegistryImpl<?> payloadTypeRegistry, ChannelHandlerContext channelHandlerContext, PacketEncoder<?> encoder, Packet<?> packet, Consumer<Packet<?>> consumer) throws Exception {
-		int size = payloadTypeRegistry.getMaxPacketSize(this.payload.type().id());
+		int size = payloadTypeRegistry.getMaxPacketSizeForSplitting(this.payload.type().id());
 
 		if (size == -1) {
 			consumer.accept((Packet<?>) this);

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/ServerboundCustomPayloadPacketMixin.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/ServerboundCustomPayloadPacketMixin.java
@@ -70,7 +70,7 @@ public class ServerboundCustomPayloadPacketMixin implements SplittablePacket, Ge
 
 	@Override
 	public void fabric_split(PayloadTypeRegistryImpl<?> payloadTypeRegistry, ChannelHandlerContext channelHandlerContext, PacketEncoder<?> encoder, Packet<?> packet, Consumer<Packet<?>> consumer) throws Exception {
-		int size = payloadTypeRegistry.getMaxPacketSize(this.payload.type().id());
+		int size = payloadTypeRegistry.getMaxPacketSizeForSplitting(this.payload.type().id());
 
 		if (size == -1) {
 			consumer.accept((Packet<?>) this);

--- a/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/splitter/NetworkingSplitterTest.java
+++ b/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/splitter/NetworkingSplitterTest.java
@@ -19,6 +19,8 @@ package net.fabricmc.fabric.test.networking.splitter;
 import java.util.Arrays;
 import java.util.stream.IntStream;
 
+import net.fabricmc.fabric.api.networking.v1.PacketSender;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,19 +38,21 @@ import net.fabricmc.fabric.test.networking.NetworkingTestmods;
 public class NetworkingSplitterTest implements ModInitializer {
 	private static final Logger LOGGER = LoggerFactory.getLogger(NetworkingSplitterTest.class);
 
-	private static final int DATA_SIZE = 20 * 1024 * 1024;
+	private static final int DATA_SIZE_1 = 20 * 1024 * 1024;
+	private static final int DATA_SIZE_2 = 50 * 1024 * 1024;
 
 	// 20 MB of random data source
 	private static final int[][] RANDOM_DATA = {
 			IntStream.generate(RandomSource.create(24534)::nextInt).limit(20).toArray(),
-			IntStream.generate(RandomSource.create(24533)::nextInt).limit(DATA_SIZE / 4).toArray()
+			IntStream.generate(RandomSource.create(24533)::nextInt).limit(DATA_SIZE_1 / 4).toArray(),
+			IntStream.generate(RandomSource.create(24532)::nextInt).limit(DATA_SIZE_2 / 4).toArray()
 	};
 
 	@Override
 	public void onInitialize() {
 		// Register the payload on both sides for play and configuration
-		PayloadTypeRegistry.clientboundPlay().registerLarge(LargePayload.TYPE, LargePayload.CODEC, DATA_SIZE + 14);
-		PayloadTypeRegistry.serverboundPlay().registerLarge(LargePayload.TYPE, LargePayload.CODEC, DATA_SIZE + 14);
+		PayloadTypeRegistry.clientboundPlay().registerLarge(LargePayload.TYPE, LargePayload.CODEC, DATA_SIZE_1 + 14);
+		PayloadTypeRegistry.serverboundPlay().registerLarge(LargePayload.TYPE, LargePayload.CODEC, DATA_SIZE_1 + 14);
 
 		// When the client joins, send a packet expecting it to be validated and echoed back
 		ServerPlayConnectionEvents.JOIN.register((listener, sender, server) -> sender.sendPacket(new LargePayload(0, RANDOM_DATA[0])));
@@ -56,13 +60,21 @@ public class NetworkingSplitterTest implements ModInitializer {
 
 		// Validate received packet
 		ServerPlayNetworking.registerGlobalReceiver(LargePayload.TYPE, (payload, context) -> {
-			validateLargePacketData(payload.index(), payload.data(), "server");
+			validateLargePacketData(payload.index(), payload.data(), "server", context.responseSender());
 		});
 	}
 
-	public static void validateLargePacketData(int index, int[] data, String side) {
+	public static void validateLargePacketData(int index, int[] data, String side, PacketSender sender) {
 		if (Arrays.equals(RANDOM_DATA[index], data)) {
-			NetworkingTestmods.LOGGER.info("Successfully received large packet [" + index + "] on " + side);
+			LOGGER.info("Successfully received large packet [" + index + "] on " + side);
+
+			if (side.equals("server") && index == 1) {
+				LOGGER.info("Increasing max large packet size to 50MB");
+				PayloadTypeRegistry.clientboundPlay().modifyLargePayloadMaxSize(LargePayload.TYPE, DATA_SIZE_2 + 14);
+				PayloadTypeRegistry.serverboundPlay().modifyLargePayloadMaxSize(LargePayload.TYPE, DATA_SIZE_2 + 14);
+				sender.sendPacket(new LargePayload(2, RANDOM_DATA[2]));
+			}
+
 			return;
 		}
 

--- a/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/splitter/NetworkingSplitterTest.java
+++ b/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/splitter/NetworkingSplitterTest.java
@@ -36,21 +36,19 @@ import net.fabricmc.fabric.test.networking.NetworkingTestmods;
 public class NetworkingSplitterTest implements ModInitializer {
 	public static final Logger LOGGER = LoggerFactory.getLogger(NetworkingSplitterTest.class);
 
-	public static final int DATA_SIZE_1 = 20 * 1024 * 1024;
-	public static final int DATA_SIZE_2 = 50 * 1024 * 1024;
+	public static final int DATA_SIZE = 20 * 1024 * 1024;
 
-	// 20 and 50 MB of random data source
+	// 20 MiB of random data source
 	private static final int[][] RANDOM_DATA = {
 			IntStream.generate(RandomSource.create(24534)::nextInt).limit(20).toArray(),
-			IntStream.generate(RandomSource.create(24533)::nextInt).limit(DATA_SIZE_1 / 4).toArray(),
-			IntStream.generate(RandomSource.create(24532)::nextInt).limit(DATA_SIZE_2 / 4).toArray()
+			IntStream.generate(RandomSource.create(24533)::nextInt).limit(DATA_SIZE / 4).toArray()
 	};
 
 	@Override
 	public void onInitialize() {
 		// Register the payload on both sides for play and configuration
-		PayloadTypeRegistry.clientboundPlay().registerLarge(LargePayload.TYPE, LargePayload.CODEC, DATA_SIZE_1 + 14);
-		PayloadTypeRegistry.serverboundPlay().registerLarge(LargePayload.TYPE, LargePayload.CODEC, DATA_SIZE_1 + 14);
+		PayloadTypeRegistry.clientboundPlay().registerLarge(LargePayload.TYPE, LargePayload.CODEC, DATA_SIZE + 14);
+		PayloadTypeRegistry.serverboundPlay().registerLarge(LargePayload.TYPE, LargePayload.CODEC, () -> DATA_SIZE + 14);
 
 		// When the client joins, send a packet expecting it to be validated and echoed back
 		ServerPlayConnectionEvents.JOIN.register((listener, sender, server) -> sender.sendPacket(new LargePayload(0, RANDOM_DATA[0])));
@@ -59,14 +57,6 @@ public class NetworkingSplitterTest implements ModInitializer {
 		// Validate received packet
 		ServerPlayNetworking.registerGlobalReceiver(LargePayload.TYPE, (payload, context) -> {
 			validateLargePacketData(payload.index(), payload.data(), "server");
-
-			// After validating 20 MB packet, try 50 MB.
-			if (payload.index() == 1) {
-				LOGGER.info("Increasing max size of LargePayload to 50MB on server");
-				PayloadTypeRegistry.clientboundPlay().setMaxPacketSize(LargePayload.TYPE, DATA_SIZE_2 + 14);
-				PayloadTypeRegistry.serverboundPlay().setMaxPacketSize(LargePayload.TYPE, DATA_SIZE_2 + 14);
-				context.responseSender().sendPacket(new LargePayload(2, RANDOM_DATA[2]));
-			}
 		});
 	}
 

--- a/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/splitter/NetworkingSplitterTest.java
+++ b/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/splitter/NetworkingSplitterTest.java
@@ -34,10 +34,10 @@ import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.test.networking.NetworkingTestmods;
 
 public class NetworkingSplitterTest implements ModInitializer {
-	private static final Logger LOGGER = LoggerFactory.getLogger(NetworkingSplitterTest.class);
+	public static final Logger LOGGER = LoggerFactory.getLogger(NetworkingSplitterTest.class);
 
-	private static final int DATA_SIZE_1 = 20 * 1024 * 1024;
-	private static final int DATA_SIZE_2 = 50 * 1024 * 1024;
+	public static final int DATA_SIZE_1 = 20 * 1024 * 1024;
+	public static final int DATA_SIZE_2 = 50 * 1024 * 1024;
 
 	// 20 and 50 MB of random data source
 	private static final int[][] RANDOM_DATA = {
@@ -62,7 +62,7 @@ public class NetworkingSplitterTest implements ModInitializer {
 
 			// After validating 20 MB packet, try 50 MB.
 			if (payload.index() == 1) {
-				LOGGER.info("Increasing max size of LargePayload to 50MB");
+				LOGGER.info("Increasing max size of LargePayload to 50MB on server");
 				PayloadTypeRegistry.clientboundPlay().setMaxPacketSize(LargePayload.TYPE, DATA_SIZE_2 + 14);
 				PayloadTypeRegistry.serverboundPlay().setMaxPacketSize(LargePayload.TYPE, DATA_SIZE_2 + 14);
 				context.responseSender().sendPacket(new LargePayload(2, RANDOM_DATA[2]));

--- a/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/splitter/NetworkingSplitterTest.java
+++ b/fabric-networking-api-v1/src/testmod/java/net/fabricmc/fabric/test/networking/splitter/NetworkingSplitterTest.java
@@ -19,8 +19,6 @@ package net.fabricmc.fabric.test.networking.splitter;
 import java.util.Arrays;
 import java.util.stream.IntStream;
 
-import net.fabricmc.fabric.api.networking.v1.PacketSender;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +39,7 @@ public class NetworkingSplitterTest implements ModInitializer {
 	private static final int DATA_SIZE_1 = 20 * 1024 * 1024;
 	private static final int DATA_SIZE_2 = 50 * 1024 * 1024;
 
-	// 20 MB of random data source
+	// 20 and 50 MB of random data source
 	private static final int[][] RANDOM_DATA = {
 			IntStream.generate(RandomSource.create(24534)::nextInt).limit(20).toArray(),
 			IntStream.generate(RandomSource.create(24533)::nextInt).limit(DATA_SIZE_1 / 4).toArray(),
@@ -60,21 +58,21 @@ public class NetworkingSplitterTest implements ModInitializer {
 
 		// Validate received packet
 		ServerPlayNetworking.registerGlobalReceiver(LargePayload.TYPE, (payload, context) -> {
-			validateLargePacketData(payload.index(), payload.data(), "server", context.responseSender());
+			validateLargePacketData(payload.index(), payload.data(), "server");
+
+			// After validating 20 MB packet, try 50 MB.
+			if (payload.index() == 1) {
+				LOGGER.info("Increasing max size of LargePayload to 50MB");
+				PayloadTypeRegistry.clientboundPlay().setMaxPacketSize(LargePayload.TYPE, DATA_SIZE_2 + 14);
+				PayloadTypeRegistry.serverboundPlay().setMaxPacketSize(LargePayload.TYPE, DATA_SIZE_2 + 14);
+				context.responseSender().sendPacket(new LargePayload(2, RANDOM_DATA[2]));
+			}
 		});
 	}
 
-	public static void validateLargePacketData(int index, int[] data, String side, PacketSender sender) {
+	public static void validateLargePacketData(int index, int[] data, String side) {
 		if (Arrays.equals(RANDOM_DATA[index], data)) {
-			LOGGER.info("Successfully received large packet [" + index + "] on " + side);
-
-			if (side.equals("server") && index == 1) {
-				LOGGER.info("Increasing max large packet size to 50MB");
-				PayloadTypeRegistry.clientboundPlay().modifyLargePayloadMaxSize(LargePayload.TYPE, DATA_SIZE_2 + 14);
-				PayloadTypeRegistry.serverboundPlay().modifyLargePayloadMaxSize(LargePayload.TYPE, DATA_SIZE_2 + 14);
-				sender.sendPacket(new LargePayload(2, RANDOM_DATA[2]));
-			}
-
+			LOGGER.info("Successfully received large packet [{}] on {}", index, side);
 			return;
 		}
 

--- a/fabric-networking-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/networking/client/splitter/NetworkingSplitterClientTest.java
+++ b/fabric-networking-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/networking/client/splitter/NetworkingSplitterClientTest.java
@@ -18,6 +18,7 @@ package net.fabricmc.fabric.test.networking.client.splitter;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.test.networking.splitter.NetworkingSplitterTest;
 
 public class NetworkingSplitterClientTest implements ClientModInitializer {
@@ -26,6 +27,13 @@ public class NetworkingSplitterClientTest implements ClientModInitializer {
 		ClientPlayNetworking.registerGlobalReceiver(NetworkingSplitterTest.LargePayload.TYPE, (payload, context) -> {
 			NetworkingSplitterTest.validateLargePacketData(payload.index(), payload.data(), "client");
 			context.responseSender().sendPacket(payload);
+
+			// After validating 20 MB packet, try 50 MB.
+			if (payload.index() == 1) {
+				NetworkingSplitterTest.LOGGER.info("Increasing max size of LargePayload to 50MB on client");
+				PayloadTypeRegistry.clientboundPlay().setMaxPacketSize(NetworkingSplitterTest.LargePayload.TYPE, NetworkingSplitterTest.DATA_SIZE_2 + 14);
+				PayloadTypeRegistry.serverboundPlay().setMaxPacketSize(NetworkingSplitterTest.LargePayload.TYPE, NetworkingSplitterTest.DATA_SIZE_2 + 14);
+			}
 		});
 	}
 }

--- a/fabric-networking-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/networking/client/splitter/NetworkingSplitterClientTest.java
+++ b/fabric-networking-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/networking/client/splitter/NetworkingSplitterClientTest.java
@@ -24,7 +24,7 @@ public class NetworkingSplitterClientTest implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
 		ClientPlayNetworking.registerGlobalReceiver(NetworkingSplitterTest.LargePayload.TYPE, (payload, context) -> {
-			NetworkingSplitterTest.validateLargePacketData(payload.index(), payload.data(), "client", context.responseSender());
+			NetworkingSplitterTest.validateLargePacketData(payload.index(), payload.data(), "client");
 			context.responseSender().sendPacket(payload);
 		});
 	}

--- a/fabric-networking-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/networking/client/splitter/NetworkingSplitterClientTest.java
+++ b/fabric-networking-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/networking/client/splitter/NetworkingSplitterClientTest.java
@@ -18,7 +18,6 @@ package net.fabricmc.fabric.test.networking.client.splitter;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
-import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.test.networking.splitter.NetworkingSplitterTest;
 
 public class NetworkingSplitterClientTest implements ClientModInitializer {
@@ -27,13 +26,6 @@ public class NetworkingSplitterClientTest implements ClientModInitializer {
 		ClientPlayNetworking.registerGlobalReceiver(NetworkingSplitterTest.LargePayload.TYPE, (payload, context) -> {
 			NetworkingSplitterTest.validateLargePacketData(payload.index(), payload.data(), "client");
 			context.responseSender().sendPacket(payload);
-
-			// After validating 20 MB packet, try 50 MB.
-			if (payload.index() == 1) {
-				NetworkingSplitterTest.LOGGER.info("Increasing max size of LargePayload to 50MB on client");
-				PayloadTypeRegistry.clientboundPlay().setMaxPacketSize(NetworkingSplitterTest.LargePayload.TYPE, NetworkingSplitterTest.DATA_SIZE_2 + 14);
-				PayloadTypeRegistry.serverboundPlay().setMaxPacketSize(NetworkingSplitterTest.LargePayload.TYPE, NetworkingSplitterTest.DATA_SIZE_2 + 14);
-			}
 		});
 	}
 }

--- a/fabric-networking-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/networking/client/splitter/NetworkingSplitterClientTest.java
+++ b/fabric-networking-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/networking/client/splitter/NetworkingSplitterClientTest.java
@@ -24,7 +24,7 @@ public class NetworkingSplitterClientTest implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
 		ClientPlayNetworking.registerGlobalReceiver(NetworkingSplitterTest.LargePayload.TYPE, (payload, context) -> {
-			NetworkingSplitterTest.validateLargePacketData(payload.index(), payload.data(), "client");
+			NetworkingSplitterTest.validateLargePacketData(payload.index(), payload.data(), "client", context.responseSender());
 			context.responseSender().sendPacket(payload);
 		});
 	}


### PR DESCRIPTION
~~Adds to the `PayloadTypeRegistry` API to allow modifying and querying the max packet size for a payload type.~~

Adds a `registerLarge` overload to `PayloadTypeRegistry` that takes an `IntSupplier`, allowing mods to defer setting the max packet size.

Partially supersedes #4996 