### PR TITLE
fix: ALLOW_GAME not working

### DIFF
--- a/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/message/ChatListenerMixin.java
+++ b/fabric-message-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/message/ChatListenerMixin.java
@@ -68,12 +68,23 @@ public abstract class ChatListenerMixin {
 	}
 
 	@Inject(method = "handleSystemMessage", at = @At("HEAD"), cancellable = true)
-	private void fabric_allowGameMessage(Component _message, boolean overlay, CallbackInfo ci, @Local(argsOnly = true) LocalRef<Component> message) {
-		if (ClientReceiveMessageEvents.ALLOW_GAME.invoker().allowReceiveGameMessage(message.get(), overlay)) {
-			message.set(ClientReceiveMessageEvents.MODIFY_GAME.invoker().modifyReceivedGameMessage(message.get(), overlay));
-			ClientReceiveMessageEvents.GAME.invoker().onReceiveGameMessage(message.get(), overlay);
+	private void fabric_allowSystemMessage(Component _message, boolean remote, CallbackInfo ci, @Local(argsOnly = true) LocalRef<Component> message) {
+		if (ClientReceiveMessageEvents.ALLOW_GAME.invoker().allowReceiveGameMessage(message.get(), false)) {
+			message.set(ClientReceiveMessageEvents.MODIFY_GAME.invoker().modifyReceivedGameMessage(message.get(), false));
+			ClientReceiveMessageEvents.GAME.invoker().onReceiveGameMessage(message.get(), false);
 		} else {
-			ClientReceiveMessageEvents.GAME_CANCELED.invoker().onReceiveGameMessageCanceled(message.get(), overlay);
+			ClientReceiveMessageEvents.GAME_CANCELED.invoker().onReceiveGameMessageCanceled(message.get(), false);
+			ci.cancel();
+		}
+	}
+
+	@Inject(method = "handleOverlay", at = @At("HEAD"), cancellable = true)
+	private void fabric_allowOverlayMessage(Component _message, CallbackInfo ci, @Local(argsOnly = true) LocalRef<Component> message) {
+		if (ClientReceiveMessageEvents.ALLOW_GAME.invoker().allowReceiveGameMessage(message.get(), true)) {
+			message.set(ClientReceiveMessageEvents.MODIFY_GAME.invoker().modifyReceivedGameMessage(message.get(), true));
+			ClientReceiveMessageEvents.GAME.invoker().onReceiveGameMessage(message.get(), true);
+		} else {
+			ClientReceiveMessageEvents.GAME_CANCELED.invoker().onReceiveGameMessageCanceled(message.get(), true);
 			ci.cancel();
 		}
 	}


### PR DESCRIPTION
* Fix system messages having overlay set to true
* Fix overlay messages not triggering the events

Adjusts for the `handleSystemMessage` change from 26.1-snapshot-7.