### PR TITLE
Make lookup API context extend nullable Object 

### DIFF
--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiCache.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiCache.java
@@ -41,7 +41,7 @@ import net.fabricmc.fabric.impl.lookup.block.BlockApiLookupImpl;
  * @see BlockApiLookup
  */
 @ApiStatus.NonExtendable
-public interface BlockApiCache<A, C> {
+public interface BlockApiCache<A, C extends @Nullable Object> {
 	/**
 	 * Attempt to retrieve an API from a block in the level, using the level and the position passed at creation time.
 	 *
@@ -92,7 +92,7 @@ public interface BlockApiCache<A, C> {
 	/**
 	 * Create a new instance bound to the passed {@link ServerLevel} and position, and querying the same API as the passed lookup.
 	 */
-	static <A, C> BlockApiCache<A, C> create(BlockApiLookup<A, C> lookup, ServerLevel level, BlockPos pos) {
+	static <A, C extends @Nullable Object> BlockApiCache<A, C> create(BlockApiLookup<A, C> lookup, ServerLevel level, BlockPos pos) {
 		Objects.requireNonNull(pos, "BlockPos may not be null.");
 		Objects.requireNonNull(level, "ServerLevel may not be null.");
 

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/block/BlockApiLookup.java
@@ -139,7 +139,7 @@ import net.fabricmc.fabric.impl.lookup.block.BlockApiLookupImpl;
  * @param <C> The type of the additional context object.
  */
 @ApiStatus.NonExtendable
-public interface BlockApiLookup<A, C> {
+public interface BlockApiLookup<A, C extends @Nullable Object> {
 	/**
 	 * Retrieve the {@link BlockApiLookup} associated with an identifier, or create it if it didn't exist yet.
 	 *
@@ -149,7 +149,7 @@ public interface BlockApiLookup<A, C> {
 	 * @return The unique lookup with the passed lookupId.
 	 * @throws IllegalArgumentException If another {@code apiClass} or another {@code contextClass} was already registered with the same identifier.
 	 */
-	static <A, C> BlockApiLookup<A, C> get(Identifier lookupId, Class<A> apiClass, Class<C> contextClass) {
+	static <A, C extends @Nullable Object> BlockApiLookup<A, C> get(Identifier lookupId, Class<A> apiClass, Class<C> contextClass) {
 		return BlockApiLookupImpl.get(lookupId, apiClass, contextClass);
 	}
 
@@ -267,7 +267,7 @@ public interface BlockApiLookup<A, C> {
 	BlockApiProvider<A, C> getProvider(Block block);
 
 	@FunctionalInterface
-	interface BlockApiProvider<A, C> {
+	interface BlockApiProvider<A, C extends @Nullable Object> {
 		/**
 		 * Return an API of type {@code A} if available in the level at the given pos with the given context, or {@code null} otherwise.
 		 *
@@ -283,7 +283,7 @@ public interface BlockApiLookup<A, C> {
 	}
 
 	@FunctionalInterface
-	interface BlockEntityApiProvider<A, C> {
+	interface BlockEntityApiProvider<A, C extends @Nullable Object> {
 		/**
 		 * Return an API of type {@code A} if available in the given block entity with the given context, or {@code null} otherwise.
 		 *

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/entity/EntityApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/entity/EntityApiLookup.java
@@ -83,7 +83,7 @@ import net.fabricmc.fabric.impl.lookup.entity.EntityApiLookupImpl;
  *            If no context is necessary, {@link Void} should be used and {@code null} instances should be passed.
  */
 @ApiStatus.NonExtendable
-public interface EntityApiLookup<A, C> {
+public interface EntityApiLookup<A, C extends @Nullable Object> {
 	/**
 	 * Retrieve the {@link EntityApiLookup} associated with an identifier, or create it if it didn't exist yet.
 	 *
@@ -93,7 +93,7 @@ public interface EntityApiLookup<A, C> {
 	 * @return the unique lookup with the passed lookupId.
 	 * @throws IllegalArgumentException If another {@code apiClass} or another {@code contextClass} was already registered with the same identifier.
 	 */
-	static <A, C> EntityApiLookup<A, C> get(Identifier lookupId, Class<A> apiClass, Class<C> contextClass) {
+	static <A, C extends @Nullable Object> EntityApiLookup<A, C> get(Identifier lookupId, Class<A> apiClass, Class<C> contextClass) {
 		return EntityApiLookupImpl.get(lookupId, apiClass, contextClass);
 	}
 
@@ -168,7 +168,7 @@ public interface EntityApiLookup<A, C> {
 	@Nullable
 	EntityApiProvider<A, C> getProvider(EntityType<?> entityType);
 
-	interface EntityApiProvider<A, C> {
+	interface EntityApiProvider<A, C extends @Nullable Object> {
 		/**
 		 * Return an instance of API {@code A} if available in the given entity with the given context, or {@code null} otherwise.
 		 *

--- a/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
+++ b/fabric-api-lookup-api-v1/src/main/java/net/fabricmc/fabric/api/lookup/v1/item/ItemApiLookup.java
@@ -92,7 +92,7 @@ import net.fabricmc.fabric.impl.lookup.item.ItemApiLookupImpl;
  * @param <C> The type of the additional context object.
  */
 @ApiStatus.NonExtendable
-public interface ItemApiLookup<A, C> {
+public interface ItemApiLookup<A, C extends @Nullable Object> {
 	/**
 	 * Retrieve the {@link ItemApiLookup} associated with an identifier, or create it if it didn't exist yet.
 	 *
@@ -102,7 +102,7 @@ public interface ItemApiLookup<A, C> {
 	 * @return The unique lookup with the passed lookupId.
 	 * @throws IllegalArgumentException If another {@code apiClass} or another {@code contextClass} was already registered with the same identifier.
 	 */
-	static <A, C> ItemApiLookup<A, C> get(Identifier lookupId, Class<A> apiClass, Class<C> contextClass) {
+	static <A, C extends @Nullable Object> ItemApiLookup<A, C> get(Identifier lookupId, Class<A> apiClass, Class<C> contextClass) {
 		return ItemApiLookupImpl.get(lookupId, apiClass, contextClass);
 	}
 
@@ -168,7 +168,7 @@ public interface ItemApiLookup<A, C> {
 	ItemApiProvider<A, C> getProvider(Item item);
 
 	@FunctionalInterface
-	interface ItemApiProvider<A, C> {
+	interface ItemApiProvider<A, C extends @Nullable Object> {
 		/**
 		 * Return an API of type {@code A} if available for the given item stack with the given context, or {@code null} otherwise.
 		 *


### PR DESCRIPTION
`@NullMarked` makes the lookup context `C` non-nullable by default. 
This is not ideal since `C` comes from the usage of the API and thus should allow for null if needed.
For example, the transfer API has a nullable `Direction` context for sided storages.

<details><summary>Before</summary>
<p>

<img width="996" height="265" alt="Screenshot_20260130_011606" src="https://github.com/user-attachments/assets/e1b35d91-b30b-482f-8aaa-fc33dd99503a" />
<img width="1095" height="247" alt="Screenshot_20260130_011636" src="https://github.com/user-attachments/assets/730b68e5-88fa-414f-b99d-9458f00c4fdd" />
<img width="907" height="221" alt="Screenshot_20260130_011701" src="https://github.com/user-attachments/assets/a7827cc2-4c0d-467c-b96f-6b1b0d51a517" />

</p>
</details> 

<details><summary>After</summary>
<p>

<img width="968" height="265" alt="Screenshot_20260130_013915" src="https://github.com/user-attachments/assets/2e78d8fa-6a19-450c-8810-ee71b7fa9e0a" />
No warnings here.
Note that I needed to invalidate the cache and reload the project for the warning to go away, classic IntelliJank. 

</p>
</details> 