### PR TITLE
Fix crash when removing none existent mob effect from entity.

### DIFF
--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/effect/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/effect/LivingEntityMixin.java
@@ -137,7 +137,12 @@ public abstract class LivingEntityMixin extends Entity {
 			return original.call(holder);
 		}
 
-		MobEffectInstance effectInstance = (this.self()).getEffect(holder);
+		MobEffectInstance effectInstance = this.self().getEffect(holder);
+
+		if (effectInstance == null) {
+			return original.call(holder);
+		}
+
 		boolean cannotRemove = !ServerMobEffectEvents.ALLOW_EARLY_REMOVE.invoker()
 				.allowEarlyRemove(effectInstance, this.self(), MobEffectUtil.getCommandContext());
 
@@ -157,8 +162,14 @@ public abstract class LivingEntityMixin extends Entity {
 			return;
 		}
 
+		MobEffectInstance effectInstance = this.self().getEffect(holder);
+
+		if (effectInstance == null) {
+			return;
+		}
+
 		ServerMobEffectEvents.BEFORE_REMOVE.invoker()
-				.beforeRemove((this.self()).getEffect(holder), (LivingEntity) (Object) this, MobEffectUtil.getCommandContext());
+				.beforeRemove(effectInstance, (LivingEntity) (Object) this, MobEffectUtil.getCommandContext());
 	}
 
 	@Inject(

--- a/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/gametest/ServerMobEffectsGameTest.java
+++ b/fabric-entity-events-v1/src/testmod/java/net/fabricmc/fabric/test/entity/event/gametest/ServerMobEffectsGameTest.java
@@ -128,6 +128,26 @@ public class ServerMobEffectsGameTest {
 		obj.contextRef = null;
 	}
 
+	// Regression test for https://github.com/FabricMC/fabric-api/issues/5121
+	@GameTest
+	public void removeNoneExistentEffect(GameTestHelper context) {
+		var obj = new Object() { // Scoped events at home
+			GameTestHelper contextRef = context;
+		};
+		ServerMobEffectEvents.BEFORE_REMOVE.register((effectInstance, entity, ctx) -> {
+			if (!isThisTheSalmon(entity) || obj.contextRef == null) return;
+			obj.contextRef.fail("The BEFORE_REMOVE event must not be called when removing a non-existent effect");
+		});
+		ServerMobEffectEvents.AFTER_REMOVE.register((effectInstance, entity, ctx) -> {
+			if (!isThisTheSalmon(entity) || obj.contextRef == null) return;
+			obj.contextRef.fail("The AFTER_REMOVE event must not be called when removing a non-existent effect");
+		});
+		Salmon theSalmon = summonTheSalmon(context);
+		theSalmon.removeEffect(MobEffects.SATURATION);
+		context.succeed();
+		obj.contextRef = null;
+	}
+
 	private static Salmon summonTheSalmon(GameTestHelper context) {
 		Salmon theSalmon = context.spawnWithNoFreeWill(EntityType.SALMON, context.relativeVec(new Vec3(0.0, 1.0, 0.0)));
 		theSalmon.setItemInHand(InteractionHand.MAIN_HAND, new ItemStack(Items.POTATO));


### PR DESCRIPTION
Fixed by not invoking the events.