### PR TITLE
Some Packet Context extras

### DIFF
--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientConfigurationNetworking.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientConfigurationNetworking.java
@@ -32,6 +32,7 @@ import net.fabricmc.fabric.api.networking.v1.PacketSender;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.api.networking.v1.ServerConfigurationNetworking;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.fabricmc.fabric.api.networking.v1.context.PacketContext;
 import net.fabricmc.fabric.impl.networking.client.ClientConfigurationNetworkAddon;
 import net.fabricmc.fabric.impl.networking.client.ClientNetworkingImpl;
 
@@ -288,5 +289,12 @@ public final class ClientConfigurationNetworking {
 		 * @return The packet sender
 		 */
 		PacketSender responseSender();
+
+		/**
+		 * @return The PacketContext instance attached to the listener
+		 */
+		default PacketContext packetContext() {
+			return this.packetListener().getPacketContext();
+		}
 	}
 }

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientPlayNetworking.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/api/client/networking/v1/ClientPlayNetworking.java
@@ -32,6 +32,7 @@ import net.minecraft.resources.Identifier;
 import net.fabricmc.fabric.api.networking.v1.PacketSender;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.fabricmc.fabric.api.networking.v1.context.PacketContext;
 import net.fabricmc.fabric.impl.networking.client.ClientNetworkingImpl;
 import net.fabricmc.fabric.impl.networking.client.ClientPlayNetworkAddon;
 
@@ -295,5 +296,12 @@ public final class ClientPlayNetworking {
 		 * @return The packet sender
 		 */
 		PacketSender responseSender();
+
+		/**
+		 * @return The PacketContext instance attached to the listener
+		 */
+		default PacketContext packetContext() {
+			return Objects.requireNonNull(this.client().getConnection(), "this.client().getConnection() is null!").getPacketContext();
+		}
 	}
 }

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/ClientConfigurationPacketListenerImplMixin.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/ClientConfigurationPacketListenerImplMixin.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.fabric.mixin.networking.client;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -26,12 +27,14 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientCommonPacketListenerImpl;
 import net.minecraft.client.multiplayer.ClientConfigurationPacketListenerImpl;
 import net.minecraft.client.multiplayer.CommonListenerCookie;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.configuration.ClientboundFinishConfigurationPacket;
 
 import net.fabricmc.fabric.impl.networking.PacketListenerExtensions;
 import net.fabricmc.fabric.impl.networking.client.ClientConfigurationNetworkAddon;
 import net.fabricmc.fabric.impl.networking.client.ClientNetworkingImpl;
+import net.fabricmc.fabric.impl.networking.context.PacketContextImpl;
 
 // We want to apply a bit earlier than other mods which may not use us in order to prevent refCount issues
 @Mixin(value = ClientConfigurationPacketListenerImpl.class, priority = 999)
@@ -52,7 +55,9 @@ public abstract class ClientConfigurationPacketListenerImplMixin extends ClientC
 	}
 
 	@Inject(method = "handleConfigurationFinished", at = @At(value = "NEW", target = "(Lnet/minecraft/client/Minecraft;Lnet/minecraft/network/Connection;Lnet/minecraft/client/multiplayer/CommonListenerCookie;)Lnet/minecraft/client/multiplayer/ClientPacketListener;"))
-	public void handleComplete(ClientboundFinishConfigurationPacket packet, CallbackInfo ci) {
+	public void handleComplete(ClientboundFinishConfigurationPacket packet, CallbackInfo ci, @Local RegistryAccess.Frozen registryAccess) {
+		this.connection.getPacketContext().set(PacketContextImpl.REGISTRY_ACCESS, registryAccess);
+
 		this.addon.handleComplete();
 	}
 

--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/LocalPlayerMixin.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/LocalPlayerMixin.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.networking.client;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.client.player.LocalPlayer;
+
+import net.fabricmc.fabric.api.networking.v1.context.PacketContext;
+import net.fabricmc.fabric.api.networking.v1.context.PacketContextProvider;
+
+@Mixin(LocalPlayer.class)
+public class LocalPlayerMixin implements PacketContextProvider {
+	@Shadow
+	@Final
+	public ClientPacketListener connection;
+
+	@Override
+	public PacketContext getPacketContext() {
+		return this.connection.getPacketContext();
+	}
+}

--- a/fabric-networking-api-v1/src/client/resources/fabric-networking-api-v1.client.mixins.json
+++ b/fabric-networking-api-v1/src/client/resources/fabric-networking-api-v1.client.mixins.json
@@ -3,15 +3,16 @@
   "package": "net.fabricmc.fabric.mixin.networking.client",
   "compatibilityLevel": "JAVA_25",
   "client": [
-    "ClientCommonPacketListenerImplMixin",
-    "ClientConfigurationPacketListenerImplMixin",
-    "ClientHandshakePacketListenerImplMixin",
-    "ClientPacketListenerMixin",
     "accessor.ClientCommonPacketListenerImplAccessor",
     "accessor.ClientConfigurationPacketListenerImplAccessor",
     "accessor.ClientHandshakePacketListenerImplAccessor",
     "accessor.ConnectScreenAccessor",
-    "accessor.MinecraftAccessor"
+    "accessor.MinecraftAccessor",
+    "ClientCommonPacketListenerImplMixin",
+    "ClientConfigurationPacketListenerImplMixin",
+    "ClientHandshakePacketListenerImplMixin",
+    "ClientPacketListenerMixin",
+    "LocalPlayerMixin"
   ],
   "injectors": {
     "defaultRequire": 1
@@ -20,6 +21,5 @@
     "requireAnnotations": true
   },
   "mixins": [
-    "LocalPlayerMixin"
   ]
 }

--- a/fabric-networking-api-v1/src/client/resources/fabric-networking-api-v1.client.mixins.json
+++ b/fabric-networking-api-v1/src/client/resources/fabric-networking-api-v1.client.mixins.json
@@ -19,7 +19,5 @@
   },
   "overwrites": {
     "requireAnnotations": true
-  },
-  "mixins": [
-  ]
+  }
 }

--- a/fabric-networking-api-v1/src/client/resources/fabric-networking-api-v1.client.mixins.json
+++ b/fabric-networking-api-v1/src/client/resources/fabric-networking-api-v1.client.mixins.json
@@ -3,20 +3,23 @@
   "package": "net.fabricmc.fabric.mixin.networking.client",
   "compatibilityLevel": "JAVA_25",
   "client": [
+    "ClientCommonPacketListenerImplMixin",
+    "ClientConfigurationPacketListenerImplMixin",
+    "ClientHandshakePacketListenerImplMixin",
+    "ClientPacketListenerMixin",
     "accessor.ClientCommonPacketListenerImplAccessor",
     "accessor.ClientConfigurationPacketListenerImplAccessor",
     "accessor.ClientHandshakePacketListenerImplAccessor",
     "accessor.ConnectScreenAccessor",
-    "accessor.MinecraftAccessor",
-    "ClientCommonPacketListenerImplMixin",
-    "ClientConfigurationPacketListenerImplMixin",
-    "ClientHandshakePacketListenerImplMixin",
-    "ClientPacketListenerMixin"
+    "accessor.MinecraftAccessor"
   ],
   "injectors": {
     "defaultRequire": 1
   },
   "overwrites": {
     "requireAnnotations": true
-  }
+  },
+  "mixins": [
+    "LocalPlayerMixin"
+  ]
 }

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/ServerConfigurationNetworking.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/ServerConfigurationNetworking.java
@@ -30,6 +30,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerConfigurationPacketListenerImpl;
 import net.minecraft.util.thread.BlockableEventLoop;
 
+import net.fabricmc.fabric.api.networking.v1.context.PacketContext;
 import net.fabricmc.fabric.impl.networking.server.ServerNetworkingImpl;
 import net.fabricmc.fabric.mixin.networking.accessor.ServerCommonPacketListenerImplAccessor;
 
@@ -292,5 +293,12 @@ public final class ServerConfigurationNetworking {
 		 * @return The packet sender
 		 */
 		PacketSender responseSender();
+
+		/**
+		 * @return The PacketContext instance attached to the listener
+		 */
+		default PacketContext packetContext() {
+			return this.packetListener().getPacketContext();
+		}
 	}
 }

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/ServerPlayNetworking.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/ServerPlayNetworking.java
@@ -30,6 +30,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 
+import net.fabricmc.fabric.api.networking.v1.context.PacketContext;
 import net.fabricmc.fabric.impl.networking.server.ServerNetworkingImpl;
 
 /**
@@ -359,5 +360,12 @@ public final class ServerPlayNetworking {
 		 * @return The packet sender
 		 */
 		PacketSender responseSender();
+
+		/**
+		 * @return The PacketContext instance attached to the listener
+		 */
+		default PacketContext packetContext() {
+			return this.player().connection.getPacketContext();
+		}
 	}
 }

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/context/PacketContext.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/context/PacketContext.java
@@ -145,7 +145,13 @@ public interface PacketContext {
 	 * @return current context or null
 	 */
 	static PacketContext orElseThrow() {
-		return PacketContextImpl.VALUE.orElseThrow(() -> new RuntimeException("PacketContext is required, but it wasn't set up!"));
+		PacketContext ctx = PacketContextImpl.VALUE.orElseThrow(() -> new RuntimeException("PacketContext is required, but it wasn't set up!"));
+
+		if (ctx == null) {
+			throw new RuntimeException("PacketContext is required, but it was disabled!");
+		}
+
+		return ctx;
 	}
 
 	/**
@@ -167,6 +173,34 @@ public interface PacketContext {
 	 */
 	static <T> T supplyWithContext(PacketContextProvider provider, Supplier<T> supplier) {
 		return ScopedValue.where(PacketContextImpl.VALUE, provider.getPacketContext()).call(supplier::get);
+	}
+
+	/**
+	 * Runs specified runnable without a packet context.
+	 *
+	 * @param runnable runnable to execute
+	 */
+	static void runWithoutContext(Runnable runnable) {
+		if (PacketContextImpl.VALUE.isBound()) {
+			ScopedValue.where(PacketContextImpl.VALUE, null).run(runnable);
+			return;
+		}
+
+		runnable.run();
+	}
+
+	/**
+	 * Runs specified runnable without a packet context, returning a value.
+	 *
+	 * @param supplier supplier to execute
+	 * @return result of supplier
+	 */
+	static <T> T supplyWithoutContext(Supplier<T> supplier) {
+		if (PacketContextImpl.VALUE.isBound()) {
+			return ScopedValue.where(PacketContextImpl.VALUE, null).call(supplier::get);
+		}
+
+		return supplier.get();
 	}
 
 	/**

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/context/PacketContext.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/context/PacketContext.java
@@ -49,7 +49,7 @@ import net.fabricmc.fabric.impl.networking.context.PacketContextImpl;
  * PacketContext.Key<TriState> TATER_MESSAGE = PacketContext.key(Identifier.fromNamespaceAndPath("mod", "tater_message"));
  *
  * ServerConfigurationNetworking.registerGlobalReceiver(ServerboundModConfig.TYPE, (packet, context) -> {
- *      context.packetListener().getPacketContext().set(TATER_MESSAGE, packet.taterMessage());
+ *      context.packetContext().set(TATER_MESSAGE, packet.taterMessage());
  * });
  *
  * ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> {

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/context/PacketContext.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/context/PacketContext.java
@@ -25,11 +25,12 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.Connection;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.network.ServerHandshakePacketListenerImpl;
+import net.minecraft.server.network.ServerLoginPacketListenerImpl;
 
 import net.fabricmc.fabric.impl.networking.context.PacketContextImpl;
 
@@ -62,9 +63,15 @@ import net.fabricmc.fabric.impl.networking.context.PacketContextImpl;
 public interface PacketContext {
 	/**
 	 * The server instance that handles this connection. Only present on clientbound connections.
-	 * This value is set once the {@link ServerHandshakePacketListenerImpl} is constructed.
+	 * This value is set once the {@link ServerLoginPacketListenerImpl} is constructed.
 	 */
 	ReadKey<MinecraftServer> SERVER_INSTANCE = PacketContextImpl.SERVER_INSTANCE;
+	/**
+	 * The instance of registry access.
+	 * This value is set once the {@link ServerLoginPacketListenerImpl} is constructed (on serve)
+	 * and once client side configuration is finished.
+	 */
+	ReadKey<RegistryAccess> REGISTRY_ACCESS = PacketContextImpl.REGISTRY_ACCESS;
 	/**
 	 * The Game Profile attached to this connection.
 	 * This value is set on both server and client, once the login process succeeds.

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/context/PacketContext.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/api/networking/v1/context/PacketContext.java
@@ -53,7 +53,7 @@ import net.fabricmc.fabric.impl.networking.context.PacketContextImpl;
  * });
  *
  * ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> {
- *      if (handler.getPacketContext().orElse(TATER_MESSAGE, TriState.DEFAULT).orElse(ModConfig.taterMessage)) {
+ *      if (handler.getPacketContext().orElse(TATER_MESSAGE, ModConfig.taterMessage)) {
  *            handler.getPlayer().sendSystemMessage(Component.literal("I am a Tiny Potato and I believe in you!"), false);
  *      }
  * });

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/context/PacketContextImpl.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/context/PacketContextImpl.java
@@ -25,6 +25,7 @@ import com.mojang.authlib.GameProfile;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.Connection;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.MinecraftServer;
@@ -34,6 +35,7 @@ import net.fabricmc.fabric.api.networking.v1.context.PacketContext;
 public final class PacketContextImpl implements PacketContext {
 	public static final ScopedValue<PacketContext> VALUE = ScopedValue.newInstance();
 	public static final Key<MinecraftServer> SERVER_INSTANCE = fabricKey("server_instance");
+	public static final Key<RegistryAccess> REGISTRY_ACCESS = fabricKey("registry_access");
 	public static final Key<GameProfile> GAME_PROFILE = fabricKey("game_profile");
 	public static final Key<@NonNull Connection> CONNECTION = fabricKey("connection");
 

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/server/ServerPlayNetworkAddon.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/server/ServerPlayNetworkAddon.java
@@ -33,6 +33,7 @@ import net.fabricmc.fabric.api.networking.v1.ClientboundPlayChannelEvents;
 import net.fabricmc.fabric.api.networking.v1.PacketSender;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.fabricmc.fabric.api.networking.v1.context.PacketContext;
 import net.fabricmc.fabric.impl.networking.AbstractChanneledNetworkAddon;
 import net.fabricmc.fabric.impl.networking.ChannelInfoHolder;
 import net.fabricmc.fabric.impl.networking.NetworkingImpl;
@@ -157,6 +158,11 @@ public final class ServerPlayNetworkAddon extends AbstractChanneledNetworkAddon<
 		@Override
 		public ServerPlayer player() {
 			return listener.getPlayer();
+		}
+
+		@Override
+		public PacketContext packetContext() {
+			return listener.getPacketContext();
 		}
 	}
 }

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/ServerHandshakePacketListenerImplMixin.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/ServerHandshakePacketListenerImplMixin.java
@@ -19,28 +19,18 @@ package net.fabricmc.fabric.mixin.networking;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.network.Connection;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerHandshakePacketListenerImpl;
 
 import net.fabricmc.fabric.api.networking.v1.context.PacketContext;
 import net.fabricmc.fabric.api.networking.v1.context.PacketContextProvider;
-import net.fabricmc.fabric.impl.networking.context.PacketContextImpl;
 
 @Mixin(ServerHandshakePacketListenerImpl.class)
 abstract class ServerHandshakePacketListenerImplMixin implements PacketContextProvider {
 	@Shadow
 	@Final
 	private Connection connection;
-
-	@Inject(method = "<init>", at = @At("TAIL"))
-	private void provideServerContext(MinecraftServer server, Connection connection, CallbackInfo ci) {
-		connection.getPacketContext().set(PacketContextImpl.SERVER_INSTANCE, server);
-	}
 
 	@Override
 	public PacketContext getPacketContext() {

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/ServerLoginPacketListenerImplMixin.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/ServerLoginPacketListenerImplMixin.java
@@ -53,7 +53,9 @@ abstract class ServerLoginPacketListenerImplMixin implements PacketListenerExten
 	private ServerLoginNetworkAddon addon;
 
 	@Inject(method = "<init>", at = @At("RETURN"))
-	private void initAddon(CallbackInfo ci) {
+	private void initAddon(MinecraftServer server, Connection connection, boolean transferred, CallbackInfo ci) {
+		connection.getPacketContext().set(PacketContextImpl.SERVER_INSTANCE, server);
+
 		this.addon = new ServerLoginNetworkAddon((ServerLoginPacketListenerImpl) (Object) this);
 		// A bit of a hack but it allows the field above to be set in case someone registers handlers during INIT event which refers to said field
 		this.addon.lateInit();

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/ServerLoginPacketListenerImplMixin.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/ServerLoginPacketListenerImplMixin.java
@@ -55,6 +55,7 @@ abstract class ServerLoginPacketListenerImplMixin implements PacketListenerExten
 	@Inject(method = "<init>", at = @At("RETURN"))
 	private void initAddon(MinecraftServer server, Connection connection, boolean transferred, CallbackInfo ci) {
 		connection.getPacketContext().set(PacketContextImpl.SERVER_INSTANCE, server);
+		connection.getPacketContext().set(PacketContextImpl.REGISTRY_ACCESS, server.registryAccess());
 
 		this.addon = new ServerLoginNetworkAddon((ServerLoginPacketListenerImpl) (Object) this);
 		// A bit of a hack but it allows the field above to be set in case someone registers handlers during INIT event which refers to said field

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/ServerPlayerMixin.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/mixin/networking/ServerPlayerMixin.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.networking;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+
+import net.fabricmc.fabric.api.networking.v1.context.PacketContext;
+import net.fabricmc.fabric.api.networking.v1.context.PacketContextProvider;
+
+@Mixin(ServerPlayer.class)
+public class ServerPlayerMixin implements PacketContextProvider {
+	@Shadow
+	public ServerGamePacketListenerImpl connection;
+
+	@Override
+	public PacketContext getPacketContext() {
+		return this.connection.getPacketContext();
+	}
+}

--- a/fabric-networking-api-v1/src/main/resources/fabric-networking-api-v1.classtweaker
+++ b/fabric-networking-api-v1/src/main/resources/fabric-networking-api-v1.classtweaker
@@ -6,6 +6,8 @@ transitive-inject-interface	net/minecraft/server/network/ServerConfigurationPack
 transitive-inject-interface	net/minecraft/server/network/ServerCommonPacketListenerImpl	net/fabricmc/fabric/api/networking/v1/context/PacketContextProvider
 transitive-inject-interface	net/minecraft/server/network/ServerLoginPacketListenerImpl	net/fabricmc/fabric/api/networking/v1/context/PacketContextProvider
 transitive-inject-interface	net/minecraft/server/network/ServerHandshakePacketListenerImpl	net/fabricmc/fabric/api/networking/v1/context/PacketContextProvider
+transitive-inject-interface	net/minecraft/server/level/ServerPlayer	net/fabricmc/fabric/api/networking/v1/context/PacketContextProvider
 transitive-inject-interface	net/minecraft/client/multiplayer/ClientHandshakePacketListenerImpl	net/fabricmc/fabric/api/networking/v1/context/PacketContextProvider
 transitive-inject-interface	net/minecraft/client/multiplayer/ClientCommonPacketListenerImpl	net/fabricmc/fabric/api/networking/v1/context/PacketContextProvider
+transitive-inject-interface	net/minecraft/client/player/LocalPlayer	net/fabricmc/fabric/api/networking/v1/context/PacketContextProvider
 transitive-inject-interface	net/minecraft/network/Connection	net/fabricmc/fabric/api/networking/v1/context/PacketContextProvider

--- a/fabric-networking-api-v1/src/main/resources/fabric-networking-api-v1.mixins.json
+++ b/fabric-networking-api-v1/src/main/resources/fabric-networking-api-v1.mixins.json
@@ -23,6 +23,7 @@
     "ServerGamePacketListenerImplMixin",
     "ServerHandshakePacketListenerImplMixin",
     "ServerLoginPacketListenerImplMixin",
+    "ServerPlayerMixin",
     "accessor.ChunkMapAccessor",
     "accessor.EntityTrackerAccessor",
     "accessor.PacketDecoderAccessor",

--- a/fabric-networking-api-v1/src/test/java/net/fabricmc/fabric/test/networking/unit/PacketContextTests.java
+++ b/fabric-networking-api-v1/src/test/java/net/fabricmc/fabric/test/networking/unit/PacketContextTests.java
@@ -84,6 +84,14 @@ public class PacketContextTests {
 		PacketContext.runWithContext(connection, () -> {
 			assertEquals(PacketContext.get(), context);
 			assertDoesNotThrow(() -> PacketContext.orElseThrow());
+
+			PacketContext.runWithoutContext(() -> {
+				assertNull(assertDoesNotThrow(() -> PacketContext.get()));
+				assertThrows(RuntimeException.class, () -> PacketContext.orElseThrow());
+			});
+
+			assertEquals(PacketContext.get(), context);
+			assertDoesNotThrow(() -> PacketContext.orElseThrow());
 		});
 
 		assertNull(assertDoesNotThrow(() -> PacketContext.get()));


### PR DESCRIPTION
Small things I found that were missing or just worked as nice qol changes.
- Fixes server not being stored in context when in singleplayer,
- Store registry access instance, as it might be something mods need to access (one of my mods does it, but I feel it's generic enough to make sense in Fapi),
- Method to run without having a context set are a requirement for Polymer, as it needs to write some things while acting as if context was missing, while running things on packet serialization. This was already doable by providing a custom instance of PacketContextProvider returning null
- Extra methods to access packet context directly from packet listener context