### PR TITLE
Add `c:item_frames` entity tag

### DIFF
--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/EnglishTagLangGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/EnglishTagLangGenerator.java
@@ -436,6 +436,7 @@ public class EnglishTagLangGenerator extends FabricLanguageProvider {
 		translationBuilder.add(ConventionalEntityTypeTags.BOSSES, "Bosses");
 		translationBuilder.add(ConventionalEntityTypeTags.MINECARTS, "Minecarts");
 		translationBuilder.add(ConventionalEntityTypeTags.BOATS, "Boats");
+		translationBuilder.add(ConventionalEntityTypeTags.ITEM_FRAMES, "Item Frames");
 		translationBuilder.add(ConventionalEntityTypeTags.CAPTURING_NOT_SUPPORTED, "Capturing Not Supported");
 		translationBuilder.add(ConventionalEntityTypeTags.TELEPORTING_NOT_SUPPORTED, "Teleporting Not Supported");
 

--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/EntityTypeTagsGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/EntityTypeTagsGenerator.java
@@ -56,6 +56,9 @@ public final class EntityTypeTagsGenerator extends FabricTagsProvider.EntityType
 				.add(EntityType.DARK_OAK_CHEST_BOAT)
 				.add(EntityType.MANGROVE_CHEST_BOAT)
 				.add(EntityType.BAMBOO_CHEST_RAFT);
+		valueLookupBuilder(ConventionalEntityTypeTags.ITEM_FRAMES)
+				.add(EntityType.ITEM_FRAME)
+				.add(EntityType.GLOW_ITEM_FRAME);
 		valueLookupBuilder(ConventionalEntityTypeTags.CAPTURING_NOT_SUPPORTED);
 		valueLookupBuilder(ConventionalEntityTypeTags.TELEPORTING_NOT_SUPPORTED);
 	}

--- a/fabric-convention-tags-v2/src/generated/resources/assets/fabric-convention-tags-v2/lang/en_us.json
+++ b/fabric-convention-tags-v2/src/generated/resources/assets/fabric-convention-tags-v2/lang/en_us.json
@@ -131,6 +131,7 @@
   "tag.entity_type.c.boats": "Boats",
   "tag.entity_type.c.bosses": "Bosses",
   "tag.entity_type.c.capturing_not_supported": "Capturing Not Supported",
+  "tag.entity_type.c.item_frames": "Item Frames",
   "tag.entity_type.c.minecarts": "Minecarts",
   "tag.entity_type.c.teleporting_not_supported": "Teleporting Not Supported",
   "tag.fluid.c.beetroot_soup": "Beetroot Soup",

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/entity_type/item_frames.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/entity_type/item_frames.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "minecraft:item_frame",
+    "minecraft:glow_item_frame"
+  ]
+}

--- a/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalEntityTypeTags.java
+++ b/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalEntityTypeTags.java
@@ -36,6 +36,9 @@ public final class ConventionalEntityTypeTags {
 
 	public static final TagKey<EntityType<?>> MINECARTS = register("minecarts");
 	public static final TagKey<EntityType<?>> BOATS = register("boats");
+	/**
+	* Tag containing entity types, generally extending {@link net.minecraft.world.entity.decoration.ItemFrame}, that can be placed on the surfaces of blocks to display an item.
+	*/
 	public static final TagKey<EntityType<?>> ITEM_FRAMES = register("item_frames");
 
 	/**

--- a/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalEntityTypeTags.java
+++ b/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalEntityTypeTags.java
@@ -36,6 +36,7 @@ public final class ConventionalEntityTypeTags {
 
 	public static final TagKey<EntityType<?>> MINECARTS = register("minecarts");
 	public static final TagKey<EntityType<?>> BOATS = register("boats");
+	public static final TagKey<EntityType<?>> ITEM_FRAMES = register("item_frames");
 
 	/**
 	 * Entities should be included in this tag if they are not allowed to be picked up by items or grabbed in a way


### PR DESCRIPTION
Neoforge PR: https://github.com/neoforged/NeoForge/pull/2969

This is to cover how vanilla has 2 item frame variants now. Might help other mods that add more variants like a light-source item frame or gamer RGB item frame.