### PR TITLE
No longer disconnect on unknown targets.

### DIFF
--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/sync/AttachmentChange.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/sync/AttachmentChange.java
@@ -169,9 +169,10 @@ public record AttachmentChange(AttachmentTargetInfo<?> targetInfo, AttachmentTyp
 
 			if (DISCONNECT_ON_UNKNOWN_TARGETS) {
 				throw new AttachmentSyncException(errorMessageComponent);
-			} else {
-				LOGGER.warn(errorMessageComponent.getString().trim());
 			}
+
+			LOGGER.warn(errorMessageComponent.getString().trim());
+			return;
 		}
 
 		target.setAttached((AttachmentType<Object>) type, value);

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/sync/AttachmentChange.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/sync/AttachmentChange.java
@@ -24,6 +24,8 @@ import java.util.Set;
 
 import io.netty.buffer.Unpooled;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.RegistryAccess;
@@ -61,6 +63,9 @@ public record AttachmentChange(AttachmentTargetInfo<?> targetInfo, AttachmentTyp
 	);
 	private static final int MAX_PADDING_SIZE_IN_BYTES = AttachmentTargetInfo.MAX_SIZE_IN_BYTES + AttachmentSync.MAX_IDENTIFIER_SIZE;
 	private static final int MAX_DATA_SIZE_IN_BYTES = ServerboundCustomPayloadPacketAccessor.getMaxPayloadSize() - MAX_PADDING_SIZE_IN_BYTES;
+	private static final boolean DISCONNECT_ON_UNKNOWN_TARGETS = System.getProperty("fabric.attachment.disconnect_on_unknown_targets") != null;
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(AttachmentChange.class);
 
 	@SuppressWarnings("unchecked")
 	public static AttachmentChange create(AttachmentTargetInfo<?> targetInfo, AttachmentType<?> type, @Nullable Object value, RegistryAccess registryAccess) {
@@ -162,7 +167,11 @@ public record AttachmentChange(AttachmentTargetInfo<?> targetInfo, AttachmentTyp
 					.append(CommonComponents.NEW_LINE);
 			targetInfo.appendDebugInformation(errorMessageComponent);
 
-			throw new AttachmentSyncException(errorMessageComponent);
+			if (DISCONNECT_ON_UNKNOWN_TARGETS) {
+				throw new AttachmentSyncException(errorMessageComponent);
+			} else {
+				LOGGER.warn(errorMessageComponent.getString().trim());
+			}
 		}
 
 		target.setAttached((AttachmentType<Object>) type, value);

--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/sync/AttachmentTargetInfo.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/impl/attachment/sync/AttachmentTargetInfo.java
@@ -33,6 +33,7 @@ import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.status.ChunkStatus;
 
 import net.fabricmc.fabric.api.attachment.v1.AttachmentTarget;
 
@@ -147,7 +148,7 @@ public sealed interface AttachmentTargetInfo<T> {
 
 		@Override
 		public AttachmentTarget getTarget(Level level) {
-			return level.getChunk(pos.x(), pos.z());
+			return level.getChunk(pos.x(), pos.z(), ChunkStatus.FULL, false);
 		}
 
 		@Override

--- a/fabric-data-attachment-api-v1/src/test/java/net/fabricmc/fabric/test/attachment/CommonAttachmentTests.java
+++ b/fabric-data-attachment-api-v1/src/test/java/net/fabricmc/fabric/test/attachment/CommonAttachmentTests.java
@@ -287,7 +287,7 @@ public class CommonAttachmentTests {
 	}
 
 	@Test
-	void applyToInvalidTarget() {
+	void applyToInvalidTarget() throws AttachmentSyncException {
 		RegistryAccess ra = mockRA();
 
 		ServerLevel level = mock(ServerLevel.class);
@@ -302,7 +302,7 @@ public class CommonAttachmentTests {
 				new byte[]{0}
 		);
 
-		assertThrows(AttachmentSyncException.class, () -> attachmentChange.tryApply(level));
+		attachmentChange.tryApply(level);
 	}
 
 	/*


### PR DESCRIPTION
Its impossible for the server to know for sure what entities are on the client.

Retained a system prop to bring back the old behaviour if we ever need an easier way to debug these issues in the future. I hate this but its the only option.

Fixes #4943