### PR TITLE
Handle id changes for queued synced attachments.

### DIFF
--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentTargetImpl.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/AttachmentTargetImpl.java
@@ -84,6 +84,13 @@ public interface AttachmentTargetImpl extends AttachmentTarget {
 		throw new UnsupportedOperationException("Implemented via mixin");
 	}
 
+	/**
+	 * Sync targets can change their identity {@link net.minecraft.world.entity.Entity#setId(int)}, use this function to update the target to match the new identity.
+	 */
+	default <T> void fabric_updateSyncTarget(AttachmentTargetInfo<T> oldTargetInfo, AttachmentTargetInfo<T> newTargetInfo) {
+		throw new UnsupportedOperationException("Implemented via mixin");
+	}
+
 	default void fabric_syncChange(AttachmentType<?> type, AttachmentChange change) {
 	}
 

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/sync/AttachmentChange.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/sync/AttachmentChange.java
@@ -167,4 +167,8 @@ public record AttachmentChange(AttachmentTargetInfo<?> targetInfo, AttachmentTyp
 
 		target.setAttached((AttachmentType<Object>) type, value);
 	}
+
+	public AttachmentChange withNewTarget(AttachmentTargetInfo<?> newTargetInfo) {
+		return new AttachmentChange(newTargetInfo, this.type, this.data);
+	}
 }

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
@@ -43,6 +43,7 @@ import net.fabricmc.fabric.impl.attachment.AttachmentSerializingImpl;
 import net.fabricmc.fabric.impl.attachment.AttachmentTargetImpl;
 import net.fabricmc.fabric.impl.attachment.AttachmentTypeImpl;
 import net.fabricmc.fabric.impl.attachment.sync.AttachmentChange;
+import net.fabricmc.fabric.impl.attachment.sync.AttachmentTargetInfo;
 
 @Mixin({BlockEntity.class, Entity.class, Level.class, ChunkAccess.class})
 abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
@@ -194,5 +195,20 @@ abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
 				changeOutput.accept(entry.getValue());
 			}
 		}
+	}
+
+	@Override
+	public <T> void fabric_updateSyncTarget(AttachmentTargetInfo<T> oldTargetInfo, AttachmentTargetInfo<T> newTargetInfo) {
+		if (syncedAttachments == null) {
+			return;
+		}
+
+		syncedAttachments.replaceAll((_, attachmentChange) -> {
+			if (attachmentChange.targetInfo().equals(oldTargetInfo)) {
+				return attachmentChange.withNewTarget(newTargetInfo);
+			}
+
+			return attachmentChange;
+		});
 	}
 }

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/EntityMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/EntityMixin.java
@@ -95,4 +95,11 @@ abstract class EntityMixin implements AttachmentTargetImpl {
 	public RegistryAccess fabric_getRegistryAccess() {
 		return this.level().registryAccess();
 	}
+
+	@Inject(method = "setId", at = @At("HEAD"))
+	private void setId(int id, CallbackInfo ci) {
+		var oldTargetInfo = new AttachmentTargetInfo.EntityTarget(this.id);
+		var newTargetInfo = new AttachmentTargetInfo.EntityTarget(id);
+		fabric_updateSyncTarget(oldTargetInfo, newTargetInfo);
+	}
 }

--- a/fabric-data-attachment-api-v1/src/test/java/net/fabricmc/fabric/test/attachment/CommonAttachmentTests.java
+++ b/fabric-data-attachment-api-v1/src/test/java/net/fabricmc/fabric/test/attachment/CommonAttachmentTests.java
@@ -47,6 +47,7 @@ import net.minecraft.resources.Identifier;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.server.Bootstrap;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.ProblemReporter;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
@@ -70,6 +71,7 @@ import net.fabricmc.fabric.impl.attachment.AttachmentSerializingImpl;
 import net.fabricmc.fabric.impl.attachment.AttachmentTargetImpl;
 import net.fabricmc.fabric.impl.attachment.sync.AttachmentChange;
 import net.fabricmc.fabric.impl.attachment.sync.AttachmentSyncException;
+import net.fabricmc.fabric.impl.attachment.sync.AttachmentTargetInfo;
 
 public class CommonAttachmentTests {
 	private static final String MOD_ID = "example";
@@ -223,6 +225,21 @@ public class CommonAttachmentTests {
 		assertFalse(respawnTarget.hasAttached(notCopiedOnRespawn));
 		assertTrue(nonRespawnTarget.hasAttached(copiedOnRespawn));
 		assertTrue(nonRespawnTarget.hasAttached(notCopiedOnRespawn));
+	}
+
+	// Test https://github.com/FabricMC/fabric-api/issues/4943#issuecomment-3790935408
+	@Test
+	void testEntityChangeId() {
+		ServerPlayer player = mockAndDisableSync(ServerPlayer.class);
+		Entity entity = mockAndDisableSync(Entity.class);
+		entity.setAttached(SYNCED, 456);
+
+		entity.setId(123);
+
+		AttachmentTargetImpl targetImpl = (AttachmentTargetImpl) entity;
+		targetImpl.fabric_computeInitialSyncChanges(player, change -> {
+			assertEquals(123, ((AttachmentTargetInfo.EntityTarget) change.targetInfo()).networkId());
+		});
 	}
 
 	@Test

--- a/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
+++ b/fabric-data-attachment-api-v1/src/testmod/java/net/fabricmc/fabric/test/attachment/AttachmentTestMod.java
@@ -121,6 +121,7 @@ public class AttachmentTestMod implements ModInitializer {
 		});
 
 		ServerEntityEvents.ENTITY_LOAD.register((entity, level) -> {
+			entity.setAttached(SYNCED_WITH_ALL, true);
 			entity.onAttachedSet(SYNCED_ITEM).register((oldValue, newValue) -> {
 				if (newValue != null && !newValue.equals(oldValue) && newValue.is(Items.BRICK)) {
 					entity.hurtServer(level, level.damageSources().generic(), 1);


### PR DESCRIPTION
Fixes the following comment made [here](https://github.com/FabricMC/fabric-api/issues/4943#issuecomment-3790935408)

> I've figured out the cause of [@Fuzss](https://github.com/Fuzss)'s creeper minion att sync problem, though it's quite complicated but I'll try my best to explain it.
> 
> The attachment is set in [`ServerPlayer#setShoulderEntityLeft/Right`](https://github.com/Fuzss/mutantmonsters/blob/3070faf037220f21dfd3478ac1ff3e8a60643502/1.21.10/Common/src/main/java/fuzs/mutantmonsters/mixin/ServerPlayerMixin.java#L22), which is called by [`ServerPlayer#restoreFrom`](https://mcsrc.dev/#1/26.1-snapshot-4/net/minecraft/server/level/ServerPlayer#L1615) when copying old player data to the new player entity. So when respawning, `setAttached()` will be called on the new player entity. Problem is the code that syncs attachments to the player's own client just assumes the client's player is always present (which is not true when respawning/logging in). So this is what causes the player that died to disconnect.
> <img alt="Image" width="1508" height="413" src="https://private-user-images.githubusercontent.com/113277083/539824440-efa2172c-47ae-4e86-b9a7-7570695f15c3.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NjkxOTM3MjksIm5iZiI6MTc2OTE5MzQyOSwicGF0aCI6Ii8xMTMyNzcwODMvNTM5ODI0NDQwLWVmYTIxNzJjLTQ3YWUtNGU4Ni1iOWE3LTc1NzA2OTVmMTVjMy5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjYwMTIzJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI2MDEyM1QxODM3MDlaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1kNzVlY2JiYjQxYzdjNjU5ZDEzNTQ3MWZhYmUyYWE1MjQ3MjQ1YTM3MDMzYmVlMTc5YmQzNGNjZWQwMjcxNTI5JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.HuqZZ3zUOlyQTSYRmerw45MNxKoJ9b8CGeqNZANKZkM">
> 
> But what about nearby players getting kicked too? This is instead caused by the attachment API syncing the wrong player network ID. When the new player entity is first created, it has a new network ID different from the old player. Then before vanilla starts syncing the new player, it sets the new player entity's network ID back to the old one. This means if `setAttached()` is called in between those two points (which is what is happening in this case), the `AttachmentChange` saved in the new player entity for future initial syncs will have the wrong network ID. So any other player that starts tracking the new player will receive that wrong network ID and disconnect. Hence why respawned players turn into "playerKickingMachines".


