### PR TITLE
Fix `AltModelBlockRendererImpl` not checking the cull cache correctly

### DIFF
--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AltModelBlockRendererImpl.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AltModelBlockRendererImpl.java
@@ -145,7 +145,7 @@ public class AltModelBlockRendererImpl implements AltModelBlockRenderer, QuadTra
 				return false;
 			}
 		} else {
-			return (shouldCullFaceCache & cacheMask) == 1;
+			return (shouldCullFaceCache & cacheMask) != 0;
 		}
 	}
 


### PR DESCRIPTION
The cull cache part of `AltModelBlockRendererImpl` was adapted from the cull cache that the vanilla `ModelBlockRenderer` uses, so this bug was carried over. However, vanilla produces correct results despite the bug in its code.

Fix #5303.