### PR TITLE
Add missing dependency to fabric-gametest-api-v1

### DIFF
--- a/fabric-gametest-api-v1/build.gradle
+++ b/fabric-gametest-api-v1/build.gradle
@@ -17,5 +17,6 @@ loom {
 
 moduleDependencies(project, [
 	'fabric-api-base',
+	'fabric-registry-sync-v0',
 	'fabric-resource-loader-v1',
 ])

--- a/fabric-gametest-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-gametest-api-v1/src/main/resources/fabric.mod.json
@@ -22,6 +22,7 @@
   },
   "depends": {
     "fabricloader": ">=0.18.4",
+    "fabric-registry-sync-v0": "*",
     "fabric-resource-loader-v1": "*"
   },
   "description": "Allows registration of custom game tests.",


### PR DESCRIPTION
Adds missing `fabric-registry-sync-v0` dependency to `fabric-gametest-api-v1` that caused a crash when trying to register tests in the registry when registry sync was not present

Also, should `fabric-client-gametest-api-v1` have a `moduleDependencies` with the resource loader api?