### PR TITLE
Update/fix `LevelRenderEvents` to mirror vanilla changes to `LevelRenderer`

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/level/LevelRenderEvents.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/level/LevelRenderEvents.java
@@ -99,11 +99,26 @@ public final class LevelRenderEvents {
 
 	/**
 	 * Called after {@linkplain ChunkSectionLayerGroup#OPAQUE opaque} terrain is drawn to the appropriate framebuffers,
-	 * and before any submit nodes from entities, block entities, or particles are added to the submit node storage.
+	 * and before any submit nodes are added to the submit node storage.
+	 *
+	 * <p>Use this event to render additional opaque terrain-like geometry.
 	 */
-	public static final Event<BeforeCollectSubmits> BEFORE_COLLECT_SUBMITS = EventFactory.createArrayBacked(BeforeCollectSubmits.class, callbacks -> context -> {
-		for (final BeforeCollectSubmits callback : callbacks) {
-			callback.beforeCollectSubmits(context);
+	public static final Event<AfterOpaqueTerrain> AFTER_OPAQUE_TERRAIN = EventFactory.createArrayBacked(AfterOpaqueTerrain.class, callbacks -> context -> {
+		for (final AfterOpaqueTerrain callback : callbacks) {
+			callback.afterOpaqueTerrain(context);
+		}
+	});
+
+	/**
+	 * Called after {@linkplain ChunkSectionLayerGroup#OPAQUE opaque} terrain is drawn to the appropriate framebuffers
+	 * and all submit nodes from entities, block entities, and particles are added to the submit node storage, and
+	 * before any submit geometry is drawn to the appropriate framebuffers.
+	 *
+	 * <p>Use this event to add additional submits to {@link LevelRenderContext#submitNodeCollector()}.
+	 */
+	public static final Event<CollectSubmits> COLLECT_SUBMITS = EventFactory.createArrayBacked(CollectSubmits.class, callbacks -> context -> {
+		for (final CollectSubmits callback : callbacks) {
+			callback.collectSubmits(context);
 		}
 	});
 
@@ -169,12 +184,24 @@ public final class LevelRenderEvents {
 
 	/**
 	 * Called after opaque terrain, entities, block entities, solid particles, overlays, and gizmos are drawn to the
-	 * appropriate framebuffers, before {@linkplain ChunkSectionLayerGroup#TRANSLUCENT translucent} terrain and
+	 * appropriate framebuffers, and before {@linkplain ChunkSectionLayerGroup#TRANSLUCENT translucent} terrain and
 	 * translucent particles are drawn to the appropriate framebuffers.
 	 */
 	public static final Event<BeforeTranslucentTerrain> BEFORE_TRANSLUCENT_TERRAIN = EventFactory.createArrayBacked(BeforeTranslucentTerrain.class, callbacks -> context -> {
 		for (final BeforeTranslucentTerrain callback : callbacks) {
 			callback.beforeTranslucentTerrain(context);
+		}
+	});
+
+	/**
+	 * Called after terrain, entities, block entities, solid particles, overlays, and gizmos are drawn to the
+	 * appropriate framebuffers, and before translucent particles are drawn to the appropriate framebuffers.
+	 *
+	 * <p>Use this event to render additional translucent terrain-like geometry.
+	 */
+	public static final Event<AfterTranslucentTerrain> AFTER_TRANSLUCENT_TERRAIN = EventFactory.createArrayBacked(AfterTranslucentTerrain.class, callbacks -> context -> {
+		for (final AfterTranslucentTerrain callback : callbacks) {
+			callback.afterTranslucentTerrain(context);
 		}
 	});
 
@@ -205,8 +232,13 @@ public final class LevelRenderEvents {
 	}
 
 	@FunctionalInterface
-	public interface BeforeCollectSubmits {
-		void beforeCollectSubmits(LevelRenderContext context);
+	public interface AfterOpaqueTerrain {
+		void afterOpaqueTerrain(LevelTerrainRenderContext context);
+	}
+
+	@FunctionalInterface
+	public interface CollectSubmits {
+		void collectSubmits(LevelRenderContext context);
 	}
 
 	@FunctionalInterface
@@ -232,6 +264,11 @@ public final class LevelRenderEvents {
 	@FunctionalInterface
 	public interface BeforeTranslucentTerrain {
 		void beforeTranslucentTerrain(LevelRenderContext context);
+	}
+
+	@FunctionalInterface
+	public interface AfterTranslucentTerrain {
+		void afterTranslucentTerrain(LevelRenderContext context);
 	}
 
 	@FunctionalInterface

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/level/LevelRenderEvents.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/level/LevelRenderEvents.java
@@ -75,7 +75,7 @@ public final class LevelRenderEvents {
 	});
 
 	/**
-	 * Called after all render states are extracted, before any is drawn.
+	 * Called after all render states are extracted, before any are drawn.
 	 * Use this to extract general custom data needed for rendering.
 	 *
 	 * <p>To attach modded data to vanilla render states, see {@link net.fabricmc.fabric.api.client.rendering.v1.FabricRenderState FabricRenderState}.
@@ -88,8 +88,8 @@ public final class LevelRenderEvents {
 	});
 
 	/**
-	 * Called at the start of the main pass, after the sky is drawn to the framebuffer and all chunks to be rendered are
-	 * uploaded to GPU, and before any chunks are drawn to the framebuffer.
+	 * Called at the start of the main pass, after the sky is drawn to the appropriate framebuffers and all chunks to be
+	 * rendered are uploaded to GPU, and before any chunks are drawn to the appropriate framebuffers.
 	 */
 	public static final Event<StartMain> START_MAIN = EventFactory.createArrayBacked(StartMain.class, callbacks -> context -> {
 		for (final StartMain callback : callbacks) {
@@ -98,8 +98,8 @@ public final class LevelRenderEvents {
 	});
 
 	/**
-	 * Called after {@linkplain ChunkSectionLayerGroup#OPAQUE opaque} terrain is drawn to the framebuffer, and before
-	 * any submit nodes from entities, block entities, or particles are added to the submit node storage.
+	 * Called after {@linkplain ChunkSectionLayerGroup#OPAQUE opaque} terrain is drawn to the appropriate framebuffers,
+	 * and before any submit nodes from entities, block entities, or particles are added to the submit node storage.
 	 */
 	public static final Event<BeforeCollectSubmits> BEFORE_COLLECT_SUBMITS = EventFactory.createArrayBacked(BeforeCollectSubmits.class, callbacks -> context -> {
 		for (final BeforeCollectSubmits callback : callbacks) {
@@ -109,7 +109,7 @@ public final class LevelRenderEvents {
 
 	/**
 	 * Called after the solid geometry of submits collected from entities, block entities, and particles are drawn to
-	 * the framebuffer.
+	 * the appropriate framebuffers.
 	 */
 	public static final Event<AfterSolidFeatures> AFTER_SOLID_FEATURES = EventFactory.createArrayBacked(AfterSolidFeatures.class, callbacks -> context -> {
 		for (final AfterSolidFeatures callback : callbacks) {
@@ -119,7 +119,7 @@ public final class LevelRenderEvents {
 
 	/**
 	 * Called after the translucent geometry of submits collected from entities and block entities are drawn to the
-	 * framebuffer. Note that this excludes translucent particle geometry, which is rendered much later.
+	 * appropriate framebuffers. Note that this excludes translucent particle geometry, which is rendered much later.
 	 */
 	public static final Event<AfterTranslucentFeatures> AFTER_TRANSLUCENT_FEATURES = EventFactory.createArrayBacked(AfterTranslucentFeatures.class, callbacks -> context -> {
 		for (final AfterTranslucentFeatures callback : callbacks) {
@@ -129,7 +129,7 @@ public final class LevelRenderEvents {
 
 	/**
 	 * Called after block outline render checks are made
-	 * and before the default block outline is drawn to the framebuffer.
+	 * and before the default block outline is drawn to the appropriate framebuffers.
 	 * This will NOT be called if the default outline render state
 	 * was set to null in {@link #AFTER_BLOCK_OUTLINE_EXTRACTION}.
 	 *
@@ -159,7 +159,7 @@ public final class LevelRenderEvents {
 	/**
 	 * Called after all geometry of submits collected from entities, block entities, and particles (except translucent
 	 * particle geometry), the block breaking overlay, and the block outline for solid blocks are drawn to the
-	 * framebuffer, and before gizmos are collected.
+	 * appropriate framebuffers, and before gizmos are collected.
 	 */
 	public static final Event<BeforeGizmos> BEFORE_GIZMOS = EventFactory.createArrayBacked(BeforeGizmos.class, callbacks -> context -> {
 		for (final BeforeGizmos callback : callbacks) {
@@ -169,8 +169,8 @@ public final class LevelRenderEvents {
 
 	/**
 	 * Called after opaque terrain, entities, block entities, solid particles, overlays, and gizmos are drawn to the
-	 * framebuffer, before {@linkplain ChunkSectionLayerGroup#TRANSLUCENT translucent} terrain and translucent particles
-	 * are drawn to the framebuffer.
+	 * appropriate framebuffers, before {@linkplain ChunkSectionLayerGroup#TRANSLUCENT translucent} terrain and
+	 * translucent particles are drawn to the appropriate framebuffers.
 	 */
 	public static final Event<BeforeTranslucentTerrain> BEFORE_TRANSLUCENT_TERRAIN = EventFactory.createArrayBacked(BeforeTranslucentTerrain.class, callbacks -> context -> {
 		for (final BeforeTranslucentTerrain callback : callbacks) {
@@ -180,8 +180,8 @@ public final class LevelRenderEvents {
 
 	/**
 	 * Called at the end of the main render pass, after terrain, entities, block entities, and particles are drawn to
-	 * the framebuffer, and before clouds, weather, and late debug are drawn to the framebuffer and before fabulous
-	 * translucent framebuffers are combined.
+	 * the appropriate framebuffers, and before clouds, weather, and late debug are drawn to the appropriate
+	 * framebuffers and before fabulous translucent framebuffers are combined.
 	 */
 	public static final Event<EndMain> END_MAIN = EventFactory.createArrayBacked(EndMain.class, callbacks -> context -> {
 		for (final EndMain callback : callbacks) {

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/level/LevelRenderEvents.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/level/LevelRenderEvents.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.api.client.rendering.v1.level;
 import org.jspecify.annotations.Nullable;
 
 import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.chunk.ChunkSectionLayerGroup;
 import net.minecraft.client.renderer.state.BlockOutlineRenderState;
 import net.minecraft.world.phys.HitResult;
 
@@ -87,8 +88,8 @@ public final class LevelRenderEvents {
 	});
 
 	/**
-	 * Called after all chunks to be rendered are uploaded to GPU,
-	 * before any chunks are drawn to the framebuffer.
+	 * Called at the start of the main pass, after the sky is drawn to the framebuffer and all chunks to be rendered are
+	 * uploaded to GPU, and before any chunks are drawn to the framebuffer.
 	 */
 	public static final Event<StartMain> START_MAIN = EventFactory.createArrayBacked(StartMain.class, callbacks -> context -> {
 		for (final StartMain callback : callbacks) {
@@ -97,65 +98,32 @@ public final class LevelRenderEvents {
 	});
 
 	/**
-	 * Called after the {@link net.minecraft.client.renderer.chunk.ChunkSectionLayer#SOLID SOLID}, {@link net.minecraft.client.renderer.chunk.ChunkSectionLayer#CUTOUT CUTOUT},
-	 * and {@link net.minecraft.client.renderer.chunk.ChunkSectionLayer#CUTOUT CUTOUT_MIPPED} terrain layers are drawn to the framebuffer,
-	 * before entity and block entities are submitted and drawn to the framebuffer.
-	 *
-	 * <p>Use to render non-translucent terrain to the framebuffer.
-	 *
-	 * <p>Note that 3rd-party renderers may combine these passes or otherwise alter the
-	 * rendering pipeline for sake of performance or features. This can break direct writes to the
-	 * framebuffer.  Use this event for cases that cannot be satisfied by FabricBakedModel,
-	 * BlockEntityRenderer or other existing abstraction. If at all possible, use an existing terrain
-	 * RenderLayer instead of outputting to the framebuffer directly with GL calls.
-	 *
-	 * <p>The consumer is responsible for setup and tear down of GL state appropriate for the intended output.
-	 *
-	 * <p>Because solid and cutout quads are depth-tested, order of output does not matter except to improve
-	 * culling performance, which should not be significant after primary terrain rendering. This means
-	 * mods that currently hook calls to individual render layers can simply execute them all at once when
-	 * the event is called.
-	 * However, you should not access any data outside the provided render states. If more data is needed,
-	 * extract them during {@link #END_EXTRACTION}.
+	 * Called after {@linkplain ChunkSectionLayerGroup#OPAQUE opaque} terrain is drawn to the framebuffer, and before
+	 * any submit nodes from entities, block entities, or particles are added to the submit node storage.
 	 */
-	public static final Event<BeforeEntities> BEFORE_ENTITIES = EventFactory.createArrayBacked(BeforeEntities.class, callbacks -> context -> {
-		for (final BeforeEntities callback : callbacks) {
-			callback.beforeEntities(context);
+	public static final Event<BeforeCollectSubmits> BEFORE_COLLECT_SUBMITS = EventFactory.createArrayBacked(BeforeCollectSubmits.class, callbacks -> context -> {
+		for (final BeforeCollectSubmits callback : callbacks) {
+			callback.beforeCollectSubmits(context);
 		}
 	});
 
 	/**
-	 * Called after entities and block entities are drawn to the framebuffer.
+	 * Called after the solid geometry of submits collected from entities, block entities, and particles are drawn to
+	 * the framebuffer.
 	 */
-	public static final Event<AfterEntities> AFTER_ENTITIES = EventFactory.createArrayBacked(AfterEntities.class, callbacks -> context -> {
-		for (final AfterEntities callback : callbacks) {
-			callback.afterEntities(context);
+	public static final Event<AfterSolidFeatures> AFTER_SOLID_FEATURES = EventFactory.createArrayBacked(AfterSolidFeatures.class, callbacks -> context -> {
+		for (final AfterSolidFeatures callback : callbacks) {
+			callback.afterSolidFeatures(context);
 		}
 	});
 
 	/**
-	 * Called after entities, block breaking, and most non-translucent objects are drawn to the framebuffer,
-	 * before vanilla debug renderers and translucency are drawn to the framebuffer.
-	 *
-	 * <p>Use to drawn lines, overlays and other content similar to vanilla debug renders.
+	 * Called after the translucent geometry of submits collected from entities and block entities are drawn to the
+	 * framebuffer. Note that this excludes translucent particle geometry, which is rendered much later.
 	 */
-	public static final Event<DebugRender> BEFORE_DEBUG_RENDER = EventFactory.createArrayBacked(DebugRender.class, callbacks -> context -> {
-		for (final DebugRender callback : callbacks) {
-			callback.beforeDebugRender(context);
-		}
-	});
-
-	/**
-	 * Called after entities and block entities are drawn to the framebuffer,
-	 * before translucent terrain is drawn to the framebuffer,
-	 * and before translucency combine has happened in fabulous mode.
-	 *
-	 * <p>Use to draw on top of the main and entity framebuffer targets
-	 * before clouds and weather are drawn.
-	 */
-	public static final Event<BeforeTranslucent> BEFORE_TRANSLUCENT = EventFactory.createArrayBacked(BeforeTranslucent.class, callbacks -> context -> {
-		for (final BeforeTranslucent callback : callbacks) {
-			callback.beforeTranslucent(context);
+	public static final Event<AfterTranslucentFeatures> AFTER_TRANSLUCENT_FEATURES = EventFactory.createArrayBacked(AfterTranslucentFeatures.class, callbacks -> context -> {
+		for (final AfterTranslucentFeatures callback : callbacks) {
+			callback.afterTranslucentFeatures(context);
 		}
 	});
 
@@ -189,11 +157,31 @@ public final class LevelRenderEvents {
 	});
 
 	/**
-	 * Called at the end of the main render pass, after entities, block entities,
-	 * terrain, and translucent terrain are drawn to the framebuffer,
-	 * before particles, clouds, weather, and late debug are drawn to the framebuffer.
-	 *
-	 * <p>Use to draw on top of the level before hand and GUI are drawn.
+	 * Called after all geometry of submits collected from entities, block entities, and particles (except translucent
+	 * particle geometry), the block breaking overlay, and the block outline for solid blocks are drawn to the
+	 * framebuffer, and before gizmos are collected.
+	 */
+	public static final Event<BeforeGizmos> BEFORE_GIZMOS = EventFactory.createArrayBacked(BeforeGizmos.class, callbacks -> context -> {
+		for (final BeforeGizmos callback : callbacks) {
+			callback.beforeGizmos(context);
+		}
+	});
+
+	/**
+	 * Called after opaque terrain, entities, block entities, solid particles, overlays, and gizmos are drawn to the
+	 * framebuffer, before {@linkplain ChunkSectionLayerGroup#TRANSLUCENT translucent} terrain and translucent particles
+	 * are drawn to the framebuffer.
+	 */
+	public static final Event<BeforeTranslucentTerrain> BEFORE_TRANSLUCENT_TERRAIN = EventFactory.createArrayBacked(BeforeTranslucentTerrain.class, callbacks -> context -> {
+		for (final BeforeTranslucentTerrain callback : callbacks) {
+			callback.beforeTranslucentTerrain(context);
+		}
+	});
+
+	/**
+	 * Called at the end of the main render pass, after terrain, entities, block entities, and particles are drawn to
+	 * the framebuffer, and before clouds, weather, and late debug are drawn to the framebuffer and before fabulous
+	 * translucent framebuffers are combined.
 	 */
 	public static final Event<EndMain> END_MAIN = EventFactory.createArrayBacked(EndMain.class, callbacks -> context -> {
 		for (final EndMain callback : callbacks) {
@@ -217,28 +205,33 @@ public final class LevelRenderEvents {
 	}
 
 	@FunctionalInterface
-	public interface BeforeEntities {
-		void beforeEntities(LevelRenderContext context);
+	public interface BeforeCollectSubmits {
+		void beforeCollectSubmits(LevelRenderContext context);
 	}
 
 	@FunctionalInterface
-	public interface AfterEntities {
-		void afterEntities(LevelRenderContext context);
+	public interface AfterSolidFeatures {
+		void afterSolidFeatures(LevelRenderContext context);
 	}
 
 	@FunctionalInterface
-	public interface DebugRender {
-		void beforeDebugRender(LevelRenderContext context);
-	}
-
-	@FunctionalInterface
-	public interface BeforeTranslucent {
-		void beforeTranslucent(LevelRenderContext context);
+	public interface AfterTranslucentFeatures {
+		void afterTranslucentFeatures(LevelRenderContext context);
 	}
 
 	@FunctionalInterface
 	public interface BeforeBlockOutline {
 		boolean beforeBlockOutline(LevelRenderContext context, BlockOutlineRenderState outlineRenderState);
+	}
+
+	@FunctionalInterface
+	public interface BeforeGizmos {
+		void beforeGizmos(LevelRenderContext context);
+	}
+
+	@FunctionalInterface
+	public interface BeforeTranslucentTerrain {
+		void beforeTranslucentTerrain(LevelRenderContext context);
 	}
 
 	@FunctionalInterface

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/LevelRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/LevelRendererMixin.java
@@ -123,7 +123,7 @@ public abstract class LevelRendererMixin {
 	}
 
 	@Inject(method = "lambda$addMainPass$0", at = @At(value = "INVOKE_STRING", target = "Lnet/minecraft/util/profiling/ProfilerFiller;popPush(Ljava/lang/String;)V", args = "ldc=solidFeatures"))
-	private void beforeCollectSubmits(CallbackInfo ci) {
+	private void afterCollectSubmits(CallbackInfo ci) {
 		LevelRenderEvents.COLLECT_SUBMITS.invoker().collectSubmits(renderContext);
 	}
 
@@ -146,7 +146,7 @@ public abstract class LevelRendererMixin {
 	}
 
 	@Inject(method = "lambda$addMainPass$0", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/LevelRenderer;finalizeGizmoCollection()V"))
-	private void beforeRenderGizmos(CallbackInfo ci) {
+	private void beforeCollectGizmos(CallbackInfo ci) {
 		LevelRenderEvents.BEFORE_GIZMOS.invoker().beforeGizmos(renderContext);
 	}
 

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/LevelRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/LevelRendererMixin.java
@@ -21,6 +21,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import com.mojang.blaze3d.resource.GraphicsResourceAllocator;
+import com.mojang.blaze3d.textures.GpuSampler;
 import com.mojang.blaze3d.vertex.PoseStack;
 import org.joml.Matrix4f;
 import org.joml.Vector4f;
@@ -32,7 +33,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.client.Camera;
@@ -44,6 +44,7 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderBuffers;
 import net.minecraft.client.renderer.SubmitNodeStorage;
 import net.minecraft.client.renderer.WorldBorderRenderer;
+import net.minecraft.client.renderer.chunk.ChunkSectionLayerGroup;
 import net.minecraft.client.renderer.chunk.ChunkSectionsToRender;
 import net.minecraft.client.renderer.culling.Frustum;
 import net.minecraft.client.renderer.state.LevelRenderState;
@@ -108,12 +109,11 @@ public abstract class LevelRendererMixin {
 		return chunkSectionsToRender;
 	}
 
-	@Inject(method = "lambda$addMainPass$0",
-			slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/LevelRenderer;prepareChunkRenders(Lorg/joml/Matrix4fc;DDD)Lnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;")),
-			at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;renderGroup(Lnet/minecraft/client/renderer/chunk/ChunkSectionLayerGroup;Lcom/mojang/blaze3d/textures/GpuSampler;)V", ordinal = 0)
-	)
-	private void beforeTerrainRender(CallbackInfo ci) {
+	@WrapOperation(method = "lambda$addMainPass$0", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;renderGroup(Lnet/minecraft/client/renderer/chunk/ChunkSectionLayerGroup;Lcom/mojang/blaze3d/textures/GpuSampler;)V", ordinal = 0))
+	private void wrapRenderOpaqueTerrain(ChunkSectionsToRender chunkSectionsToRender, ChunkSectionLayerGroup group, GpuSampler sampler, Operation<Void> original) {
 		LevelRenderEvents.START_MAIN.invoker().startMain(renderContext);
+		original.call(chunkSectionsToRender, group, sampler);
+		LevelRenderEvents.AFTER_OPAQUE_TERRAIN.invoker().afterOpaqueTerrain(renderContext);
 	}
 
 	@ModifyExpressionValue(method = "lambda$addMainPass$0", at = @At(value = "NEW", target = "Lcom/mojang/blaze3d/vertex/PoseStack;"))
@@ -122,9 +122,9 @@ public abstract class LevelRendererMixin {
 		return poseStack;
 	}
 
-	@Inject(method = "lambda$addMainPass$0", at = @At(value = "INVOKE_STRING", target = "Lnet/minecraft/util/profiling/ProfilerFiller;popPush(Ljava/lang/String;)V", args = "ldc=submitEntities"))
+	@Inject(method = "lambda$addMainPass$0", at = @At(value = "INVOKE_STRING", target = "Lnet/minecraft/util/profiling/ProfilerFiller;popPush(Ljava/lang/String;)V", args = "ldc=solidFeatures"))
 	private void beforeCollectSubmits(CallbackInfo ci) {
-		LevelRenderEvents.BEFORE_COLLECT_SUBMITS.invoker().beforeCollectSubmits(renderContext);
+		LevelRenderEvents.COLLECT_SUBMITS.invoker().collectSubmits(renderContext);
 	}
 
 	@Inject(method = "lambda$addMainPass$0", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/LevelRenderer;checkPoseStack(Lcom/mojang/blaze3d/vertex/PoseStack;)V", ordinal = 0))
@@ -150,9 +150,11 @@ public abstract class LevelRendererMixin {
 		LevelRenderEvents.BEFORE_GIZMOS.invoker().beforeGizmos(renderContext);
 	}
 
-	@Inject(method = "lambda$addMainPass$0", at = @At(value = "INVOKE_STRING", target = "Lnet/minecraft/util/profiling/ProfilerFiller;push(Ljava/lang/String;)V", args = "ldc=translucentTerrain"))
-	private void beforeTranslucentRender(CallbackInfo ci) {
+	@WrapOperation(method = "lambda$addMainPass$0", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;renderGroup(Lnet/minecraft/client/renderer/chunk/ChunkSectionLayerGroup;Lcom/mojang/blaze3d/textures/GpuSampler;)V", ordinal = 1))
+	private void wrapRenderTranslucentTerrain(ChunkSectionsToRender chunkSectionsToRender, ChunkSectionLayerGroup group, GpuSampler sampler, Operation<Void> original) {
 		LevelRenderEvents.BEFORE_TRANSLUCENT_TERRAIN.invoker().beforeTranslucentTerrain(renderContext);
+		original.call(chunkSectionsToRender, group, sampler);
+		LevelRenderEvents.AFTER_TRANSLUCENT_TERRAIN.invoker().afterTranslucentTerrain(renderContext);
 	}
 
 	@Inject(method = "lambda$addMainPass$0", at = @At("RETURN"))

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/LevelRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/LevelRendererMixin.java
@@ -41,7 +41,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.OutlineBufferSource;
 import net.minecraft.client.renderer.RenderBuffers;
 import net.minecraft.client.renderer.SubmitNodeStorage;
 import net.minecraft.client.renderer.WorldBorderRenderer;
@@ -124,38 +123,39 @@ public abstract class LevelRendererMixin {
 	}
 
 	@Inject(method = "lambda$addMainPass$0", at = @At(value = "INVOKE_STRING", target = "Lnet/minecraft/util/profiling/ProfilerFiller;popPush(Ljava/lang/String;)V", args = "ldc=submitEntities"))
-	private void beforeEntitySubmission(CallbackInfo ci) {
-		LevelRenderEvents.BEFORE_ENTITIES.invoker().beforeEntities(renderContext);
+	private void beforeCollectSubmits(CallbackInfo ci) {
+		LevelRenderEvents.BEFORE_COLLECT_SUBMITS.invoker().beforeCollectSubmits(renderContext);
 	}
 
-	@WrapOperation(method = "lambda$addMainPass$0",
-			slice = @Slice(from = @At(value = "INVOKE_STRING", target = "Lnet/minecraft/util/profiling/ProfilerFiller;popPush(Ljava/lang/String;)V", args = "ldc=submitEntities")),
-			at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/OutlineBufferSource;endOutlineBatch()V")
-	)
-	private void afterEntityRender(OutlineBufferSource instance, Operation<Void> original) {
-		original.call(instance);
-		LevelRenderEvents.AFTER_ENTITIES.invoker().afterEntities(renderContext);
+	@Inject(method = "lambda$addMainPass$0", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/LevelRenderer;checkPoseStack(Lcom/mojang/blaze3d/vertex/PoseStack;)V", ordinal = 0))
+	private void afterRenderSolidFeatures(CallbackInfo ci) {
+		LevelRenderEvents.AFTER_SOLID_FEATURES.invoker().afterSolidFeatures(renderContext);
 	}
 
-	@Inject(method = "renderLevel", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/debug/DebugRenderer;emitGizmos(Lnet/minecraft/client/renderer/culling/Frustum;DDDF)V"))
-	private void beforeDebugRender(CallbackInfo ci) {
-		LevelRenderEvents.BEFORE_DEBUG_RENDER.invoker().beforeDebugRender(renderContext);
-	}
-
-	@Inject(method = "lambda$addMainPass$0", at = @At(value = "INVOKE_STRING", target = "Lnet/minecraft/util/profiling/ProfilerFiller;push(Ljava/lang/String;)V", args = "ldc=translucentTerrain"))
-	private void beforeTranslucentRender(CallbackInfo ci) {
-		LevelRenderEvents.BEFORE_TRANSLUCENT.invoker().beforeTranslucent(renderContext);
+	@Inject(method = "lambda$addMainPass$0", at = @At(value = "INVOKE_STRING", target = "Lnet/minecraft/util/profiling/ProfilerFiller;popPush(Ljava/lang/String;)V", args = "ldc=destroyProgress"))
+	private void afterRenderTranslucentFeatures(CallbackInfo ci) {
+		LevelRenderEvents.AFTER_TRANSLUCENT_FEATURES.invoker().afterTranslucentFeatures(renderContext);
 	}
 
 	@Inject(method = "renderBlockOutline", at = @At(value = "FIELD", target = "Lnet/minecraft/client/renderer/state/CameraRenderState;pos:Lnet/minecraft/world/phys/Vec3;", opcode = Opcodes.GETFIELD), cancellable = true)
-	private void beforeDrawBlockOutline(MultiBufferSource.BufferSource consumers, PoseStack poseStack, boolean bl, LevelRenderState worldRenderState, CallbackInfo ci) {
+	private void beforeRenderBlockOutline(MultiBufferSource.BufferSource bufferSource, PoseStack poseStack, boolean translucent, LevelRenderState levelRenderState, CallbackInfo ci) {
 		if (!LevelRenderEvents.BEFORE_BLOCK_OUTLINE.invoker().beforeBlockOutline(renderContext, renderContext.levelState().blockOutlineRenderState)) {
-			consumers.endLastBatch();
+			bufferSource.endLastBatch();
 			ci.cancel();
 		}
 	}
 
-	@Inject(method = "lambda$addMainPass$0", at = @At(value = "INVOKE:LAST", target = "Lnet/minecraft/client/renderer/MultiBufferSource$BufferSource;endBatch()V"))
+	@Inject(method = "lambda$addMainPass$0", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/LevelRenderer;finalizeGizmoCollection()V"))
+	private void beforeRenderGizmos(CallbackInfo ci) {
+		LevelRenderEvents.BEFORE_GIZMOS.invoker().beforeGizmos(renderContext);
+	}
+
+	@Inject(method = "lambda$addMainPass$0", at = @At(value = "INVOKE_STRING", target = "Lnet/minecraft/util/profiling/ProfilerFiller;push(Ljava/lang/String;)V", args = "ldc=translucentTerrain"))
+	private void beforeTranslucentRender(CallbackInfo ci) {
+		LevelRenderEvents.BEFORE_TRANSLUCENT_TERRAIN.invoker().beforeTranslucentTerrain(renderContext);
+	}
+
+	@Inject(method = "lambda$addMainPass$0", at = @At("RETURN"))
 	private void endMainRender(CallbackInfo ci) {
 		LevelRenderEvents.END_MAIN.invoker().endMain(renderContext);
 	}

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/LevelRenderEventsTests.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/LevelRenderEventsTests.java
@@ -97,7 +97,7 @@ public class LevelRenderEventsTests implements ClientModInitializer, FabricClien
 				LevelRenderEventsTests::extractBlockOutline);
 		LevelRenderEvents.BEFORE_BLOCK_OUTLINE.register(LevelRenderEventsTests::beforeBlockOutline);
 		// Renders a translucent filled box at (0, 100, 0)
-		LevelRenderEvents.BEFORE_TRANSLUCENT.register(LevelRenderEventsTests::renderBeforeTranslucent);
+		LevelRenderEvents.BEFORE_TRANSLUCENT_TERRAIN.register(LevelRenderEventsTests::renderBeforeTranslucent);
 	}
 
 	@Override
@@ -105,10 +105,11 @@ public class LevelRenderEventsTests implements ClientModInitializer, FabricClien
 		LevelRenderEvents.AFTER_BLOCK_OUTLINE_EXTRACTION.register((renderContext, hitResult) -> assertExtractionContext(renderContext));
 		LevelRenderEvents.END_EXTRACTION.register(LevelRenderEventsTests::assertExtractionContext);
 		LevelRenderEvents.START_MAIN.register(LevelRenderEventsTests::assertTerrainRenderContext);
-		LevelRenderEvents.BEFORE_ENTITIES.register(LevelRenderEventsTests::assertRenderContext);
-		LevelRenderEvents.AFTER_ENTITIES.register(LevelRenderEventsTests::assertRenderContext);
-		LevelRenderEvents.BEFORE_DEBUG_RENDER.register(LevelRenderEventsTests::assertRenderContext);
-		LevelRenderEvents.BEFORE_TRANSLUCENT.register(LevelRenderEventsTests::assertRenderContext);
+		LevelRenderEvents.BEFORE_COLLECT_SUBMITS.register(LevelRenderEventsTests::assertRenderContext);
+		LevelRenderEvents.AFTER_SOLID_FEATURES.register(LevelRenderEventsTests::assertRenderContext);
+		LevelRenderEvents.AFTER_TRANSLUCENT_FEATURES.register(LevelRenderEventsTests::assertRenderContext);
+		LevelRenderEvents.BEFORE_GIZMOS.register(LevelRenderEventsTests::assertRenderContext);
+		LevelRenderEvents.BEFORE_TRANSLUCENT_TERRAIN.register(LevelRenderEventsTests::assertRenderContext);
 		LevelRenderEvents.END_MAIN.register(LevelRenderEventsTests::assertRenderContext);
 
 		try (TestSingleplayerContext singleplayer = context.worldBuilder().create()) {

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/LevelRenderEventsTests.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/LevelRenderEventsTests.java
@@ -105,11 +105,13 @@ public class LevelRenderEventsTests implements ClientModInitializer, FabricClien
 		LevelRenderEvents.AFTER_BLOCK_OUTLINE_EXTRACTION.register((renderContext, hitResult) -> assertExtractionContext(renderContext));
 		LevelRenderEvents.END_EXTRACTION.register(LevelRenderEventsTests::assertExtractionContext);
 		LevelRenderEvents.START_MAIN.register(LevelRenderEventsTests::assertTerrainRenderContext);
-		LevelRenderEvents.BEFORE_COLLECT_SUBMITS.register(LevelRenderEventsTests::assertRenderContext);
+		LevelRenderEvents.AFTER_OPAQUE_TERRAIN.register(LevelRenderEventsTests::assertTerrainRenderContext);
+		LevelRenderEvents.COLLECT_SUBMITS.register(LevelRenderEventsTests::assertRenderContext);
 		LevelRenderEvents.AFTER_SOLID_FEATURES.register(LevelRenderEventsTests::assertRenderContext);
 		LevelRenderEvents.AFTER_TRANSLUCENT_FEATURES.register(LevelRenderEventsTests::assertRenderContext);
 		LevelRenderEvents.BEFORE_GIZMOS.register(LevelRenderEventsTests::assertRenderContext);
 		LevelRenderEvents.BEFORE_TRANSLUCENT_TERRAIN.register(LevelRenderEventsTests::assertRenderContext);
+		LevelRenderEvents.AFTER_TRANSLUCENT_TERRAIN.register(LevelRenderEventsTests::assertRenderContext);
 		LevelRenderEvents.END_MAIN.register(LevelRenderEventsTests::assertRenderContext);
 
 		try (TestSingleplayerContext singleplayer = context.worldBuilder().create()) {


### PR DESCRIPTION
- Rename `BEFORE_ENTITIES` -> `COLLECT_SUBMITS` and move injection point to after all vanilla submits have been collected
- Remove `AFTER_ENTITIES`
- Add `AFTER_SOLID_FEATURES` and `AFTER_TRANSLUCENT_FEATURES`
- Rename `BEFORE_DEBUG_RENDER` -> `BEFORE_GIZMOS` and fix injection point
- Rename `BEFORE_TRANSLUCENT` -> `BEFORE_TRANSLUCENT_TERRAIN`
- Add `AFTER_OPAQUE_TERRAIN` and `AFTER_TRANSLUCENT_TERRAIN`
- Move injection point for `END_MAIN` after `endBatch` to be consistent with other events and documentation
- Update documentation to be clearer and more consistent