### PR TITLE
[1.21.1] Add RecipeOutputMixin to support FabricRecipeExporter (#5008)

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/RecipeExporterMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/RecipeExporterMixin.java
@@ -18,10 +18,10 @@ package net.fabricmc.fabric.mixin.datagen.recipe;
 
 import org.spongepowered.asm.mixin.Mixin;
 
-import net.minecraft.data.recipes.RecipeOutput;
+import net.minecraft.data.server.recipe.RecipeExporter;
 
 import net.fabricmc.fabric.api.datagen.v1.recipe.FabricRecipeExporter;
 
-@Mixin(RecipeOutput.class)
-public interface RecipeOutputMixin extends FabricRecipeExporter {
+@Mixin(RecipeExporter.class)
+public interface RecipeExporterMixin extends FabricRecipeExporter {
 }

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/RecipeOutputMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/RecipeOutputMixin.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.datagen.recipe;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import net.minecraft.data.recipes.RecipeOutput;
+
+import net.fabricmc.fabric.api.datagen.v1.recipe.FabricRecipeExporter;
+
+@Mixin(RecipeOutput.class)
+public interface RecipeOutputMixin extends FabricRecipeExporter {
+}

--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
@@ -10,6 +10,7 @@
     "loot.BlockLootTableGeneratorAccessor",
     "loot.BlockLootTableGeneratorMixin",
     "recipe.AllCraftingRecipeJsonBuildersMixin",
+    "recipe.RecipeOutputMixin",
     "recipe.ComplexRecipeJsonBuilderMixin",
     "recipe.SmithingTransformRecipeJsonBuilderMixin",
     "recipe.SmithingTrimRecipeJsonBuilderMixin"

--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
@@ -10,7 +10,7 @@
     "loot.BlockLootTableGeneratorAccessor",
     "loot.BlockLootTableGeneratorMixin",
     "recipe.AllCraftingRecipeJsonBuildersMixin",
-    "recipe.RecipeOutputMixin",
+    "recipe.RecipeExporterMixin",
     "recipe.ComplexRecipeJsonBuilderMixin",
     "recipe.SmithingTransformRecipeJsonBuilderMixin",
     "recipe.SmithingTrimRecipeJsonBuilderMixin"


### PR DESCRIPTION
(cherry picked from commit 1d9b5c35f75e938be2326c46bbffe08d032ea78d)

Backports https://github.com/FabricMC/fabric-api/pull/5008