### PR TITLE
use =~ instead of ==~ for package-info regex

### DIFF
--- a/gradle/package-info.gradle
+++ b/gradle/package-info.gradle
@@ -83,7 +83,7 @@ abstract class GeneratePackageInfos extends DefaultTask {
 			}
 
 			def implPattern = /^(net[\/\\]fabricmc[\/\\]fabric[\/\\](impl|mixin))/
-			def isImpl = relativePath.toString() ==~ implPattern
+			def isImpl = relativePath.toString() =~ implPattern
 
 			target.resolve('package-info.java').withWriter {
 				if (isImpl) {


### PR DESCRIPTION
Noticed that all the generated package-info's had `API code for ...`, even the impl/mixin ones. 

`==~` only matches if the entire string matches, while `=~` matches substrings.