### PR TITLE
Suggest a max line length of 100 chars

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,7 @@ indent_style = tab
 ij_continuation_indent_size = 8
 ij_java_imports_layout = $*,|,java.**,|,javax.**,|,*,|,net.minecraft.**,|,net.fabricmc.**
 ij_java_class_count_to_use_import_on_demand = 999
+max_line_length = 100
 
 [*.json]
 indent_style = space


### PR DESCRIPTION
Sets the right margin in Intelij to 100 chars, this is just a rough suggestion we have 8361 lines over this so enfocing it would be impossible.

100 seems to be a reasonable middle ground that fits on most screens (with the IDE taking up some of the room), not everyone works on a high res display with ample room.