### PR TITLE
Utilise BlockItemTagAppender

### DIFF
--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BlockTagsGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BlockTagsGenerator.java
@@ -62,35 +62,35 @@ public final class BlockTagsGenerator extends FabricTagsProvider.BlockTagsProvid
 	@Override
 	protected void addTags(HolderLookup.Provider registries) {
 		builder(ConventionalBlockTags.STONES)
-				.add(BlockItemIds.STONE.block())
-				.add(BlockItemIds.ANDESITE.block())
-				.add(BlockItemIds.DIORITE.block())
-				.add(BlockItemIds.GRANITE.block())
-				.add(BlockItemIds.TUFF.block())
-				.add(BlockItemIds.DEEPSLATE.block());
+				.add(BlockItemIds.STONE)
+				.add(BlockItemIds.ANDESITE)
+				.add(BlockItemIds.DIORITE)
+				.add(BlockItemIds.GRANITE)
+				.add(BlockItemIds.TUFF)
+				.add(BlockItemIds.DEEPSLATE);
 		builder(ConventionalBlockTags.NORMAL_COBBLESTONES)
-				.add(BlockItemIds.COBBLESTONE.block());
+				.add(BlockItemIds.COBBLESTONE);
 		builder(ConventionalBlockTags.MOSSY_COBBLESTONES)
-				.add(BlockItemIds.MOSSY_COBBLESTONE.block());
+				.add(BlockItemIds.MOSSY_COBBLESTONE);
 		builder(ConventionalBlockTags.INFESTED_COBBLESTONES)
-				.add(BlockItemIds.INFESTED_COBBLESTONE.block());
+				.add(BlockItemIds.INFESTED_COBBLESTONE);
 		builder(ConventionalBlockTags.DEEPSLATE_COBBLESTONES)
-				.add(BlockItemIds.COBBLED_DEEPSLATE.block());
+				.add(BlockItemIds.COBBLED_DEEPSLATE);
 		builder(ConventionalBlockTags.COBBLESTONES)
 				.addOptionalTag(ConventionalBlockTags.NORMAL_COBBLESTONES)
 				.addOptionalTag(ConventionalBlockTags.MOSSY_COBBLESTONES)
 				.addOptionalTag(ConventionalBlockTags.INFESTED_COBBLESTONES)
 				.addOptionalTag(ConventionalBlockTags.DEEPSLATE_COBBLESTONES);
 		builder(ConventionalBlockTags.NETHERRACKS)
-				.add(BlockItemIds.NETHERRACK.block());
+				.add(BlockItemIds.NETHERRACK);
 		builder(ConventionalBlockTags.END_STONES)
-				.add(BlockItemIds.END_STONE.block());
+				.add(BlockItemIds.END_STONE);
 		builder(ConventionalBlockTags.GRAVELS)
-				.add(BlockItemIds.GRAVEL.block());
+				.add(BlockItemIds.GRAVEL);
 		builder(ConventionalBlockTags.NORMAL_OBSIDIANS)
-				.add(BlockItemIds.OBSIDIAN.block());
+				.add(BlockItemIds.OBSIDIAN);
 		builder(ConventionalBlockTags.CRYING_OBSIDIANS)
-				.add(BlockItemIds.CRYING_OBSIDIAN.block());
+				.add(BlockItemIds.CRYING_OBSIDIAN);
 		builder(ConventionalBlockTags.OBSIDIANS)
 				.addOptionalTag(ConventionalBlockTags.NORMAL_OBSIDIANS)
 				.addOptionalTag(ConventionalBlockTags.CRYING_OBSIDIANS);
@@ -110,11 +110,11 @@ public final class BlockTagsGenerator extends FabricTagsProvider.BlockTagsProvid
 		builder(ConventionalBlockTags.LAPIS_ORES)
 				.addOptionalTag(BlockItemTags.LAPIS_ORES.block());
 		builder(ConventionalBlockTags.NETHERITE_SCRAP_ORES)
-				.add(BlockItemIds.ANCIENT_DEBRIS.block());
+				.add(BlockItemIds.ANCIENT_DEBRIS);
 		builder(ConventionalBlockTags.REDSTONE_ORES)
 				.addOptionalTag(BlockItemTags.REDSTONE_ORES.block());
 		builder(ConventionalBlockTags.QUARTZ_ORES)
-				.add(BlockItemIds.NETHER_QUARTZ_ORE.block());
+				.add(BlockItemIds.NETHER_QUARTZ_ORE);
 		builder(ConventionalBlockTags.ORES)
 				.addOptionalTag(ConventionalBlockTags.COAL_ORES)
 				.addOptionalTag(ConventionalBlockTags.COPPER_ORES)
@@ -128,74 +128,74 @@ public final class BlockTagsGenerator extends FabricTagsProvider.BlockTagsProvid
 				.addOptionalTag(ConventionalBlockTags.QUARTZ_ORES);
 
 		builder(ConventionalBlockTags.ORE_BEARING_GROUND_DEEPSLATE)
-				.add(BlockItemIds.DEEPSLATE.block());
+				.add(BlockItemIds.DEEPSLATE);
 		builder(ConventionalBlockTags.ORE_BEARING_GROUND_NETHERRACK)
-				.add(BlockItemIds.NETHERRACK.block());
+				.add(BlockItemIds.NETHERRACK);
 		builder(ConventionalBlockTags.ORE_BEARING_GROUND_STONE)
-				.add(BlockItemIds.STONE.block());
+				.add(BlockItemIds.STONE);
 		builder(ConventionalBlockTags.ORE_RATES_DENSE)
-				.add(BlockItemIds.COPPER_ORE.block())
-				.add(BlockItemIds.DEEPSLATE_COPPER_ORE.block())
-				.add(BlockItemIds.DEEPSLATE_LAPIS_ORE.block())
-				.add(BlockItemIds.DEEPSLATE_REDSTONE_ORE.block())
-				.add(BlockItemIds.LAPIS_ORE.block())
-				.add(BlockItemIds.REDSTONE_ORE.block());
+				.add(BlockItemIds.COPPER_ORE)
+				.add(BlockItemIds.DEEPSLATE_COPPER_ORE)
+				.add(BlockItemIds.DEEPSLATE_LAPIS_ORE)
+				.add(BlockItemIds.DEEPSLATE_REDSTONE_ORE)
+				.add(BlockItemIds.LAPIS_ORE)
+				.add(BlockItemIds.REDSTONE_ORE);
 		builder(ConventionalBlockTags.ORE_RATES_SINGULAR)
-				.add(BlockItemIds.ANCIENT_DEBRIS.block())
-				.add(BlockItemIds.COAL_ORE.block())
-				.add(BlockItemIds.DEEPSLATE_COAL_ORE.block())
-				.add(BlockItemIds.DEEPSLATE_DIAMOND_ORE.block())
-				.add(BlockItemIds.DEEPSLATE_EMERALD_ORE.block())
-				.add(BlockItemIds.DEEPSLATE_GOLD_ORE.block())
-				.add(BlockItemIds.DEEPSLATE_IRON_ORE.block())
-				.add(BlockItemIds.DIAMOND_ORE.block())
-				.add(BlockItemIds.EMERALD_ORE.block())
-				.add(BlockItemIds.GOLD_ORE.block())
-				.add(BlockItemIds.IRON_ORE.block())
-				.add(BlockItemIds.NETHER_QUARTZ_ORE.block());
+				.add(BlockItemIds.ANCIENT_DEBRIS)
+				.add(BlockItemIds.COAL_ORE)
+				.add(BlockItemIds.DEEPSLATE_COAL_ORE)
+				.add(BlockItemIds.DEEPSLATE_DIAMOND_ORE)
+				.add(BlockItemIds.DEEPSLATE_EMERALD_ORE)
+				.add(BlockItemIds.DEEPSLATE_GOLD_ORE)
+				.add(BlockItemIds.DEEPSLATE_IRON_ORE)
+				.add(BlockItemIds.DIAMOND_ORE)
+				.add(BlockItemIds.EMERALD_ORE)
+				.add(BlockItemIds.GOLD_ORE)
+				.add(BlockItemIds.IRON_ORE)
+				.add(BlockItemIds.NETHER_QUARTZ_ORE);
 		builder(ConventionalBlockTags.ORE_RATES_SPARSE)
-				.add(BlockItemIds.NETHER_GOLD_ORE.block());
+				.add(BlockItemIds.NETHER_GOLD_ORE);
 		builder(ConventionalBlockTags.ORES_IN_GROUND_DEEPSLATE)
-				.add(BlockItemIds.DEEPSLATE_COAL_ORE.block())
-				.add(BlockItemIds.DEEPSLATE_COPPER_ORE.block())
-				.add(BlockItemIds.DEEPSLATE_DIAMOND_ORE.block())
-				.add(BlockItemIds.DEEPSLATE_EMERALD_ORE.block())
-				.add(BlockItemIds.DEEPSLATE_GOLD_ORE.block())
-				.add(BlockItemIds.DEEPSLATE_IRON_ORE.block())
-				.add(BlockItemIds.DEEPSLATE_LAPIS_ORE.block())
-				.add(BlockItemIds.DEEPSLATE_REDSTONE_ORE.block());
+				.add(BlockItemIds.DEEPSLATE_COAL_ORE)
+				.add(BlockItemIds.DEEPSLATE_COPPER_ORE)
+				.add(BlockItemIds.DEEPSLATE_DIAMOND_ORE)
+				.add(BlockItemIds.DEEPSLATE_EMERALD_ORE)
+				.add(BlockItemIds.DEEPSLATE_GOLD_ORE)
+				.add(BlockItemIds.DEEPSLATE_IRON_ORE)
+				.add(BlockItemIds.DEEPSLATE_LAPIS_ORE)
+				.add(BlockItemIds.DEEPSLATE_REDSTONE_ORE);
 		builder(ConventionalBlockTags.ORES_IN_GROUND_NETHERRACK)
-				.add(BlockItemIds.NETHER_GOLD_ORE.block())
-				.add(BlockItemIds.NETHER_QUARTZ_ORE.block());
+				.add(BlockItemIds.NETHER_GOLD_ORE)
+				.add(BlockItemIds.NETHER_QUARTZ_ORE);
 		builder(ConventionalBlockTags.ORES_IN_GROUND_STONE)
-				.add(BlockItemIds.COAL_ORE.block())
-				.add(BlockItemIds.COPPER_ORE.block())
-				.add(BlockItemIds.DIAMOND_ORE.block())
-				.add(BlockItemIds.EMERALD_ORE.block())
-				.add(BlockItemIds.GOLD_ORE.block())
-				.add(BlockItemIds.IRON_ORE.block())
-				.add(BlockItemIds.LAPIS_ORE.block())
-				.add(BlockItemIds.REDSTONE_ORE.block());
+				.add(BlockItemIds.COAL_ORE)
+				.add(BlockItemIds.COPPER_ORE)
+				.add(BlockItemIds.DIAMOND_ORE)
+				.add(BlockItemIds.EMERALD_ORE)
+				.add(BlockItemIds.GOLD_ORE)
+				.add(BlockItemIds.IRON_ORE)
+				.add(BlockItemIds.LAPIS_ORE)
+				.add(BlockItemIds.REDSTONE_ORE);
 
 		builder(ConventionalBlockTags.WOODEN_CHESTS)
-				.add(BlockItemIds.CHEST.block())
-				.add(BlockItemIds.TRAPPED_CHEST.block());
+				.add(BlockItemIds.CHEST)
+				.add(BlockItemIds.TRAPPED_CHEST);
 		builder(ConventionalBlockTags.TRAPPED_CHESTS)
-				.add(BlockItemIds.TRAPPED_CHEST.block());
+				.add(BlockItemIds.TRAPPED_CHEST);
 		builder(ConventionalBlockTags.ENDER_CHESTS)
-				.add(BlockItemIds.ENDER_CHEST.block());
+				.add(BlockItemIds.ENDER_CHEST);
 		builder(ConventionalBlockTags.CHESTS)
 				.addTag(ConventionalBlockTags.WOODEN_CHESTS)
 				.addTag(ConventionalBlockTags.TRAPPED_CHESTS)
 				.addTag(ConventionalBlockTags.ENDER_CHESTS)
 				.addOptionalTag(BlockTags.COPPER_CHESTS);
 		builder(ConventionalBlockTags.BOOKSHELVES)
-				.add(BlockItemIds.BOOKSHELF.block());
+				.add(BlockItemIds.BOOKSHELF);
 		generateGlassTags();
 		generateGlazeTerracottaTags();
 		generateConcreteTags();
 		builder(ConventionalBlockTags.WOODEN_BARRELS)
-				.add(BlockItemIds.BARREL.block());
+				.add(BlockItemIds.BARREL);
 		builder(ConventionalBlockTags.BARRELS)
 				.addTag(ConventionalBlockTags.WOODEN_BARRELS);
 
@@ -222,32 +222,32 @@ public final class BlockTagsGenerator extends FabricTagsProvider.BlockTagsProvid
 
 	private void generateFlowerTags() {
 		builder(ConventionalBlockTags.SMALL_FLOWERS)
-				.add(BlockItemIds.DANDELION.block(), BlockItemIds.POPPY.block(), BlockItemIds.BLUE_ORCHID.block(),
-						BlockItemIds.ALLIUM.block(), BlockItemIds.AZURE_BLUET.block(), BlockItemIds.RED_TULIP.block(),
-						BlockItemIds.ORANGE_TULIP.block(), BlockItemIds.WHITE_TULIP.block(), BlockItemIds.PINK_TULIP.block(),
-						BlockItemIds.OXEYE_DAISY.block(), BlockItemIds.CORNFLOWER.block(), BlockItemIds.LILY_OF_THE_VALLEY.block(),
-						BlockItemIds.WITHER_ROSE.block(), BlockItemIds.TORCHFLOWER.block(), BlockItemIds.OPEN_EYEBLOSSOM.block(),
-						BlockItemIds.CLOSED_EYEBLOSSOM.block()
+				.add(BlockItemIds.DANDELION, BlockItemIds.POPPY, BlockItemIds.BLUE_ORCHID,
+						BlockItemIds.ALLIUM, BlockItemIds.AZURE_BLUET, BlockItemIds.RED_TULIP,
+						BlockItemIds.ORANGE_TULIP, BlockItemIds.WHITE_TULIP, BlockItemIds.PINK_TULIP,
+						BlockItemIds.OXEYE_DAISY, BlockItemIds.CORNFLOWER, BlockItemIds.LILY_OF_THE_VALLEY,
+						BlockItemIds.WITHER_ROSE, BlockItemIds.TORCHFLOWER, BlockItemIds.OPEN_EYEBLOSSOM,
+						BlockItemIds.CLOSED_EYEBLOSSOM
 				);
 
 		builder(ConventionalBlockTags.TALL_FLOWERS)
-				.add(BlockItemIds.SUNFLOWER.block(), BlockItemIds.LILAC.block(), BlockItemIds.PEONY.block(),
-						BlockItemIds.ROSE_BUSH.block(), BlockItemIds.PITCHER_PLANT.block()
+				.add(BlockItemIds.SUNFLOWER, BlockItemIds.LILAC, BlockItemIds.PEONY,
+						BlockItemIds.ROSE_BUSH, BlockItemIds.PITCHER_PLANT
 				);
 
 		builder(ConventionalBlockTags.FLOWERS)
-				.add(BlockItemIds.CHERRY_LEAVES.block(), BlockItemIds.FLOWERING_AZALEA_LEAVES.block(), BlockItemIds.FLOWERING_AZALEA.block(),
-						BlockItemIds.MANGROVE_PROPAGULE.block(), BlockItemIds.PINK_PETALS.block(), BlockItemIds.WILDFLOWERS.block(), BlockItemIds.CHORUS_FLOWER.block(),
-						BlockItemIds.SPORE_BLOSSOM.block(), BlockItemIds.CACTUS_FLOWER.block()
+				.add(BlockItemIds.CHERRY_LEAVES, BlockItemIds.FLOWERING_AZALEA_LEAVES, BlockItemIds.FLOWERING_AZALEA,
+						BlockItemIds.MANGROVE_PROPAGULE, BlockItemIds.PINK_PETALS, BlockItemIds.WILDFLOWERS, BlockItemIds.CHORUS_FLOWER,
+						BlockItemIds.SPORE_BLOSSOM, BlockItemIds.CACTUS_FLOWER
 				).addOptionalTag(ConventionalBlockTags.SMALL_FLOWERS)
 				.addOptionalTag(ConventionalBlockTags.TALL_FLOWERS);
 	}
 
 	private void generateMiscTags() {
 		builder(ConventionalBlockTags.PLAYER_WORKSTATIONS_CRAFTING_TABLES)
-				.add(BlockItemIds.CRAFTING_TABLE.block());
+				.add(BlockItemIds.CRAFTING_TABLE);
 		builder(ConventionalBlockTags.PLAYER_WORKSTATIONS_FURNACES)
-				.add(BlockItemIds.FURNACE.block());
+				.add(BlockItemIds.FURNACE);
 
 		builder(ConventionalBlockTags.VILLAGER_JOB_SITES)
 				.addAll(VILLAGER_JOB_SITE_BLOCKS.stream().map(BlockItemId::block))
@@ -258,7 +258,7 @@ public final class BlockTagsGenerator extends FabricTagsProvider.BlockTagsProvid
 		builder(ConventionalBlockTags.ROPES); // Generate tag so others can see it exists through JSON.
 
 		builder(ConventionalBlockTags.CHAINS)
-				.add(BlockItemIds.IRON_CHAIN.block())
+				.add(BlockItemIds.IRON_CHAIN)
 				.addAll(BlockItemIds.COPPER_CHAIN.asList().stream().map(BlockItemId::block));
 
 		builder(ConventionalBlockTags.HIDDEN_FROM_RECIPE_VIEWERS); // Generate tag so others can see it exists through JSON.
@@ -266,36 +266,36 @@ public final class BlockTagsGenerator extends FabricTagsProvider.BlockTagsProvid
 
 	private void generateFenceAndFenceGateTags() {
 		builder(ConventionalBlockTags.WOODEN_FENCES)
-				.add(BlockItemIds.OAK_FENCE.block())
-				.add(BlockItemIds.SPRUCE_FENCE.block())
-				.add(BlockItemIds.BIRCH_FENCE.block())
-				.add(BlockItemIds.JUNGLE_FENCE.block())
-				.add(BlockItemIds.ACACIA_FENCE.block())
-				.add(BlockItemIds.DARK_OAK_FENCE.block())
-				.add(BlockItemIds.CRIMSON_FENCE.block())
-				.add(BlockItemIds.WARPED_FENCE.block())
-				.add(BlockItemIds.MANGROVE_FENCE.block())
-				.add(BlockItemIds.BAMBOO_FENCE.block())
-				.add(BlockItemIds.CHERRY_FENCE.block())
-				.add(BlockItemIds.PALE_OAK_FENCE.block());
+				.add(BlockItemIds.OAK_FENCE)
+				.add(BlockItemIds.SPRUCE_FENCE)
+				.add(BlockItemIds.BIRCH_FENCE)
+				.add(BlockItemIds.JUNGLE_FENCE)
+				.add(BlockItemIds.ACACIA_FENCE)
+				.add(BlockItemIds.DARK_OAK_FENCE)
+				.add(BlockItemIds.CRIMSON_FENCE)
+				.add(BlockItemIds.WARPED_FENCE)
+				.add(BlockItemIds.MANGROVE_FENCE)
+				.add(BlockItemIds.BAMBOO_FENCE)
+				.add(BlockItemIds.CHERRY_FENCE)
+				.add(BlockItemIds.PALE_OAK_FENCE);
 		builder(ConventionalBlockTags.NETHER_BRICK_FENCES)
-				.add(BlockItemIds.NETHER_BRICK_FENCE.block());
+				.add(BlockItemIds.NETHER_BRICK_FENCE);
 		builder(ConventionalBlockTags.FENCES)
 				.addOptionalTag(ConventionalBlockTags.WOODEN_FENCES)
 				.addOptionalTag(ConventionalBlockTags.NETHER_BRICK_FENCES);
 		builder(ConventionalBlockTags.WOODEN_FENCE_GATES)
-				.add(BlockItemIds.OAK_FENCE_GATE.block())
-				.add(BlockItemIds.SPRUCE_FENCE_GATE.block())
-				.add(BlockItemIds.BIRCH_FENCE_GATE.block())
-				.add(BlockItemIds.JUNGLE_FENCE_GATE.block())
-				.add(BlockItemIds.ACACIA_FENCE_GATE.block())
-				.add(BlockItemIds.DARK_OAK_FENCE_GATE.block())
-				.add(BlockItemIds.CRIMSON_FENCE_GATE.block())
-				.add(BlockItemIds.WARPED_FENCE_GATE.block())
-				.add(BlockItemIds.MANGROVE_FENCE_GATE.block())
-				.add(BlockItemIds.BAMBOO_FENCE_GATE.block())
-				.add(BlockItemIds.CHERRY_FENCE_GATE.block())
-				.add(BlockItemIds.PALE_OAK_FENCE_GATE.block());
+				.add(BlockItemIds.OAK_FENCE_GATE)
+				.add(BlockItemIds.SPRUCE_FENCE_GATE)
+				.add(BlockItemIds.BIRCH_FENCE_GATE)
+				.add(BlockItemIds.JUNGLE_FENCE_GATE)
+				.add(BlockItemIds.ACACIA_FENCE_GATE)
+				.add(BlockItemIds.DARK_OAK_FENCE_GATE)
+				.add(BlockItemIds.CRIMSON_FENCE_GATE)
+				.add(BlockItemIds.WARPED_FENCE_GATE)
+				.add(BlockItemIds.MANGROVE_FENCE_GATE)
+				.add(BlockItemIds.BAMBOO_FENCE_GATE)
+				.add(BlockItemIds.CHERRY_FENCE_GATE)
+				.add(BlockItemIds.PALE_OAK_FENCE_GATE);
 		builder(ConventionalBlockTags.FENCE_GATES)
 				.addOptionalTag(ConventionalBlockTags.WOODEN_FENCE_GATES);
 		builder(ConventionalBlockTags.PUMPKINS)
@@ -303,18 +303,18 @@ public final class BlockTagsGenerator extends FabricTagsProvider.BlockTagsProvid
 				.addTag(ConventionalBlockTags.CARVED_PUMPKINS)
 				.addTag(ConventionalBlockTags.JACK_O_LANTERNS_PUMPKINS);
 		builder(ConventionalBlockTags.NORMAL_PUMPKINS)
-				.add(BlockItemIds.PUMPKIN.block());
+				.add(BlockItemIds.PUMPKIN);
 		builder(ConventionalBlockTags.CARVED_PUMPKINS)
-				.add(BlockItemIds.CARVED_PUMPKIN.block());
+				.add(BlockItemIds.CARVED_PUMPKIN);
 		builder(ConventionalBlockTags.JACK_O_LANTERNS_PUMPKINS)
-				.add(BlockItemIds.JACK_O_LANTERN.block());
+				.add(BlockItemIds.JACK_O_LANTERN);
 	}
 
 	private void generateSandstoneTags() {
 		builder(ConventionalBlockTags.COLORLESS_SANDS)
-				.add(BlockItemIds.SAND.block());
+				.add(BlockItemIds.SAND);
 		builder(ConventionalBlockTags.RED_SANDS)
-				.add(BlockItemIds.RED_SAND.block());
+				.add(BlockItemIds.RED_SAND);
 		builder(ConventionalBlockTags.SANDS)
 				.addOptionalTag(ConventionalBlockTags.COLORLESS_SANDS)
 				.addOptionalTag(ConventionalBlockTags.RED_SANDS);
@@ -330,41 +330,41 @@ public final class BlockTagsGenerator extends FabricTagsProvider.BlockTagsProvid
 				.addOptionalTag(ConventionalBlockTags.RED_SANDSTONE_STAIRS);
 
 		builder(ConventionalBlockTags.RED_SANDSTONE_BLOCKS)
-				.add(BlockItemIds.RED_SANDSTONE.block())
-				.add(BlockItemIds.CUT_RED_SANDSTONE.block())
-				.add(BlockItemIds.SMOOTH_RED_SANDSTONE.block())
-				.add(BlockItemIds.CHISELED_RED_SANDSTONE.block());
+				.add(BlockItemIds.RED_SANDSTONE)
+				.add(BlockItemIds.CUT_RED_SANDSTONE)
+				.add(BlockItemIds.SMOOTH_RED_SANDSTONE)
+				.add(BlockItemIds.CHISELED_RED_SANDSTONE);
 		builder(ConventionalBlockTags.RED_SANDSTONE_SLABS)
-				.add(BlockItemIds.RED_SANDSTONE_SLAB.block())
-				.add(BlockItemIds.CUT_RED_SANDSTONE_SLAB.block())
-				.add(BlockItemIds.SMOOTH_RED_SANDSTONE_SLAB.block());
+				.add(BlockItemIds.RED_SANDSTONE_SLAB)
+				.add(BlockItemIds.CUT_RED_SANDSTONE_SLAB)
+				.add(BlockItemIds.SMOOTH_RED_SANDSTONE_SLAB);
 		builder(ConventionalBlockTags.RED_SANDSTONE_STAIRS)
-				.add(BlockItemIds.RED_SANDSTONE_STAIRS.block())
-				.add(BlockItemIds.SMOOTH_RED_SANDSTONE_STAIRS.block());
+				.add(BlockItemIds.RED_SANDSTONE_STAIRS)
+				.add(BlockItemIds.SMOOTH_RED_SANDSTONE_STAIRS);
 
 		builder(ConventionalBlockTags.UNCOLORED_SANDSTONE_BLOCKS)
-				.add(BlockItemIds.SANDSTONE.block())
-				.add(BlockItemIds.CUT_SANDSTONE.block())
-				.add(BlockItemIds.SMOOTH_SANDSTONE.block())
-				.add(BlockItemIds.CHISELED_SANDSTONE.block());
+				.add(BlockItemIds.SANDSTONE)
+				.add(BlockItemIds.CUT_SANDSTONE)
+				.add(BlockItemIds.SMOOTH_SANDSTONE)
+				.add(BlockItemIds.CHISELED_SANDSTONE);
 		builder(ConventionalBlockTags.UNCOLORED_SANDSTONE_SLABS)
-				.add(BlockItemIds.SANDSTONE_SLAB.block())
-				.add(BlockItemIds.CUT_SANDSTONE_SLAB.block())
-				.add(BlockItemIds.SMOOTH_SANDSTONE_SLAB.block());
+				.add(BlockItemIds.SANDSTONE_SLAB)
+				.add(BlockItemIds.CUT_SANDSTONE_SLAB)
+				.add(BlockItemIds.SMOOTH_SANDSTONE_SLAB);
 		builder(ConventionalBlockTags.UNCOLORED_SANDSTONE_STAIRS)
-				.add(BlockItemIds.SANDSTONE_STAIRS.block())
-				.add(BlockItemIds.SMOOTH_SANDSTONE_STAIRS.block());
+				.add(BlockItemIds.SANDSTONE_STAIRS)
+				.add(BlockItemIds.SMOOTH_SANDSTONE_STAIRS);
 	}
 
 	private void generateBuddingTags() {
 		builder(ConventionalBlockTags.BUDDING_BLOCKS)
-				.add(BlockItemIds.BUDDING_AMETHYST.block());
+				.add(BlockItemIds.BUDDING_AMETHYST);
 		builder(ConventionalBlockTags.BUDS)
-				.add(BlockItemIds.SMALL_AMETHYST_BUD.block())
-				.add(BlockItemIds.MEDIUM_AMETHYST_BUD.block())
-				.add(BlockItemIds.LARGE_AMETHYST_BUD.block());
+				.add(BlockItemIds.SMALL_AMETHYST_BUD)
+				.add(BlockItemIds.MEDIUM_AMETHYST_BUD)
+				.add(BlockItemIds.LARGE_AMETHYST_BUD);
 		builder(ConventionalBlockTags.CLUSTERS)
-				.add(BlockItemIds.AMETHYST_CLUSTER.block());
+				.add(BlockItemIds.AMETHYST_CLUSTER);
 	}
 
 	private void generateGlassTags() {
@@ -373,17 +373,17 @@ public final class BlockTagsGenerator extends FabricTagsProvider.BlockTagsProvid
 				.addOptionalTag(ConventionalBlockTags.GLASS_BLOCKS_CHEAP)
 				.addOptionalTag(ConventionalBlockTags.GLASS_BLOCKS_TINTED);
 		builder(ConventionalBlockTags.GLASS_BLOCKS_COLORLESS)
-				.add(BlockItemIds.GLASS.block());
+				.add(BlockItemIds.GLASS);
 		builder(ConventionalBlockTags.GLASS_BLOCKS_CHEAP)
-				.add(BlockItemIds.GLASS.block())
+				.add(BlockItemIds.GLASS)
 				.addAll(BlockItemIds.STAINED_GLASS.asList().stream().map(BlockItemId::block));
 		builder(ConventionalBlockTags.GLASS_BLOCKS_TINTED)
-				.add(BlockItemIds.TINTED_GLASS.block());
+				.add(BlockItemIds.TINTED_GLASS);
 		builder(ConventionalBlockTags.GLASS_PANES)
 				.addAll(BlockItemIds.STAINED_GLASS_PANE.asList().stream().map(BlockItemId::block))
 				.addOptionalTag(ConventionalBlockTags.GLASS_PANES_COLORLESS);
 		builder(ConventionalBlockTags.GLASS_PANES_COLORLESS)
-				.add(BlockItemIds.GLASS_PANE.block());
+				.add(BlockItemIds.GLASS_PANE);
 	}
 
 	private void generateGlazeTerracottaTags() {
@@ -398,100 +398,100 @@ public final class BlockTagsGenerator extends FabricTagsProvider.BlockTagsProvid
 
 	private void generateDyedTags() {
 		builder(ConventionalBlockTags.BLACK_DYED)
-				.add(BlockItemIds.BANNER.black().block()).add(BlockItemIds.BED.black().block()).add(BlockItemIds.DYED_CANDLE.black().block()).add(BlockItemIds.CARPET.black().block())
-				.add(BlockItemIds.CONCRETE.black().block()).add(BlockItemIds.CONCRETE_POWDER.black().block()).add(BlockItemIds.GLAZED_TERRACOTTA.black().block())
-				.add(BlockItemIds.DYED_SHULKER_BOX.black().block()).add(BlockItemIds.STAINED_GLASS.black().block()).add(BlockItemIds.STAINED_GLASS_PANE.black().block())
-				.add(BlockItemIds.DYED_TERRACOTTA.black().block()).add(BlockIds.WALL_BANNER.black()).add(BlockItemIds.WOOL.black().block());
+				.add(BlockItemIds.BANNER.black()).add(BlockItemIds.BED.black()).add(BlockItemIds.DYED_CANDLE.black()).add(BlockItemIds.CARPET.black())
+				.add(BlockItemIds.CONCRETE.black()).add(BlockItemIds.CONCRETE_POWDER.black()).add(BlockItemIds.GLAZED_TERRACOTTA.black())
+				.add(BlockItemIds.DYED_SHULKER_BOX.black()).add(BlockItemIds.STAINED_GLASS.black()).add(BlockItemIds.STAINED_GLASS_PANE.black())
+				.add(BlockItemIds.DYED_TERRACOTTA.black()).add(BlockIds.WALL_BANNER.black()).add(BlockItemIds.WOOL.black());
 
 		builder(ConventionalBlockTags.BLUE_DYED)
-				.add(BlockItemIds.BANNER.blue().block()).add(BlockItemIds.BED.blue().block()).add(BlockItemIds.DYED_CANDLE.blue().block()).add(BlockItemIds.CARPET.blue().block())
-				.add(BlockItemIds.CONCRETE.blue().block()).add(BlockItemIds.CONCRETE_POWDER.blue().block()).add(BlockItemIds.GLAZED_TERRACOTTA.blue().block())
-				.add(BlockItemIds.DYED_SHULKER_BOX.blue().block()).add(BlockItemIds.STAINED_GLASS.blue().block()).add(BlockItemIds.STAINED_GLASS_PANE.blue().block())
-				.add(BlockItemIds.DYED_TERRACOTTA.blue().block()).add(BlockIds.WALL_BANNER.blue()).add(BlockItemIds.WOOL.blue().block());
+				.add(BlockItemIds.BANNER.blue()).add(BlockItemIds.BED.blue()).add(BlockItemIds.DYED_CANDLE.blue()).add(BlockItemIds.CARPET.blue())
+				.add(BlockItemIds.CONCRETE.blue()).add(BlockItemIds.CONCRETE_POWDER.blue()).add(BlockItemIds.GLAZED_TERRACOTTA.blue())
+				.add(BlockItemIds.DYED_SHULKER_BOX.blue()).add(BlockItemIds.STAINED_GLASS.blue()).add(BlockItemIds.STAINED_GLASS_PANE.blue())
+				.add(BlockItemIds.DYED_TERRACOTTA.blue()).add(BlockIds.WALL_BANNER.blue()).add(BlockItemIds.WOOL.blue());
 
 		builder(ConventionalBlockTags.BROWN_DYED)
-				.add(BlockItemIds.BANNER.brown().block()).add(BlockItemIds.BED.brown().block()).add(BlockItemIds.DYED_CANDLE.brown().block()).add(BlockItemIds.CARPET.brown().block())
-				.add(BlockItemIds.CONCRETE.brown().block()).add(BlockItemIds.CONCRETE_POWDER.brown().block()).add(BlockItemIds.GLAZED_TERRACOTTA.brown().block())
-				.add(BlockItemIds.DYED_SHULKER_BOX.brown().block()).add(BlockItemIds.STAINED_GLASS.brown().block()).add(BlockItemIds.STAINED_GLASS_PANE.brown().block())
-				.add(BlockItemIds.DYED_TERRACOTTA.brown().block()).add(BlockIds.WALL_BANNER.brown()).add(BlockItemIds.WOOL.brown().block());
+				.add(BlockItemIds.BANNER.brown()).add(BlockItemIds.BED.brown()).add(BlockItemIds.DYED_CANDLE.brown()).add(BlockItemIds.CARPET.brown())
+				.add(BlockItemIds.CONCRETE.brown()).add(BlockItemIds.CONCRETE_POWDER.brown()).add(BlockItemIds.GLAZED_TERRACOTTA.brown())
+				.add(BlockItemIds.DYED_SHULKER_BOX.brown()).add(BlockItemIds.STAINED_GLASS.brown()).add(BlockItemIds.STAINED_GLASS_PANE.brown())
+				.add(BlockItemIds.DYED_TERRACOTTA.brown()).add(BlockIds.WALL_BANNER.brown()).add(BlockItemIds.WOOL.brown());
 
 		builder(ConventionalBlockTags.CYAN_DYED)
-				.add(BlockItemIds.BANNER.cyan().block()).add(BlockItemIds.BED.cyan().block()).add(BlockItemIds.DYED_CANDLE.cyan().block()).add(BlockItemIds.CARPET.cyan().block())
-				.add(BlockItemIds.CONCRETE.cyan().block()).add(BlockItemIds.CONCRETE_POWDER.cyan().block()).add(BlockItemIds.GLAZED_TERRACOTTA.cyan().block())
-				.add(BlockItemIds.DYED_SHULKER_BOX.cyan().block()).add(BlockItemIds.STAINED_GLASS.cyan().block()).add(BlockItemIds.STAINED_GLASS_PANE.cyan().block())
-				.add(BlockItemIds.DYED_TERRACOTTA.cyan().block()).add(BlockIds.WALL_BANNER.cyan()).add(BlockItemIds.WOOL.cyan().block());
+				.add(BlockItemIds.BANNER.cyan()).add(BlockItemIds.BED.cyan()).add(BlockItemIds.DYED_CANDLE.cyan()).add(BlockItemIds.CARPET.cyan())
+				.add(BlockItemIds.CONCRETE.cyan()).add(BlockItemIds.CONCRETE_POWDER.cyan()).add(BlockItemIds.GLAZED_TERRACOTTA.cyan())
+				.add(BlockItemIds.DYED_SHULKER_BOX.cyan()).add(BlockItemIds.STAINED_GLASS.cyan()).add(BlockItemIds.STAINED_GLASS_PANE.cyan())
+				.add(BlockItemIds.DYED_TERRACOTTA.cyan()).add(BlockIds.WALL_BANNER.cyan()).add(BlockItemIds.WOOL.cyan());
 
 		builder(ConventionalBlockTags.GRAY_DYED)
-				.add(BlockItemIds.BANNER.gray().block()).add(BlockItemIds.BED.gray().block()).add(BlockItemIds.DYED_CANDLE.gray().block()).add(BlockItemIds.CARPET.gray().block())
-				.add(BlockItemIds.CONCRETE.gray().block()).add(BlockItemIds.CONCRETE_POWDER.gray().block()).add(BlockItemIds.GLAZED_TERRACOTTA.gray().block())
-				.add(BlockItemIds.DYED_SHULKER_BOX.gray().block()).add(BlockItemIds.STAINED_GLASS.gray().block()).add(BlockItemIds.STAINED_GLASS_PANE.gray().block())
-				.add(BlockItemIds.DYED_TERRACOTTA.gray().block()).add(BlockIds.WALL_BANNER.gray()).add(BlockItemIds.WOOL.gray().block());
+				.add(BlockItemIds.BANNER.gray()).add(BlockItemIds.BED.gray()).add(BlockItemIds.DYED_CANDLE.gray()).add(BlockItemIds.CARPET.gray())
+				.add(BlockItemIds.CONCRETE.gray()).add(BlockItemIds.CONCRETE_POWDER.gray()).add(BlockItemIds.GLAZED_TERRACOTTA.gray())
+				.add(BlockItemIds.DYED_SHULKER_BOX.gray()).add(BlockItemIds.STAINED_GLASS.gray()).add(BlockItemIds.STAINED_GLASS_PANE.gray())
+				.add(BlockItemIds.DYED_TERRACOTTA.gray()).add(BlockIds.WALL_BANNER.gray()).add(BlockItemIds.WOOL.gray());
 
 		builder(ConventionalBlockTags.GREEN_DYED)
-				.add(BlockItemIds.BANNER.green().block()).add(BlockItemIds.BED.green().block()).add(BlockItemIds.DYED_CANDLE.green().block()).add(BlockItemIds.CARPET.green().block())
-				.add(BlockItemIds.CONCRETE.green().block()).add(BlockItemIds.CONCRETE_POWDER.green().block()).add(BlockItemIds.GLAZED_TERRACOTTA.green().block())
-				.add(BlockItemIds.DYED_SHULKER_BOX.green().block()).add(BlockItemIds.STAINED_GLASS.green().block()).add(BlockItemIds.STAINED_GLASS_PANE.green().block())
-				.add(BlockItemIds.DYED_TERRACOTTA.green().block()).add(BlockIds.WALL_BANNER.green()).add(BlockItemIds.WOOL.green().block());
+				.add(BlockItemIds.BANNER.green()).add(BlockItemIds.BED.green()).add(BlockItemIds.DYED_CANDLE.green()).add(BlockItemIds.CARPET.green())
+				.add(BlockItemIds.CONCRETE.green()).add(BlockItemIds.CONCRETE_POWDER.green()).add(BlockItemIds.GLAZED_TERRACOTTA.green())
+				.add(BlockItemIds.DYED_SHULKER_BOX.green()).add(BlockItemIds.STAINED_GLASS.green()).add(BlockItemIds.STAINED_GLASS_PANE.green())
+				.add(BlockItemIds.DYED_TERRACOTTA.green()).add(BlockIds.WALL_BANNER.green()).add(BlockItemIds.WOOL.green());
 
 		builder(ConventionalBlockTags.LIGHT_BLUE_DYED)
-				.add(BlockItemIds.BANNER.lightBlue().block()).add(BlockItemIds.BED.lightBlue().block()).add(BlockItemIds.DYED_CANDLE.lightBlue().block()).add(BlockItemIds.CARPET.lightBlue().block())
-				.add(BlockItemIds.CONCRETE.lightBlue().block()).add(BlockItemIds.CONCRETE_POWDER.lightBlue().block()).add(BlockItemIds.GLAZED_TERRACOTTA.lightBlue().block())
-				.add(BlockItemIds.DYED_SHULKER_BOX.lightBlue().block()).add(BlockItemIds.STAINED_GLASS.lightBlue().block()).add(BlockItemIds.STAINED_GLASS_PANE.lightBlue().block())
-				.add(BlockItemIds.DYED_TERRACOTTA.lightBlue().block()).add(BlockIds.WALL_BANNER.lightBlue()).add(BlockItemIds.WOOL.lightBlue().block());
+				.add(BlockItemIds.BANNER.lightBlue()).add(BlockItemIds.BED.lightBlue()).add(BlockItemIds.DYED_CANDLE.lightBlue()).add(BlockItemIds.CARPET.lightBlue())
+				.add(BlockItemIds.CONCRETE.lightBlue()).add(BlockItemIds.CONCRETE_POWDER.lightBlue()).add(BlockItemIds.GLAZED_TERRACOTTA.lightBlue())
+				.add(BlockItemIds.DYED_SHULKER_BOX.lightBlue()).add(BlockItemIds.STAINED_GLASS.lightBlue()).add(BlockItemIds.STAINED_GLASS_PANE.lightBlue())
+				.add(BlockItemIds.DYED_TERRACOTTA.lightBlue()).add(BlockIds.WALL_BANNER.lightBlue()).add(BlockItemIds.WOOL.lightBlue());
 
 		builder(ConventionalBlockTags.LIGHT_GRAY_DYED)
-				.add(BlockItemIds.BANNER.lightGray().block()).add(BlockItemIds.BED.lightGray().block()).add(BlockItemIds.DYED_CANDLE.lightGray().block()).add(BlockItemIds.CARPET.lightGray().block())
-				.add(BlockItemIds.CONCRETE.lightGray().block()).add(BlockItemIds.CONCRETE_POWDER.lightGray().block()).add(BlockItemIds.GLAZED_TERRACOTTA.lightGray().block())
-				.add(BlockItemIds.DYED_SHULKER_BOX.lightGray().block()).add(BlockItemIds.STAINED_GLASS.lightGray().block()).add(BlockItemIds.STAINED_GLASS_PANE.lightGray().block())
-				.add(BlockItemIds.DYED_TERRACOTTA.lightGray().block()).add(BlockIds.WALL_BANNER.lightGray()).add(BlockItemIds.WOOL.lightGray().block());
+				.add(BlockItemIds.BANNER.lightGray()).add(BlockItemIds.BED.lightGray()).add(BlockItemIds.DYED_CANDLE.lightGray()).add(BlockItemIds.CARPET.lightGray())
+				.add(BlockItemIds.CONCRETE.lightGray()).add(BlockItemIds.CONCRETE_POWDER.lightGray()).add(BlockItemIds.GLAZED_TERRACOTTA.lightGray())
+				.add(BlockItemIds.DYED_SHULKER_BOX.lightGray()).add(BlockItemIds.STAINED_GLASS.lightGray()).add(BlockItemIds.STAINED_GLASS_PANE.lightGray())
+				.add(BlockItemIds.DYED_TERRACOTTA.lightGray()).add(BlockIds.WALL_BANNER.lightGray()).add(BlockItemIds.WOOL.lightGray());
 
 		builder(ConventionalBlockTags.LIME_DYED)
-				.add(BlockItemIds.BANNER.lime().block()).add(BlockItemIds.BED.lime().block()).add(BlockItemIds.DYED_CANDLE.lime().block()).add(BlockItemIds.CARPET.lime().block())
-				.add(BlockItemIds.CONCRETE.lime().block()).add(BlockItemIds.CONCRETE_POWDER.lime().block()).add(BlockItemIds.GLAZED_TERRACOTTA.lime().block())
-				.add(BlockItemIds.DYED_SHULKER_BOX.lime().block()).add(BlockItemIds.STAINED_GLASS.lime().block()).add(BlockItemIds.STAINED_GLASS_PANE.lime().block())
-				.add(BlockItemIds.DYED_TERRACOTTA.lime().block()).add(BlockIds.WALL_BANNER.lime()).add(BlockItemIds.WOOL.lime().block());
+				.add(BlockItemIds.BANNER.lime()).add(BlockItemIds.BED.lime()).add(BlockItemIds.DYED_CANDLE.lime()).add(BlockItemIds.CARPET.lime())
+				.add(BlockItemIds.CONCRETE.lime()).add(BlockItemIds.CONCRETE_POWDER.lime()).add(BlockItemIds.GLAZED_TERRACOTTA.lime())
+				.add(BlockItemIds.DYED_SHULKER_BOX.lime()).add(BlockItemIds.STAINED_GLASS.lime()).add(BlockItemIds.STAINED_GLASS_PANE.lime())
+				.add(BlockItemIds.DYED_TERRACOTTA.lime()).add(BlockIds.WALL_BANNER.lime()).add(BlockItemIds.WOOL.lime());
 
 		builder(ConventionalBlockTags.MAGENTA_DYED)
-				.add(BlockItemIds.BANNER.magenta().block()).add(BlockItemIds.BED.magenta().block()).add(BlockItemIds.DYED_CANDLE.magenta().block()).add(BlockItemIds.CARPET.magenta().block())
-				.add(BlockItemIds.CONCRETE.magenta().block()).add(BlockItemIds.CONCRETE_POWDER.magenta().block()).add(BlockItemIds.GLAZED_TERRACOTTA.magenta().block())
-				.add(BlockItemIds.DYED_SHULKER_BOX.magenta().block()).add(BlockItemIds.STAINED_GLASS.magenta().block()).add(BlockItemIds.STAINED_GLASS_PANE.magenta().block())
-				.add(BlockItemIds.DYED_TERRACOTTA.magenta().block()).add(BlockIds.WALL_BANNER.magenta()).add(BlockItemIds.WOOL.magenta().block());
+				.add(BlockItemIds.BANNER.magenta()).add(BlockItemIds.BED.magenta()).add(BlockItemIds.DYED_CANDLE.magenta()).add(BlockItemIds.CARPET.magenta())
+				.add(BlockItemIds.CONCRETE.magenta()).add(BlockItemIds.CONCRETE_POWDER.magenta()).add(BlockItemIds.GLAZED_TERRACOTTA.magenta())
+				.add(BlockItemIds.DYED_SHULKER_BOX.magenta()).add(BlockItemIds.STAINED_GLASS.magenta()).add(BlockItemIds.STAINED_GLASS_PANE.magenta())
+				.add(BlockItemIds.DYED_TERRACOTTA.magenta()).add(BlockIds.WALL_BANNER.magenta()).add(BlockItemIds.WOOL.magenta());
 
 		builder(ConventionalBlockTags.ORANGE_DYED)
-				.add(BlockItemIds.BANNER.orange().block()).add(BlockItemIds.BED.orange().block()).add(BlockItemIds.DYED_CANDLE.orange().block()).add(BlockItemIds.CARPET.orange().block())
-				.add(BlockItemIds.CONCRETE.orange().block()).add(BlockItemIds.CONCRETE_POWDER.orange().block()).add(BlockItemIds.GLAZED_TERRACOTTA.orange().block())
-				.add(BlockItemIds.DYED_SHULKER_BOX.orange().block()).add(BlockItemIds.STAINED_GLASS.orange().block()).add(BlockItemIds.STAINED_GLASS_PANE.orange().block())
-				.add(BlockItemIds.DYED_TERRACOTTA.orange().block()).add(BlockIds.WALL_BANNER.orange()).add(BlockItemIds.WOOL.orange().block());
+				.add(BlockItemIds.BANNER.orange()).add(BlockItemIds.BED.orange()).add(BlockItemIds.DYED_CANDLE.orange()).add(BlockItemIds.CARPET.orange())
+				.add(BlockItemIds.CONCRETE.orange()).add(BlockItemIds.CONCRETE_POWDER.orange()).add(BlockItemIds.GLAZED_TERRACOTTA.orange())
+				.add(BlockItemIds.DYED_SHULKER_BOX.orange()).add(BlockItemIds.STAINED_GLASS.orange()).add(BlockItemIds.STAINED_GLASS_PANE.orange())
+				.add(BlockItemIds.DYED_TERRACOTTA.orange()).add(BlockIds.WALL_BANNER.orange()).add(BlockItemIds.WOOL.orange());
 
 		builder(ConventionalBlockTags.PINK_DYED)
-				.add(BlockItemIds.BANNER.pink().block()).add(BlockItemIds.BED.pink().block()).add(BlockItemIds.DYED_CANDLE.pink().block()).add(BlockItemIds.CARPET.pink().block())
-				.add(BlockItemIds.CONCRETE.pink().block()).add(BlockItemIds.CONCRETE_POWDER.pink().block()).add(BlockItemIds.GLAZED_TERRACOTTA.pink().block())
-				.add(BlockItemIds.DYED_SHULKER_BOX.pink().block()).add(BlockItemIds.STAINED_GLASS.pink().block()).add(BlockItemIds.STAINED_GLASS_PANE.pink().block())
-				.add(BlockItemIds.DYED_TERRACOTTA.pink().block()).add(BlockIds.WALL_BANNER.pink()).add(BlockItemIds.WOOL.pink().block());
+				.add(BlockItemIds.BANNER.pink()).add(BlockItemIds.BED.pink()).add(BlockItemIds.DYED_CANDLE.pink()).add(BlockItemIds.CARPET.pink())
+				.add(BlockItemIds.CONCRETE.pink()).add(BlockItemIds.CONCRETE_POWDER.pink()).add(BlockItemIds.GLAZED_TERRACOTTA.pink())
+				.add(BlockItemIds.DYED_SHULKER_BOX.pink()).add(BlockItemIds.STAINED_GLASS.pink()).add(BlockItemIds.STAINED_GLASS_PANE.pink())
+				.add(BlockItemIds.DYED_TERRACOTTA.pink()).add(BlockIds.WALL_BANNER.pink()).add(BlockItemIds.WOOL.pink());
 
 		builder(ConventionalBlockTags.PURPLE_DYED)
-				.add(BlockItemIds.BANNER.purple().block()).add(BlockItemIds.BED.purple().block()).add(BlockItemIds.DYED_CANDLE.purple().block()).add(BlockItemIds.CARPET.purple().block())
-				.add(BlockItemIds.CONCRETE.purple().block()).add(BlockItemIds.CONCRETE_POWDER.purple().block()).add(BlockItemIds.GLAZED_TERRACOTTA.purple().block())
-				.add(BlockItemIds.DYED_SHULKER_BOX.purple().block()).add(BlockItemIds.STAINED_GLASS.purple().block()).add(BlockItemIds.STAINED_GLASS_PANE.purple().block())
-				.add(BlockItemIds.DYED_TERRACOTTA.purple().block()).add(BlockIds.WALL_BANNER.purple()).add(BlockItemIds.WOOL.purple().block());
+				.add(BlockItemIds.BANNER.purple()).add(BlockItemIds.BED.purple()).add(BlockItemIds.DYED_CANDLE.purple()).add(BlockItemIds.CARPET.purple())
+				.add(BlockItemIds.CONCRETE.purple()).add(BlockItemIds.CONCRETE_POWDER.purple()).add(BlockItemIds.GLAZED_TERRACOTTA.purple())
+				.add(BlockItemIds.DYED_SHULKER_BOX.purple()).add(BlockItemIds.STAINED_GLASS.purple()).add(BlockItemIds.STAINED_GLASS_PANE.purple())
+				.add(BlockItemIds.DYED_TERRACOTTA.purple()).add(BlockIds.WALL_BANNER.purple()).add(BlockItemIds.WOOL.purple());
 
 		builder(ConventionalBlockTags.RED_DYED)
-				.add(BlockItemIds.BANNER.red().block()).add(BlockItemIds.BED.red().block()).add(BlockItemIds.DYED_CANDLE.red().block()).add(BlockItemIds.CARPET.red().block())
-				.add(BlockItemIds.CONCRETE.red().block()).add(BlockItemIds.CONCRETE_POWDER.red().block()).add(BlockItemIds.GLAZED_TERRACOTTA.red().block())
-				.add(BlockItemIds.DYED_SHULKER_BOX.red().block()).add(BlockItemIds.STAINED_GLASS.red().block()).add(BlockItemIds.STAINED_GLASS_PANE.red().block())
-				.add(BlockItemIds.DYED_TERRACOTTA.red().block()).add(BlockIds.WALL_BANNER.red()).add(BlockItemIds.WOOL.red().block());
+				.add(BlockItemIds.BANNER.red()).add(BlockItemIds.BED.red()).add(BlockItemIds.DYED_CANDLE.red()).add(BlockItemIds.CARPET.red())
+				.add(BlockItemIds.CONCRETE.red()).add(BlockItemIds.CONCRETE_POWDER.red()).add(BlockItemIds.GLAZED_TERRACOTTA.red())
+				.add(BlockItemIds.DYED_SHULKER_BOX.red()).add(BlockItemIds.STAINED_GLASS.red()).add(BlockItemIds.STAINED_GLASS_PANE.red())
+				.add(BlockItemIds.DYED_TERRACOTTA.red()).add(BlockIds.WALL_BANNER.red()).add(BlockItemIds.WOOL.red());
 
 		builder(ConventionalBlockTags.WHITE_DYED)
-				.add(BlockItemIds.BANNER.white().block()).add(BlockItemIds.BED.white().block()).add(BlockItemIds.DYED_CANDLE.white().block()).add(BlockItemIds.CARPET.white().block())
-				.add(BlockItemIds.CONCRETE.white().block()).add(BlockItemIds.CONCRETE_POWDER.white().block()).add(BlockItemIds.GLAZED_TERRACOTTA.white().block())
-				.add(BlockItemIds.DYED_SHULKER_BOX.white().block()).add(BlockItemIds.STAINED_GLASS.white().block()).add(BlockItemIds.STAINED_GLASS_PANE.white().block())
-				.add(BlockItemIds.DYED_TERRACOTTA.white().block()).add(BlockIds.WALL_BANNER.white()).add(BlockItemIds.WOOL.white().block());
+				.add(BlockItemIds.BANNER.white()).add(BlockItemIds.BED.white()).add(BlockItemIds.DYED_CANDLE.white()).add(BlockItemIds.CARPET.white())
+				.add(BlockItemIds.CONCRETE.white()).add(BlockItemIds.CONCRETE_POWDER.white()).add(BlockItemIds.GLAZED_TERRACOTTA.white())
+				.add(BlockItemIds.DYED_SHULKER_BOX.white()).add(BlockItemIds.STAINED_GLASS.white()).add(BlockItemIds.STAINED_GLASS_PANE.white())
+				.add(BlockItemIds.DYED_TERRACOTTA.white()).add(BlockIds.WALL_BANNER.white()).add(BlockItemIds.WOOL.white());
 
 		builder(ConventionalBlockTags.YELLOW_DYED)
-				.add(BlockItemIds.BANNER.yellow().block()).add(BlockItemIds.BED.yellow().block()).add(BlockItemIds.DYED_CANDLE.yellow().block()).add(BlockItemIds.CARPET.yellow().block())
-				.add(BlockItemIds.CONCRETE.yellow().block()).add(BlockItemIds.CONCRETE_POWDER.yellow().block()).add(BlockItemIds.GLAZED_TERRACOTTA.yellow().block())
-				.add(BlockItemIds.DYED_SHULKER_BOX.yellow().block()).add(BlockItemIds.STAINED_GLASS.yellow().block()).add(BlockItemIds.STAINED_GLASS_PANE.yellow().block())
-				.add(BlockItemIds.DYED_TERRACOTTA.yellow().block()).add(BlockIds.WALL_BANNER.yellow()).add(BlockItemIds.WOOL.yellow().block());
+				.add(BlockItemIds.BANNER.yellow()).add(BlockItemIds.BED.yellow()).add(BlockItemIds.DYED_CANDLE.yellow()).add(BlockItemIds.CARPET.yellow())
+				.add(BlockItemIds.CONCRETE.yellow()).add(BlockItemIds.CONCRETE_POWDER.yellow()).add(BlockItemIds.GLAZED_TERRACOTTA.yellow())
+				.add(BlockItemIds.DYED_SHULKER_BOX.yellow()).add(BlockItemIds.STAINED_GLASS.yellow()).add(BlockItemIds.STAINED_GLASS_PANE.yellow())
+				.add(BlockItemIds.DYED_TERRACOTTA.yellow()).add(BlockIds.WALL_BANNER.yellow()).add(BlockItemIds.WOOL.yellow());
 
 		builder(ConventionalBlockTags.DYED)
 				.addTag(ConventionalBlockTags.WHITE_DYED)
@@ -533,134 +533,134 @@ public final class BlockTagsGenerator extends FabricTagsProvider.BlockTagsProvid
 				.addTag(ConventionalBlockTags.STORAGE_BLOCKS_WHEAT);
 
 		builder(ConventionalBlockTags.STORAGE_BLOCKS_BONE_MEAL)
-				.add(BlockItemIds.BONE_BLOCK.block());
+				.add(BlockItemIds.BONE_BLOCK);
 
 		builder(ConventionalBlockTags.STORAGE_BLOCKS_COAL)
-				.add(BlockItemIds.COAL_BLOCK.block());
+				.add(BlockItemIds.COAL_BLOCK);
 
 		builder(ConventionalBlockTags.STORAGE_BLOCKS_COPPER)
-				.add(BlockItemIds.COPPER_BLOCK.weathering().unaffected().block());
+				.add(BlockItemIds.COPPER_BLOCK.weathering().unaffected());
 
 		builder(ConventionalBlockTags.STORAGE_BLOCKS_DIAMOND)
-				.add(BlockItemIds.DIAMOND_BLOCK.block());
+				.add(BlockItemIds.DIAMOND_BLOCK);
 
 		builder(ConventionalBlockTags.STORAGE_BLOCKS_DRIED_KELP)
-				.add(BlockItemIds.DRIED_KELP_BLOCK.block());
+				.add(BlockItemIds.DRIED_KELP_BLOCK);
 
 		builder(ConventionalBlockTags.STORAGE_BLOCKS_EMERALD)
-				.add(BlockItemIds.EMERALD_BLOCK.block());
+				.add(BlockItemIds.EMERALD_BLOCK);
 
 		builder(ConventionalBlockTags.STORAGE_BLOCKS_GOLD)
-				.add(BlockItemIds.GOLD_BLOCK.block());
+				.add(BlockItemIds.GOLD_BLOCK);
 
 		builder(ConventionalBlockTags.STORAGE_BLOCKS_IRON)
-				.add(BlockItemIds.IRON_BLOCK.block());
+				.add(BlockItemIds.IRON_BLOCK);
 
 		builder(ConventionalBlockTags.STORAGE_BLOCKS_LAPIS)
-				.add(BlockItemIds.LAPIS_BLOCK.block());
+				.add(BlockItemIds.LAPIS_BLOCK);
 
 		builder(ConventionalBlockTags.STORAGE_BLOCKS_NETHERITE)
-				.add(BlockItemIds.NETHERITE_BLOCK.block());
+				.add(BlockItemIds.NETHERITE_BLOCK);
 
 		builder(ConventionalBlockTags.STORAGE_BLOCKS_RAW_COPPER)
-				.add(BlockItemIds.RAW_COPPER_BLOCK.block());
+				.add(BlockItemIds.RAW_COPPER_BLOCK);
 
 		builder(ConventionalBlockTags.STORAGE_BLOCKS_RAW_GOLD)
-				.add(BlockItemIds.RAW_GOLD_BLOCK.block());
+				.add(BlockItemIds.RAW_GOLD_BLOCK);
 
 		builder(ConventionalBlockTags.STORAGE_BLOCKS_RAW_IRON)
-				.add(BlockItemIds.RAW_IRON_BLOCK.block());
+				.add(BlockItemIds.RAW_IRON_BLOCK);
 
 		builder(ConventionalBlockTags.STORAGE_BLOCKS_REDSTONE)
-				.add(BlockItemIds.REDSTONE_BLOCK.block());
+				.add(BlockItemIds.REDSTONE_BLOCK);
 
 		builder(ConventionalBlockTags.STORAGE_BLOCKS_RESIN)
-				.add(BlockItemIds.RESIN_BLOCK.block());
+				.add(BlockItemIds.RESIN_BLOCK);
 
 		builder(ConventionalBlockTags.STORAGE_BLOCKS_SLIME)
-				.add(BlockItemIds.SLIME_BLOCK.block());
+				.add(BlockItemIds.SLIME_BLOCK);
 
 		builder(ConventionalBlockTags.STORAGE_BLOCKS_WHEAT)
-				.add(BlockItemIds.HAY_BLOCK.block());
+				.add(BlockItemIds.HAY_BLOCK);
 	}
 
 	private void generateLogTags() {
 		builder(ConventionalBlockTags.OVERWORLD_NATURAL_LOGS)
-				.add(BlockItemIds.ACACIA_LOG.block())
-				.add(BlockItemIds.BAMBOO_BLOCK.block())
-				.add(BlockItemIds.BIRCH_LOG.block())
-				.add(BlockItemIds.CHERRY_LOG.block())
-				.add(BlockItemIds.DARK_OAK_LOG.block())
-				.add(BlockItemIds.JUNGLE_LOG.block())
-				.add(BlockItemIds.MANGROVE_LOG.block())
-				.add(BlockItemIds.OAK_LOG.block())
-				.add(BlockItemIds.PALE_OAK_LOG.block())
-				.add(BlockItemIds.SPRUCE_LOG.block());
+				.add(BlockItemIds.ACACIA_LOG)
+				.add(BlockItemIds.BAMBOO_BLOCK)
+				.add(BlockItemIds.BIRCH_LOG)
+				.add(BlockItemIds.CHERRY_LOG)
+				.add(BlockItemIds.DARK_OAK_LOG)
+				.add(BlockItemIds.JUNGLE_LOG)
+				.add(BlockItemIds.MANGROVE_LOG)
+				.add(BlockItemIds.OAK_LOG)
+				.add(BlockItemIds.PALE_OAK_LOG)
+				.add(BlockItemIds.SPRUCE_LOG);
 
 		builder(ConventionalBlockTags.NETHER_NATURAL_LOGS)
-				.add(BlockItemIds.CRIMSON_STEM.block())
-				.add(BlockItemIds.WARPED_STEM.block());
+				.add(BlockItemIds.CRIMSON_STEM)
+				.add(BlockItemIds.WARPED_STEM);
 
 		builder(ConventionalBlockTags.NATURAL_LOGS)
 				.addOptionalTag(ConventionalBlockTags.OVERWORLD_NATURAL_LOGS)
 				.addOptionalTag(ConventionalBlockTags.NETHER_NATURAL_LOGS);
 
 		builder(ConventionalBlockTags.NATURAL_WOODS)
-				.add(BlockItemIds.ACACIA_WOOD.block())
-				.add(BlockItemIds.BIRCH_WOOD.block())
-				.add(BlockItemIds.CHERRY_WOOD.block())
-				.add(BlockItemIds.DARK_OAK_WOOD.block())
-				.add(BlockItemIds.JUNGLE_WOOD.block())
-				.add(BlockItemIds.MANGROVE_WOOD.block())
-				.add(BlockItemIds.OAK_WOOD.block())
-				.add(BlockItemIds.PALE_OAK_WOOD.block())
-				.add(BlockItemIds.SPRUCE_WOOD.block())
-				.add(BlockItemIds.CRIMSON_HYPHAE.block())
-				.add(BlockItemIds.WARPED_HYPHAE.block());
+				.add(BlockItemIds.ACACIA_WOOD)
+				.add(BlockItemIds.BIRCH_WOOD)
+				.add(BlockItemIds.CHERRY_WOOD)
+				.add(BlockItemIds.DARK_OAK_WOOD)
+				.add(BlockItemIds.JUNGLE_WOOD)
+				.add(BlockItemIds.MANGROVE_WOOD)
+				.add(BlockItemIds.OAK_WOOD)
+				.add(BlockItemIds.PALE_OAK_WOOD)
+				.add(BlockItemIds.SPRUCE_WOOD)
+				.add(BlockItemIds.CRIMSON_HYPHAE)
+				.add(BlockItemIds.WARPED_HYPHAE);
 
 		builder(ConventionalBlockTags.STRIPPED_LOGS)
-				.add(BlockItemIds.STRIPPED_ACACIA_LOG.block())
-				.add(BlockItemIds.STRIPPED_BAMBOO_BLOCK.block())
-				.add(BlockItemIds.STRIPPED_BIRCH_LOG.block())
-				.add(BlockItemIds.STRIPPED_CHERRY_LOG.block())
-				.add(BlockItemIds.STRIPPED_DARK_OAK_LOG.block())
-				.add(BlockItemIds.STRIPPED_JUNGLE_LOG.block())
-				.add(BlockItemIds.STRIPPED_MANGROVE_LOG.block())
-				.add(BlockItemIds.STRIPPED_OAK_LOG.block())
-				.add(BlockItemIds.STRIPPED_PALE_OAK_LOG.block())
-				.add(BlockItemIds.STRIPPED_SPRUCE_LOG.block())
-				.add(BlockItemIds.STRIPPED_CRIMSON_STEM.block())
-				.add(BlockItemIds.STRIPPED_WARPED_STEM.block());
+				.add(BlockItemIds.STRIPPED_ACACIA_LOG)
+				.add(BlockItemIds.STRIPPED_BAMBOO_BLOCK)
+				.add(BlockItemIds.STRIPPED_BIRCH_LOG)
+				.add(BlockItemIds.STRIPPED_CHERRY_LOG)
+				.add(BlockItemIds.STRIPPED_DARK_OAK_LOG)
+				.add(BlockItemIds.STRIPPED_JUNGLE_LOG)
+				.add(BlockItemIds.STRIPPED_MANGROVE_LOG)
+				.add(BlockItemIds.STRIPPED_OAK_LOG)
+				.add(BlockItemIds.STRIPPED_PALE_OAK_LOG)
+				.add(BlockItemIds.STRIPPED_SPRUCE_LOG)
+				.add(BlockItemIds.STRIPPED_CRIMSON_STEM)
+				.add(BlockItemIds.STRIPPED_WARPED_STEM);
 
 		builder(ConventionalBlockTags.STRIPPED_WOODS)
-				.add(BlockItemIds.STRIPPED_ACACIA_WOOD.block())
-				.add(BlockItemIds.STRIPPED_BIRCH_WOOD.block())
-				.add(BlockItemIds.STRIPPED_CHERRY_WOOD.block())
-				.add(BlockItemIds.STRIPPED_DARK_OAK_WOOD.block())
-				.add(BlockItemIds.STRIPPED_JUNGLE_WOOD.block())
-				.add(BlockItemIds.STRIPPED_MANGROVE_WOOD.block())
-				.add(BlockItemIds.STRIPPED_OAK_WOOD.block())
-				.add(BlockItemIds.STRIPPED_PALE_OAK_WOOD.block())
-				.add(BlockItemIds.STRIPPED_SPRUCE_WOOD.block())
-				.add(BlockItemIds.STRIPPED_CRIMSON_HYPHAE.block())
-				.add(BlockItemIds.STRIPPED_WARPED_HYPHAE.block());
+				.add(BlockItemIds.STRIPPED_ACACIA_WOOD)
+				.add(BlockItemIds.STRIPPED_BIRCH_WOOD)
+				.add(BlockItemIds.STRIPPED_CHERRY_WOOD)
+				.add(BlockItemIds.STRIPPED_DARK_OAK_WOOD)
+				.add(BlockItemIds.STRIPPED_JUNGLE_WOOD)
+				.add(BlockItemIds.STRIPPED_MANGROVE_WOOD)
+				.add(BlockItemIds.STRIPPED_OAK_WOOD)
+				.add(BlockItemIds.STRIPPED_PALE_OAK_WOOD)
+				.add(BlockItemIds.STRIPPED_SPRUCE_WOOD)
+				.add(BlockItemIds.STRIPPED_CRIMSON_HYPHAE)
+				.add(BlockItemIds.STRIPPED_WARPED_HYPHAE);
 	}
 
 	private void generateHeadTags() {
 		builder(ConventionalBlockTags.SKULLS)
-				.add(BlockItemIds.SKELETON_SKULL.block())
+				.add(BlockItemIds.SKELETON_SKULL)
 				.add(BlockIds.SKELETON_WALL_SKULL)
-				.add(BlockItemIds.WITHER_SKELETON_SKULL.block())
+				.add(BlockItemIds.WITHER_SKELETON_SKULL)
 				.add(BlockIds.WITHER_SKELETON_WALL_SKULL)
-				.add(BlockItemIds.PLAYER_HEAD.block())
+				.add(BlockItemIds.PLAYER_HEAD)
 				.add(BlockIds.PLAYER_WALL_HEAD)
-				.add(BlockItemIds.ZOMBIE_HEAD.block())
+				.add(BlockItemIds.ZOMBIE_HEAD)
 				.add(BlockIds.ZOMBIE_WALL_HEAD)
-				.add(BlockItemIds.CREEPER_HEAD.block())
+				.add(BlockItemIds.CREEPER_HEAD)
 				.add(BlockIds.CREEPER_WALL_HEAD)
-				.add(BlockItemIds.PIGLIN_HEAD.block())
+				.add(BlockItemIds.PIGLIN_HEAD)
 				.add(BlockIds.PIGLIN_WALL_HEAD)
-				.add(BlockItemIds.DRAGON_HEAD.block())
+				.add(BlockItemIds.DRAGON_HEAD)
 				.add(BlockIds.DRAGON_WALL_HEAD);
 	}
 

--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/ItemTagsGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/ItemTagsGenerator.java
@@ -81,7 +81,7 @@ public final class ItemTagsGenerator extends FabricTagsProvider.ItemTagsProvider
 		copy(ConventionalBlockTags.GLASS_PANES, ConventionalItemTags.GLASS_PANES);
 		copy(ConventionalBlockTags.GLASS_PANES_COLORLESS, ConventionalItemTags.GLASS_PANES_COLORLESS);
 		builder(ConventionalItemTags.SHULKER_BOXES)
-				.add(BlockItemIds.SHULKER_BOX.item())
+				.add(BlockItemIds.SHULKER_BOX)
 				.addAll(BlockItemIds.DYED_SHULKER_BOX.asList().stream().map(BlockItemId::item));
 		copy(ConventionalBlockTags.GLAZED_TERRACOTTAS, ConventionalItemTags.GLAZED_TERRACOTTAS);
 		copy(ConventionalBlockTags.CONCRETES, ConventionalItemTags.CONCRETES);
@@ -213,14 +213,14 @@ public final class ItemTagsGenerator extends FabricTagsProvider.ItemTagsProvider
 				.add(ItemIds.MELON_SLICE);
 
 		builder(ConventionalItemTags.VEGETABLE_FOODS)
-				.add(BlockItemIds.CARROT_CROP.item())
+				.add(BlockItemIds.CARROT_CROP)
 				.add(ItemIds.GOLDEN_CARROT)
-				.add(BlockItemIds.POTATO_CROP.item())
+				.add(BlockItemIds.POTATO_CROP)
 				.add(ItemIds.BEETROOT);
 
 		builder(ConventionalItemTags.BERRY_FOODS)
-				.add(BlockItemIds.SWEET_BERRY_CROP.item())
-				.add(BlockItemIds.GLOW_BERRY_CROP.item());
+				.add(BlockItemIds.SWEET_BERRY_CROP)
+				.add(BlockItemIds.GLOW_BERRY_CROP);
 
 		builder(ConventionalItemTags.BREAD_FOODS)
 				.add(ItemIds.BREAD);
@@ -271,7 +271,7 @@ public final class ItemTagsGenerator extends FabricTagsProvider.ItemTagsProvider
 				.add(ItemIds.GOLDEN_CARROT);
 
 		builder(ConventionalItemTags.EDIBLE_WHEN_PLACED_FOODS)
-				.add(BlockItemIds.CAKE.item());
+				.add(BlockItemIds.CAKE);
 
 		builder(ConventionalItemTags.FOOD_POISONING_FOODS)
 				.add(ItemIds.POISONOUS_POTATO)
@@ -385,7 +385,7 @@ public final class ItemTagsGenerator extends FabricTagsProvider.ItemTagsProvider
 		builder(ConventionalItemTags.MILK_BUCKETS)
 				.add(ItemIds.MILK_BUCKET);
 		builder(ConventionalItemTags.POWDER_SNOW_BUCKETS)
-				.add(BlockItemIds.POWDER_SNOW.item());
+				.add(BlockItemIds.POWDER_SNOW);
 		builder(ConventionalItemTags.BUCKETS)
 				.addOptionalTag(ConventionalItemTags.EMPTY_BUCKETS)
 				.addOptionalTag(ConventionalItemTags.WATER_BUCKETS)
@@ -453,7 +453,7 @@ public final class ItemTagsGenerator extends FabricTagsProvider.ItemTagsProvider
 				.add(ItemIds.RAW_GOLD);
 
 		builder(ConventionalItemTags.REDSTONE_DUSTS)
-				.add(BlockItemIds.REDSTONE_DUST.item());
+				.add(BlockItemIds.REDSTONE_DUST);
 		builder(ConventionalItemTags.GLOWSTONE_DUSTS)
 				.add(ItemIds.GLOWSTONE_DUST);
 
@@ -469,7 +469,7 @@ public final class ItemTagsGenerator extends FabricTagsProvider.ItemTagsProvider
 		copy(ConventionalBlockTags.QUARTZ_ORES, ConventionalItemTags.QUARTZ_ORES);
 
 		builder(ConventionalItemTags.RESIN_CLUMPS)
-				.add(BlockItemIds.RESIN_CLUMP.item());
+				.add(BlockItemIds.RESIN_CLUMP);
 
 		builder(ConventionalItemTags.QUARTZ_GEMS)
 				.add(ItemIds.QUARTZ);
@@ -654,21 +654,21 @@ public final class ItemTagsGenerator extends FabricTagsProvider.ItemTagsProvider
 		builder(ConventionalItemTags.BEETROOT_CROPS)
 				.add(ItemIds.BEETROOT);
 		builder(ConventionalItemTags.CACTUS_CROPS)
-				.add(BlockItemIds.CACTUS.item());
+				.add(BlockItemIds.CACTUS);
 		builder(ConventionalItemTags.CARROT_CROPS)
-				.add(BlockItemIds.CARROT_CROP.item());
+				.add(BlockItemIds.CARROT_CROP);
 		builder(ConventionalItemTags.COCOA_BEAN_CROPS)
-				.add(BlockItemIds.COCOA_CROP.item());
+				.add(BlockItemIds.COCOA_CROP);
 		builder(ConventionalItemTags.MELON_CROPS)
-				.add(BlockItemIds.MELON.item());
+				.add(BlockItemIds.MELON);
 		builder(ConventionalItemTags.NETHER_WART_CROPS)
-				.add(BlockItemIds.NETHER_WART.item());
+				.add(BlockItemIds.NETHER_WART);
 		builder(ConventionalItemTags.POTATO_CROPS)
-				.add(BlockItemIds.POTATO_CROP.item());
+				.add(BlockItemIds.POTATO_CROP);
 		builder(ConventionalItemTags.PUMPKIN_CROPS)
-				.add(BlockItemIds.PUMPKIN.item());
+				.add(BlockItemIds.PUMPKIN);
 		builder(ConventionalItemTags.SUGAR_CANE_CROPS)
-				.add(BlockItemIds.SUGAR_CANE.item());
+				.add(BlockItemIds.SUGAR_CANE);
 		builder(ConventionalItemTags.WHEAT_CROPS)
 				.add(ItemIds.WHEAT);
 
@@ -680,17 +680,17 @@ public final class ItemTagsGenerator extends FabricTagsProvider.ItemTagsProvider
 				.addOptionalTag(ConventionalItemTags.PITCHER_PLANT_SEEDS)
 				.addOptionalTag(ConventionalItemTags.WHEAT_SEEDS);
 		builder(ConventionalItemTags.BEETROOT_SEEDS)
-				.add(BlockItemIds.BEETROOT_CROP.item());
+				.add(BlockItemIds.BEETROOT_CROP);
 		builder(ConventionalItemTags.MELON_SEEDS)
-				.add(BlockItemIds.MELON_CROP.item());
+				.add(BlockItemIds.MELON_CROP);
 		builder(ConventionalItemTags.PUMPKIN_SEEDS)
-				.add(BlockItemIds.PUMPKIN_CROP.item());
+				.add(BlockItemIds.PUMPKIN_CROP);
 		builder(ConventionalItemTags.TORCHFLOWER_SEEDS)
-				.add(BlockItemIds.TORCHFLOWER_CROP.item());
+				.add(BlockItemIds.TORCHFLOWER_CROP);
 		builder(ConventionalItemTags.PITCHER_PLANT_SEEDS)
-				.add(BlockItemIds.PITCHER_CROP.item());
+				.add(BlockItemIds.PITCHER_CROP);
 		builder(ConventionalItemTags.WHEAT_SEEDS)
-				.add(BlockItemIds.WHEAT_CROP.item());
+				.add(BlockItemIds.WHEAT_CROP);
 	}
 
 	private void generateFlowerTags() {
@@ -701,13 +701,13 @@ public final class ItemTagsGenerator extends FabricTagsProvider.ItemTagsProvider
 
 	private void generateOtherTags() {
 		builder(ConventionalItemTags.PLAYER_WORKSTATIONS_CRAFTING_TABLES)
-				.add(BlockItemIds.CRAFTING_TABLE.item());
+				.add(BlockItemIds.CRAFTING_TABLE);
 
 		builder(ConventionalItemTags.PLAYER_WORKSTATIONS_FURNACES)
-				.add(BlockItemIds.FURNACE.item());
+				.add(BlockItemIds.FURNACE);
 
 		builder(ConventionalItemTags.STRINGS)
-				.add(BlockItemIds.TRIPWIRE.item());
+				.add(BlockItemIds.TRIPWIRE);
 
 		builder(ConventionalItemTags.LEATHERS)
 				.add(ItemIds.LEATHER);
@@ -725,8 +725,8 @@ public final class ItemTagsGenerator extends FabricTagsProvider.ItemTagsProvider
 				.add(ItemIds.GUNPOWDER);
 
 		builder(ConventionalItemTags.MUSHROOMS)
-				.add(BlockItemIds.RED_MUSHROOM.item())
-				.add(BlockItemIds.BROWN_MUSHROOM.item());
+				.add(BlockItemIds.RED_MUSHROOM)
+				.add(BlockItemIds.BROWN_MUSHROOM);
 
 		builder(ConventionalItemTags.NETHER_STARS)
 				.add(ItemIds.NETHER_STAR);
@@ -755,7 +755,7 @@ public final class ItemTagsGenerator extends FabricTagsProvider.ItemTagsProvider
 		builder(ConventionalItemTags.ROPES); // Generate tag so others can see it exists through JSON.
 
 		TagAppender<Item> chains = builder(ConventionalItemTags.CHAINS)
-				.add(BlockItemIds.IRON_CHAIN.item());
+				.add(BlockItemIds.IRON_CHAIN);
 		BlockItemIds.COPPER_CHAIN.asList().stream().map(BlockItemId::item).forEach(chains::add);
 
 		builder(ConventionalItemTags.ENDER_PEARLS)
@@ -773,100 +773,100 @@ public final class ItemTagsGenerator extends FabricTagsProvider.ItemTagsProvider
 	private void generateDyedTags() {
 		// Cannot pull entries from block tag because Wall Banners do not have an item form
 		builder(ConventionalItemTags.BLACK_DYED)
-				.add(BlockItemIds.BANNER.black().item()).add(BlockItemIds.BED.black().item()).add(BlockItemIds.DYED_CANDLE.black().item()).add(BlockItemIds.CARPET.black().item())
-				.add(BlockItemIds.CONCRETE.black().item()).add(BlockItemIds.CONCRETE_POWDER.black().item()).add(BlockItemIds.GLAZED_TERRACOTTA.black().item())
-				.add(BlockItemIds.DYED_SHULKER_BOX.black().item()).add(BlockItemIds.STAINED_GLASS.black().item()).add(BlockItemIds.STAINED_GLASS_PANE.black().item())
-				.add(BlockItemIds.DYED_TERRACOTTA.black().item()).add(BlockItemIds.WOOL.black().item()).add(ItemIds.DYED_BUNDLE.black()).add(ItemIds.HARNESS.black());
+				.add(BlockItemIds.BANNER.black()).add(BlockItemIds.BED.black()).add(BlockItemIds.DYED_CANDLE.black()).add(BlockItemIds.CARPET.black())
+				.add(BlockItemIds.CONCRETE.black()).add(BlockItemIds.CONCRETE_POWDER.black()).add(BlockItemIds.GLAZED_TERRACOTTA.black())
+				.add(BlockItemIds.DYED_SHULKER_BOX.black()).add(BlockItemIds.STAINED_GLASS.black()).add(BlockItemIds.STAINED_GLASS_PANE.black())
+				.add(BlockItemIds.DYED_TERRACOTTA.black()).add(BlockItemIds.WOOL.black()).add(ItemIds.DYED_BUNDLE.black()).add(ItemIds.HARNESS.black());
 
 		builder(ConventionalItemTags.BLUE_DYED)
-				.add(BlockItemIds.BANNER.blue().item()).add(BlockItemIds.BED.blue().item()).add(BlockItemIds.DYED_CANDLE.blue().item()).add(BlockItemIds.CARPET.blue().item())
-				.add(BlockItemIds.CONCRETE.blue().item()).add(BlockItemIds.CONCRETE_POWDER.blue().item()).add(BlockItemIds.GLAZED_TERRACOTTA.blue().item())
-				.add(BlockItemIds.DYED_SHULKER_BOX.blue().item()).add(BlockItemIds.STAINED_GLASS.blue().item()).add(BlockItemIds.STAINED_GLASS_PANE.blue().item())
-				.add(BlockItemIds.DYED_TERRACOTTA.blue().item()).add(BlockItemIds.WOOL.blue().item()).add(ItemIds.DYED_BUNDLE.blue()).add(ItemIds.HARNESS.blue());
+				.add(BlockItemIds.BANNER.blue()).add(BlockItemIds.BED.blue()).add(BlockItemIds.DYED_CANDLE.blue()).add(BlockItemIds.CARPET.blue())
+				.add(BlockItemIds.CONCRETE.blue()).add(BlockItemIds.CONCRETE_POWDER.blue()).add(BlockItemIds.GLAZED_TERRACOTTA.blue())
+				.add(BlockItemIds.DYED_SHULKER_BOX.blue()).add(BlockItemIds.STAINED_GLASS.blue()).add(BlockItemIds.STAINED_GLASS_PANE.blue())
+				.add(BlockItemIds.DYED_TERRACOTTA.blue()).add(BlockItemIds.WOOL.blue()).add(ItemIds.DYED_BUNDLE.blue()).add(ItemIds.HARNESS.blue());
 
 		builder(ConventionalItemTags.BROWN_DYED)
-				.add(BlockItemIds.BANNER.brown().item()).add(BlockItemIds.BED.brown().item()).add(BlockItemIds.DYED_CANDLE.brown().item()).add(BlockItemIds.CARPET.brown().item())
-				.add(BlockItemIds.CONCRETE.brown().item()).add(BlockItemIds.CONCRETE_POWDER.brown().item()).add(BlockItemIds.GLAZED_TERRACOTTA.brown().item())
-				.add(BlockItemIds.DYED_SHULKER_BOX.brown().item()).add(BlockItemIds.STAINED_GLASS.brown().item()).add(BlockItemIds.STAINED_GLASS_PANE.brown().item())
-				.add(BlockItemIds.DYED_TERRACOTTA.brown().item()).add(BlockItemIds.WOOL.brown().item()).add(ItemIds.DYED_BUNDLE.brown()).add(ItemIds.HARNESS.brown());
+				.add(BlockItemIds.BANNER.brown()).add(BlockItemIds.BED.brown()).add(BlockItemIds.DYED_CANDLE.brown()).add(BlockItemIds.CARPET.brown())
+				.add(BlockItemIds.CONCRETE.brown()).add(BlockItemIds.CONCRETE_POWDER.brown()).add(BlockItemIds.GLAZED_TERRACOTTA.brown())
+				.add(BlockItemIds.DYED_SHULKER_BOX.brown()).add(BlockItemIds.STAINED_GLASS.brown()).add(BlockItemIds.STAINED_GLASS_PANE.brown())
+				.add(BlockItemIds.DYED_TERRACOTTA.brown()).add(BlockItemIds.WOOL.brown()).add(ItemIds.DYED_BUNDLE.brown()).add(ItemIds.HARNESS.brown());
 
 		builder(ConventionalItemTags.CYAN_DYED)
-				.add(BlockItemIds.BANNER.cyan().item()).add(BlockItemIds.BED.cyan().item()).add(BlockItemIds.DYED_CANDLE.cyan().item()).add(BlockItemIds.CARPET.cyan().item())
-				.add(BlockItemIds.CONCRETE.cyan().item()).add(BlockItemIds.CONCRETE_POWDER.cyan().item()).add(BlockItemIds.GLAZED_TERRACOTTA.cyan().item())
-				.add(BlockItemIds.DYED_SHULKER_BOX.cyan().item()).add(BlockItemIds.STAINED_GLASS.cyan().item()).add(BlockItemIds.STAINED_GLASS_PANE.cyan().item())
-				.add(BlockItemIds.DYED_TERRACOTTA.cyan().item()).add(BlockItemIds.WOOL.cyan().item()).add(ItemIds.DYED_BUNDLE.cyan()).add(ItemIds.HARNESS.cyan());
+				.add(BlockItemIds.BANNER.cyan()).add(BlockItemIds.BED.cyan()).add(BlockItemIds.DYED_CANDLE.cyan()).add(BlockItemIds.CARPET.cyan())
+				.add(BlockItemIds.CONCRETE.cyan()).add(BlockItemIds.CONCRETE_POWDER.cyan()).add(BlockItemIds.GLAZED_TERRACOTTA.cyan())
+				.add(BlockItemIds.DYED_SHULKER_BOX.cyan()).add(BlockItemIds.STAINED_GLASS.cyan()).add(BlockItemIds.STAINED_GLASS_PANE.cyan())
+				.add(BlockItemIds.DYED_TERRACOTTA.cyan()).add(BlockItemIds.WOOL.cyan()).add(ItemIds.DYED_BUNDLE.cyan()).add(ItemIds.HARNESS.cyan());
 
 		builder(ConventionalItemTags.GRAY_DYED)
-				.add(BlockItemIds.BANNER.gray().item()).add(BlockItemIds.BED.gray().item()).add(BlockItemIds.DYED_CANDLE.gray().item()).add(BlockItemIds.CARPET.gray().item())
-				.add(BlockItemIds.CONCRETE.gray().item()).add(BlockItemIds.CONCRETE_POWDER.gray().item()).add(BlockItemIds.GLAZED_TERRACOTTA.gray().item())
-				.add(BlockItemIds.DYED_SHULKER_BOX.gray().item()).add(BlockItemIds.STAINED_GLASS.gray().item()).add(BlockItemIds.STAINED_GLASS_PANE.gray().item())
-				.add(BlockItemIds.DYED_TERRACOTTA.gray().item()).add(BlockItemIds.WOOL.gray().item()).add(ItemIds.DYED_BUNDLE.gray()).add(ItemIds.HARNESS.gray());
+				.add(BlockItemIds.BANNER.gray()).add(BlockItemIds.BED.gray()).add(BlockItemIds.DYED_CANDLE.gray()).add(BlockItemIds.CARPET.gray())
+				.add(BlockItemIds.CONCRETE.gray()).add(BlockItemIds.CONCRETE_POWDER.gray()).add(BlockItemIds.GLAZED_TERRACOTTA.gray())
+				.add(BlockItemIds.DYED_SHULKER_BOX.gray()).add(BlockItemIds.STAINED_GLASS.gray()).add(BlockItemIds.STAINED_GLASS_PANE.gray())
+				.add(BlockItemIds.DYED_TERRACOTTA.gray()).add(BlockItemIds.WOOL.gray()).add(ItemIds.DYED_BUNDLE.gray()).add(ItemIds.HARNESS.gray());
 
 		builder(ConventionalItemTags.GREEN_DYED)
-				.add(BlockItemIds.BANNER.green().item()).add(BlockItemIds.BED.green().item()).add(BlockItemIds.DYED_CANDLE.green().item()).add(BlockItemIds.CARPET.green().item())
-				.add(BlockItemIds.CONCRETE.green().item()).add(BlockItemIds.CONCRETE_POWDER.green().item()).add(BlockItemIds.GLAZED_TERRACOTTA.green().item())
-				.add(BlockItemIds.DYED_SHULKER_BOX.green().item()).add(BlockItemIds.STAINED_GLASS.green().item()).add(BlockItemIds.STAINED_GLASS_PANE.green().item())
-				.add(BlockItemIds.DYED_TERRACOTTA.green().item()).add(BlockItemIds.WOOL.green().item()).add(ItemIds.DYED_BUNDLE.green()).add(ItemIds.HARNESS.green());
+				.add(BlockItemIds.BANNER.green()).add(BlockItemIds.BED.green()).add(BlockItemIds.DYED_CANDLE.green()).add(BlockItemIds.CARPET.green())
+				.add(BlockItemIds.CONCRETE.green()).add(BlockItemIds.CONCRETE_POWDER.green()).add(BlockItemIds.GLAZED_TERRACOTTA.green())
+				.add(BlockItemIds.DYED_SHULKER_BOX.green()).add(BlockItemIds.STAINED_GLASS.green()).add(BlockItemIds.STAINED_GLASS_PANE.green())
+				.add(BlockItemIds.DYED_TERRACOTTA.green()).add(BlockItemIds.WOOL.green()).add(ItemIds.DYED_BUNDLE.green()).add(ItemIds.HARNESS.green());
 
 		builder(ConventionalItemTags.LIGHT_BLUE_DYED)
-				.add(BlockItemIds.BANNER.lightBlue().item()).add(BlockItemIds.BED.lightBlue().item()).add(BlockItemIds.DYED_CANDLE.lightBlue().item()).add(BlockItemIds.CARPET.lightBlue().item())
-				.add(BlockItemIds.CONCRETE.lightBlue().item()).add(BlockItemIds.CONCRETE_POWDER.lightBlue().item()).add(BlockItemIds.GLAZED_TERRACOTTA.lightBlue().item())
-				.add(BlockItemIds.DYED_SHULKER_BOX.lightBlue().item()).add(BlockItemIds.STAINED_GLASS.lightBlue().item()).add(BlockItemIds.STAINED_GLASS_PANE.lightBlue().item())
-				.add(BlockItemIds.DYED_TERRACOTTA.lightBlue().item()).add(BlockItemIds.WOOL.lightBlue().item()).add(ItemIds.DYED_BUNDLE.lightBlue()).add(ItemIds.HARNESS.lightBlue());
+				.add(BlockItemIds.BANNER.lightBlue()).add(BlockItemIds.BED.lightBlue()).add(BlockItemIds.DYED_CANDLE.lightBlue()).add(BlockItemIds.CARPET.lightBlue())
+				.add(BlockItemIds.CONCRETE.lightBlue()).add(BlockItemIds.CONCRETE_POWDER.lightBlue()).add(BlockItemIds.GLAZED_TERRACOTTA.lightBlue())
+				.add(BlockItemIds.DYED_SHULKER_BOX.lightBlue()).add(BlockItemIds.STAINED_GLASS.lightBlue()).add(BlockItemIds.STAINED_GLASS_PANE.lightBlue())
+				.add(BlockItemIds.DYED_TERRACOTTA.lightBlue()).add(BlockItemIds.WOOL.lightBlue()).add(ItemIds.DYED_BUNDLE.lightBlue()).add(ItemIds.HARNESS.lightBlue());
 
 		builder(ConventionalItemTags.LIGHT_GRAY_DYED)
-				.add(BlockItemIds.BANNER.lightGray().item()).add(BlockItemIds.BED.lightGray().item()).add(BlockItemIds.DYED_CANDLE.lightGray().item()).add(BlockItemIds.CARPET.lightGray().item())
-				.add(BlockItemIds.CONCRETE.lightGray().item()).add(BlockItemIds.CONCRETE_POWDER.lightGray().item()).add(BlockItemIds.GLAZED_TERRACOTTA.lightGray().item())
-				.add(BlockItemIds.DYED_SHULKER_BOX.lightGray().item()).add(BlockItemIds.STAINED_GLASS.lightGray().item()).add(BlockItemIds.STAINED_GLASS_PANE.lightGray().item())
-				.add(BlockItemIds.DYED_TERRACOTTA.lightGray().item()).add(BlockItemIds.WOOL.lightGray().item()).add(ItemIds.DYED_BUNDLE.lightGray()).add(ItemIds.HARNESS.lightGray());
+				.add(BlockItemIds.BANNER.lightGray()).add(BlockItemIds.BED.lightGray()).add(BlockItemIds.DYED_CANDLE.lightGray()).add(BlockItemIds.CARPET.lightGray())
+				.add(BlockItemIds.CONCRETE.lightGray()).add(BlockItemIds.CONCRETE_POWDER.lightGray()).add(BlockItemIds.GLAZED_TERRACOTTA.lightGray())
+				.add(BlockItemIds.DYED_SHULKER_BOX.lightGray()).add(BlockItemIds.STAINED_GLASS.lightGray()).add(BlockItemIds.STAINED_GLASS_PANE.lightGray())
+				.add(BlockItemIds.DYED_TERRACOTTA.lightGray()).add(BlockItemIds.WOOL.lightGray()).add(ItemIds.DYED_BUNDLE.lightGray()).add(ItemIds.HARNESS.lightGray());
 
 		builder(ConventionalItemTags.LIME_DYED)
-				.add(BlockItemIds.BANNER.lime().item()).add(BlockItemIds.BED.lime().item()).add(BlockItemIds.DYED_CANDLE.lime().item()).add(BlockItemIds.CARPET.lime().item())
-				.add(BlockItemIds.CONCRETE.lime().item()).add(BlockItemIds.CONCRETE_POWDER.lime().item()).add(BlockItemIds.GLAZED_TERRACOTTA.lime().item())
-				.add(BlockItemIds.DYED_SHULKER_BOX.lime().item()).add(BlockItemIds.STAINED_GLASS.lime().item()).add(BlockItemIds.STAINED_GLASS_PANE.lime().item())
-				.add(BlockItemIds.DYED_TERRACOTTA.lime().item()).add(BlockItemIds.WOOL.lime().item()).add(ItemIds.DYED_BUNDLE.lime()).add(ItemIds.HARNESS.lime());
+				.add(BlockItemIds.BANNER.lime()).add(BlockItemIds.BED.lime()).add(BlockItemIds.DYED_CANDLE.lime()).add(BlockItemIds.CARPET.lime())
+				.add(BlockItemIds.CONCRETE.lime()).add(BlockItemIds.CONCRETE_POWDER.lime()).add(BlockItemIds.GLAZED_TERRACOTTA.lime())
+				.add(BlockItemIds.DYED_SHULKER_BOX.lime()).add(BlockItemIds.STAINED_GLASS.lime()).add(BlockItemIds.STAINED_GLASS_PANE.lime())
+				.add(BlockItemIds.DYED_TERRACOTTA.lime()).add(BlockItemIds.WOOL.lime()).add(ItemIds.DYED_BUNDLE.lime()).add(ItemIds.HARNESS.lime());
 
 		builder(ConventionalItemTags.MAGENTA_DYED)
-				.add(BlockItemIds.BANNER.magenta().item()).add(BlockItemIds.BED.magenta().item()).add(BlockItemIds.DYED_CANDLE.magenta().item()).add(BlockItemIds.CARPET.magenta().item())
-				.add(BlockItemIds.CONCRETE.magenta().item()).add(BlockItemIds.CONCRETE_POWDER.magenta().item()).add(BlockItemIds.GLAZED_TERRACOTTA.magenta().item())
-				.add(BlockItemIds.DYED_SHULKER_BOX.magenta().item()).add(BlockItemIds.STAINED_GLASS.magenta().item()).add(BlockItemIds.STAINED_GLASS_PANE.magenta().item())
-				.add(BlockItemIds.DYED_TERRACOTTA.magenta().item()).add(BlockItemIds.WOOL.magenta().item()).add(ItemIds.DYED_BUNDLE.magenta()).add(ItemIds.HARNESS.magenta());
+				.add(BlockItemIds.BANNER.magenta()).add(BlockItemIds.BED.magenta()).add(BlockItemIds.DYED_CANDLE.magenta()).add(BlockItemIds.CARPET.magenta())
+				.add(BlockItemIds.CONCRETE.magenta()).add(BlockItemIds.CONCRETE_POWDER.magenta()).add(BlockItemIds.GLAZED_TERRACOTTA.magenta())
+				.add(BlockItemIds.DYED_SHULKER_BOX.magenta()).add(BlockItemIds.STAINED_GLASS.magenta()).add(BlockItemIds.STAINED_GLASS_PANE.magenta())
+				.add(BlockItemIds.DYED_TERRACOTTA.magenta()).add(BlockItemIds.WOOL.magenta()).add(ItemIds.DYED_BUNDLE.magenta()).add(ItemIds.HARNESS.magenta());
 
 		builder(ConventionalItemTags.ORANGE_DYED)
-				.add(BlockItemIds.BANNER.orange().item()).add(BlockItemIds.BED.orange().item()).add(BlockItemIds.DYED_CANDLE.orange().item()).add(BlockItemIds.CARPET.orange().item())
-				.add(BlockItemIds.CONCRETE.orange().item()).add(BlockItemIds.CONCRETE_POWDER.orange().item()).add(BlockItemIds.GLAZED_TERRACOTTA.orange().item())
-				.add(BlockItemIds.DYED_SHULKER_BOX.orange().item()).add(BlockItemIds.STAINED_GLASS.orange().item()).add(BlockItemIds.STAINED_GLASS_PANE.orange().item())
-				.add(BlockItemIds.DYED_TERRACOTTA.orange().item()).add(BlockItemIds.WOOL.orange().item()).add(ItemIds.DYED_BUNDLE.orange()).add(ItemIds.HARNESS.orange());
+				.add(BlockItemIds.BANNER.orange()).add(BlockItemIds.BED.orange()).add(BlockItemIds.DYED_CANDLE.orange()).add(BlockItemIds.CARPET.orange())
+				.add(BlockItemIds.CONCRETE.orange()).add(BlockItemIds.CONCRETE_POWDER.orange()).add(BlockItemIds.GLAZED_TERRACOTTA.orange())
+				.add(BlockItemIds.DYED_SHULKER_BOX.orange()).add(BlockItemIds.STAINED_GLASS.orange()).add(BlockItemIds.STAINED_GLASS_PANE.orange())
+				.add(BlockItemIds.DYED_TERRACOTTA.orange()).add(BlockItemIds.WOOL.orange()).add(ItemIds.DYED_BUNDLE.orange()).add(ItemIds.HARNESS.orange());
 
 		builder(ConventionalItemTags.PINK_DYED)
-				.add(BlockItemIds.BANNER.pink().item()).add(BlockItemIds.BED.pink().item()).add(BlockItemIds.DYED_CANDLE.pink().item()).add(BlockItemIds.CARPET.pink().item())
-				.add(BlockItemIds.CONCRETE.pink().item()).add(BlockItemIds.CONCRETE_POWDER.pink().item()).add(BlockItemIds.GLAZED_TERRACOTTA.pink().item())
-				.add(BlockItemIds.DYED_SHULKER_BOX.pink().item()).add(BlockItemIds.STAINED_GLASS.pink().item()).add(BlockItemIds.STAINED_GLASS_PANE.pink().item())
-				.add(BlockItemIds.DYED_TERRACOTTA.pink().item()).add(BlockItemIds.WOOL.pink().item()).add(ItemIds.DYED_BUNDLE.pink()).add(ItemIds.HARNESS.pink());
+				.add(BlockItemIds.BANNER.pink()).add(BlockItemIds.BED.pink()).add(BlockItemIds.DYED_CANDLE.pink()).add(BlockItemIds.CARPET.pink())
+				.add(BlockItemIds.CONCRETE.pink()).add(BlockItemIds.CONCRETE_POWDER.pink()).add(BlockItemIds.GLAZED_TERRACOTTA.pink())
+				.add(BlockItemIds.DYED_SHULKER_BOX.pink()).add(BlockItemIds.STAINED_GLASS.pink()).add(BlockItemIds.STAINED_GLASS_PANE.pink())
+				.add(BlockItemIds.DYED_TERRACOTTA.pink()).add(BlockItemIds.WOOL.pink()).add(ItemIds.DYED_BUNDLE.pink()).add(ItemIds.HARNESS.pink());
 
 		builder(ConventionalItemTags.PURPLE_DYED)
-				.add(BlockItemIds.BANNER.purple().item()).add(BlockItemIds.BED.purple().item()).add(BlockItemIds.DYED_CANDLE.purple().item()).add(BlockItemIds.CARPET.purple().item())
-				.add(BlockItemIds.CONCRETE.purple().item()).add(BlockItemIds.CONCRETE_POWDER.purple().item()).add(BlockItemIds.GLAZED_TERRACOTTA.purple().item())
-				.add(BlockItemIds.DYED_SHULKER_BOX.purple().item()).add(BlockItemIds.STAINED_GLASS.purple().item()).add(BlockItemIds.STAINED_GLASS_PANE.purple().item())
-				.add(BlockItemIds.DYED_TERRACOTTA.purple().item()).add(BlockItemIds.WOOL.purple().item()).add(ItemIds.DYED_BUNDLE.purple()).add(ItemIds.HARNESS.purple());
+				.add(BlockItemIds.BANNER.purple()).add(BlockItemIds.BED.purple()).add(BlockItemIds.DYED_CANDLE.purple()).add(BlockItemIds.CARPET.purple())
+				.add(BlockItemIds.CONCRETE.purple()).add(BlockItemIds.CONCRETE_POWDER.purple()).add(BlockItemIds.GLAZED_TERRACOTTA.purple())
+				.add(BlockItemIds.DYED_SHULKER_BOX.purple()).add(BlockItemIds.STAINED_GLASS.purple()).add(BlockItemIds.STAINED_GLASS_PANE.purple())
+				.add(BlockItemIds.DYED_TERRACOTTA.purple()).add(BlockItemIds.WOOL.purple()).add(ItemIds.DYED_BUNDLE.purple()).add(ItemIds.HARNESS.purple());
 
 		builder(ConventionalItemTags.RED_DYED)
-				.add(BlockItemIds.BANNER.red().item()).add(BlockItemIds.BED.red().item()).add(BlockItemIds.DYED_CANDLE.red().item()).add(BlockItemIds.CARPET.red().item())
-				.add(BlockItemIds.CONCRETE.red().item()).add(BlockItemIds.CONCRETE_POWDER.red().item()).add(BlockItemIds.GLAZED_TERRACOTTA.red().item())
-				.add(BlockItemIds.DYED_SHULKER_BOX.red().item()).add(BlockItemIds.STAINED_GLASS.red().item()).add(BlockItemIds.STAINED_GLASS_PANE.red().item())
-				.add(BlockItemIds.DYED_TERRACOTTA.red().item()).add(BlockItemIds.WOOL.red().item()).add(ItemIds.DYED_BUNDLE.red()).add(ItemIds.HARNESS.red());
+				.add(BlockItemIds.BANNER.red()).add(BlockItemIds.BED.red()).add(BlockItemIds.DYED_CANDLE.red()).add(BlockItemIds.CARPET.red())
+				.add(BlockItemIds.CONCRETE.red()).add(BlockItemIds.CONCRETE_POWDER.red()).add(BlockItemIds.GLAZED_TERRACOTTA.red())
+				.add(BlockItemIds.DYED_SHULKER_BOX.red()).add(BlockItemIds.STAINED_GLASS.red()).add(BlockItemIds.STAINED_GLASS_PANE.red())
+				.add(BlockItemIds.DYED_TERRACOTTA.red()).add(BlockItemIds.WOOL.red()).add(ItemIds.DYED_BUNDLE.red()).add(ItemIds.HARNESS.red());
 
 		builder(ConventionalItemTags.WHITE_DYED)
-				.add(BlockItemIds.BANNER.white().item()).add(BlockItemIds.BED.white().item()).add(BlockItemIds.DYED_CANDLE.white().item()).add(BlockItemIds.CARPET.white().item())
-				.add(BlockItemIds.CONCRETE.white().item()).add(BlockItemIds.CONCRETE_POWDER.white().item()).add(BlockItemIds.GLAZED_TERRACOTTA.white().item())
-				.add(BlockItemIds.DYED_SHULKER_BOX.white().item()).add(BlockItemIds.STAINED_GLASS.white().item()).add(BlockItemIds.STAINED_GLASS_PANE.white().item())
-				.add(BlockItemIds.DYED_TERRACOTTA.white().item()).add(BlockItemIds.WOOL.white().item()).add(ItemIds.DYED_BUNDLE.white()).add(ItemIds.HARNESS.white());
+				.add(BlockItemIds.BANNER.white()).add(BlockItemIds.BED.white()).add(BlockItemIds.DYED_CANDLE.white()).add(BlockItemIds.CARPET.white())
+				.add(BlockItemIds.CONCRETE.white()).add(BlockItemIds.CONCRETE_POWDER.white()).add(BlockItemIds.GLAZED_TERRACOTTA.white())
+				.add(BlockItemIds.DYED_SHULKER_BOX.white()).add(BlockItemIds.STAINED_GLASS.white()).add(BlockItemIds.STAINED_GLASS_PANE.white())
+				.add(BlockItemIds.DYED_TERRACOTTA.white()).add(BlockItemIds.WOOL.white()).add(ItemIds.DYED_BUNDLE.white()).add(ItemIds.HARNESS.white());
 
 		builder(ConventionalItemTags.YELLOW_DYED)
-				.add(BlockItemIds.BANNER.yellow().item()).add(BlockItemIds.BED.yellow().item()).add(BlockItemIds.DYED_CANDLE.yellow().item()).add(BlockItemIds.CARPET.yellow().item())
-				.add(BlockItemIds.CONCRETE.yellow().item()).add(BlockItemIds.CONCRETE_POWDER.yellow().item()).add(BlockItemIds.GLAZED_TERRACOTTA.yellow().item())
-				.add(BlockItemIds.DYED_SHULKER_BOX.yellow().item()).add(BlockItemIds.STAINED_GLASS.yellow().item()).add(BlockItemIds.STAINED_GLASS_PANE.yellow().item())
-				.add(BlockItemIds.DYED_TERRACOTTA.yellow().item()).add(BlockItemIds.WOOL.yellow().item()).add(ItemIds.DYED_BUNDLE.yellow()).add(ItemIds.HARNESS.yellow());
+				.add(BlockItemIds.BANNER.yellow()).add(BlockItemIds.BED.yellow()).add(BlockItemIds.DYED_CANDLE.yellow()).add(BlockItemIds.CARPET.yellow())
+				.add(BlockItemIds.CONCRETE.yellow()).add(BlockItemIds.CONCRETE_POWDER.yellow()).add(BlockItemIds.GLAZED_TERRACOTTA.yellow())
+				.add(BlockItemIds.DYED_SHULKER_BOX.yellow()).add(BlockItemIds.STAINED_GLASS.yellow()).add(BlockItemIds.STAINED_GLASS_PANE.yellow())
+				.add(BlockItemIds.DYED_TERRACOTTA.yellow()).add(BlockItemIds.WOOL.yellow()).add(ItemIds.DYED_BUNDLE.yellow()).add(ItemIds.HARNESS.yellow());
 
 		builder(ConventionalItemTags.DYED)
 				.addTag(ConventionalItemTags.WHITE_DYED)

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagAppender.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagAppender.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.api.datagen.v1.provider;
 
 import net.minecraft.data.tags.TagAppender;
+import net.minecraft.tags.TagBuilder;
 import net.minecraft.tags.TagKey;
 
 /**
@@ -36,5 +37,9 @@ public interface FabricTagAppender<T> {
 
 	default TagAppender<T> forceAddTag(TagKey<T> tag) {
 		return (TagAppender<T>) this;
+	}
+
+	default TagBuilder getBuilder() {
+		return null;
 	}
 }

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagsProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricTagsProvider.java
@@ -31,8 +31,10 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistrySetBuilder;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.data.tags.BlockItemTagAppender;
 import net.minecraft.data.tags.TagAppender;
 import net.minecraft.data.tags.TagsProvider;
+import net.minecraft.references.BlockItemId;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.tags.TagBuilder;
@@ -125,6 +127,15 @@ public abstract class FabricTagsProvider<T> extends TagsProvider<T> {
 		public BlockTagsProvider(FabricPackOutput output, CompletableFuture<HolderLookup.Provider> registryLookupFuture) {
 			super(output, Registries.BLOCK, registryLookupFuture);
 		}
+
+		protected BlockItemTagAppender<Block> builder(TagKey<Block> tag) {
+			return new BlockItemTagAppender<>(super.builder(tag)) {
+				@Override
+				protected ResourceKey<Block> convertElement(BlockItemId element) {
+					return element.block();
+				}
+			};
+		}
 	}
 
 	/**
@@ -175,6 +186,15 @@ public abstract class FabricTagsProvider<T> extends TagsProvider<T> {
 			TagBuilder blockTagBuilder = Objects.requireNonNull(this.blockTagBuilderProvider, "Pass Block tags provider via constructor to use copy").apply(blockTag);
 			TagBuilder itemTagBuilder = this.getOrCreateRawBuilder(itemTag);
 			blockTagBuilder.build().forEach(itemTagBuilder::add);
+		}
+
+		protected BlockItemTagAppender<Item> builder(TagKey<Item> tag) {
+			return new BlockItemTagAppender<>(super.builder(tag)) {
+				@Override
+				protected ResourceKey<Item> convertElement(BlockItemId element) {
+					return element.item();
+				}
+			};
 		}
 	}
 

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/BlockItemTagAppenderMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/BlockItemTagAppenderMixin.java
@@ -20,8 +20,8 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
+import net.minecraft.data.tags.BlockItemTagAppender;
 import net.minecraft.data.tags.TagAppender;
-import net.minecraft.tags.TagBuilder;
 import net.minecraft.tags.TagKey;
 
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagAppender;
@@ -31,30 +31,28 @@ import net.fabricmc.fabric.impl.datagen.FabricTagBuilder;
  * Extends TagAppender to support setting the replace field.
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-@Mixin(TagAppender.class)
-interface TagAppenderMixin<T> extends FabricTagAppender<T> {
-	@Mixin(targets = "net.minecraft.data.tags.TagAppender$1")
-	abstract class TagAppender1Mixin<T> implements TagAppenderMixin<T> {
-		// the builder param
-		@Shadow
-		@Final
-		TagBuilder val$builder;
+@Mixin(BlockItemTagAppender.class)
+abstract class BlockItemTagAppenderMixin<T> implements FabricTagAppender<T> {
+	// the builder param
+	@Shadow
+	@Final
+	TagAppender<T> original;
 
-		@Override
-		public TagAppender<T> setReplace(boolean replace) {
-			((FabricTagBuilder) this.val$builder).fabric_setReplace(replace);
-			return (TagAppender<T>) this;
+	@Override
+	public BlockItemTagAppender<T> setReplace(boolean replace) {
+		if (this.original.getBuilder() instanceof FabricTagBuilder builder) {
+			builder.fabric_setReplace(replace);
 		}
 
-		@Override
-		public TagAppender<T> forceAddTag(TagKey<T> tag) {
-			((FabricTagBuilder) this.val$builder).fabric_forceAddTag(tag.location());
-			return (TagAppender<T>) this;
+		return (BlockItemTagAppender<T>) (Object) this;
+	}
+
+	@Override
+	public BlockItemTagAppender<T> forceAddTag(TagKey<T> tag) {
+		if (this.original.getBuilder() instanceof FabricTagBuilder builder) {
+			builder.fabric_forceAddTag(tag.location());
 		}
 
-		@Override
-		public TagBuilder getBuilder() {
-			return val$builder;
-		}
+		return (BlockItemTagAppender<T>) (Object) this;
 	}
 }

--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
@@ -5,6 +5,7 @@
   "mixins": [
     "HashCacheProviderCacheMixin",
     "HashCacheMixin",
+    "BlockItemTagAppenderMixin",
     "DataProviderMixin",
     "TagAppenderMixin",
     "TagAppenderMixin$TagAppender1Mixin",


### PR DESCRIPTION
Didn't realise that one commit in #5317 removing FabricIntrinsicHolderTagsProvider reverted using this until after it was merged. Restored it.