### PR TITLE
Fix attachment sync gametest flakiness

### DIFF
--- a/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/gametest/SyncGametest.java
+++ b/fabric-data-attachment-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/attachment/client/gametest/SyncGametest.java
@@ -38,6 +38,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.level.storage.LevelData;
 
 import net.fabricmc.fabric.api.attachment.v1.AttachmentTarget;
 import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
@@ -120,6 +121,9 @@ public class SyncGametest implements FabricClientGameTest {
 
 				ServerLevel nether = server.getLevel(Level.NETHER);
 				setSyncedWithAll(Objects.requireNonNull(nether));
+
+				// in case world spawn is too far from 0 0
+				server.setRespawnData(LevelData.RespawnData.DEFAULT);
 			});
 
 			LOGGER.info("Joining dedicated server");


### PR DESCRIPTION
Sometimes world spawn is too far from 0 0, where all the attachment targets are setup.