### PR TITLE
Alias dye tags

### DIFF
--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/ItemTagsGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/ItemTagsGenerator.java
@@ -932,5 +932,6 @@ public final class ItemTagsGenerator extends FabricTagsProvider.ItemTagsProvider
 		aliasGroup("fence_gates").add(ItemTags.FENCE_GATES, ConventionalItemTags.FENCE_GATES);
 
 		aliasGroup("flowers/small").add(ItemTags.SMALL_FLOWERS, ConventionalItemTags.SMALL_FLOWERS);
+		aliasGroup("dyes").add(ItemTags.DYES, ConventionalItemTags.DYES);
 	}
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/fabric-convention-tags-v2/fabric/tag_aliases/item/dyes.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/fabric-convention-tags-v2/fabric/tag_aliases/item/dyes.json
@@ -1,0 +1,6 @@
+{
+  "tags": [
+    "minecraft:dyes",
+    "c:dyes"
+  ]
+}


### PR DESCRIPTION
26.1 introduces the new `minecraft:dyes` tag, which presumably can be expected to hold all dyes. This can be aliased with the existing conventional `c:dyes` tag, which does the same.