### PR TITLE
Change return type of bufferSource to MultiBufferSource.BufferSource and recommend calling endBatch() after rendering in EndMain event.

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/level/LevelRenderContext.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/level/LevelRenderContext.java
@@ -22,8 +22,10 @@ import org.jetbrains.annotations.ApiStatus;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 
+import net.fabricmc.fabric.impl.client.rendering.LevelRenderContextBackwardsCompatHack;
+
 @ApiStatus.NonExtendable
-public interface LevelRenderContext extends LevelTerrainRenderContext {
+public interface LevelRenderContext extends LevelTerrainRenderContext, LevelRenderContextBackwardsCompatHack {
 	SubmitNodeCollector submitNodeCollector();
 
 	PoseStack poseStack();
@@ -40,5 +42,6 @@ public interface LevelRenderContext extends LevelTerrainRenderContext {
 	 * <p>Renders that cannot draw in one of the supported events must be drawn directly to the frame buffer,
 	 * preferably in {@link LevelRenderEvents#END_MAIN} to avoid being overdrawn or cleared.
 	 */
-	MultiBufferSource bufferSource();
+	@Override
+	MultiBufferSource.BufferSource bufferSource();
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/level/LevelRenderEvents.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/level/LevelRenderEvents.java
@@ -213,7 +213,7 @@ public final class LevelRenderEvents {
 	 *
 	 * <p><strong>Warning:</strong> after rendering things in this event, consumers should call
 	 * {@link MultiBufferSource.BufferSource#endBatch() context.bufferSource().endBatch()}, otherwise
-	 * you may get strange rendering behavior!
+	 * you may get strange rendering bugs!
 	 */
 	public static final Event<EndMain> END_MAIN = EventFactory.createArrayBacked(EndMain.class, callbacks -> context -> {
 		for (final EndMain callback : callbacks) {

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/level/LevelRenderEvents.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/level/LevelRenderEvents.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.api.client.rendering.v1.level;
 import org.jspecify.annotations.Nullable;
 
 import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayerGroup;
 import net.minecraft.client.renderer.state.level.BlockOutlineRenderState;
 import net.minecraft.world.phys.HitResult;
@@ -209,6 +210,10 @@ public final class LevelRenderEvents {
 	 * Called at the end of the main render pass, after terrain, entities, block entities, and particles are drawn to
 	 * the appropriate framebuffers, and before clouds, weather, and late debug are drawn to the appropriate
 	 * framebuffers and before fabulous translucent framebuffers are combined.
+	 *
+	 * <p><strong>Warning:</strong> after rendering things in this event, consumers should call
+	 * {@link MultiBufferSource.BufferSource#endBatch() context.bufferSource().endBatch()}, otherwise
+	 * you may get strange rendering behavior!
 	 */
 	public static final Event<EndMain> END_MAIN = EventFactory.createArrayBacked(EndMain.class, callbacks -> context -> {
 		for (final EndMain callback : callbacks) {

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/LevelRenderContextBackwardsCompatHack.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/LevelRenderContextBackwardsCompatHack.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.rendering;
+
+import net.minecraft.client.renderer.MultiBufferSource;
+
+// Forces javac to generate a bridge method in LevelRenderContext returning MultiBufferSource,
+// allowing code compiled against the old LevelRenderContext, where this method returned
+// MultiBufferSource, to still run. Should be removed as soon as we're allowed to make breaking
+// changes.
+@Deprecated(forRemoval = true)
+public interface LevelRenderContextBackwardsCompatHack {
+	MultiBufferSource bufferSource();
+}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/level/LevelRenderContextImpl.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/level/LevelRenderContextImpl.java
@@ -39,7 +39,7 @@ public final class LevelRenderContextImpl implements AbstractLevelRenderContext,
 	private SubmitNodeCollector nodeCollector;
 	@Nullable
 	private PoseStack poseStack;
-	private MultiBufferSource bufferSource;
+	private MultiBufferSource.BufferSource bufferSource;
 
 	public void prepare(
 			GameRenderer gameRenderer,
@@ -47,7 +47,7 @@ public final class LevelRenderContextImpl implements AbstractLevelRenderContext,
 			LevelRenderState levelRenderState,
 			ChunkSectionsToRender sectionsToRender,
 			SubmitNodeCollector nodeCollector,
-			MultiBufferSource bufferSource
+			MultiBufferSource.BufferSource bufferSource
 	) {
 		this.gameRenderer = gameRenderer;
 		this.levelRenderer = levelRenderer;
@@ -96,7 +96,7 @@ public final class LevelRenderContextImpl implements AbstractLevelRenderContext,
 	}
 
 	@Override
-	public MultiBufferSource bufferSource() {
+	public MultiBufferSource.BufferSource bufferSource() {
 		return bufferSource;
 	}
 }


### PR DESCRIPTION
I did a small backwards compat hack here so that code compiled against the old version of `LevelRenderContext` will still run after this PR without being recompiled. See the comment on `LevelRenderContextBackwardsCompatHack`, which is in the impl package. This class can be removed again as soon rendering backwards compat is broken anyway by other changes (which seems likely in 26.2).