### PR TITLE
Implement a simple API for creating and registering FileFix-es

### DIFF
--- a/fabric-serialization-api-v1/build.gradle
+++ b/fabric-serialization-api-v1/build.gradle
@@ -3,3 +3,5 @@ version = getSubprojectVersion(project)
 loom {
 	accessWidenerPath = file('src/main/resources/fabric-serialization-api-v1.classtweaker')
 }
+
+moduleDependencies(project, ['fabric-api-base'])

--- a/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/api/serialization/v1/filefix/FileFixHelpers.java
+++ b/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/api/serialization/v1/filefix/FileFixHelpers.java
@@ -1,0 +1,54 @@
+package net.fabricmc.fabric.api.serialization.v1.filefix;
+
+import com.mojang.datafixers.schemas.Schema;
+
+import net.fabricmc.fabric.impl.serialization.filefix.CombinedFileFixOperation;
+import net.fabricmc.fabric.impl.serialization.filefix.FileFixHelpersImpl;
+
+import net.fabricmc.fabric.mixin.serialization.filefix.FileFixerUpperAccessor;
+
+import net.minecraft.resources.Identifier;
+import net.minecraft.util.filefix.FileFix;
+import net.minecraft.util.filefix.operations.FileFixOperation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public interface FileFixHelpers {
+
+	static FileFixOperation createDimensionDataMoveOperation(String oldSaveId, Identifier newSaveId) {
+		return createDimensionDataMoveOperation(Map.of(oldSaveId, newSaveId));
+	}
+
+	static FileFixOperation createDimensionDataMoveOperation(Map<String, Identifier> saveIdMap) {
+		List<FileFixOperation> operations = new ArrayList<>();
+		operations.addAll(FileFixHelpersImpl.createDimensionMoveOperations(saveIdMap, "", "dimensions/minecraft/overworld"));
+		operations.addAll(FileFixHelpersImpl.createDimensionMoveOperations(saveIdMap, "DIM-1", "dimensions/minecraft/the_nether"));
+		operations.addAll(FileFixHelpersImpl.createDimensionMoveOperations(saveIdMap, "DIM1", "dimensions/minecraft/the_end"));
+		operations.add(FileFixHelpersImpl.createCustomDimensionDataMoveOperation(saveIdMap));
+		return new CombinedFileFixOperation(operations);
+	}
+
+	static Function<Schema, FileFix> createDimensionDataMoveFileFix(String oldSaveId, Identifier newSaveId) {
+		return createDimensionDataMoveFileFix(Map.of(oldSaveId, newSaveId));
+	}
+
+	static Function<Schema, FileFix> createDimensionDataMoveFileFix(Map<String, Identifier> saveIdMap) {
+		return schema -> new FileFix(schema) {
+			@Override
+			public void makeFixer() {
+				addFileFixOperation(createDimensionDataMoveOperation(saveIdMap));
+			}
+		};
+	}
+
+	static void registerDimensionDataMoveFileFix(String oldSaveId, Identifier newSaveId) {
+		registerDimensionDataMoveFileFix(Map.of(oldSaveId, newSaveId));
+	}
+
+	static void registerDimensionDataMoveFileFix(Map<String, Identifier> saveIdMap) {
+		FileFixSchemaRegisterCallback.registerFileFixes(FileFixerUpperAccessor.getFileFixerIntroductionVersion(), createDimensionDataMoveFileFix(saveIdMap));
+	}
+}

--- a/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/api/serialization/v1/filefix/FileFixHelpers.java
+++ b/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/api/serialization/v1/filefix/FileFixHelpers.java
@@ -9,7 +9,9 @@ import net.fabricmc.fabric.mixin.serialization.filefix.FileFixerUpperAccessor;
 
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.filefix.FileFix;
+import net.minecraft.util.filefix.access.FileRelation;
 import net.minecraft.util.filefix.operations.FileFixOperation;
+import net.minecraft.util.filefix.operations.FileFixOperations;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,5 +52,39 @@ public interface FileFixHelpers {
 
 	static void registerDimensionDataMoveFileFix(Map<String, Identifier> saveIdMap) {
 		FileFixSchemaRegisterCallback.registerFileFixes(FileFixerUpperAccessor.getFileFixerIntroductionVersion(), createDimensionDataMoveFileFix(saveIdMap));
+	}
+
+	static FileFixOperation createGlobalDataMoveOperation(String oldSaveId, Identifier newSaveId) {
+		return createGlobalDataMoveOperation(Map.of(oldSaveId, newSaveId));
+	}
+
+	static FileFixOperation createGlobalDataMoveOperation(Map<String, Identifier> saveIdMap) {
+		return FileFixOperations.applyInFolders(
+				FileRelation.DATA,
+				saveIdMap.entrySet().stream()
+						.map(entry -> FileFixHelpersImpl.createNamespacedDataMoveOperation(entry.getKey(), entry.getValue(), "", ""))
+						.toList()
+		);
+	}
+
+	static Function<Schema, FileFix> createGlobalDataMoveFileFix(String oldSaveId, Identifier newSaveId) {
+		return createGlobalDataMoveFileFix(Map.of(oldSaveId, newSaveId));
+	}
+
+	static Function<Schema, FileFix> createGlobalDataMoveFileFix(Map<String, Identifier> saveIdMap) {
+		return schema -> new FileFix(schema) {
+			@Override
+			public void makeFixer() {
+				addFileFixOperation(createGlobalDataMoveOperation(saveIdMap));
+			}
+		};
+	}
+
+	static void registerGlobalDataMoveFileFix(String oldSaveId, Identifier newSaveId) {
+		registerGlobalDataMoveFileFix(Map.of(oldSaveId, newSaveId));
+	}
+
+	static void registerGlobalDataMoveFileFix(Map<String, Identifier> saveIdMap) {
+		FileFixSchemaRegisterCallback.registerFileFixes(FileFixerUpperAccessor.getFileFixerIntroductionVersion(), createGlobalDataMoveFileFix(saveIdMap));
 	}
 }

--- a/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/api/serialization/v1/filefix/FileFixSchemaRegisterCallback.java
+++ b/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/api/serialization/v1/filefix/FileFixSchemaRegisterCallback.java
@@ -10,6 +10,14 @@ import net.minecraft.util.filefix.FileFixerUpper;
 
 import java.util.function.Function;
 
+/**
+ * Event for registering file fixes. This event is called for every {@link Schema} added to
+ * Minecraft's {@link FileFixerUpper}, before any of vanilla's fixes are added to it.
+ *
+ * <p>Please note that this event is called early during the game launch, before {@link net.fabricmc.api.ModInitializer}s
+ * are run. Therefore, make sure to register callbacks early during the mod loading process, using
+ * a {@link net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint}.</p>
+ */
 @FunctionalInterface
 public interface FileFixSchemaRegisterCallback {
 
@@ -22,6 +30,16 @@ public interface FileFixSchemaRegisterCallback {
 
 	void schemaRegistered(FileFixerUpper.Builder fileFixerUpper, Schema schema, int version);
 
+	/**
+	 * Can be used to easily register file fixes for a data version. This method registers a callback
+	 * at {@link FileFixSchemaRegisterCallback#EVENT}, which adds the given {@code fixes} to the
+	 * game's {@link FileFixerUpper} at the given data version.
+	 *
+	 * <p>Please note that this method does not throw for invalid data versions.</p>
+	 *
+	 * @param version the data version to register the file fixes for.
+	 * @param fixes the file fixes to register.
+	 */
 	@SafeVarargs
 	static void registerFileFixes(int version, Function<Schema, FileFix>... fixes) {
 		EVENT.register((fileFixerUpper, schema, schemaVersion) -> {

--- a/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/api/serialization/v1/filefix/FileFixSchemaRegisterCallback.java
+++ b/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/api/serialization/v1/filefix/FileFixSchemaRegisterCallback.java
@@ -35,7 +35,9 @@ public interface FileFixSchemaRegisterCallback {
 	 * at {@link FileFixSchemaRegisterCallback#EVENT}, which adds the given {@code fixes} to the
 	 * game's {@link FileFixerUpper} at the given data version.
 	 *
-	 * <p>Please note that this method does not throw for invalid data versions.</p>
+	 * <p>Please note that this method does not throw for invalid data versions, and that
+	 * fixes can only be registered for a data version that has file fixes in vanilla, because
+	 * there won't be a schema registered for those versions.</p>
 	 *
 	 * @param version the data version to register the file fixes for.
 	 * @param fixes the file fixes to register.

--- a/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/api/serialization/v1/filefix/FileFixSchemaRegisterCallback.java
+++ b/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/api/serialization/v1/filefix/FileFixSchemaRegisterCallback.java
@@ -1,0 +1,35 @@
+package net.fabricmc.fabric.api.serialization.v1.filefix;
+
+import com.mojang.datafixers.schemas.Schema;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+import net.minecraft.util.filefix.FileFix;
+import net.minecraft.util.filefix.FileFixerUpper;
+
+import java.util.function.Function;
+
+@FunctionalInterface
+public interface FileFixSchemaRegisterCallback {
+
+	Event<FileFixSchemaRegisterCallback> EVENT = EventFactory.createArrayBacked(FileFixSchemaRegisterCallback.class,
+			listeners -> (fileFixerUpper, schema, version) -> {
+				for (FileFixSchemaRegisterCallback callback : listeners) {
+					callback.schemaRegistered(fileFixerUpper, schema, version);
+				}
+			});
+
+	void schemaRegistered(FileFixerUpper.Builder fileFixerUpper, Schema schema, int version);
+
+	@SafeVarargs
+	static void registerFileFixes(int version, Function<Schema, FileFix>... fixes) {
+		EVENT.register((fileFixerUpper, schema, schemaVersion) -> {
+			if (schemaVersion == version) {
+				for (Function<Schema, FileFix> fix : fixes) {
+					fileFixerUpper.addFixer(fix.apply(schema));
+				}
+			}
+		});
+	}
+}

--- a/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/impl/serialization/filefix/CombinedFileFixOperation.java
+++ b/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/impl/serialization/filefix/CombinedFileFixOperation.java
@@ -1,0 +1,18 @@
+package net.fabricmc.fabric.impl.serialization.filefix;
+
+import net.minecraft.util.filefix.operations.FileFixOperation;
+import net.minecraft.util.worldupdate.UpgradeProgress;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+public record CombinedFileFixOperation(List<FileFixOperation> operations) implements FileFixOperation {
+
+	@Override
+	public void fix(Path baseDirectory, UpgradeProgress upgradeProgress) throws IOException {
+		for (FileFixOperation operation : operations) {
+			operation.fix(baseDirectory, upgradeProgress);
+		}
+	}
+}

--- a/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/impl/serialization/filefix/FileFixHelpersImpl.java
+++ b/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/impl/serialization/filefix/FileFixHelpersImpl.java
@@ -14,9 +14,8 @@ public interface FileFixHelpersImpl {
 																String oldDimensionPath,
 																String newDimensionPath) {
 		return saveIdMap.entrySet().stream()
-				.map(entry -> (FileFixOperation)
-						FileFixOperations.move(oldDimensionPath + "/data/" + entry.getKey() + ".dat",
-								newDimensionPath + "/data/" + entry.getValue().getNamespace() + "/" + entry.getValue().getPath() + ".dat"))
+				.map(entry -> createNamespacedDataMoveOperation(entry.getKey(), entry.getValue(),
+						oldDimensionPath + "/data/", newDimensionPath + "/data/"))
 				.toList();
 	}
 
@@ -24,10 +23,12 @@ public interface FileFixHelpersImpl {
 		return FileFixOperations.applyInFolders(
 				FileRelation.DIMENSIONS_DATA,
 				saveIdMap.entrySet().stream()
-						// example.dat -> example_mod/example.dat
-						.map(entry -> (FileFixOperation)
-								FileFixOperations.move(entry.getKey() + ".dat", entry.getValue().getNamespace() + "/" + entry.getValue().getPath() + ".dat"))
+						.map(entry -> createNamespacedDataMoveOperation(entry.getKey(), entry.getValue(), "", ""))
 						.toList()
 		);
+	}
+
+	static FileFixOperation createNamespacedDataMoveOperation(String oldId, Identifier newId, String oldPrefix, String newPrefix) {
+		return FileFixOperations.move(oldPrefix + oldId + ".dat", newPrefix + newId.getNamespace() + "/" + newId.getPath() + ".dat");
 	}
 }

--- a/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/impl/serialization/filefix/FileFixHelpersImpl.java
+++ b/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/impl/serialization/filefix/FileFixHelpersImpl.java
@@ -1,0 +1,33 @@
+package net.fabricmc.fabric.impl.serialization.filefix;
+
+import net.minecraft.resources.Identifier;
+import net.minecraft.util.filefix.access.FileRelation;
+import net.minecraft.util.filefix.operations.FileFixOperation;
+import net.minecraft.util.filefix.operations.FileFixOperations;
+
+import java.util.List;
+import java.util.Map;
+
+public interface FileFixHelpersImpl {
+
+	static List<FileFixOperation> createDimensionMoveOperations(Map<String, Identifier> saveIdMap,
+																String oldDimensionPath,
+																String newDimensionPath) {
+		return saveIdMap.entrySet().stream()
+				.map(entry -> (FileFixOperation)
+						FileFixOperations.move(oldDimensionPath + "/data/" + entry.getKey() + ".dat",
+								newDimensionPath + "/data/" + entry.getValue().getNamespace() + "/" + entry.getValue().getPath() + ".dat"))
+				.toList();
+	}
+
+	static FileFixOperation createCustomDimensionDataMoveOperation(Map<String, Identifier> saveIdMap) {
+		return FileFixOperations.applyInFolders(
+				FileRelation.DIMENSIONS_DATA,
+				saveIdMap.entrySet().stream()
+						// example.dat -> example_mod/example.dat
+						.map(entry -> (FileFixOperation)
+								FileFixOperations.move(entry.getKey() + ".dat", entry.getValue().getNamespace() + "/" + entry.getValue().getPath() + ".dat"))
+						.toList()
+		);
+	}
+}

--- a/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/mixin/serialization/filefix/DataFixersMixin.java
+++ b/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/mixin/serialization/filefix/DataFixersMixin.java
@@ -1,0 +1,28 @@
+package net.fabricmc.fabric.mixin.serialization.filefix;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.datafixers.DataFixerBuilder;
+import com.mojang.datafixers.schemas.Schema;
+
+import net.fabricmc.fabric.api.serialization.v1.filefix.FileFixSchemaRegisterCallback;
+
+import net.minecraft.util.datafix.DataFixers;
+
+import net.minecraft.util.filefix.FileFixerUpper;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.function.BiFunction;
+
+@Mixin(DataFixers.class)
+public abstract class DataFixersMixin {
+
+	@WrapOperation(method = "addFixers", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/filefix/FileFixerUpper$Builder;addSchema(Lcom/mojang/datafixers/DataFixerBuilder;ILjava/util/function/BiFunction;)Lcom/mojang/datafixers/schemas/Schema;"))
+	private static Schema runSchemaRegisterCallback(FileFixerUpper.Builder instance, DataFixerBuilder fixerUpper, int version, BiFunction<Integer, Schema, Schema> factory, Operation<Schema> original) {
+		Schema schema = original.call(instance, fixerUpper, version, factory);
+		FileFixSchemaRegisterCallback.EVENT.invoker().schemaRegistered(instance, schema, version);
+		return schema;
+	}
+}

--- a/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/mixin/serialization/filefix/FileFixerUpperAccessor.java
+++ b/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/mixin/serialization/filefix/FileFixerUpperAccessor.java
@@ -1,0 +1,15 @@
+package net.fabricmc.fabric.mixin.serialization.filefix;
+
+import net.minecraft.util.filefix.FileFixerUpper;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(FileFixerUpper.class)
+public interface FileFixerUpperAccessor {
+
+	@Accessor("FILE_FIXER_INTRODUCTION_VERSION")
+	static int getFileFixerIntroductionVersion() {
+		throw new AssertionError();
+	}
+}

--- a/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/mixin/serialization/filefix/package-info.java
+++ b/fabric-serialization-api-v1/src/main/java/net/fabricmc/fabric/mixin/serialization/filefix/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package net.fabricmc.fabric.mixin.serialization.filefix;
+
+import org.jspecify.annotations.NullMarked;

--- a/fabric-serialization-api-v1/src/main/resources/fabric-serialization-api-v1.mixins.json
+++ b/fabric-serialization-api-v1/src/main/resources/fabric-serialization-api-v1.mixins.json
@@ -6,7 +6,9 @@
     "TagValueInputMixin",
     "TagValueOutputMixin",
     "ValueInputMixin",
-    "ValueOutputMixin"
+    "ValueOutputMixin",
+    "filefix.DataFixersMixin",
+    "filefix.FileFixerUpperAccessor"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This PR adds a simple API for creating and registering file-fixes to the game's `FileFixerUpper`.

The main use case for this API, as of right now, is to easily allow mod developers using `SavedData` to support loading pre-Minecraft 26.1 worlds in 26.1 and above. Minecraft 26.1 has made huge changes to the way Minecraft worlds are structured directory wise, and `SavedDataType` now uses a namespaced ID compared to a simple string:

```diff
-new SavedDataType<>("example_data", () -> new ExampleData(), CODEC, null);
+new SavedDataType<>(Identifier.fromNamespaceAndPath("example_mod", "example_data"), () -> new ExampleData(), ExampleData.CODEC, null);
```

This results in the following change in a world's directory layout:

```diff
-data/example_data.dat
+data/example_mod/example_data.dat
// or:
+dimensions/overworld/data/example_mod/example_data.dat

-DIM-1/data/example_data.dat
+dimensions/the_nether/data/example_mod/example_data.dat

-DIM1/data/example_data.dat
+dimensions/the_end/data/example_mod/example_data.dat
```

Note the "or" in there: `SavedData` can be used per-dimension, or globally/server-wide. In Minecraft 1.21.11 and below, server-wide `SavedData` was stored together with overworld `SavedData` in the root `data` folder. This was changed in Minecraft 26.1, overworld `SavedData` is now stored in its respective folder in the `dimensions` folder.

Vanilla Minecraft handles these path changes through `FileFix`es, which are registered at a `FileFixerUpper` instance (also see the [`DimensionStorageFileFix`](https://mcsrc.dev/1/26.1-pre-2/net/minecraft/util/filefix/fixes/DimensionStorageFileFix) class). This API allows mod developers to easily create and register these `FileFix`es, so that they can provide support for loading worlds created in Minecraft 1.21.11 and below in 26.1.

---

Currently, developers can register a `FileFix` for a specific `Schema` version as follows:

```java
FileFixSchemaRegisterCallback.registerFileFixes(4772, ExampleFileFix::new);
```
(where `ExampleFileFix` is a `FileFix` with `ExampleFileFix(Schema)` as constructor)

This method allows multiple `FileFix` constructors to be passed at once. For more flexibility, developers can also use the `FileFixSchemaRegisterCallback#EVENT` directly. File-fixes added by mods are added to a schema before vanilla's file fixes.

Developers can also make use of the utility methods present in the `FileFixHelpers` interface to create file-fixes or `FileFixOperation`s. Currently, there are only methods to help aid the move to namespaced saved-data:

- `createDimensionDataMoveOperation` and `createGlobalDataMoveOperation`: can be used to create a `FileFixOperation` to move one or multiple `SavedData` data files to their respective folders for their new namespaced IDs.
- `createDimensionDataMoveFileFix` and `createGlobalDataMoveFileFix`: can be used to create a `FileFix` constructor to move one or multiple `SavedData` data files to their respective folders for their new namespaced IDs.
- `registerDimensionDataMoveFileFix` and `registerGlobalDataMoveFileFix`: can be used to create and automatically register a `FileFix` constructor to move one or multiple `SavedData` data files to their respective folders for their new namespaced IDs. The file-fix is registered at schema 4772, in line with vanilla.

These methods make it easy for mod developers to support loading older worlds in Minecraft 26.1, without losing `SavedData`. This can be done as follows, for example:

```diff
-new SavedDataType<>("example_data", () -> new ExampleData(), CODEC, null);
-ExampleData myData = server.overworld().getDataStorage().computeIfAbsent(myGlobalDataType);

+Identifier id = Identifier.fromNamespaceAndPath("example_mod", "example_data");
+new SavedDataType<>(id, () -> new ExampleData(), ExampleData.CODEC, null);
+ExampleData myData = server.getDataStorage().computeIfAbsent(myGlobalDataType);
+FileFixHelpers.registerGlobalDataMoveFileFix("example_data", id);
```