### PR TITLE
Finalize FRAPI 26.1 Port

### DIFF
--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/wrapper/WrapperBlockStateModel.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/api/client/model/loading/v1/wrapper/WrapperBlockStateModel.java
@@ -82,4 +82,15 @@ public abstract class WrapperBlockStateModel implements BlockStateModel {
 	public Material.Baked particleMaterial(BlockAndTintGetter level, BlockPos pos, BlockState state) {
 		return wrapped.particleMaterial(level, pos, state);
 	}
+
+	@Override
+	@BakedQuad.MaterialFlags
+	public int materialFlags(BlockAndTintGetter level, BlockPos pos, BlockState state, RandomSource random) {
+		return wrapped.materialFlags(level, pos, state, random);
+	}
+
+	@Override
+	public boolean hasMaterialFlag(BlockAndTintGetter level, BlockPos pos, BlockState state, RandomSource random, @BakedQuad.MaterialFlags int flag) {
+		return wrapped.hasMaterialFlag(level, pos, state, random, flag);
+	}
 }

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/client/renderer/v1/Renderer.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/client/renderer/v1/Renderer.java
@@ -25,6 +25,8 @@ import net.minecraft.client.renderer.block.BlockQuadOutput;
 import net.minecraft.client.renderer.block.ModelBlockRenderer;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
 import net.minecraft.client.renderer.chunk.SectionCompiler;
+import net.minecraft.client.renderer.feature.BlockFeatureRenderer;
+import net.minecraft.client.renderer.feature.ItemFeatureRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.state.BlockState;
@@ -34,6 +36,7 @@ import net.fabricmc.fabric.api.client.renderer.v1.mesh.MutableMesh;
 import net.fabricmc.fabric.api.client.renderer.v1.mesh.MutableQuadView;
 import net.fabricmc.fabric.api.client.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.client.renderer.v1.render.AltModelBlockRenderer;
+import net.fabricmc.fabric.api.client.renderer.v1.render.FabricSubmitNodeCollection;
 import net.fabricmc.fabric.impl.client.renderer.RendererManager;
 
 /**
@@ -50,6 +53,10 @@ import net.fabricmc.fabric.impl.client.renderer.RendererManager;
  * are, where appropriate, patched automatically to invoke {@link BlockStateModel#emitQuads} or
  * {@link AltModelBlockRenderer#tesselateBlock(QuadEmitter, float, float, float, BlockAndTintGetter, BlockPos, BlockState, BlockStateModel, long)},
  * respectively, instead.
+ *
+ * <p>Renderers must patch {@link ItemFeatureRenderer} to support
+ * {@link FabricSubmitNodeCollection#getExtendedItemSubmits()}. {@link BlockFeatureRenderer} is automatically patched
+ * to support {@link FabricSubmitNodeCollection#getExtendedBlockModelSubmits()} and {@link BlockStateModel#emitQuads}.
  */
 public interface Renderer {
 	/**

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/client/renderer/v1/mesh/MutableQuadView.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/client/renderer/v1/mesh/MutableQuadView.java
@@ -380,7 +380,7 @@ public interface MutableQuadView extends QuadView {
 	 */
 	MutableQuadView chunkLayer(ChunkSectionLayer layer);
 
-	// TODO FRAPI 26.1: allow using any RenderType
+	// TODO: allow using any RenderType
 
 	/**
 	 * Controls how this quad should be rendered after buffering in item contexts. The atlas texture used by the set

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/client/renderer/v1/render/FabricBlockModelRenderState.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/client/renderer/v1/render/FabricBlockModelRenderState.java
@@ -16,25 +16,30 @@
 
 package net.fabricmc.fabric.api.client.renderer.v1.render;
 
+import java.util.function.Predicate;
+
 import org.joml.Matrix4fc;
 
 import net.minecraft.client.renderer.block.BlockModelRenderState;
-import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
 
 import net.fabricmc.fabric.api.client.renderer.v1.mesh.QuadEmitter;
+import net.fabricmc.fabric.api.client.renderer.v1.model.FabricBlockStateModelPart;
 
 /**
  * Note: This interface is automatically implemented on {@link BlockModelRenderState} via Mixin and interface injection.
  */
 public interface FabricBlockModelRenderState {
-	// TODO FRAPI 26.1: the design here is not ideal because both setupModel and setupMesh override the transformation and renderType fields.
-	//  if a user wants to use both methods, that's unnecessary and unintuitive. might not be worth changing as the part list is always initialized by setupModel.
-	//  also, the user might not know hasTranslucency a priori.
 	/**
 	 * Alternative to {@link BlockModelRenderState#setupModel(Matrix4fc, boolean)} that returns a
-	 * {@link QuadEmitter}.
+	 * {@link QuadEmitter} that adds geometry to this state. Calling this method a second time
+	 * clears all previously added geometry and any changes made to the emitter.
 	 *
-	 * @return a quad emitter to use with {@link BlockStateModel#emitQuads}.
+	 * <p>Calling this method or {@link BlockModelRenderState#setupModel(Matrix4fc, boolean)} clears
+	 * both this state's vanilla model parts and mesh (whose quad emitter is returned by this
+	 * method). If you must use both vanilla model parts and a quad emitter, use this method in
+	 * conjunction with {@link FabricBlockStateModelPart#emitQuads(QuadEmitter, Predicate)}.
+	 *
+	 * @return a quad emitter that appends geometry to this state.
 	 */
 	default QuadEmitter setupMesh(Matrix4fc transformation, boolean hasTranslucency) {
 		throw new IllegalStateException("Implemented via Mixin.");

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/client/renderer/v1/render/FabricLayerRenderState.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/client/renderer/v1/render/FabricLayerRenderState.java
@@ -28,9 +28,6 @@ import net.fabricmc.fabric.api.client.renderer.v1.mesh.QuadEmitter;
  * injection.
  */
 public interface FabricLayerRenderState {
-	// TODO FRAPI 26.1: consider automatically marking the state as animated if any quads with
-	//  animated quads or guaranteed glint are added to this emitter. the only concern is
-	//  efficiency.
 	/**
 	 * Retrieves the {@link QuadEmitter} used to append quads to this layer. Calling this method a second time
 	 * invalidates any prior result. Geometry added to this emitter will not be visible in
@@ -39,7 +36,7 @@ public interface FabricLayerRenderState {
 	 * positions of geometry added to this emitter will automatically be output on
 	 * {@link ItemStackRenderState#visitExtents(Consumer)} ({@link ItemStackRenderState.LayerRenderState#setExtents(Supplier)} must still
 	 * be used to add positions of {@linkplain ItemStackRenderState.LayerRenderState#prepareQuadList() vanilla quads}). Adding quads
-	 * that use animated sprites to this emitter will not automatically call {@link ItemStackRenderState#setAnimated()}. Any
+	 * that use animated sprites or guaranteed glint to this emitter will not automatically call {@link ItemStackRenderState#setAnimated()}. Any
 	 * quads added to this emitter will be cleared on {@link ItemStackRenderState.LayerRenderState#clear()}.
 	 *
 	 * <p>Do not retain references outside the context of this layer.

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/client/renderer/v1/render/FabricOrderedSubmitNodeCollector.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/client/renderer/v1/render/FabricOrderedSubmitNodeCollector.java
@@ -17,11 +17,14 @@
 package net.fabricmc.fabric.api.client.renderer.v1.render;
 
 import java.util.List;
+import java.util.function.Function;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import org.jspecify.annotations.Nullable;
 
 import net.minecraft.client.renderer.OrderedSubmitNodeCollector;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
+import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.client.renderer.item.ItemStackRenderState;
 import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.resources.model.geometry.BakedQuad;
@@ -34,14 +37,16 @@ import net.fabricmc.fabric.api.client.renderer.v1.mesh.MeshView;
  * Note: This interface is automatically implemented on {@link OrderedSubmitNodeCollector} via Mixin and interface injection.
  */
 public interface FabricOrderedSubmitNodeCollector {
-	// TODO FRAPI 26.1
-	//  reintroduce Function<ChunkSectionLayer, RenderType> renderTypeFunction? probably yes, but
-	//  needs thought about how to determine whether a submit is translucent or not
 	/**
-	 * Alternative to {@link OrderedSubmitNodeCollector#submitBlockModel(PoseStack, RenderType, List, int[], int, int, int)} that also accepts a {@link Mesh}.
+	 * Alternative to
+	 * {@link OrderedSubmitNodeCollector#submitBlockModel(PoseStack, RenderType, List, int[], int, int, int)} that also
+	 * optionally accepts a {@link Mesh} and can be rendered to multiple render types. To render to a single render
+	 * type like the vanilla submit, pass a render type function that always returns the same value and that render
+	 * type's {@link RenderType#hasBlending()} value as the translucent parameter.
 	 *
 	 * @param poseStack the pose stack
-	 * @param renderType the render type
+	 * @param renderTypeFunction the render type function to convert quads' chunk layers to render types
+	 * @param translucent whether this submit should be considered translucent
 	 * @param parts the vanilla {@linkplain BlockStateModelPart parts}
 	 * @param mesh the mesh
 	 * @param tintLayers the array of tint layers
@@ -49,8 +54,8 @@ public interface FabricOrderedSubmitNodeCollector {
 	 * @param overlayCoords the overlay coordinates
 	 * @param outlineColor the block outline color
 	 */
-	default void submitBlockModel(PoseStack poseStack, RenderType renderType, List<BlockStateModelPart> parts, Mesh mesh, int[] tintLayers, int lightCoords, int overlayCoords, int outlineColor) {
-		((OrderedSubmitNodeCollector) this).submitBlockModel(poseStack, renderType, parts, tintLayers, lightCoords, overlayCoords, outlineColor);
+	default void submitBlockModel(PoseStack poseStack, Function<ChunkSectionLayer, RenderType> renderTypeFunction, boolean translucent, List<BlockStateModelPart> parts, @Nullable Mesh mesh, int[] tintLayers, int lightCoords, int overlayCoords, int outlineColor) {
+		((OrderedSubmitNodeCollector) this).submitBlockModel(poseStack, ChunkSectionLayerHelper.getRenderType(translucent), parts, tintLayers, lightCoords, overlayCoords, outlineColor);
 	}
 
 	/**

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/client/renderer/v1/render/FabricSubmitNodeCollection.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/client/renderer/v1/render/FabricSubmitNodeCollection.java
@@ -17,13 +17,16 @@
 package net.fabricmc.fabric.api.client.renderer.v1.render;
 
 import java.util.List;
+import java.util.function.Function;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import org.jspecify.annotations.Nullable;
 
 import net.minecraft.client.renderer.SubmitNodeCollection;
 import net.minecraft.client.renderer.SubmitNodeStorage.BlockModelSubmit;
 import net.minecraft.client.renderer.SubmitNodeStorage.ItemSubmit;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
+import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.client.renderer.item.ItemStackRenderState;
 import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.resources.model.geometry.BakedQuad;
@@ -56,7 +59,7 @@ public interface FabricSubmitNodeCollection {
 	/**
 	 * An alternative to {@link BlockModelSubmit} that accepts a {@link Mesh}.
 	 */
-	record ExtendedBlockModelSubmit(PoseStack.Pose pose, RenderType renderType, List<BlockStateModelPart> modelParts, Mesh mesh, int[] tintLayers, int lightCoords, int overlayCoords, int outlineColor) {
+	record ExtendedBlockModelSubmit(PoseStack.Pose pose, Function<ChunkSectionLayer, RenderType> renderTypeFunction, boolean translucent, List<BlockStateModelPart> modelParts, @Nullable Mesh mesh, int[] tintLayers, int lightCoords, int overlayCoords, int outlineColor) {
 	}
 
 	/**

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/impl/client/renderer/BlockModelBufferCache.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/impl/client/renderer/BlockModelBufferCache.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.renderer;
+
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import org.jspecify.annotations.Nullable;
+
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.OutlineBufferSource;
+import net.minecraft.client.renderer.rendertype.RenderType;
+
+public class BlockModelBufferCache {
+	private final MultiBufferSource.BufferSource bufferSource;
+	private final OutlineBufferSource outlineBufferSource;
+
+	private int outlineColor;
+
+	@Nullable
+	private RenderType lastRenderType;
+	@Nullable
+	private VertexConsumer lastBuffer;
+	@Nullable
+	private VertexConsumer lastOutlineBuffer;
+
+	public BlockModelBufferCache(MultiBufferSource.BufferSource bufferSource, OutlineBufferSource outlineBufferSource) {
+		this.bufferSource = bufferSource;
+		this.outlineBufferSource = outlineBufferSource;
+	}
+
+	public void outlineColor(int outlineColor) {
+		this.outlineColor = outlineColor;
+		lastRenderType = null;
+	}
+
+	public VertexConsumer getBuffer(RenderType renderType) {
+		if (renderType != lastRenderType) {
+			update(renderType);
+		}
+
+		return lastBuffer;
+	}
+
+	@Nullable
+	public VertexConsumer getOutlineBuffer(RenderType renderType) {
+		if (renderType != lastRenderType) {
+			update(renderType);
+		}
+
+		return lastOutlineBuffer;
+	}
+
+	private void update(RenderType renderType) {
+		lastRenderType = renderType;
+		lastBuffer = bufferSource.getBuffer(renderType);
+
+		if (outlineColor != 0) {
+			outlineBufferSource.setColor(outlineColor);
+			lastOutlineBuffer = outlineBufferSource.getBuffer(renderType);
+		} else {
+			lastOutlineBuffer = null;
+		}
+	}
+}

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/impl/client/renderer/QuadConsumers.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/impl/client/renderer/QuadConsumers.java
@@ -17,11 +17,13 @@
 package net.fabricmc.fabric.impl.client.renderer;
 
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
-import org.jspecify.annotations.Nullable;
 
+import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
+import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.util.LightCoordsUtil;
 
@@ -38,9 +40,8 @@ public final class QuadConsumers {
 		public int lightCoords;
 		public int overlayCoords;
 		public PoseStack.Pose pose;
-		public VertexConsumer buffer;
-		@Nullable
-		public VertexConsumer outlineBuffer;
+		public Function<ChunkSectionLayer, RenderType> renderTypeFunction;
+		public BlockModelBufferCache bufferCache;
 
 		@Override
 		public void accept(MutableQuadView quad) {
@@ -56,7 +57,9 @@ public final class QuadConsumers {
 				quad.multiplyColor(tintLayers[tintIndex]);
 			}
 
-			quad.buffer(overlayCoords, pose, buffer);
+			RenderType renderType = renderTypeFunction.apply(quad.chunkLayer());
+			quad.buffer(overlayCoords, pose, bufferCache.getBuffer(renderType));
+			VertexConsumer outlineBuffer = bufferCache.getOutlineBuffer(renderType);
 
 			if (outlineBuffer != null) {
 				quad.buffer(overlayCoords, pose, outlineBuffer);

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/renderer/block/render/BlockFeatureRendererMixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/renderer/block/render/BlockFeatureRendererMixin.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.mixin.client.renderer.block.render;
 
+import java.util.function.Function;
+
 import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.Share;
 import com.llamalad7.mixinextras.sugar.ref.LocalRef;
@@ -28,6 +30,7 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -45,6 +48,7 @@ import net.minecraft.client.renderer.block.ModelBlockRenderer;
 import net.minecraft.client.renderer.block.MovingBlockRenderState;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
+import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.client.renderer.feature.BlockFeatureRenderer;
 import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.state.OptionsRenderState;
@@ -52,6 +56,7 @@ import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.client.resources.model.ModelBakery;
 import net.minecraft.client.resources.model.geometry.BakedQuad;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
@@ -61,11 +66,14 @@ import net.fabricmc.fabric.api.client.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.client.renderer.v1.render.AltModelBlockRenderer;
 import net.fabricmc.fabric.api.client.renderer.v1.render.ChunkSectionLayerHelper;
 import net.fabricmc.fabric.api.client.renderer.v1.render.FabricSubmitNodeCollection;
+import net.fabricmc.fabric.impl.client.renderer.BlockModelBufferCache;
 import net.fabricmc.fabric.impl.client.renderer.QuadConsumers;
 
-// TODO FRAPI 26.1: how much of this, if any, should be moved to Indigo?
 @Mixin(BlockFeatureRenderer.class)
 abstract class BlockFeatureRendererMixin {
+	@Shadow
+	@Final
+	private static Direction[] DIRECTIONS;
 	@Shadow
 	@Final
 	private QuadInstance quadInstance;
@@ -74,7 +82,22 @@ abstract class BlockFeatureRendererMixin {
 	private RandomSource random;
 
 	@Shadow
-	private static void putPartQuads(BlockStateModelPart part, PoseStack.Pose pose, QuadInstance quadInstance, int[] tintLayers, VertexConsumer buffer, @Nullable VertexConsumer outlineBuffer) {
+	private static void putQuad(PoseStack.Pose pose, BakedQuad quad, QuadInstance instance, int[] tintLayers, VertexConsumer buffer, @Nullable VertexConsumer outlineBuffer) {
+	}
+
+	@Unique
+	private static void putPartQuads(BlockStateModelPart part, PoseStack.Pose pose, QuadInstance quadInstance, int[] tintLayers, Function<ChunkSectionLayer, RenderType> renderTypeFunction, BlockModelBufferCache bufferCache) {
+		for (Direction direction : DIRECTIONS) {
+			for (BakedQuad quad : part.getQuads(direction)) {
+				RenderType renderType = renderTypeFunction.apply(quad.materialInfo().layer());
+				putQuad(pose, quad, quadInstance, tintLayers, bufferCache.getBuffer(renderType), bufferCache.getOutlineBuffer(renderType));
+			}
+		}
+
+		for (BakedQuad quad : part.getQuads(null)) {
+			RenderType renderType = renderTypeFunction.apply(quad.materialInfo().layer());
+			putQuad(pose, quad, quadInstance, tintLayers, bufferCache.getBuffer(renderType), bufferCache.getOutlineBuffer(renderType));
+		}
 	}
 
 	@Inject(method = "renderMovingBlockSubmits", at = @At(value = "INVOKE", target = "net/minecraft/client/renderer/block/ModelBlockRenderer.<init>(ZZLnet/minecraft/client/color/block/BlockColors;)V"))
@@ -101,40 +124,38 @@ abstract class BlockFeatureRendererMixin {
 
 	@Inject(method = "renderBlockModelSubmits", at = @At("RETURN"))
 	private void onReturnRenderBlockModelSubmits(SubmitNodeCollection nodeCollection, MultiBufferSource.BufferSource bufferSource, OutlineBufferSource outlineBufferSource, boolean translucent, CallbackInfo ci) {
+		BlockModelBufferCache bufferCache = new BlockModelBufferCache(bufferSource, outlineBufferSource);
 		QuadConsumers.BlockModel quadConsumer = new QuadConsumers.BlockModel();
 		QuadEmitter output = Renderer.get().quadEmitter(quadConsumer);
 
 		for (FabricSubmitNodeCollection.ExtendedBlockModelSubmit submit : nodeCollection.getExtendedBlockModelSubmits()) {
-			if (submit.renderType().hasBlending() == translucent) {
-				VertexConsumer buffer = bufferSource.getBuffer(submit.renderType());
-				VertexConsumer outlineBuffer;
+			if (submit.translucent() == translucent) {
+				PoseStack.Pose pose = submit.pose();
+				int[] tintLayers = submit.tintLayers();
+				Function<ChunkSectionLayer, RenderType> renderTypeFunction = submit.renderTypeFunction();
 
-				if (submit.outlineColor() != 0) {
-					outlineBufferSource.setColor(submit.outlineColor());
-					outlineBuffer = outlineBufferSource.getBuffer(submit.renderType());
-				} else {
-					outlineBuffer = null;
-				}
+				bufferCache.outlineColor(submit.outlineColor());
 
 				quadInstance.setLightCoords(submit.lightCoords());
 				quadInstance.setOverlayCoords(submit.overlayCoords());
 
 				for (BlockStateModelPart part : submit.modelParts()) {
-					putPartQuads(part, submit.pose(), quadInstance, submit.tintLayers(), buffer, outlineBuffer);
+					putPartQuads(part, pose, quadInstance, tintLayers, renderTypeFunction, bufferCache);
 				}
 
-				quadConsumer.tintLayers = submit.tintLayers();
-				quadConsumer.lightCoords = submit.lightCoords();
-				quadConsumer.overlayCoords = submit.overlayCoords();
-				quadConsumer.pose = submit.pose();
-				quadConsumer.buffer = buffer;
-				quadConsumer.outlineBuffer = outlineBuffer;
-				submit.mesh().outputTo(output);
+				if (submit.mesh() != null) {
+					quadConsumer.tintLayers = tintLayers;
+					quadConsumer.lightCoords = submit.lightCoords();
+					quadConsumer.overlayCoords = submit.overlayCoords();
+					quadConsumer.pose = pose;
+					quadConsumer.renderTypeFunction = renderTypeFunction;
+					quadConsumer.bufferCache = bufferCache;
+					submit.mesh().outputTo(output);
+				}
 			}
 		}
 	}
 
-	// TODO FRAPI 26.1: don't use an overwrite if possible
 	@Overwrite
 	private void renderBreakingBlockModelSubmits(final SubmitNodeCollection nodeCollection, final MultiBufferSource.BufferSource bufferSource) {
 		QuadConsumers.BreakingBlockModel quadConsumer = new QuadConsumers.BreakingBlockModel();
@@ -146,7 +167,7 @@ abstract class BlockFeatureRendererMixin {
 			quadConsumer.buffer = buffer;
 			output.clear();
 			random.setSeed(submit.seed());
-			// TODO FRAPI 26.1: somehow pass the level, pos, and state here when available? maybe via extended submit type?
+			// TODO 26.1: somehow pass the level, pos, and state here when available? maybe via extended submit type?
 			submit.model().emitQuads(output, BlockAndTintGetter.EMPTY, BlockPos.ZERO, Blocks.AIR.defaultBlockState(), random, _ -> false);
 		}
 	}

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/renderer/block/render/BlockModelRenderStateMixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/renderer/block/render/BlockModelRenderStateMixin.java
@@ -33,6 +33,7 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.SubmitNodeCollector;
@@ -86,6 +87,10 @@ public abstract class BlockModelRenderStateMixin implements FabricBlockModelRend
 			mesh.clear();
 		}
 
+		if (modelParts != null) {
+			modelParts.clear();
+		}
+
 		return mesh.emitter();
 	}
 
@@ -99,7 +104,14 @@ public abstract class BlockModelRenderStateMixin implements FabricBlockModelRend
 		return original && mesh == null;
 	}
 
-	// TODO FRAPI 26.1: improve this injection or use a second submit for just the mesh
+	@Inject(method = "setupModel", at = @At("RETURN"))
+	private void onReturnSetupModel(CallbackInfoReturnable<List<BlockStateModelPart>> cir) {
+		if (mesh != null) {
+			mesh.clear();
+		}
+	}
+
+	// TODO: improve this injection or use a second submit for just the mesh
 	@Inject(method = "submitModel", at = @At("HEAD"), cancellable = true)
 	private void submitMesh(RenderType renderType, PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int lightCoords, int overlayCoords, int outlineColor, CallbackInfo ci) {
 		if (mesh != null && mesh.size() > 0) {
@@ -110,10 +122,10 @@ public abstract class BlockModelRenderStateMixin implements FabricBlockModelRend
 			if (transformation != null) {
 				poseStack.pushPose();
 				poseStack.mulPose(transformation);
-				submitNodeCollector.submitBlockModel(poseStack, renderType, modelPartsCopy, meshCopy, tints, lightCoords, overlayCoords, outlineColor);
+				submitNodeCollector.submitBlockModel(poseStack, _ -> renderType, renderType.hasBlending(), modelPartsCopy, meshCopy, tints, lightCoords, overlayCoords, outlineColor);
 				poseStack.popPose();
 			} else {
-				submitNodeCollector.submitBlockModel(poseStack, renderType, modelPartsCopy, meshCopy, tints, lightCoords, overlayCoords, outlineColor);
+				submitNodeCollector.submitBlockModel(poseStack, _ -> renderType, renderType.hasBlending(), modelPartsCopy, meshCopy, tints, lightCoords, overlayCoords, outlineColor);
 			}
 
 			ci.cancel();

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/renderer/block/render/BlockStateModelWrapperMixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/renderer/block/render/BlockStateModelWrapperMixin.java
@@ -51,7 +51,7 @@ abstract class BlockStateModelWrapperMixin implements BlockModel {
 	public void update(BlockModelRenderState output, BlockState blockState, BlockDisplayContext displayContext, long seed) {
 		// This could be optimized to inspect the quad output rather than calling hasMaterialFlag
 		QuadEmitter emitter = output.setupMesh(transformation, model.hasMaterialFlag(BlockAndTintGetter.EMPTY, BlockPos.ZERO, blockState, output.scratchRandomSource(seed), BakedQuad.FLAG_TRANSLUCENT));
-		// TODO FRAPI 26.1: somehow pass the level and pos here when available?
+		// TODO 26.1: somehow pass the level and pos here when available?
 		model.emitQuads(emitter, BlockAndTintGetter.EMPTY, BlockPos.ZERO, blockState, output.scratchRandomSource(seed), _ -> false);
 		updateTints(output, blockState);
 	}

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/renderer/submit/SubmitNodeCollectionMixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/renderer/submit/SubmitNodeCollectionMixin.java
@@ -18,8 +18,10 @@ package net.fabricmc.fabric.mixin.client.renderer.submit;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -30,6 +32,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import net.minecraft.client.renderer.OrderedSubmitNodeCollector;
 import net.minecraft.client.renderer.SubmitNodeCollection;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
+import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.client.renderer.item.ItemStackRenderState;
 import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.resources.model.geometry.BakedQuad;
@@ -50,9 +53,9 @@ abstract class SubmitNodeCollectionMixin implements OrderedSubmitNodeCollector, 
 	private final List<ExtendedItemSubmit> extendedItemSubmits = new ArrayList<>();
 
 	@Override
-	public void submitBlockModel(PoseStack poseStack, RenderType renderType, List<BlockStateModelPart> parts, Mesh mesh, int[] tintLayers, int lightCoords, int overlayCoords, int outlineColor) {
+	public void submitBlockModel(PoseStack poseStack, Function<ChunkSectionLayer, RenderType> renderTypeFunction, boolean translucent, List<BlockStateModelPart> parts, @Nullable Mesh mesh, int[] tintLayers, int lightCoords, int overlayCoords, int outlineColor) {
 		wasUsed = true;
-		extendedBlockModelSubmits.add(new ExtendedBlockModelSubmit(poseStack.last().copy(), renderType, parts, mesh, tintLayers, lightCoords, overlayCoords, outlineColor));
+		extendedBlockModelSubmits.add(new ExtendedBlockModelSubmit(poseStack.last().copy(), renderTypeFunction, translucent, parts, mesh, tintLayers, lightCoords, overlayCoords, outlineColor));
 	}
 
 	@Override

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/renderer/submit/SubmitNodeStorageMixin.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/renderer/submit/SubmitNodeStorageMixin.java
@@ -17,13 +17,16 @@
 package net.fabricmc.fabric.mixin.client.renderer.submit;
 
 import java.util.List;
+import java.util.function.Function;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.SubmitNodeStorage;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
+import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.client.renderer.item.ItemStackRenderState;
 import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.resources.model.geometry.BakedQuad;
@@ -35,8 +38,8 @@ import net.fabricmc.fabric.api.client.renderer.v1.mesh.MeshView;
 @Mixin(SubmitNodeStorage.class)
 abstract class SubmitNodeStorageMixin implements SubmitNodeCollector {
 	@Override
-	public void submitBlockModel(PoseStack poseStack, RenderType renderType, List<BlockStateModelPart> parts, Mesh mesh, int[] tintLayers, int lightCoords, int overlayCoords, int outlineColor) {
-		order(0).submitBlockModel(poseStack, renderType, parts, mesh, tintLayers, lightCoords, overlayCoords, outlineColor);
+	public void submitBlockModel(PoseStack poseStack, Function<ChunkSectionLayer, RenderType> renderTypeFunction, boolean translucent, List<BlockStateModelPart> parts, @Nullable Mesh mesh, int[] tintLayers, int lightCoords, int overlayCoords, int outlineColor) {
+		order(0).submitBlockModel(poseStack, renderTypeFunction, translucent, parts, mesh, tintLayers, lightCoords, overlayCoords, outlineColor);
 	}
 
 	@Override

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl.java
@@ -107,10 +107,6 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 		return this;
 	}
 
-	// Much more efficient than default impl as it does not invalidate geometry
-	// FIXME FRAPI 26.1: some geometry flags should be invalidated, but partial invalidation might
-	//  add too much complexity. in all existing code, geometry is never queried after calling this
-	//  method, so the default implementation may be sufficient.
 	@Override
 	public final MutableQuadViewImpl translate(float x, float y, float z) {
 		for (int i = 0; i < 4; i++) {
@@ -120,6 +116,9 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 			data[index + 2] = Float.floatToRawIntBits(Float.intBitsToFloat(data[index + 2]) + z);
 		}
 
+		// In reality, only the CUBIC and LIGHT_FACE flags need to be invalidated.
+		// AXIS_ALIGNED and the face normal are unchanged after translation.
+		isGeometryInvalid = true;
 		return this;
 	}
 


### PR DESCRIPTION
- Replace single render type with render type function and make mesh nullable in extended block model submits
- Refine contract of `FabricBlockModelRenderState#setupMesh` to avoid footguns
- Specify in `Renderer` javadoc that the renderer needs to add support for extended item submits
- Fix `MutableQuadViewImpl#translate` not invalidating geometry
- Fix `WrapperBlockStateModel` not overriding new extension methods