### PR TITLE
Backport vanilla tag as `c:loom_patterns`

### DIFF
--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/EnglishTagLangGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/EnglishTagLangGenerator.java
@@ -419,6 +419,7 @@ public class EnglishTagLangGenerator extends FabricLanguageProvider {
 		translationBuilder.add(ConventionalItemTags.MUSHROOMS, "Mushrooms");
 		translationBuilder.add(ConventionalItemTags.NETHER_STARS, "Nether Stars");
 		translationBuilder.add(ConventionalItemTags.MUSIC_DISCS, "Music Discs");
+		translationBuilder.add(ConventionalItemTags.LOOM_PATTERNS, "Loom Patterns");
 		translationBuilder.add(ConventionalItemTags.RODS, "Rods");
 		translationBuilder.add(ConventionalItemTags.WOODEN_RODS, "Wooden Rods");
 		translationBuilder.add(ConventionalItemTags.BLAZE_RODS, "Blaze Rods");

--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/ItemTagGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/ItemTagGenerator.java
@@ -857,6 +857,11 @@ public final class ItemTagGenerator extends FabricTagProvider.ItemTagProvider {
 						Items.MUSIC_DISC_11, Items.MUSIC_DISC_WAIT, Items.MUSIC_DISC_OTHERSIDE, Items.MUSIC_DISC_5, Items.MUSIC_DISC_PIGSTEP,
 						Items.MUSIC_DISC_RELIC, Items.MUSIC_DISC_CREATOR, Items.MUSIC_DISC_CREATOR_MUSIC_BOX, Items.MUSIC_DISC_PRECIPICE);
 
+		getOrCreateTagBuilder(ConventionalItemTags.LOOM_PATTERNS)
+				.add(Items.FLOWER_BANNER_PATTERN, Items.CREEPER_BANNER_PATTERN, Items.SKULL_BANNER_PATTERN,
+						Items.MOJANG_BANNER_PATTERN, Items.GLOBE_BANNER_PATTERN, Items.PIGLIN_BANNER_PATTERN,
+						Items.FLOW_BANNER_PATTERN, Items.GUSTER_BANNER_PATTERN);
+
 		getOrCreateTagBuilder(ConventionalItemTags.WOODEN_RODS)
 				.add(Items.STICK);
 

--- a/fabric-convention-tags-v2/src/generated/resources/assets/fabric-convention-tags-v2/lang/en_us.json
+++ b/fabric-convention-tags-v2/src/generated/resources/assets/fabric-convention-tags-v2/lang/en_us.json
@@ -295,6 +295,7 @@
   "tag.item.c.ingots.iron": "Iron Ingots",
   "tag.item.c.ingots.netherite": "Netherite Ingots",
   "tag.item.c.leathers": "Leathers",
+  "tag.item.c.loom_patterns": "Loom Patterns",
   "tag.item.c.mushrooms": "Mushrooms",
   "tag.item.c.music_discs": "Music Discs",
   "tag.item.c.nether_stars": "Nether Stars",

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/loom_patterns.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/loom_patterns.json
@@ -1,0 +1,12 @@
+{
+  "values": [
+    "minecraft:flower_banner_pattern",
+    "minecraft:creeper_banner_pattern",
+    "minecraft:skull_banner_pattern",
+    "minecraft:mojang_banner_pattern",
+    "minecraft:globe_banner_pattern",
+    "minecraft:piglin_banner_pattern",
+    "minecraft:flow_banner_pattern",
+    "minecraft:guster_banner_pattern"
+  ]
+}

--- a/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalItemTags.java
+++ b/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalItemTags.java
@@ -496,7 +496,7 @@ public final class ConventionalItemTags {
 	public static final TagKey<Item> MUSIC_DISCS = register("music_discs");
 	/**
 	 * For banner patterns to be used in recipes.
-	 * This is a backport of 21.6 Minecraft's #minecraft:loom_patterns item tag.
+	 * This is a backport of 26.1 Minecraft's #minecraft:loom_patterns item tag.
 	 */
 	public static final TagKey<Item> LOOM_PATTERNS = register("loom_patterns");
 	/**

--- a/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalItemTags.java
+++ b/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalItemTags.java
@@ -495,6 +495,11 @@ public final class ConventionalItemTags {
 	 */
 	public static final TagKey<Item> MUSIC_DISCS = register("music_discs");
 	/**
+	 * For banner patterns to be used in recipes.
+	 * This is a backport of 21.6 Minecraft's #minecraft:loom_patterns item tag.
+	 */
+	public static final TagKey<Item> LOOM_PATTERNS = register("loom_patterns");
+	/**
 	 * For rod-like materials to be used in recipes.
 	 */
 	public static final TagKey<Item> RODS = register("rods");


### PR DESCRIPTION
I need a collection of banner pattern for a trade system in my mod in 1.21.1. Vanilla has a tag of banner patterns as `minecraft:loom_patterns` in 26.1. So it seems like a good idea to backport it to 1.21.1 as `c:loom_patterns`.

I don't think the other mc versions need a backport to as 1.21.1 is the dominate 1.21.x version afaik

Neo PR: https://github.com/neoforged/NeoForge/pull/3052