### PR TITLE
[26.1] Add HolderLookup.Provider context to DefaultItemComponentEvents.

### DIFF
--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/DefaultItemComponentEvents.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/DefaultItemComponentEvents.java
@@ -21,6 +21,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
+import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.world.item.Item;
 
@@ -50,7 +51,37 @@ public final class DefaultItemComponentEvents {
 		 * @param itemPredicate A predicate to match items to modify
 		 * @param builderConsumer A consumer that provides a {@link DataComponentMap.Builder} to modify the item's components.
 		 */
-		void modify(Predicate<Item> itemPredicate, BiConsumer<DataComponentMap.Builder, Item> builderConsumer);
+		void modify(Predicate<Item> itemPredicate, ModifyConsumer builderConsumer);
+
+		/**
+		 * Modify the default data components of the specified item.
+		 *
+		 * @param item The item to modify
+		 * @param builderConsumer A consumer that provides a {@link DataComponentMap.Builder} to modify the item's components.
+		 */
+		default void modify(Item item, ModifyConsumer builderConsumer) {
+			modify(Predicate.isEqual(item), builderConsumer);
+		}
+
+		/**
+		 * Modify the default data components of the specified items.
+		 *
+		 * @param items The items to modify
+		 * @param builderConsumer A consumer that provides a {@link DataComponentMap.Builder} to modify the item's components.
+		 */
+		default void modify(Collection<Item> items, ModifyConsumer builderConsumer) {
+			modify(items::contains, builderConsumer);
+		}
+
+		/**
+		 * Modify the default data components of the specified item.
+		 *
+		 * @param itemPredicate A predicate to match items to modify
+		 * @param builderConsumer A consumer that provides a {@link DataComponentMap.Builder} to modify the item's components.
+		 */
+		default void modify(Predicate<Item> itemPredicate, BiConsumer<DataComponentMap.Builder, Item> builderConsumer) {
+			modify(itemPredicate, ((builder, _lookupProvider, item) -> builderConsumer.accept(builder, item)));
+		}
 
 		/**
 		 * Modify the default data components of the specified item.
@@ -80,5 +111,17 @@ public final class DefaultItemComponentEvents {
 		 * @param context The context to modify items
 		 */
 		void modify(ModifyContext context);
+	}
+
+	@FunctionalInterface
+	public interface ModifyConsumer {
+		/**
+		 * A consumer used for modifying the provided {@link DataComponentMap.Builder}.
+		 *
+		 * @param builder The data component builder for the item.
+		 * @param lookupProvider A lookup provider to obtain holders and holder sets from registries.
+		 * @param item The item to modify.
+		 */
+		void modify(DataComponentMap.Builder builder, HolderLookup.Provider lookupProvider, Item item);
 	}
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/DefaultItemComponentImpl.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/DefaultItemComponentImpl.java
@@ -16,9 +16,9 @@
 
 package net.fabricmc.fabric.impl.item;
 
-import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 
+import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.item.Item;
@@ -26,22 +26,25 @@ import net.minecraft.world.item.Item;
 import net.fabricmc.fabric.api.item.v1.DefaultItemComponentEvents;
 
 public class DefaultItemComponentImpl {
-	public static void modifyItemComponents() {
-		DefaultItemComponentEvents.MODIFY.invoker().modify(ModifyContextImpl.INSTANCE);
+	public static final ScopedValue<HolderLookup.Provider> LOOKUP_PROVIDER_SCOPED_VALUE = ScopedValue.newInstance();
+
+	public static void modifyItemComponents(HolderLookup.Provider registries) {
+		DefaultItemComponentEvents.MODIFY.invoker().modify(new ModifyContextImpl(registries));
 	}
 
 	static class ModifyContextImpl implements DefaultItemComponentEvents.ModifyContext {
-		private static final ModifyContextImpl INSTANCE = new ModifyContextImpl();
+		private final HolderLookup.Provider registryLookup;
 
-		private ModifyContextImpl() {
+		private ModifyContextImpl(HolderLookup.Provider registries) {
+			this.registryLookup = registries;
 		}
 
 		@Override
-		public void modify(Predicate<Item> itemPredicate, BiConsumer<DataComponentMap.Builder, Item> builderConsumer) {
+		public void modify(Predicate<Item> itemPredicate, DefaultItemComponentEvents.ModifyConsumer builderConsumer) {
 			for (Item item : BuiltInRegistries.ITEM) {
 				if (itemPredicate.test(item)) {
 					DataComponentMap.Builder builder = DataComponentMap.builder().addAll(item.components());
-					builderConsumer.accept(builder, item);
+					builderConsumer.modify(builder, registryLookup, item);
 					item.builtInRegistryHolder().bindComponents(builder.build());
 				}
 			}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/DataComponentInitializersMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/DataComponentInitializersMixin.java
@@ -16,27 +16,19 @@
 
 package net.fabricmc.fabric.mixin.item;
 
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import net.minecraft.core.Registry;
-import net.minecraft.core.registries.Registries;
-import net.minecraft.resources.ResourceKey;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.component.DataComponentInitializers;
 
 import net.fabricmc.fabric.impl.item.DefaultItemComponentImpl;
 
-@Mixin(targets = "net.minecraft.core.component.DataComponentInitializers$1")
+@Mixin(DataComponentInitializers.class)
 public abstract class DataComponentInitializersMixin {
-	@Shadow
-	public abstract ResourceKey<? extends Registry<?>> key();
-
-	@Inject(method = "apply", at = @At("RETURN"))
-	private void apply(CallbackInfo ci) {
-		if (Registries.ITEM.identifier().equals(key().identifier())) {
-			DefaultItemComponentImpl.modifyItemComponents();
-		}
+	@WrapMethod(method = "createInitializerForRegistry")
+	private static <T> DataComponentInitializers.PendingComponents<T> captureLookup(HolderLookup.Provider context, DataComponentInitializers.PendingComponentBuilders<T> elementBuilders, Operation<DataComponentInitializers.PendingComponents<T>> original) {
+		return ScopedValue.where(DefaultItemComponentImpl.LOOKUP_PROVIDER_SCOPED_VALUE, context).call(() -> original.call(context, elementBuilders));
 	}
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/DataComponentInitializersPendingComponentsMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/DataComponentInitializersPendingComponentsMixin.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.item;
+
+import java.util.List;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.Registry;
+import net.minecraft.core.component.DataComponentInitializers;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+
+import net.fabricmc.fabric.impl.item.DefaultItemComponentImpl;
+
+@Mixin(targets = "net.minecraft.core.component.DataComponentInitializers$1")
+public abstract class DataComponentInitializersPendingComponentsMixin<T> {
+	@Unique
+	private HolderLookup.Provider registryLookup;
+
+	@Shadow
+	public abstract ResourceKey<? extends Registry<?>> key();
+
+	@Inject(method = "<init>", at = @At("TAIL"))
+	private void store(ResourceKey<T> par1, List<DataComponentInitializers.BakedEntry<T>> par2, CallbackInfo ci) {
+		registryLookup = DefaultItemComponentImpl.LOOKUP_PROVIDER_SCOPED_VALUE.get();
+	}
+
+	@Inject(method = "apply", at = @At("RETURN"))
+	private void apply(CallbackInfo ci) {
+		if (Registries.ITEM.identifier().equals(key().identifier())) {
+			DefaultItemComponentImpl.modifyItemComponents(registryLookup);
+		}
+	}
+}

--- a/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.classtweaker
+++ b/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.classtweaker
@@ -1,6 +1,7 @@
 classTweaker	v1	official
 accessible class net/minecraft/resources/RegistryLoadTask$PendingRegistration
 accessible class net/minecraft/core/component/DataComponentInitializers$BakedEntry
+accessible class net/minecraft/core/component/DataComponentInitializers$PendingComponentBuilders
 transitive-inject-interface	net/minecraft/world/item/Item	net/fabricmc/fabric/api/item/v1/FabricItem
 transitive-inject-interface	net/minecraft/world/item/Item$Properties	net/fabricmc/fabric/api/item/v1/FabricItem$Properties
 transitive-inject-interface	net/minecraft/world/item/ItemStack	net/fabricmc/fabric/api/item/v1/FabricItemStack

--- a/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.mixins.json
+++ b/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.mixins.json
@@ -6,9 +6,11 @@
     "AbstractFurnaceBlockEntityMixin",
     "AnvilMenuMixin",
     "BrewingStandBlockEntityMixin",
-    "DataComponentMapBuilderMixin",
+    "BuiltInRegistriesMixin",
     "CraftingRecipeMixin",
     "DataComponentInitializersMixin",
+    "DataComponentInitializersPendingComponentsMixin",
+    "DataComponentMapBuilderMixin",
     "EnchantCommandMixin",
     "EnchantmentBuilderAccessor",
     "EnchantmentBuilderMixin",
@@ -18,7 +20,6 @@
     "ItemPropertiesMixin",
     "ItemStackMixin",
     "LivingEntityMixin",
-    "BuiltInRegistriesMixin",
     "ResourceManagerRegistryLoadTaskMixin"
   ],
   "injectors": {

--- a/fabric-item-api-v1/src/test/java/net/fabricmc/fabric/test/item/unittest/ItemComponentTooltipProviderRegistryTest.java
+++ b/fabric-item-api-v1/src/test/java/net/fabricmc/fabric/test/item/unittest/ItemComponentTooltipProviderRegistryTest.java
@@ -19,16 +19,22 @@ package net.fabricmc.fabric.test.item.unittest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import net.minecraft.SharedConstants;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.Registry;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.Bootstrap;
 import net.minecraft.util.Unit;
 import net.minecraft.world.item.Item;
@@ -52,7 +58,17 @@ public class ItemComponentTooltipProviderRegistryTest {
 			item.builtInRegistryHolder().bindComponents(DataComponentMap.EMPTY);
 		}
 
-		DefaultItemComponentImpl.modifyItemComponents();
+		DefaultItemComponentImpl.modifyItemComponents(new HolderLookup.Provider() {
+			@Override
+			public @NonNull Stream<ResourceKey<? extends Registry<?>>> listRegistryKeys() {
+				return Stream.empty();
+			}
+
+			@Override
+			public <T> @NonNull Optional<? extends HolderLookup.RegistryLookup<T>> lookup(ResourceKey<? extends Registry<? extends T>> key) {
+				return Optional.empty();
+			}
+		});
 	}
 
 	@Test

--- a/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/DefaultItemComponentTest.java
+++ b/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/DefaultItemComponentTest.java
@@ -27,6 +27,8 @@ import net.minecraft.resources.Identifier;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.component.FireworkExplosion;
 import net.minecraft.world.item.component.Fireworks;
+import net.minecraft.world.item.enchantment.Enchantments;
+import net.minecraft.world.item.enchantment.ItemEnchantments;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.Event;
@@ -58,6 +60,12 @@ public class DefaultItemComponentTest implements ModInitializer {
 						() -> Items.DIAMOND_PICKAXE.getName(Items.DIAMOND_PICKAXE.getDefaultInstance())
 				);
 				builder.set(DataComponents.ITEM_NAME, prependModifiedLiteral(baseName));
+			});
+			// Make all Netherite Axes have Fire Aspect I
+			context.modify(Items.NETHERITE_AXE, (builder, registryLookup, item) -> {
+				ItemEnchantments.Mutable mutableEnchantments = new ItemEnchantments.Mutable(ItemEnchantments.EMPTY);
+				mutableEnchantments.set(registryLookup.getOrThrow(Enchantments.FIRE_ASPECT), 1);
+				builder.set(DataComponents.ENCHANTMENTS, mutableEnchantments.toImmutable());
 			});
 		});
 


### PR DESCRIPTION
This PR adds methods with `HolderLookup$Provider` context to `DefaultItemComponentEvents#MODIFY`'s consumers.

The test for this method gives Fire Aspect I to Netherite Axes by default.