### PR TITLE
(26.1) Optimize `TransformCopyingModel` instantiation

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TransformCopyingModel.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/TransformCopyingModel.java
@@ -17,8 +17,12 @@
 package net.fabricmc.fabric.api.client.rendering.v1;
 
 import com.mojang.datafixers.util.Pair;
+import org.jspecify.annotations.Nullable;
 
 import net.minecraft.client.model.Model;
+import net.minecraft.client.model.geom.ModelPart;
+
+import net.fabricmc.fabric.impl.client.rendering.ModelExtensions;
 
 /**
  * A model that copies transforms from a source model to a delegate model.
@@ -27,7 +31,7 @@ import net.minecraft.client.model.Model;
  * @param <S> type of the source model state
  * @param <D> type of the delegate model state
  */
-public final class TransformCopyingModel<S, D> extends Model<Pair<S, D>> {
+public final class TransformCopyingModel<S, D> extends Model<Pair<S, D>> implements ModelExtensions {
 	private final Model<? super S> source;
 	private final Model<? super D> delegate;
 	private final boolean setDelegateAngles;
@@ -58,5 +62,19 @@ public final class TransformCopyingModel<S, D> extends Model<Pair<S, D>> {
 		if (setDelegateAngles) {
 			delegate.setupAnim(state.getSecond());
 		}
+	}
+
+	@Override
+	public void fabric$calculateChildParts(ModelPart root) {
+	}
+
+	@Override
+	public @Nullable ModelPart getChildPart(String name) {
+		return delegate.getChildPart(name);
+	}
+
+	@Override
+	public void copyTransforms(Model<?> model) {
+		delegate.copyTransforms(model);
 	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/ModelExtensions.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/ModelExtensions.java
@@ -14,17 +14,10 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.mixin.client.rendering;
-
-import java.util.function.BiConsumer;
-
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.gen.Invoker;
+package net.fabricmc.fabric.impl.client.rendering;
 
 import net.minecraft.client.model.geom.ModelPart;
 
-@Mixin(ModelPart.class)
-public interface ModelPartAccessor {
-	@Invoker("addAllChildren")
-	void fabric$callAddAllChildren(BiConsumer<String, ModelPart> partBiConsumer);
+public interface ModelExtensions {
+	void fabric$calculateChildParts(ModelPart root);
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/ModelMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/ModelMixin.java
@@ -34,9 +34,10 @@ import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.resources.Identifier;
 
 import net.fabricmc.fabric.api.client.rendering.v1.FabricModel;
+import net.fabricmc.fabric.impl.client.rendering.ModelExtensions;
 
 @Mixin(Model.class)
-abstract class ModelMixin<S> implements FabricModel<S> {
+abstract class ModelMixin<S> implements FabricModel<S>, ModelExtensions {
 	@Shadow
 	public abstract ModelPart root();
 
@@ -45,7 +46,12 @@ abstract class ModelMixin<S> implements FabricModel<S> {
 
 	@Inject(method = "<init>", at = @At("TAIL"))
 	private void fillChildPartMap(ModelPart root, Function<Identifier, RenderType> layerFactory, CallbackInfo ci) {
-		((ModelPartAccessor) (Object) root).fabric$callForEachChild(childPartMap::putIfAbsent);
+		this.fabric$calculateChildParts(root);
+	}
+
+	@Override
+	public void fabric$calculateChildParts(ModelPart root) {
+		((ModelPartAccessor) (Object) root).fabric$callAddAllChildren(childPartMap::putIfAbsent);
 	}
 
 	@Override
@@ -57,7 +63,7 @@ abstract class ModelMixin<S> implements FabricModel<S> {
 	@Override
 	public void copyTransforms(Model<?> model) {
 		copyTransforms(model.root(), root());
-		((ModelPartAccessor) (Object) model.root()).fabric$callForEachChild((name, part) -> {
+		((ModelPartAccessor) (Object) model.root()).fabric$callAddAllChildren((name, part) -> {
 			ModelPart childPart = getChildPart(name);
 
 			if (childPart != null) {


### PR DESCRIPTION
Optimizes instantiation of `TransformCopyingModel` by skipping the calculation of its child model parts and instead delegating method calls to its `delegate` field.