### PR TITLE
Client gametest: make respawn radius 0 when using consistent world settings

### DIFF
--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/world/TestWorldBuilderImpl.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/world/TestWorldBuilderImpl.java
@@ -142,5 +142,6 @@ public class TestWorldBuilderImpl implements TestWorldBuilder {
 		creator.getGameRules().set(GameRules.ADVANCE_TIME, false, null);
 		creator.getGameRules().set(GameRules.ADVANCE_WEATHER, false, null);
 		creator.getGameRules().set(GameRules.SPAWN_MOBS, false, null);
+		creator.getGameRules().set(GameRules.RESPAWN_RADIUS, 0, null);
 	}
 }


### PR DESCRIPTION
Will make the spawn position consistent between runs and deaths.