### PR TITLE
Update getId and getIdOrThrow to match vanilla added method.

### DIFF
--- a/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/api/block/v1/FabricBlock.java
+++ b/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/api/block/v1/FabricBlock.java
@@ -116,7 +116,7 @@ public interface FabricBlock {
 		 *
 		 * @return currently stored block id or null, if not set
 		 */
-		default @Nullable ResourceKey<Block> getId() {
+		default @Nullable ResourceKey<Block> blockId() {
 			throw new AssertionError("Implemented in Mixin");
 		}
 
@@ -126,8 +126,8 @@ public interface FabricBlock {
 		 * @return currently stored block id
 		 * @throws NullPointerException if id is not set
 		 */
-		default ResourceKey<Block> getIdOrThrow() {
-			return Objects.requireNonNull(this.getId(), "Block id not set");
+		default ResourceKey<Block> blockIdOrThrow() {
+			return Objects.requireNonNull(this.blockId(), "Block id not set");
 		}
 	}
 }

--- a/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/mixin/block/BlockBehaviourPropertiesMixin.java
+++ b/fabric-block-api-v1/src/main/java/net/fabricmc/fabric/mixin/block/BlockBehaviourPropertiesMixin.java
@@ -32,7 +32,7 @@ public class BlockBehaviourPropertiesMixin implements FabricBlock.FabricProperti
 	private @Nullable ResourceKey<Block> id;
 
 	@Override
-	public @Nullable ResourceKey<Block> getId() {
+	public @Nullable ResourceKey<Block> blockId() {
 		return this.id;
 	}
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.fabric.api.item.v1;
 
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -206,18 +205,8 @@ public interface FabricItem {
 		 *
 		 * @return currently stored item id or null, if not set
 		 */
-		default @Nullable ResourceKey<Item> getId() {
+		default @Nullable ResourceKey<Item> itemId() {
 			throw new AssertionError("Implemented in Mixin");
-		}
-
-		/**
-		 * Return the id of item that was defined by {@link Item.Properties#setId}.
-		 *
-		 * @return currently stored item id
-		 * @throws NullPointerException if id is not set
-		 */
-		default ResourceKey<Item> getIdOrThrow() {
-			return Objects.requireNonNull(this.getId(), "Item id not set");
 		}
 	}
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemPropertiesMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemPropertiesMixin.java
@@ -46,7 +46,7 @@ public class ItemPropertiesMixin implements FabricItem.Properties {
 	}
 
 	@Override
-	public @Nullable ResourceKey<Item> getId() {
+	public @Nullable ResourceKey<Item> itemId() {
 		return this.id;
 	}
 }

--- a/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.classtweaker
+++ b/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.classtweaker
@@ -136,6 +136,9 @@ transitive-accessible	method	net/minecraft/client/renderer/rendertype/RenderType
 # Armor defense map helper
 transitive-accessible	method	net/minecraft/world/item/equipment/ArmorMaterials makeDefense	(IIIII)Ljava/util/Map;
 
+# Item Properties methods
+transitive-accessible   method  net/minecraft/world/item/Item$Properties itemIdOrThrow ()Lnet/minecraft/resources/ResourceKey;
+
 # World generation helpers
 transitive-accessible   method  net/minecraft/data/worldgen/biome/OverworldBiomes baseBiome (FF)Lnet/minecraft/world/level/biome/Biome$BiomeBuilder;
 transitive-accessible   method  net/minecraft/data/worldgen/biome/OverworldBiomes globalOverworldGeneration (Lnet/minecraft/world/level/biome/BiomeGenerationSettings$Builder;)V

--- a/fabric-transitive-access-wideners-v1/template.classtweaker
+++ b/fabric-transitive-access-wideners-v1/template.classtweaker
@@ -131,6 +131,9 @@ transitive-accessible	method	net/minecraft/client/renderer/rendertype/RenderType
 # Armor defense map helper
 transitive-accessible	method	net/minecraft/world/item/equipment/ArmorMaterials makeDefense	(IIIII)Ljava/util/Map;
 
+# Item Properties methods
+transitive-accessible   method  net/minecraft/world/item/Item$Properties itemIdOrThrow ()Lnet/minecraft/resources/ResourceKey;
+
 # World generation helpers
 transitive-accessible   method  net/minecraft/data/worldgen/biome/OverworldBiomes baseBiome (FF)Lnet/minecraft/world/level/biome/Biome$BiomeBuilder;
 transitive-accessible   method  net/minecraft/data/worldgen/biome/OverworldBiomes globalOverworldGeneration (Lnet/minecraft/world/level/biome/BiomeGenerationSettings$Builder;)V


### PR DESCRIPTION
Simple pr that updates methods added in #5116 to match vanilla naming, as Mojang added a private method to Item.Properties that does the same thing.
So this pr:
- Renames Item.Properties#getId() -> #itemId()
- Renames BlockBehaviour.Properties#getId() -> #blockId()
- Renames BlockBehaviour.Properties#getIdOrThrow() -> #blockIdOrThrow()
- Removes Item.Properties#getIdOrThrow()
- Access widens Item.Properties#itemIdOrThrow()