### PR TITLE
Defer calling setChanged() when setting attachments if BE's chunk is not fully loaded yet

### DIFF
--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/BlockEntityMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/BlockEntityMixin.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.mixin.attachment;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.jspecify.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -26,8 +28,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.RegistryAccess;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ChunkHolder;
+import net.minecraft.server.level.ChunkResult;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.storage.ValueInput;
 import net.minecraft.world.level.storage.ValueOutput;
 
@@ -73,7 +81,29 @@ abstract class BlockEntityMixin implements AttachmentTargetImpl {
 
 	@Override
 	public void fabric_markChanged(AttachmentType<?> type) {
-		this.setChanged();
+		if (this.level instanceof ServerLevel serverLevel) {
+			ChunkHolder chunkHolder = serverLevel.getChunkSource().chunkMap.getUpdatingChunkIfPresent(ChunkPos.pack(this.worldPosition));
+
+			// If chunkHolder is null, then chunk is probably unloaded/unloading.
+			// calling setChanged() may start loading the chunk again, causing an infinite loop of chunk loading/unloading.
+			// so just do nothing.
+			if (chunkHolder == null) {
+				return;
+			}
+
+			CompletableFuture<ChunkResult<LevelChunk>> chunkFuture = chunkHolder.getFullChunkFuture();
+
+			if (chunkFuture.isDone()) {
+				// If chunk is already loaded successfully, then call setChanged() immediately
+				chunkFuture.thenAccept(chunkResult -> chunkResult.ifSuccess(_ -> this.setChanged()));
+			} else {
+				// Otherwise setChanged() is called after to avoid deadlocking the server thread
+				MinecraftServer server = serverLevel.getServer();
+				server.schedule(server.wrapRunnable(() -> fabric_markChanged(type)));
+			}
+		} else {
+			this.setChanged();
+		}
 	}
 
 	@Override


### PR DESCRIPTION
The implementation does feel a bit overkill but it's the only way I managed to ensure that calling `setChanged()` does not either deadlock the server thread or cause an infinite loop of chunk (un)loading.

Closes #4718 