### PR TITLE
Respect item MAX_STACK_SIZE in Storage.insert

### DIFF
--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/compat/WrappedInventory.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/compat/WrappedInventory.java
@@ -61,7 +61,7 @@ final class WrappedInventory implements ItemInsertable, ItemExtractable {
 				ItemStack stack = inv.getStack(i);
 
 				if (stack.isEmpty() || ItemStack.areItemsAndComponentsEqual(stack, input)) {
-					int remainingSpace = Math.min(inv.getMaxCountPerStack(), stack.getItem().getMaxCount()) - stack.getCount();
+					int remainingSpace = Math.min(inv.getMaxCountPerStack(), stack.getMaxCount()) - stack.getCount();
 					int inserted = Math.min(remainingSpace, input.getCount());
 
 					if (!simulate) {

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleStackStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleStackStorage.java
@@ -69,12 +69,12 @@ public abstract class SingleStackStorage extends SnapshotParticipant<ItemStack> 
 	 *
 	 * <p>If the capacity should be limited by the max count of the item, this function must take it into account.
 	 * For example, a storage with a maximum count of 4, or less for items that have a smaller max count,
-	 * should override this to return {@code Math.min(itemVariant.getItem().getMaxCount(), 4);}.
+	 * should override this to return {@code Math.min(itemVariant.toStack().getMaxCount(), 4);}.
 	 *
 	 * @return The maximum capacity of this storage for the passed item variant.
 	 */
 	protected int getCapacity(ItemVariant itemVariant) {
-		return itemVariant.getItem().getMaxCount();
+		return itemVariant.toStack().getMaxCount();
 	}
 
 	@Override

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleStackStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleStackStorage.java
@@ -20,6 +20,7 @@ import net.minecraft.item.ItemStack;
 
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.StoragePreconditions;
+import net.fabricmc.fabric.impl.transfer.item.ItemVariantImpl;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleSlotStorage;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.fabricmc.fabric.api.transfer.v1.transaction.base.SnapshotParticipant;
@@ -69,12 +70,12 @@ public abstract class SingleStackStorage extends SnapshotParticipant<ItemStack> 
 	 *
 	 * <p>If the capacity should be limited by the max count of the item, this function must take it into account.
 	 * For example, a storage with a maximum count of 4, or less for items that have a smaller max count,
-	 * should override this to return {@code Math.min(itemVariant.toStack().getMaxCount(), 4);}.
+	 * should override this to return {@code Math.min(ItemVariantImpl.getMaxStackSize(itemVariant), 4);}.
 	 *
 	 * @return The maximum capacity of this storage for the passed item variant.
 	 */
 	protected int getCapacity(ItemVariant itemVariant) {
-		return itemVariant.toStack().getMaxCount();
+		return ItemVariantImpl.getMaxStackSize(itemVariant);
 	}
 
 	@Override

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleStackStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleStackStorage.java
@@ -20,10 +20,10 @@ import net.minecraft.item.ItemStack;
 
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.StoragePreconditions;
-import net.fabricmc.fabric.impl.transfer.item.ItemVariantImpl;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleSlotStorage;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.fabricmc.fabric.api.transfer.v1.transaction.base.SnapshotParticipant;
+import net.fabricmc.fabric.impl.transfer.item.ItemVariantImpl;
 
 /**
  * An item variant storage backed by an {@link ItemStack}.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleStackStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleStackStorage.java
@@ -70,7 +70,7 @@ public abstract class SingleStackStorage extends SnapshotParticipant<ItemStack> 
 	 *
 	 * <p>If the capacity should be limited by the max count of the item, this function must take it into account.
 	 * For example, a storage with a maximum count of 4, or less for items that have a smaller max count,
-	 * should override this to return {@code Math.min(ItemVariantImpl.getMaxStackSize(itemVariant), 4);}.
+	 * should override this to return {@code Math.min(super.getCapacity(itemVariant), 4);}.
 	 *
 	 * @return The maximum capacity of this storage for the passed item variant.
 	 */

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/ContainerComponentStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/ContainerComponentStorage.java
@@ -166,7 +166,7 @@ public class ContainerComponentStorage extends CombinedSlottedStorage<ItemVarian
 
 		@Override
 		public long getCapacity() {
-			return getStack().getItem().getMaxCount();
+			return getStack().getMaxCount();
 		}
 
 		@Override

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/InventorySlotWrapper.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/InventorySlotWrapper.java
@@ -121,7 +121,7 @@ class InventorySlotWrapper extends SingleStackStorage {
 			return 1;
 		}
 
-		return Math.min(storage.inventory.getMaxCountPerStack(), variant.getItem().getMaxCount());
+		return Math.min(storage.inventory.getMaxCountPerStack(), variant.toStack().getMaxCount());
 	}
 
 	// We override updateSnapshots to also schedule a markDirty call for the backing inventory.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/InventorySlotWrapper.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/InventorySlotWrapper.java
@@ -121,7 +121,7 @@ class InventorySlotWrapper extends SingleStackStorage {
 			return 1;
 		}
 
-		return Math.min(storage.inventory.getMaxCountPerStack(), variant.toStack().getMaxCount());
+		return Math.min(storage.inventory.getMaxCountPerStack(), ItemVariantImpl.getMaxStackSize(variant));
 	}
 
 	// We override updateSnapshots to also schedule a markDirty call for the backing inventory.

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/ItemVariantImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/ItemVariantImpl.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.component.ComponentChanges;
 import net.minecraft.component.ComponentMap;
+import net.minecraft.component.DataComponentTypes;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -106,6 +107,14 @@ public class ItemVariantImpl implements ItemVariant {
 	@Override
 	public int hashCode() {
 		return hashCode;
+	}
+
+	/**
+	 * Return the max stack size for this variant, respecting component overrides such as
+	 * {@link DataComponentTypes#MAX_STACK_SIZE}.
+	 */
+	public static int getMaxStackSize(ItemVariant variant) {
+		return variant.getComponentMap().getOrDefault(DataComponentTypes.MAX_STACK_SIZE, variant.getItem().getMaxCount());
 	}
 
 	public ItemStack getCachedStack() {

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/PlayerInventoryStorageImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/PlayerInventoryStorageImpl.java
@@ -132,7 +132,7 @@ class PlayerInventoryStorageImpl extends InventoryStorageImpl implements PlayerI
 				long remainder = entry.amount;
 
 				while (remainder > 0) {
-					int dropped = (int) Math.min(entry.key.getItem().getMaxCount(), remainder);
+					int dropped = (int) Math.min(entry.key.toStack().getMaxCount(), remainder);
 					playerInventory.player.dropItem(entry.key.toStack(dropped), entry.throwRandomly, entry.retainOwnership);
 					remainder -= dropped;
 				}

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/PlayerInventoryStorageImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/PlayerInventoryStorageImpl.java
@@ -132,7 +132,7 @@ class PlayerInventoryStorageImpl extends InventoryStorageImpl implements PlayerI
 				long remainder = entry.amount;
 
 				while (remainder > 0) {
-					int dropped = (int) Math.min(entry.key.toStack().getMaxCount(), remainder);
+					int dropped = (int) Math.min(ItemVariantImpl.getMaxStackSize(entry.key), remainder);
 					playerInventory.player.dropItem(entry.key.toStack(dropped), entry.throwRandomly, entry.retainOwnership);
 					remainder -= dropped;
 				}

--- a/fabric-transfer-api-v1/src/test/java/net/fabricmc/fabric/test/transfer/unittests/ItemTests.java
+++ b/fabric-transfer-api-v1/src/test/java/net/fabricmc/fabric/test/transfer/unittests/ItemTests.java
@@ -245,6 +245,87 @@ class ItemTests extends AbstractTransferApiTest {
 		}
 	}
 
+	/**
+	 * Test that {@link DataComponentTypes#MAX_STACK_SIZE} overrides on an item variant are respected.
+	 * Items that are normally stackable (e.g. diamonds, max 64) but have a component override
+	 * reducing their max stack size (e.g. to 1) should not be merged into existing stacks.
+	 *
+	 * <p>This is a regression test for a bug where {@code Item.getMaxCount()} was used instead of
+	 * {@code ItemStack.getMaxCount()}, causing the component override to be ignored.
+	 */
+	@Test
+	public void testComponentMaxStackSizeOverride() {
+		// Create a variant of a normally-stackable item (diamond, default max 64)
+		// with MAX_STACK_SIZE overridden to 1 via components.
+		ComponentChanges components = ComponentChanges.builder()
+				.add(DataComponentTypes.MAX_STACK_SIZE, 1)
+				.build();
+		ItemVariant unstackableDiamond = ItemVariant.of(Items.DIAMOND, components);
+
+		// Also create a normal diamond variant for comparison.
+		ItemVariant normalDiamond = ItemVariant.of(Items.DIAMOND);
+
+		// Test 1: Inserting into a fresh inventory should place 1 per slot.
+		SimpleInventory inventory = new SimpleInventory(3);
+		InventoryStorage wrapper = InventoryStorage.of(inventory, null);
+
+		try (Transaction transaction = Transaction.openOuter()) {
+			// Try to insert 3 unstackable diamonds. Should go into 3 separate slots.
+			long inserted = wrapper.insert(unstackableDiamond, 3, transaction);
+
+			if (inserted != 3) {
+				throw new AssertionError("Should have inserted 3 unstackable diamonds, but inserted " + inserted);
+			}
+
+			// Verify each slot has exactly 1.
+			for (int i = 0; i < 3; i++) {
+				ItemStack stack = inventory.getStack(i);
+
+				if (stack.getCount() != 1) {
+					throw new AssertionError("Slot " + i + " should have count 1, but has " + stack.getCount());
+				}
+			}
+
+			transaction.commit();
+		}
+
+		// Test 2: Inserting into a slot that already has one should NOT merge.
+		SimpleInventory inventory2 = new SimpleInventory(1);
+		InventoryStorage wrapper2 = InventoryStorage.of(inventory2, null);
+
+		try (Transaction transaction = Transaction.openOuter()) {
+			// Insert one first.
+			long first = wrapper2.insert(unstackableDiamond, 1, transaction);
+
+			if (first != 1) {
+				throw new AssertionError("First insert should have succeeded.");
+			}
+
+			// Try to insert another into the same single-slot inventory. Should fail.
+			long second = wrapper2.insert(unstackableDiamond, 1, transaction);
+
+			if (second != 0) {
+				throw new AssertionError("Second insert should have returned 0 (slot full), but inserted " + second);
+			}
+
+			transaction.commit();
+		}
+
+		// Test 3: Normal diamonds (no component override) should still stack to 64.
+		SimpleInventory inventory3 = new SimpleInventory(1);
+		InventoryStorage wrapper3 = InventoryStorage.of(inventory3, null);
+
+		try (Transaction transaction = Transaction.openOuter()) {
+			long inserted = wrapper3.insert(normalDiamond, 100, transaction);
+
+			if (inserted != 64) {
+				throw new AssertionError("Normal diamonds should stack to 64, but inserted " + inserted);
+			}
+
+			transaction.commit();
+		}
+	}
+
 	private static class LimitedStackCountInventory extends SimpleInventory {
 		LimitedStackCountInventory(int size) {
 			super(size);


### PR DESCRIPTION
This commit addresses the bug described in issue #5219 .

When an item has a stack size specified via DataComponents.MAX_STACK_SIZE, if the stack size differs from the item's default stack size, the updated `transfer` methods could accidentally cause items to be deleted after transfers. This would occur if the target inventory already contained an identical item. Since getCapacity used the item type's default size (rather than the size specified by the item DataComponents), the insert logic would see plenty of room in a slot already containing items, merge the new item into that slot.

After this occurs, the slot would claim to hold (e.g.) 2 of a max-stack-1 item. After the next inventory update, the extra item was silently lost.

Changing the getCapacity logic to call toStack() on the variant correctly prevents the faulty merge and fixes the bug.

**Note for reviewers:** The only one of these cases I know how to test in game is the update to `InventorySlotWrapper.getCapacity`. However, it seemed best to update the other places where this pattern appeared as well. The existing tests passed after my change, and my new tests fail appropriately if the change is reverted, so I think I've done all I know how to do to validate the change. 

**Disclaimer / transparency**: I used Claude Code to help navigate this codebase, find the bug, and make this change. I hope you won't hold it against me as considerable human judgment and labor was applied to test the change :) 

With that said, given my lack of experience in this code, I don't have a good understanding of potential ramifications of this change, so I'm open to being told this is the wrong approach. 